### PR TITLE
jetbrains.rust-rover: fix darwin install

### DIFF
--- a/pkgs/applications/editors/jetbrains/darwin.nix
+++ b/pkgs/applications/editors/jetbrains/darwin.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation {
     cp -Tr *.app "$APP_DIR"
     mkdir -p "$out/bin"
     cat << EOF > "$out/bin/${loname}"
-    open -na '$APP_DIR/Contents/MacOS/${loname}' --args "\$@"
+    open -na '$APP_DIR' --args "\$@"
     EOF
     chmod +x "$out/bin/${loname}"
     runHook postInstall

--- a/pkgs/applications/editors/jetbrains/darwin.nix
+++ b/pkgs/applications/editors/jetbrains/darwin.nix
@@ -25,12 +25,12 @@ stdenvNoCC.mkDerivation {
   dontFixup = true;
   installPhase = ''
     runHook preInstall
-    APP_DIR="$out/Applications/"
+    APP_DIR="$out/Applications/${product}.app"
     mkdir -p "$APP_DIR"
-    cp -r *.app "$APP_DIR"
+    cp -Tr *.app "$APP_DIR"
     mkdir -p "$out/bin"
     cat << EOF > "$out/bin/${loname}"
-    open -na '$APP_DIR' --args "\$@"
+    open -na '$APP_DIR/Contents/MacOS/${loname}' --args "\$@"
     EOF
     chmod +x "$out/bin/${loname}"
     runHook postInstall

--- a/pkgs/applications/editors/jetbrains/darwin.nix
+++ b/pkgs/applications/editors/jetbrains/darwin.nix
@@ -25,9 +25,9 @@ stdenvNoCC.mkDerivation {
   dontFixup = true;
   installPhase = ''
     runHook preInstall
-    APP_DIR="$out/Applications/${product}.app"
+    APP_DIR="$out/Applications/"
     mkdir -p "$APP_DIR"
-    cp -Tr "${product}.app" "$APP_DIR"
+    cp -r *.app "$APP_DIR"
     mkdir -p "$out/bin"
     cat << EOF > "$out/bin/${loname}"
     open -na '$APP_DIR' --args "\$@"


### PR DESCRIPTION
## Description of changes

JetBrains doesn't guarantee that the macOS app will be called `${product}.app` so I modified the installPhase to copy *.app instead of ${product}.app, which fails on file does not exist for Rust Rover, which is `RustRover 2023.2 EAP.app`

I've tested with some other JetBrains apps on darwin aarch64 and they continue to build as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
