### PR TITLE
bump luarocks packages

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -41,6 +41,7 @@ lrexlib-posix,,,,,,
 lua-cjson,,,,,,
 lua-cmsgpack,,,,,,
 lua-curl,,,,,,
+lua-ffi-zlib,,,,,,
 lua-lsp,,,,,,
 lua-messagepack,,,,,,
 lua-protobuf,,,,,,lockejan

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -1,9 +1,9 @@
 name,src,ref,server,version,luaversion,maintainers
 alt-getopt,,,,,,arobyn
 bit32,,,,5.3.0-1,5.1,lblasc
-argparse,https://github.com/luarocks/argparse.git,,,,,
-basexx,https://github.com/teto/basexx.git,,,,,
-binaryheap,https://github.com/Tieske/binaryheap.lua,,,,,vcunat
+argparse,,,,,,
+basexx,,,,,,
+binaryheap,,,,,,vcunat
 busted,,,,,,
 cassowary,,,,,,marsam alerque
 cldr,,,,,,alerque
@@ -12,8 +12,8 @@ cosmo,,,,,,marsam
 coxpcall,,,,1.17.0-1,,
 cqueues,,,,,,vcunat
 cyan,,,,,,
-cyrussasl,https://github.com/JorjBauer/lua-cyrussasl.git,,,,,
-digestif,https://github.com/astoff/digestif.git,,,0.2-1,5.3,
+cyrussasl,,,,,,
+digestif,https://github.com/astoff/digestif.git,,,,5.3,
 dkjson,,,,,,
 fennel,,,,,,misterio77
 ferris.nvim,,,,,,mrcjkb
@@ -25,7 +25,7 @@ http,,,,0.3-0,,vcunat
 inspect,,,,,,
 jsregexp,,,,,,
 ldbus,,,http://luarocks.org/dev,,,
-ldoc,https://github.com/stevedonovan/LDoc.git,,,,,
+ldoc,,,,,,
 lgi,,,,,,
 linenoise,https://github.com/hoelzro/lua-linenoise.git,,,,,
 ljsyscall,,,,,5.1,lblasc
@@ -41,7 +41,6 @@ lrexlib-posix,,,,,,
 lua-cjson,,,,,,
 lua-cmsgpack,,,,,,
 lua-curl,,,,,,
-lua-iconv,,,,,,
 lua-lsp,,,,,,
 lua-messagepack,,,,,,
 lua-protobuf,,,,,,lockejan
@@ -83,17 +82,18 @@ luaunit,,,,,,lockejan
 luautf8,,,,,,pstn
 luazip,,,,,,
 lua-yajl,,,,,,pstn
+lua-iconv,,,,7.0.0,,
 luuid,,,,,,
 luv,,,,1.44.2-1,,
 lush.nvim,https://github.com/rktjmp/lush.nvim,,,,,teto
 lyaml,,,,,,lblasc
-magick,,,,,,donovanglover
+magick,,,,,5.1,donovanglover
 markdown,,,,,,
 mediator_lua,,,,,,
 middleclass,,,,,,
 mpack,,,,,,
 moonscript,https://github.com/leafo/moonscript.git,dev-1,,,,arobyn
-nui-nvim,,,,,,mrcjkb
+nui.nvim,,,,,,mrcjkb
 nvim-client,https://github.com/neovim/lua-client.git,,,,,
 nvim-cmp,https://github.com/hrsh7th/nvim-cmp,,,,,
 penlight,https://github.com/lunarmodules/Penlight.git,,,,,alerque
@@ -105,7 +105,7 @@ say,https://github.com/Olivine-Labs/say.git,,,,,
 serpent,,,,,,lockejan
 sqlite,,,,,,
 std._debug,https://github.com/lua-stdlib/_debug.git,,,,,
-std.normalize,https://github.com/lua-stdlib/normalize.git,,,,,
+std.normalize,,,,,,
 stdlib,,,,41.2.2,,vyp
 teal-language-server,,,http://luarocks.org/dev,,,
 telescope.nvim,,,,,5.1,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -100,7 +100,6 @@ penlight,https://github.com/lunarmodules/Penlight.git,,,,,alerque
 plenary.nvim,https://github.com/nvim-lua/plenary.nvim.git,,,,5.1,
 rapidjson,https://github.com/xpol/lua-rapidjson.git,,,,,
 rest.nvim,,,,,5.1,teto
-readline,,,,,,
 say,https://github.com/Olivine-Labs/say.git,,,,,
 serpent,,,,,,lockejan
 sqlite,,,,,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -12,7 +12,6 @@ cosmo,,,,,,marsam
 coxpcall,,,,1.17.0-1,,
 cqueues,,,,,,vcunat
 cyan,,,,,,
-cyrussasl,,,,,,
 digestif,https://github.com/astoff/digestif.git,,,,5.3,
 dkjson,,,,,,
 fennel,,,,,,misterio77

--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -103,7 +103,7 @@ class LuaEditor(pluginupdate.Editor):
             header2 = textwrap.dedent(
                 # header2 = inspect.cleandoc(
                 """
-                { self, stdenv, lib, fetchurl, fetchgit, callPackage, ... } @ args:
+				{ stdenv, lib, fetchurl, fetchgit, callPackage, ... }:
                 final: prev:
                 {
             """

--- a/pkgs/development/interpreters/nelua/default.nix
+++ b/pkgs/development/interpreters/nelua/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "nelua";
-  version = "unstable-2023-01-21";
+  version = "unstable-2023-09-16";
 
   src = fetchFromGitHub {
     owner = "edubart";
     repo = "nelua-lang";
-    rev = "d10cc61bc54050b07874a8597f8df20534885105";
-    hash = "sha256-HyNYqhPCQVBJqEcAUUXfvycXE8tWIMIUJJMTIV48ne8=";
+    rev = "596fcca5c77932da8a07c249de59a9dff3099495";
+    hash = "sha256-gXTlAxW7s3VBiC1fGU0aUlGspHlvyY7FC5KLeU2FyGQ=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/development/lua-modules/aliases.nix
+++ b/pkgs/development/lua-modules/aliases.nix
@@ -39,5 +39,6 @@ let
 in
 
 mapAliases {
-  "lpty" = throw "lpy was removed because broken and unmaintained "; # added 2023-10-14
+  lpty = throw "lpy was removed because broken and unmaintained "; # added 2023-10-14
+  cyrussasl = throw "cyrussasl was removed because broken and unmaintained "; # added 2023-10-18
 }

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -383,29 +383,6 @@ buildLuarocksPackage {
   };
 }) {};
 
-cyrussasl = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
-buildLuarocksPackage {
-  pname = "cyrussasl";
-  version = "1.1.0-3";
-  knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/cyrussasl-1.1.0-3.rockspec";
-    sha256 = "1nqklhi6ny44pg027s6jydgs6q0il99q29rlfs5k42kz72592p91";
-  }).outPath;
-  src = fetchurl {
-    url    = "https://github.com/JorjBauer/lua-cyrussasl";
-    sha256 = "13piq5lw79g5bx2z80ak9k6756bi7c9hh1y963iavmw067ldr1mb";
-  };
-
-  disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ lua ];
-
-  meta = {
-    homepage = "http://github.com/JorjBauer/lua-cyrussasl";
-    description = "Cyrus SASL library for Lua 5.1+";
-    license.fullName = "BSD";
-  };
-}) {};
-
 digestif = callPackage({ buildLuarocksPackage, fetchgit, lpeg, lua, luaOlder, luafilesystem }:
 buildLuarocksPackage {
   pname = "digestif";

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -5,10 +5,10 @@ nixpkgs$ ./maintainers/scripts/update-luarocks-packages
 You can customize the generated packages in pkgs/development/lua-modules/overrides.nix
 */
 
-{ stdenv, lib, fetchurl, fetchgit, callPackage, ... } @ args:
+{ stdenv, lib, fetchurl, fetchgit, callPackage, ... }:
 final: prev:
 {
-alt-getopt = callPackage({ luaAtLeast, lua, luaOlder, fetchgit, buildLuarocksPackage }:
+alt-getopt = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "alt-getopt";
   version = "0.8.0-1";
@@ -22,12 +22,13 @@ buildLuarocksPackage {
   "date": "2017-01-06T13:50:55+03:00",
   "path": "/nix/store/z72v77cw9188408ynsppwhlzii2dr740-lua-alt-getopt",
   "sha256": "1kq7r5668045diavsqd1j6i9hxdpsk99w8q4zr8cby9y3ws4q6rv",
+  "hash": "sha256-OxtMNB8++cVQ/gQjntLUt3WYopGhYb1VbIUAZEzJB88=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -40,23 +41,18 @@ buildLuarocksPackage {
   };
 }) {};
 
-argparse = callPackage({ luaOlder, buildLuarocksPackage, luaAtLeast, lua, fetchgit }:
+argparse = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "argparse";
-  version = "scm-2";
-
-  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
-  "url": "https://github.com/luarocks/argparse.git",
-  "rev": "27967d7b52295ea7885671af734332038c132837",
-  "date": "2020-07-08T11:17:50+10:00",
-  "path": "/nix/store/vjm6c826hgvj7h7vqlbgkfpvijsd8yaf-argparse",
-  "sha256": "0idg79d0dfis4qhbkbjlmddq87np75hb2vj41i6prjpvqacvg5v1",
-  "fetchLFS": false,
-  "fetchSubmodules": true,
-  "deepClone": false,
-  "leaveDotGit": false
-}
- '') ["date" "path"]) ;
+  version = "0.7.1-1";
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/argparse-0.7.1-1.rockspec";
+    sha256 = "116iaczq6glzzin6qqa2zn7i22hdyzzsq6mzjiqnz6x1qmi0hig8";
+  }).outPath;
+  src = fetchzip {
+    url    = "https://github.com/luarocks/argparse/archive/0.7.1.zip";
+    sha256 = "0idg79d0dfis4qhbkbjlmddq87np75hb2vj41i6prjpvqacvg5v1";
+  };
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
@@ -68,15 +64,17 @@ buildLuarocksPackage {
   };
 }) {};
 
-basexx = callPackage({ buildLuarocksPackage, lua, fetchurl, luaOlder }:
+basexx = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "basexx";
-  version = "scm-0";
-  rockspecDir = "dist";
-
+  version = "0.4.1-1";
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/basexx-0.4.1-1.rockspec";
+    sha256 = "0kmydxm2wywl18cgj303apsx7hnfd68a9hx9yhq10fj7yfcxzv5f";
+  }).outPath;
   src = fetchurl {
-    url    = "https://github.com/aiq/basexx/archive/master.tar.gz";
-    sha256 = "1x0d24aaj4zld4ifr7mi8zwrym5shsfphmwx5jzw2zg22r6xzlz1";
+    url    = "https://github.com/aiq/basexx/archive/v0.4.1.tar.gz";
+    sha256 = "1rnz6xixxqwy0q6y2hi14rfid4w47h69gfi0rnlq24fz8q2b0qpz";
   };
 
   disabled = (luaOlder "5.1");
@@ -89,11 +87,14 @@ buildLuarocksPackage {
   };
 }) {};
 
-binaryheap = callPackage({ buildLuarocksPackage, lua, fetchurl, luaOlder }:
+binaryheap = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "binaryheap";
   version = "0.4-1";
-
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/binaryheap-0.4-1.rockspec";
+    sha256 = "1ah37lhskmrb26by5ygs7jblx7qnf6mphgw8kwhw0yacvmkcbql4";
+  }).outPath;
   src = fetchurl {
     url    = "https://github.com/Tieske/binaryheap.lua/archive/version_0v4.tar.gz";
     sha256 = "0f5l4nb5s7dycbkgh3rrl7pf0npcf9k6m2gr2bsn09fjyb3bdc8h";
@@ -110,7 +111,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-bit32 = callPackage({ fetchgit, buildLuarocksPackage, lua, luaOlder }:
+bit32 = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "bit32";
   version = "5.3.0-1";
@@ -124,12 +125,13 @@ buildLuarocksPackage {
   "date": "2015-02-17T10:44:04+01:00",
   "path": "/nix/store/9kz7kgjmq0w9plrpha866bmwsgp4rfhn-lua-compat-5.2",
   "sha256": "1ipqlbvb5w394qwhm2f3w6pdrgy8v4q8sps5hh3pqz14dcqwakhj",
+  "hash": "sha256-Ek7FMWskfHwHhEVfjTDZyL/cruHDiQo5Jmnwsvai+MY=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -142,26 +144,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-busted = callPackage({ buildLuarocksPackage, luafilesystem, luasystem, fetchgit, luaOlder, lua-term, say, mediator_lua, penlight, luassert, lua_cliargs, lua, dkjson }:
+busted = callPackage({ buildLuarocksPackage, dkjson, fetchgit, fetchurl, lua, lua-term, luaOlder, lua_cliargs, luafilesystem, luassert, luasystem, mediator_lua, penlight, say }:
 buildLuarocksPackage {
   pname = "busted";
-  version = "2.1.1-1";
+  version = "2.1.2-3";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/busted-2.1.1-1.rockspec";
-    sha256 = "0f9iz3pa2gmb2vccvygp6zdiji7l8bap0vlgqgrcg331qsrkf70h";
+    url    = "mirror://luarocks/busted-2.1.2-3.rockspec";
+    sha256 = "0ll8jzbpp6a9zdbbjglmq30jmx2zvr0rs83jgsjxmlfzzylkry8p";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lunarmodules/busted.git",
-  "rev": "e3ed48759b625f2e37bf02ccc057b2b98108f108",
-  "date": "2022-08-24T17:34:58+03:00",
-  "path": "/nix/store/7g9rxkyhabgx0acwmzl4r4xfh193avpw-busted",
-  "sha256": "0nab0s5lhk0nhh58c4jspv5sj4g7839gb5q145hrlgbsxqncp8wy",
+  "rev": "673cb6bad2ee3876d45e004fcac1c2f8a816344f",
+  "date": "2023-03-20T10:00:33+01:00",
+  "path": "/nix/store/k7xnpg0s36gxk5mb59wx1dj8ikiz92ja-busted",
+  "sha256": "1wsiiiw26yqglqkkailksinzcb9gaffcldrcfhga3zawf2518h8y",
+  "hash": "sha256-HkEUinBc/aEedCw3ypxTLy32bdSTRjUnpg97I3iMUfM=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ dkjson lua lua-term lua_cliargs luafilesystem luassert luasystem mediator_lua penlight say ];
@@ -173,7 +176,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-cassowary = callPackage({ buildLuarocksPackage, fetchgit, penlight, luaOlder, lua }:
+cassowary = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder, penlight }:
 buildLuarocksPackage {
   pname = "cassowary";
   version = "2.3.2-1";
@@ -187,12 +190,13 @@ buildLuarocksPackage {
   "date": "2022-04-22T11:23:46+03:00",
   "path": "/nix/store/51mb376xh9pnh2krk08ljmy01zhr9y3z-cassowary.lua",
   "sha256": "1lvl40dhzmbqqjrqpjgqlg2kl993fpdy1mpc6d1610zpa9znx1f0",
+  "hash": "sha256-wIVuf1L3g2BCM+zW4Nt1IyU6xaP4yYuzxHjVDxsgdNM=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua penlight ];
@@ -205,7 +209,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-cldr = callPackage({ penlight, luaOlder, lua, fetchgit, buildLuarocksPackage }:
+cldr = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder, penlight }:
 buildLuarocksPackage {
   pname = "cldr";
   version = "0.3.0-0";
@@ -219,12 +223,13 @@ buildLuarocksPackage {
   "date": "2022-12-06T12:36:06+03:00",
   "path": "/nix/store/3xgwqd2pica8301sbfrw4bmv0xm2wzx5-cldr-lua",
   "sha256": "0hlfb115qhamczzskvckxczf9dpp8cv8h6vz7zgdl2n025ik9dp4",
+  "hash": "sha256-5LY0YxHACtreP38biDZD97bkPuuT7an/Z1VBXEJYjkI=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua penlight ];
@@ -237,7 +242,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-compat53 = callPackage({ lua, luaAtLeast, fetchzip, luaOlder, buildLuarocksPackage }:
+compat53 = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "compat53";
   version = "0.7-1";
@@ -261,7 +266,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-cosmo = callPackage({ buildLuarocksPackage, fetchgit, lpeg }:
+cosmo = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lpeg }:
 buildLuarocksPackage {
   pname = "cosmo";
   version = "16.06.04-1";
@@ -275,12 +280,13 @@ buildLuarocksPackage {
   "date": "2016-06-17T05:39:58-07:00",
   "path": "/nix/store/k3p4xc4cfihp4h8aj6vacr25rpcsjd96-cosmo",
   "sha256": "03b5gwsgxd777970d2h6rx86p7ivqx7bry8xmx2r396g3w85qy2p",
+  "hash": "sha256-V3hcEB/PpJFFrx35vE7HO55rUM8GigZOOue0/jR/ZQ0=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ lpeg ];
 
@@ -292,7 +298,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-coxpcall = callPackage({ buildLuarocksPackage, fetchgit }:
+coxpcall = callPackage({ buildLuarocksPackage, fetchgit, fetchurl }:
 buildLuarocksPackage {
   pname = "coxpcall";
   version = "1.17.0-1";
@@ -306,12 +312,13 @@ buildLuarocksPackage {
   "date": "2018-02-26T19:53:11-03:00",
   "path": "/nix/store/1q4p5qvr6rlwisyarlgnmk4dx6vp8xdl-coxpcall",
   "sha256": "1k3q1rr2kavkscf99b5njxhibhp6iwhclrjk6nnnp233iwc2jvqi",
+  "hash": "sha256-EW8pGI9jiGutNVNmyiCP5sIVYZe2rJQc03OrKXIOeMw=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
 
   meta = {
@@ -321,7 +328,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-cqueues = callPackage({ fetchurl, buildLuarocksPackage, lua }:
+cqueues = callPackage({ buildLuarocksPackage, fetchurl, lua }:
 buildLuarocksPackage {
   pname = "cqueues";
   version = "20200726.52-0";
@@ -345,7 +352,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-cyan = callPackage({ argparse, buildLuarocksPackage, tl, fetchgit, luafilesystem }:
+cyan = callPackage({ argparse, buildLuarocksPackage, fetchgit, fetchurl, luafilesystem, tl }:
 buildLuarocksPackage {
   pname = "cyan";
   version = "0.3.0-1";
@@ -359,12 +366,13 @@ buildLuarocksPackage {
   "date": "2023-02-19T18:58:20-06:00",
   "path": "/nix/store/smpj81z2a2blb3qfpjwx9n52d50rp39w-cyan",
   "sha256": "0pskargvjn2phgz481b08ndhp3z23s7lqfs8qlwailr7a4f2fc7h",
+  "hash": "sha256-8DAnHFEn06g4xUg7TI8e4o8Lm0VgBUT+g1dYuV9WU18=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ argparse luafilesystem tl ];
 
@@ -375,23 +383,18 @@ buildLuarocksPackage {
   };
 }) {};
 
-cyrussasl = callPackage({ lua, luaOlder, buildLuarocksPackage, fetchgit }:
+cyrussasl = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "cyrussasl";
-  version = "1.1.0-1";
-
-  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
-  "url": "https://github.com/JorjBauer/lua-cyrussasl",
-  "rev": "78ceec610da76d745d0eff4e21a4fb24832aa72d",
-  "date": "2015-08-21T18:24:54-04:00",
-  "path": "/nix/store/s7n7f80pz8k6lvfav55a5rwy5l45vs4l-lua-cyrussasl",
-  "sha256": "14kzm3vk96k2i1m9f5zvpvq4pnzaf7s91h5g4h4x2bq1mynzw2s1",
-  "fetchLFS": false,
-  "fetchSubmodules": true,
-  "deepClone": false,
-  "leaveDotGit": false
-}
- '') ["date" "path"]) ;
+  version = "1.1.0-3";
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/cyrussasl-1.1.0-3.rockspec";
+    sha256 = "1nqklhi6ny44pg027s6jydgs6q0il99q29rlfs5k42kz72592p91";
+  }).outPath;
+  src = fetchurl {
+    url    = "https://github.com/JorjBauer/lua-cyrussasl";
+    sha256 = "13piq5lw79g5bx2z80ak9k6756bi7c9hh1y963iavmw067ldr1mb";
+  };
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -403,23 +406,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-digestif = callPackage({ luafilesystem, fetchgit, lpeg, lua, buildLuarocksPackage, luaOlder }:
+digestif = callPackage({ buildLuarocksPackage, fetchgit, lpeg, lua, luaOlder, luafilesystem }:
 buildLuarocksPackage {
   pname = "digestif";
   version = "dev-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/astoff/digestif",
-  "rev": "8f8448fa3f27611b32fe6398fe22ef24b8602ec9",
-  "date": "2023-02-24T22:38:11+01:00",
-  "path": "/nix/store/s7wxqcj3k8pgb3m86d8rs2ggpl63jxwn-digestif",
-  "sha256": "0k3srmilrz3ajj76kklksmifkgqrm0y7gr25h0vrrldrf1xp4pk0",
+  "rev": "c0199f9cd86021c0a89662002d7a3411d12fb168",
+  "date": "2023-03-10T15:04:26+01:00",
+  "path": "/nix/store/3s849fwc80lf7pvgsiavqmvc5538cwwd-digestif",
+  "sha256": "0xccrrfwvcj03nnrzs3iwig7y2ahl706h413hkywcplyd5407dv9",
+  "hash": "sha256-abcDSGmeXsb9hCMQaMChUAl/XuRx6J+tHUCyzV3OjHU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.3");
   propagatedBuildInputs = [ lpeg lua luafilesystem ];
@@ -431,7 +435,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-dkjson = callPackage({ buildLuarocksPackage, lua, luaAtLeast, luaOlder, fetchurl }:
+dkjson = callPackage({ buildLuarocksPackage, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "dkjson";
   version = "2.6-1";
@@ -454,17 +458,17 @@ buildLuarocksPackage {
   };
 }) {};
 
-fennel = callPackage({ luaOlder, buildLuarocksPackage, fetchurl, lua }:
+fennel = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "fennel";
-  version = "1.3.0-1";
+  version = "1.3.1-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/fennel-1.3.0-1.rockspec";
-    sha256 = "1by78423n8k8i5sz7ji6w5igm8jkmyvd5x1y519hzmknphjqa263";
+    url    = "mirror://luarocks/fennel-1.3.1-1.rockspec";
+    sha256 = "1dsavrsvngwx8vf1l2sj44arvip3bqkhsfh2sdkwa6r9mnw9zx87";
   }).outPath;
   src = fetchurl {
-    url    = "https://fennel-lang.org/downloads/fennel-1.3.0.tar.gz";
-    sha256 = "0m754c74pj10c1qmc4zl89ifjiqcwafn8qagzfpfmcqv6r46pr23";
+    url    = "https://fennel-lang.org/downloads/fennel-1.3.1.tar.gz";
+    sha256 = "1c7iwyc9f3a9k34fjq77zjk0minl3bl3f7wqlj8i1n2x7598nzgx";
   };
 
   disabled = (luaOlder "5.1");
@@ -502,7 +506,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-fifo = callPackage({ fetchzip, lua, buildLuarocksPackage }:
+fifo = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua }:
 buildLuarocksPackage {
   pname = "fifo";
   version = "0.2-0";
@@ -524,7 +528,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-fluent = callPackage({ lua, luaepnf, fetchgit, cldr, buildLuarocksPackage, penlight, luaOlder }:
+fluent = callPackage({ buildLuarocksPackage, cldr, fetchgit, fetchurl, lua, luaOlder, luaepnf, penlight }:
 buildLuarocksPackage {
   pname = "fluent";
   version = "0.2.0-0";
@@ -538,12 +542,13 @@ buildLuarocksPackage {
   "date": "2022-04-16T23:08:20+03:00",
   "path": "/nix/store/flxlnrzg6rx75qikiggmy494npx59p0b-fluent-lua",
   "sha256": "12js8l4hcxhziza0sry0f01kfm8f8m6kx843dmcky36z1y2mccmq",
+  "hash": "sha256-uDJWhQ/fDD9ZbYOgPk1FDlU3A3DAZw3Ujx92BglFWoo=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ cldr lua luaepnf penlight ];
@@ -556,23 +561,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-gitsigns-nvim = callPackage({ lua, fetchgit, buildLuarocksPackage }:
+gitsigns-nvim = callPackage({ buildLuarocksPackage, fetchgit, lua }:
 buildLuarocksPackage {
   pname = "gitsigns.nvim";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lewis6991/gitsigns.nvim",
-  "rev": "f388995990aba04cfdc7c3ab870c33e280601109",
-  "date": "2023-02-16T11:22:47+00:00",
-  "path": "/nix/store/i4acpc5h3sv909gyppm1qv2vqjq84xs1-gitsigns.nvim",
-  "sha256": "1nm1f1d8c632nfnkiak4j7ynyin379bmhag5qp2p912cd9cjvsgx",
+  "rev": "ff01d34daaed72f271a8ffa088a7e839a60c640f",
+  "date": "2023-10-06T09:04:46+01:00",
+  "path": "/nix/store/2m4fyzkkg6bdbfb4kpjrqgbawvs3khqg-gitsigns.nvim",
+  "sha256": "0clyngmmz0qilnjykqc8n7c5kidspywazwy3axsikgh4x8wzdn17",
+  "hash": "sha256-J9j2OeoEvhl1V8Pzr7i/usVZ2LGI4emlpRGDX+uznjI=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (lua.luaversion != "5.1");
   propagatedBuildInputs = [ lua ];
@@ -584,17 +590,17 @@ buildLuarocksPackage {
   };
 }) {};
 
-haskell-tools-nvim = callPackage({ plenary-nvim, fetchzip, lua, luaOlder, buildLuarocksPackage }:
+haskell-tools-nvim = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaOlder, plenary-nvim }:
 buildLuarocksPackage {
   pname = "haskell-tools.nvim";
-  version = "2.3.0-1";
+  version = "2.4.0-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/haskell-tools.nvim-2.3.0-1.rockspec";
-    sha256 = "0jcmb0hzyhq14b2xcwdhwr9a9wbmfaw27vzfzkv52is24mwfr0p0";
+    url    = "mirror://luarocks/haskell-tools.nvim-2.4.0-1.rockspec";
+    sha256 = "1sapapkz3ay9yrljmc1lwxjglv27f1zbh6m014r2z59px4ir61dz";
   }).outPath;
   src = fetchzip {
-    url    = "https://github.com/mrcjkb/haskell-tools.nvim/archive/2.3.0.zip";
-    sha256 = "0lg8g2j9fbikgmhimvz9d0yb63csn85racc09qyszba2kviipr24";
+    url    = "https://github.com/mrcjkb/haskell-tools.nvim/archive/2.4.0.zip";
+    sha256 = "054vfqsccq1qmqmglnppi2n7ksckldx8b5p62y35y0cbcdyh7wz3";
   };
 
   disabled = (luaOlder "5.1");
@@ -607,7 +613,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-http = callPackage({ luaossl, lpeg_patterns, lpeg, binaryheap, compat53, cqueues, bit32, basexx, fetchzip, lua, fifo, luaOlder, buildLuarocksPackage }:
+http = callPackage({ basexx, binaryheap, bit32, buildLuarocksPackage, compat53, cqueues, fetchurl, fetchzip, fifo, lpeg, lpeg_patterns, lua, luaOlder, luaossl }:
 buildLuarocksPackage {
   pname = "http";
   version = "0.3-0";
@@ -631,7 +637,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-inspect = callPackage({ fetchurl, buildLuarocksPackage, lua, luaOlder }:
+inspect = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "inspect";
   version = "3.1.3-0";
@@ -654,7 +660,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-jsregexp = callPackage({ buildLuarocksPackage, lua, luaOlder, fetchgit }:
+jsregexp = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "jsregexp";
   version = "0.0.6-1";
@@ -668,12 +674,13 @@ buildLuarocksPackage {
   "date": "2023-02-12T14:19:03+01:00",
   "path": "/nix/store/aj42wy1yp53w406id33dyxpv1ws23g4b-jsregexp",
   "sha256": "0l7hn5f2jl4n2bpikb72szfzgc192jy3ig5pxx9061j44amyq89m",
+  "hash": "sha256-NSHsqyJEBgNS77e8OLwUKbD33dfirBnvEpZQKVyx8FA=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -685,7 +692,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-ldbus = callPackage({ luaOlder, fetchgit, lua, luaAtLeast, buildLuarocksPackage }:
+ldbus = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "ldbus";
   version = "scm-0";
@@ -699,12 +706,13 @@ buildLuarocksPackage {
   "date": "2021-11-10T23:58:54+11:00",
   "path": "/nix/store/j830jk2hkanz7abkdsbvg2warsyr0a2c-ldbus",
   "sha256": "18q98b98mfvjzbyssf18bpnlx4hsx4s9lwcwia4z9dxiaiw7b77j",
+  "hash": "sha256-8px1eFSxt/SJipxxmjTpGpJO7V0oOK39+nK7itJCCaM=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
@@ -716,34 +724,35 @@ buildLuarocksPackage {
   };
 }) {};
 
-ldoc = callPackage({ fetchgit, buildLuarocksPackage, markdown, penlight }:
+ldoc = callPackage({ buildLuarocksPackage, fetchgit, markdown, penlight }:
 buildLuarocksPackage {
   pname = "ldoc";
-  version = "scm-3";
+  version = "dev-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
-  "url": "https://github.com/stevedonovan/LDoc.git",
-  "rev": "01d648f4ad50c3d14f2acadee6acb26beda56990",
-  "date": "2022-11-18T00:01:45+01:00",
-  "path": "/nix/store/m7vvl2b5k69jrb88d0y60f2y4ryazkp9-LDoc",
-  "sha256": "1kl0ba9mnd7nksakzb3vwr0hkkkgyk92v93r2w9xnrq879dhy5mm",
+  "url": "https://github.com/lunarmodules/ldoc.git",
+  "rev": "e4940daf748affb86489b0782ed8abab2e88bebc",
+  "date": "2023-05-13T08:12:31+03:00",
+  "path": "/nix/store/sqhilwlh0glw1dxcx6w98wjkp65amvil-ldoc",
+  "sha256": "0an92jxvhbw2lvg269x6z3874x3wqmbmx52j4gsgxf9ldpizssgd",
+  "hash": "sha256-7Wn94200uf70I1KUXlfFfHRy0PimJyPepoIvuLsUySo=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ markdown penlight ];
 
   meta = {
-    homepage = "https://github.com/lunarmodules/LDoc";
+    homepage = "http://lunarmodules.github.io/ldoc";
     description = "A Lua Documentation Tool";
-    license.fullName = "MIT/X11";
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 }) {};
 
-lgi = callPackage({ luaOlder, fetchgit, buildLuarocksPackage, lua }:
+lgi = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lgi";
   version = "0.9.2-1";
@@ -757,12 +766,13 @@ buildLuarocksPackage {
   "date": "2017-10-09T20:55:55+02:00",
   "path": "/nix/store/vh82n8pc8dy5c8nph0vssk99vv7q4qg2-lgi",
   "sha256": "03rbydnj411xpjvwsyvhwy4plm96481d7jax544mvk7apd8sd5jj",
+  "hash": "sha256-UpamUbvqzF0JKV3J0wIiJlV6iedwe823vD0EIm3zKw8=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -774,7 +784,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-linenoise = callPackage({ buildLuarocksPackage, lua, fetchurl, luaOlder }:
+linenoise = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "linenoise";
   version = "0.9-1";
@@ -794,7 +804,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-ljsyscall = callPackage({ lua, fetchurl, buildLuarocksPackage }:
+ljsyscall = callPackage({ buildLuarocksPackage, fetchurl, lua }:
 buildLuarocksPackage {
   pname = "ljsyscall";
   version = "0.12-1";
@@ -818,7 +828,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lmathx = callPackage({ fetchurl, buildLuarocksPackage, lua }:
+lmathx = callPackage({ buildLuarocksPackage, fetchurl, lua }:
 buildLuarocksPackage {
   pname = "lmathx";
   version = "20150624-1";
@@ -841,7 +851,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lmpfrlib = callPackage({ buildLuarocksPackage, fetchurl, luaAtLeast, lua, luaOlder }:
+lmpfrlib = callPackage({ buildLuarocksPackage, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "lmpfrlib";
   version = "20170112-2";
@@ -851,7 +861,7 @@ buildLuarocksPackage {
   }).outPath;
   src = fetchurl {
     url    = "http://www.circuitwizard.de/lmpfrlib/lmpfrlib.c";
-    sha256 = "00d32cwvk298k3vyrjkdmfjgc69x1fwyks3hs7dqr2514zdhgssm";
+    sha256 = "1bkfwdacj1drzqsfxf352fjppqqwi5d4j084jr9vj9dvjb31rbc1";
   };
 
   disabled = (luaOlder "5.3") || (luaAtLeast "5.5");
@@ -865,7 +875,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-loadkit = callPackage({ luaOlder, lua, buildLuarocksPackage, fetchgit }:
+loadkit = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "loadkit";
   version = "1.1.0-1";
@@ -875,16 +885,17 @@ buildLuarocksPackage {
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/leafo/loadkit.git",
-  "rev": "c6c712dab45f6c568821f9ed7b49c790a44d12e7",
-  "date": "2021-01-07T14:41:10-08:00",
-  "path": "/nix/store/xvwq7b2za8ciww1gjw7vnspg9183xmfa-loadkit",
-  "sha256": "15znriijs7izf9f6vmhr6dnvw3pzr0yr0mh6ah41fmdwjqi7jzcz",
+  "rev": "95b13a36442f59b41ab52df96d52233c4a725dfd",
+  "date": "2023-08-17T11:36:25-07:00",
+  "path": "/nix/store/9xcy2p5pxiq0p17szv8p2lagb6xzb8c8-loadkit",
+  "sha256": "0hivmn5r1scxv3nckm4hqfplq33wiab3ypjwsfdkmp3bdri0dhxs",
+  "hash": "sha256-usMGYm5r3Dqb01xeP5aKfAxMr8OQ1Mns2J3pkIutO0I=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -897,17 +908,17 @@ buildLuarocksPackage {
   };
 }) {};
 
-lpeg = callPackage({ luaOlder, buildLuarocksPackage, fetchurl, lua }:
+lpeg = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lpeg";
-  version = "1.0.2-1";
+  version = "1.1.0-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lpeg-1.0.2-1.rockspec";
-    sha256 = "08a8p5cwlwpjawk8sczb7bq2whdsng4mmhphahyklf1bkvl2li89";
+    url    = "mirror://luarocks/lpeg-1.1.0-1.rockspec";
+    sha256 = "03af1p00madfhfxjzrsxb0jm0n49ixwadnkdp0vbgs77d2v985jn";
   }).outPath;
   src = fetchurl {
-    url    = "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz";
-    sha256 = "1zjzl7acvcdavmcg5l7wi12jd4rh95q9pl5aiww7hv0v0mv6bmj8";
+    url    = "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.1.0.tar.gz";
+    sha256 = "0aimsjpcpkh3kk65f0pg1z2bp6d83rn4dg6pgbx1yv14s9kms5ab";
   };
 
   disabled = (luaOlder "5.1");
@@ -921,7 +932,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lpeg_patterns = callPackage({ lpeg, fetchzip, buildLuarocksPackage, lua }:
+lpeg_patterns = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lpeg, lua }:
 buildLuarocksPackage {
   pname = "lpeg_patterns";
   version = "0.5-0";
@@ -943,7 +954,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lpeglabel = callPackage({ fetchurl, lua, luaOlder, buildLuarocksPackage }:
+lpeglabel = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lpeglabel";
   version = "1.6.0-1";
@@ -966,7 +977,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lrexlib-gnu = callPackage({ buildLuarocksPackage, luaOlder, lua, fetchgit }:
+lrexlib-gnu = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lrexlib-gnu";
   version = "2.9.1-1";
@@ -980,12 +991,13 @@ buildLuarocksPackage {
   "date": "2020-08-07T12:10:29+03:00",
   "path": "/nix/store/vnnhcc0r9zhqwshmfzrn0ryai61l6xrd-lrexlib",
   "sha256": "15dsxq0363940rij9za8mc224n9n58i2iqw1z7r1jh3qpkaciw7j",
+  "hash": "sha256-8vDI1Lx4QBny+YHjKCIqNlkiBKtI/SRjBiQNMwDuupU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -997,7 +1009,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lrexlib-pcre = callPackage({ lua, luaOlder, buildLuarocksPackage, fetchgit }:
+lrexlib-pcre = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lrexlib-pcre";
   version = "2.9.1-1";
@@ -1011,12 +1023,13 @@ buildLuarocksPackage {
   "date": "2020-08-07T12:10:29+03:00",
   "path": "/nix/store/vnnhcc0r9zhqwshmfzrn0ryai61l6xrd-lrexlib",
   "sha256": "15dsxq0363940rij9za8mc224n9n58i2iqw1z7r1jh3qpkaciw7j",
+  "hash": "sha256-8vDI1Lx4QBny+YHjKCIqNlkiBKtI/SRjBiQNMwDuupU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1029,7 +1042,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lrexlib-posix = callPackage({ lua, luaOlder, buildLuarocksPackage, fetchgit }:
+lrexlib-posix = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lrexlib-posix";
   version = "2.9.1-1";
@@ -1043,12 +1056,13 @@ buildLuarocksPackage {
   "date": "2020-08-07T12:10:29+03:00",
   "path": "/nix/store/vnnhcc0r9zhqwshmfzrn0ryai61l6xrd-lrexlib",
   "sha256": "15dsxq0363940rij9za8mc224n9n58i2iqw1z7r1jh3qpkaciw7j",
+  "hash": "sha256-8vDI1Lx4QBny+YHjKCIqNlkiBKtI/SRjBiQNMwDuupU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1060,7 +1074,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-cjson = callPackage({ luaOlder, fetchgit, lua, buildLuarocksPackage }:
+lua-cjson = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-cjson";
   version = "2.1.0.10-1";
@@ -1074,12 +1088,13 @@ buildLuarocksPackage {
   "date": "2021-12-10T20:19:58+08:00",
   "path": "/nix/store/1ac8lz6smfa8zqfipqfsg749l9rw4ly9-lua-cjson",
   "sha256": "03hdsv7d77mggis58k8fmlpbh1d544m0lfqyl9rpjcqkiqs1qvza",
+  "hash": "sha256-6m8cNI4TM3lzoh47CiohpQW4Lq0OTVR0fK+e087WDQ4=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1091,7 +1106,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-cmsgpack = callPackage({ luaOlder, fetchgit, lua, buildLuarocksPackage }:
+lua-cmsgpack = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-cmsgpack";
   version = "0.4.0-0";
@@ -1105,12 +1120,13 @@ buildLuarocksPackage {
   "date": "2015-06-03T08:39:04+02:00",
   "path": "/nix/store/ksqvl7hbd5s7nb6hjffyic1shldac4z2-lua-cmsgpack",
   "sha256": "0j0ahc9rprgl6dqxybaxggjam2r5i2wqqsd6764n0d7fdpj9fqm0",
+  "hash": "sha256-oGKX5G3uNGCJOaZpjLmIJYuq5HtdLd9xM/TlmxODCkg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1122,7 +1138,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-curl = callPackage({ lua, buildLuarocksPackage, fetchzip, luaOlder, luaAtLeast }:
+lua-curl = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-curl";
   version = "0.3.13-1";
@@ -1145,30 +1161,61 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-iconv = callPackage({ fetchurl, lua, buildLuarocksPackage, luaOlder }:
+lua-ffi-zlib = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
+buildLuarocksPackage {
+  pname = "lua-ffi-zlib";
+  version = "0.6-0";
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/lua-ffi-zlib-0.6-0.rockspec";
+    sha256 = "060sac715f1ris13fjv6gwqm0lk6by0a2zhldxd8hdrc0jss8p34";
+  }).outPath;
+  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
+  "url": "https://github.com/hamishforbes/lua-ffi-zlib",
+  "rev": "61e95cb434e4047c8bc65a180c293a05bf754416",
+  "date": "2023-08-11T09:28:16+12:00",
+  "path": "/nix/store/gfyr81q84mgpgwyh28xpzlf34ndjkfwc-lua-ffi-zlib",
+  "sha256": "0r6vima495h0d4f8ibf3fv9b6k7rqnavgvsy78dybslrm7lwsz4p",
+  "hash": "sha256-l3zN6amZ6uUbOl7vt5XF+Uyz0nbDrYgcaQCWRFSN22Q=",
+  "fetchLFS": false,
+  "fetchSubmodules": true,
+  "deepClone": false,
+  "leaveDotGit": false
+}
+ '') ["date" "path" "sha256"]) ;
+
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "https://github.com/hamishforbes/lua-ffi-zlib";
+    description = "A Lua module using LuaJIT's FFI feature to access zlib.";
+  };
+}) {};
+
+lua-iconv = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-iconv";
-  version = "7-3";
+  version = "7.0.0-2";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lua-iconv-7-3.rockspec";
-    sha256 = "0qh5vsaxd7s31p7a8rl08lwd6zv90wnvp15nll4fcz452kffpp72";
+    url    = "mirror://luarocks/lua-iconv-7.0.0-2.rockspec";
+    sha256 = "1bj512kqcj2cxna7si4648fci51fs4bqvdn592i9cahscsc0kk9g";
   }).outPath;
   src = fetchurl {
-    url    = "https://github.com/downloads/ittner/lua-iconv/lua-iconv-7.tar.gz";
-    sha256 = "02dg5x79fg5mwsycr0fj6w04zykdpiki9xjswkkwzdalqwaikny1";
+    url    = "https://github.com/lunarmodules/lua-iconv/archive/v7.0.0/lua-iconv-7.0.0.tar.gz";
+    sha256 = "0arp0h342hpp4kfdxc69yxspziky4v7c13jbf12yrs8f1lnjzr0x";
   };
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://ittner.github.com/lua-iconv/";
+    homepage = "https://github.com/lunarmodules/lua-iconv/";
     description = "Lua binding to the iconv";
     license.fullName = "MIT/X11";
   };
 }) {};
 
-lua-lsp = callPackage({ fetchgit, inspect, lua, lpeglabel, dkjson, luaAtLeast, luaOlder, buildLuarocksPackage }:
+lua-lsp = callPackage({ buildLuarocksPackage, dkjson, fetchgit, fetchurl, inspect, lpeglabel, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-lsp";
   version = "0.1.0-2";
@@ -1182,12 +1229,13 @@ buildLuarocksPackage {
   "date": "2020-10-17T15:07:11-04:00",
   "path": "/nix/store/qn9syhm875k1qardhhsp025cm3dbnqvm-lua-lsp",
   "sha256": "17k3jq61jz6j9bz4vc3hmsfx1s26cfgq1acja8fqyixljklmsbqp",
+  "hash": "sha256-Fy9d6ZS0R48dUpKpgJ9jRujQna5wsE3+StJ8GQyWY54=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ dkjson inspect lpeglabel lua ];
@@ -1199,17 +1247,17 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-messagepack = callPackage({ buildLuarocksPackage, lua, fetchurl, luaOlder }:
+lua-messagepack = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-messagepack";
-  version = "0.5.2-1";
+  version = "0.5.3-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lua-messagepack-0.5.2-1.rockspec";
-    sha256 = "15liz6v8hsqgb3xrcd74a71nnjcz79gpc3ak351hk6k4gyjq2rfc";
+    url    = "mirror://luarocks/lua-messagepack-0.5.3-1.rockspec";
+    sha256 = "0sc11ckizivijgdnqvb0xnagrak6d2caxc5j8jz8ad1b2plp50pq";
   }).outPath;
   src = fetchurl {
-    url    = "https://framagit.org/fperrad/lua-MessagePack/raw/releases/lua-messagepack-0.5.2.tar.gz";
-    sha256 = "1jgi944d0vx4zs9lrphys9pw0wrsibip93sh141qjwymrjyjg1nc";
+    url    = "https://framagit.org/fperrad/lua-MessagePack/raw/releases/lua-messagepack-0.5.3.tar.gz";
+    sha256 = "17qdigs2pzi38rfqgs63xh44n1vylb6bcmmbz3sby68f0n9p8kq6";
   };
 
   disabled = (luaOlder "5.1");
@@ -1222,26 +1270,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-protobuf = callPackage({ luaOlder, buildLuarocksPackage, lua, fetchgit }:
+lua-protobuf = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-protobuf";
-  version = "0.4.1-1";
+  version = "0.5.0-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lua-protobuf-0.4.1-1.rockspec";
-    sha256 = "0b395lhby26drb8dzf2gn2avlwvxmnaqmqx5m4g3ik7dmmn7p09i";
+    url    = "mirror://luarocks/lua-protobuf-0.5.0-1.rockspec";
+    sha256 = "08z73rsqi7ysdyjcwfqyr8z6i5r43kx5fd8l32wlzv6cx6yvlqc9";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/starwing/lua-protobuf.git",
-  "rev": "2a2b0b95117642ad9470bfe0add7dd6ce82f3869",
-  "date": "2022-11-29T21:34:24+08:00",
-  "path": "/nix/store/8yjzfj6gy8nkz1dxf0bmy8afwiv8gsjr-lua-protobuf",
-  "sha256": "0c1vjji0nj9lznsxw5gbnhab0ibs69298yrsn5yky0hhz8mmx5nr",
+  "rev": "a256c34e12cad643d6ad189bddcbc314da9b0658",
+  "date": "2023-04-30T02:11:27+08:00",
+  "path": "/nix/store/n7ihjh36kp2f80016f9y8xydia2pclzq-lua-protobuf",
+  "sha256": "1kbanbgvmzcfnxq30f8hmirgc1d768lacpjihis9961pc7w96l9n",
+  "hash": "sha256-NlGT+GE3mJR0hFFepigypwX2cqwQOTBwt479ut+yas0=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1254,26 +1303,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-resty-http = callPackage({ lua, fetchgit, luaOlder, buildLuarocksPackage }:
+lua-resty-http = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-resty-http";
-  version = "0.17.0.beta.1-0";
+  version = "0.17.1-0";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lua-resty-http-0.17.0.beta.1-0.rockspec";
-    sha256 = "1cjl007k43cyrwvj0p58hvp00q4lnd9rq3v3pcvwi5an2pvxnv80";
+    url    = "mirror://luarocks/lua-resty-http-0.17.1-0.rockspec";
+    sha256 = "05gid7c5i459clw707z1jic42s52ap4z66dbr9ims5znaq5s3wdk";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/ledgetech/lua-resty-http",
-  "rev": "8cb73c4cc2118f0c62d9132e3b3b14aa36192e34",
-  "date": "2022-02-11T16:44:50+00:00",
-  "path": "/nix/store/29kr6whllphz0nla5nh1f8q30dgp9vnz-lua-resty-http",
-  "sha256": "0y253dnnx59a5c1nbkcv1p5kq7kdsd5i094i7wzpg5ar6xwvqhjb",
+  "rev": "4ab4269cf442ba52507aa2c718f606054452fcad",
+  "date": "2023-03-22T09:48:56+00:00",
+  "path": "/nix/store/ykd1d5fa56i1c286k58jm233lqvdv2mi-lua-resty-http",
+  "sha256": "0xdhygjqjpfkq1bq8b09fichww57q1z694lz16i3hcc3g4sr4hxg",
+  "hash": "sha256-r0OSNXmDMTiiCZ+SZH7Ap3AOWXQJLIRXwNNdieXzsHU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1285,7 +1335,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-resty-jwt = callPackage({ luaOlder, lua-resty-openssl, fetchgit, lua, buildLuarocksPackage }:
+lua-resty-jwt = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, lua-resty-openssl, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-resty-jwt";
   version = "0.2.3-0";
@@ -1299,12 +1349,13 @@ buildLuarocksPackage {
   "date": "2021-01-20T16:53:57-05:00",
   "path": "/nix/store/z4a8ffxj2i3gbjp0f8r377cdp88lkzl4-lua-resty-jwt",
   "sha256": "07w8r8gqbby06x493qzislig7a3giw0anqr4ivp3g2ms8v9fnng6",
+  "hash": "sha256-5lnr0ka6ijfujiRjqwCPb6jzItXx45FIN8CvhR/KiB8=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua lua-resty-openssl ];
@@ -1316,7 +1367,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-resty-openidc = callPackage({ lua-resty-http, buildLuarocksPackage, fetchgit, lua-resty-session, luaOlder, lua, lua-resty-jwt }:
+lua-resty-openidc = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, lua-resty-http, lua-resty-jwt, lua-resty-session, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-resty-openidc";
   version = "1.7.6-3";
@@ -1330,12 +1381,13 @@ buildLuarocksPackage {
   "date": "2023-01-30T19:06:51+01:00",
   "path": "/nix/store/nyd2jqhlq8gx4chapqyxk2q4dsxgm8hz-lua-resty-openidc",
   "sha256": "15dh9z7y84n840x02xsn2m9h9hdakbbv4p1z7dfz85v5w5i6c86p",
+  "hash": "sha256-1yBmYuFlF/RdOz9csteaqsEEUxVWdwE6IMgS5M9PsJU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua lua-resty-http lua-resty-jwt lua-resty-session ];
@@ -1347,26 +1399,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-resty-openssl = callPackage({ fetchgit, buildLuarocksPackage }:
+lua-resty-openssl = callPackage({ buildLuarocksPackage, fetchgit, fetchurl }:
 buildLuarocksPackage {
   pname = "lua-resty-openssl";
-  version = "0.8.17-1";
+  version = "0.8.25-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lua-resty-openssl-0.8.17-1.rockspec";
-    sha256 = "1b4dv9mdb90n0f6982pnjb05rgb12nkn1j66a1ywcs5fqcmj4sb5";
+    url    = "mirror://luarocks/lua-resty-openssl-0.8.25-1.rockspec";
+    sha256 = "0wy0fjb50kpcyk6mkjj364p4lrfxl0b34xnv2n0wib1brk536s1l";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/fffonion/lua-resty-openssl.git",
-  "rev": "dc17f6b2ff3adaa3bcb586f1d09073a4f4f4ec9d",
-  "date": "2023-01-20T01:36:57+08:00",
-  "path": "/nix/store/hh9i8ndb861iplkf9mz6vs2akkyibazn-lua-resty-openssl",
-  "sha256": "14xmxskbw3clqr97y69d311rs6i97vl7dg8pzixsqf4ypgllzvig",
+  "rev": "f9a153288238e9b7e3d5d40144610410a06a83cd",
+  "date": "2023-09-05T15:19:20+08:00",
+  "path": "/nix/store/jnvr2pzvxl2psd5w030m4qnv5dsm8spb-lua-resty-openssl",
+  "sha256": "08fqgdfi0dr3n2lqrbgwa94dd2f6crn1kb0cfpccphknaypaw7dp",
+  "hash": "sha256-tx2urld2wsvYdQysGWxmxonWSFL8rYypsCM3EF172CE=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
 
   meta = {
@@ -1376,39 +1429,39 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-resty-session = callPackage({ buildLuarocksPackage, fetchgit, luaOlder, lua, lua-resty-openssl /*, lua_pack, lua-ffi-zlib */  }:
+lua-resty-session = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, lua-ffi-zlib, lua-resty-openssl, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-resty-session";
-  version = "4.0.3-1";
+  version = "4.0.5-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lua-resty-session-4.0.3-1.rockspec";
-    sha256 = "17q8gf0zjdbfgphvjsnlzw1d6158v4ppiqxap6hjqr0prqa5yyfq";
+    url    = "mirror://luarocks/lua-resty-session-4.0.5-1.rockspec";
+    sha256 = "0h0kqwna46mrraq310qjb7yigxwv13n4czk24xnqr21czxsskzkg";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/bungle/lua-resty-session.git",
-  "rev": "3373d8138930b6d1e255bb80d9127503019301d7",
-  "date": "2023-02-21T20:52:32+02:00",
-  "path": "/nix/store/pdwd03w7505wkv4fw79a3mdlfijk9ngd-lua-resty-session",
-  "sha256": "1d105785jzn9x3by4r0baaffr5xmc2ilgd7z7izcwq9z29pnfv02",
+  "rev": "5f2aed616d16fa7ca04dc40e23d6941740cd634d",
+  "date": "2023-08-16T18:24:43+03:00",
+  "path": "/nix/store/s6i1idv9lx52x7lcl0kc2c9sm9pic4kq-lua-resty-session",
+  "sha256": "08pih1baqhlvsqvcr1zzympmn8v7gskmis6ffhigll37hbzvljcz",
+  "hash": "sha256-n0m6/4JnUPoidM7oWKd+ZyNbb/X/h8w21ptCrFaA8SI=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ lua lua-resty-openssl /* lua_pack lua-ffi-zlib */ ];
+  propagatedBuildInputs = [ lua lua-ffi-zlib lua-resty-openssl ];
 
   meta = {
     homepage = "https://github.com/bungle/lua-resty-session";
     description = "Session Library for OpenResty - Flexible and Secure";
     license.fullName = "BSD";
-    broken = true; # lua_pack and lua-ffi-zlib are unpackaged, causing this package to not evaluate
   };
 }) {};
 
-lua-subprocess = callPackage({ lua, buildLuarocksPackage, fetchgit, luaOlder }:
+lua-subprocess = callPackage({ buildLuarocksPackage, fetchgit, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "subprocess";
   version = "scm-1";
@@ -1419,12 +1472,13 @@ buildLuarocksPackage {
   "date": "2021-01-09T22:31:54+01:00",
   "path": "/nix/store/3lr7n1k85kbf718wxr51xd40i8dfs5qd-lua-subprocess",
   "sha256": "0p91hda0b0hpgdbff5drcyygaizq086gw8vnvzn0y0fg3mc9if70",
+  "hash": "sha256-4LiYWB3PAQ/s33Yj/gwC+Ef1vGe5FedWexeCBVSDIV0=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1437,7 +1491,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-term = callPackage({ fetchurl, buildLuarocksPackage }:
+lua-term = callPackage({ buildLuarocksPackage, fetchurl }:
 buildLuarocksPackage {
   pname = "lua-term";
   version = "0.7-1";
@@ -1458,7 +1512,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-toml = callPackage({ fetchgit, buildLuarocksPackage, luaOlder, lua }:
+lua-toml = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-toml";
   version = "2.0-1";
@@ -1472,12 +1526,13 @@ buildLuarocksPackage {
   "date": "2017-12-08T16:30:50-08:00",
   "path": "/nix/store/cnpflpyj441c65jhb68hjr2bcvnj9han-lua-toml",
   "sha256": "0lklhgs4n7gbgva5frs39240da1y4nwlx6yxaj3ix6r5lp9sh07b",
+  "hash": "sha256-6wCo06Ulmx6HVN2bTrklPqgGiEhDZ1fUfusdS/SDdFI=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1489,7 +1544,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-yajl = callPackage({ luaOlder, buildLuarocksPackage, lua, fetchgit }:
+lua-yajl = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-yajl";
   version = "2.0-1";
@@ -1503,12 +1558,13 @@ buildLuarocksPackage {
   "date": "2020-11-12T06:22:23-08:00",
   "path": "/nix/store/9acgxpqk52kwn03m5xasn4f6mmsby2r9-lua-yajl",
   "sha256": "1frry90y7vqnw1rd1dfnksilynh0n24gfhkmjd6wwba73prrg0pf",
+  "hash": "sha256-7oKX8x1HLc5Nk3VC94iwAFpPo57WtdBy4Bbv40HyObs=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1521,7 +1577,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-zlib = callPackage({ fetchgit, buildLuarocksPackage, luaOlder, lua }:
+lua-zlib = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua-zlib";
   version = "1.2-2";
@@ -1535,12 +1591,13 @@ buildLuarocksPackage {
   "date": "2017-10-07T08:26:37-07:00",
   "path": "/nix/store/6hjfczd3xkilkdxidgqzdrwmaiwnlf05-lua-zlib",
   "sha256": "1cv12s5c5lihmf3hb0rz05qf13yihy1bjpb7448v8mkiss6y1s5c",
+  "hash": "sha256-rOjgjdZxVrQRIWdduYKH0Y/gcAE/gwWHqzDSwooWYbM=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1553,7 +1610,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua_cliargs = callPackage({ lua, luaOlder, buildLuarocksPackage, fetchurl }:
+lua_cliargs = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lua_cliargs";
   version = "3.0-2";
@@ -1573,7 +1630,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luabitop = callPackage({ luaAtLeast, lua, fetchgit, buildLuarocksPackage, luaOlder }:
+luabitop = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luabitop";
   version = "1.0.2-3";
@@ -1584,12 +1641,13 @@ buildLuarocksPackage {
   "date": "2021-08-30T10:14:03+02:00",
   "path": "/nix/store/sdnza0zpmlkz9jppnysasbvqy29f4zia-luabitop",
   "sha256": "1b57f99lrjbwsi4m23cq5kpj0dbpxh3xwr0mxs2rzykr2ijpgwrw",
+  "hash": "sha256-PPN3ZRR5+p+F7hVk3gfsdzUg7yyYDVFJ1HzJTFNyp6w=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.3");
   propagatedBuildInputs = [ lua ];
@@ -1601,26 +1659,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-luacheck = callPackage({ argparse, luafilesystem, lua, luaOlder, fetchgit, buildLuarocksPackage }:
+luacheck = callPackage({ argparse, buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder, luafilesystem }:
 buildLuarocksPackage {
   pname = "luacheck";
-  version = "1.1.0-1";
+  version = "1.1.1-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/luacheck-1.1.0-1.rockspec";
-    sha256 = "1r8d02x0hw28rd5p2gr7sf503lczjxv6qk1q66b375ibx6smpyza";
+    url    = "mirror://luarocks/luacheck-1.1.1-1.rockspec";
+    sha256 = "11nrryqff2yis5s7jscbyv221p21i9sh924x7g9l3d6ijns8zmba";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lunarmodules/luacheck.git",
-  "rev": "fcbdeacad00e643e0d78c56b9ba6d8b3c7fa584f",
-  "date": "2022-12-19T20:51:56+03:00",
-  "path": "/nix/store/srzi8dfrbb9gby9lc7r4sndzzrpzd7nm-luacheck",
-  "sha256": "0bkbcxadlf0j59lyvadp7hs7l107blkci15i0hrbi72bx18hj99h",
+  "rev": "ababb6d403d634eb74d2c541035e9ede966e710d",
+  "date": "2023-06-10T11:27:25+03:00",
+  "path": "/nix/store/wkrhda7nww45g1waxdv9ghm35mwbvlfq-luacheck",
+  "sha256": "0abd5rfxv667n8d8v3g9cnkyghiwzhj3yk498gr2agd3mfcni7d7",
+  "hash": "sha256-p51omaujPSXyQ4lMPyT8PMLnp2XpjY0asseY3V0ubSk=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ argparse lua luafilesystem ];
@@ -1632,7 +1691,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luacov = callPackage({ luaAtLeast, buildLuarocksPackage, luaOlder, lua, fetchgit }:
+luacov = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luacov";
   version = "0.15.0-1";
@@ -1646,12 +1705,13 @@ buildLuarocksPackage {
   "date": "2021-02-15T18:47:58-03:00",
   "path": "/nix/store/9vm38il9knzx2m66m250qj1fzdfzqg0y-luacov",
   "sha256": "08550nna6qcb5jn6ds1hjm6010y8973wx4qbf9vrvrcn1k2yr6ki",
+  "hash": "sha256-cZrsxQyW5Z13cguTzsdJyIMATJUw6GasLItho6wFpSA=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
@@ -1663,7 +1723,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luadbi = callPackage({ buildLuarocksPackage, lua, luaOlder, fetchgit, luaAtLeast }:
+luadbi = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luadbi";
   version = "0.7.2-1";
@@ -1677,12 +1737,13 @@ buildLuarocksPackage {
   "date": "2019-01-14T09:39:17+00:00",
   "path": "/nix/store/a3qgawila4r4jc2lpdc4mwyzd1gvzazd-luadbi",
   "sha256": "167ivwmczhp98bxzpz3wdxcfj6vi0a10gpi7rdfjs2rbfwkzqvjh",
+  "hash": "sha256-UG78J3crCy1dyyfeB4ICcRvpWG98/Pv7QunCzyrf8Zg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -1694,7 +1755,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luadbi-mysql = callPackage({ luaOlder, lua, buildLuarocksPackage, fetchgit, luadbi, luaAtLeast }:
+luadbi-mysql = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder, luadbi }:
 buildLuarocksPackage {
   pname = "luadbi-mysql";
   version = "0.7.2-1";
@@ -1708,12 +1769,13 @@ buildLuarocksPackage {
   "date": "2019-01-14T09:39:17+00:00",
   "path": "/nix/store/a3qgawila4r4jc2lpdc4mwyzd1gvzazd-luadbi",
   "sha256": "167ivwmczhp98bxzpz3wdxcfj6vi0a10gpi7rdfjs2rbfwkzqvjh",
+  "hash": "sha256-UG78J3crCy1dyyfeB4ICcRvpWG98/Pv7QunCzyrf8Zg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luadbi ];
@@ -1725,7 +1787,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luadbi-postgresql = callPackage({ lua, fetchgit, buildLuarocksPackage, luaOlder, luaAtLeast, luadbi }:
+luadbi-postgresql = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder, luadbi }:
 buildLuarocksPackage {
   pname = "luadbi-postgresql";
   version = "0.7.2-1";
@@ -1739,12 +1801,13 @@ buildLuarocksPackage {
   "date": "2019-01-14T09:39:17+00:00",
   "path": "/nix/store/a3qgawila4r4jc2lpdc4mwyzd1gvzazd-luadbi",
   "sha256": "167ivwmczhp98bxzpz3wdxcfj6vi0a10gpi7rdfjs2rbfwkzqvjh",
+  "hash": "sha256-UG78J3crCy1dyyfeB4ICcRvpWG98/Pv7QunCzyrf8Zg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luadbi ];
@@ -1756,7 +1819,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luadbi-sqlite3 = callPackage({ luaAtLeast, lua, luaOlder, buildLuarocksPackage, fetchgit, luadbi }:
+luadbi-sqlite3 = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder, luadbi }:
 buildLuarocksPackage {
   pname = "luadbi-sqlite3";
   version = "0.7.2-1";
@@ -1770,12 +1833,13 @@ buildLuarocksPackage {
   "date": "2019-01-14T09:39:17+00:00",
   "path": "/nix/store/a3qgawila4r4jc2lpdc4mwyzd1gvzazd-luadbi",
   "sha256": "167ivwmczhp98bxzpz3wdxcfj6vi0a10gpi7rdfjs2rbfwkzqvjh",
+  "hash": "sha256-UG78J3crCy1dyyfeB4ICcRvpWG98/Pv7QunCzyrf8Zg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luadbi ];
@@ -1787,7 +1851,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaepnf = callPackage({ luaOlder, buildLuarocksPackage, lpeg, luaAtLeast, lua, fetchgit }:
+luaepnf = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lpeg, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luaepnf";
   version = "0.3-2";
@@ -1801,12 +1865,13 @@ buildLuarocksPackage {
   "date": "2015-01-15T16:54:10+01:00",
   "path": "/nix/store/n7gb0z26sl7dzdyy3bx1y3cz3npsna7d-lua-luaepnf",
   "sha256": "1lvsi3fklhvz671jgg0iqn0xbkzn9qjcbf2ks41xxjz3lapjr6c9",
+  "hash": "sha256-iZksr6Ljy94D0VO4xSRO9s/VgcURvCfDMX9DOt2IetM=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lpeg lua ];
@@ -1818,7 +1883,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaevent = callPackage({ lua, fetchurl, luaOlder, buildLuarocksPackage }:
+luaevent = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luaevent";
   version = "0.4.6-1";
@@ -1841,7 +1906,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaexpat = callPackage({ buildLuarocksPackage, fetchgit, luaOlder, lua }:
+luaexpat = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luaexpat";
   version = "1.4.1-1";
@@ -1855,12 +1920,13 @@ buildLuarocksPackage {
   "date": "2022-10-04T16:36:23+02:00",
   "path": "/nix/store/dgrdkalikpqdap642qhppha1ajdnsvx0-luaexpat",
   "sha256": "1b4ck23p01ks3hgayan9n33f2kb6jvv63v4ww2mqczc09rqi0q46",
+  "hash": "sha256-hmAQcU6AfYar4JzsYfaWZk3hxrDJKq8eHHoGcIeYjKw=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1873,7 +1939,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaffi = callPackage({ fetchgit, buildLuarocksPackage, lua, luaOlder }:
+luaffi = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luaffi";
   version = "scm-1";
@@ -1887,12 +1953,13 @@ buildLuarocksPackage {
   "date": "2021-03-01T11:46:30-05:00",
   "path": "/nix/store/6dwfn64p3clcsxkq41b307q8izi0fvji-luaffifb",
   "sha256": "0nj76fw3yi57vfn35yvbdmpdbg9gmn5j1gw84ajs9w1j86sc0661",
+  "hash": "sha256-wRjAtEEy8KSlIoi/IIutL73Vbm1r+zKs26dEP7gzR1o=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1904,7 +1971,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luafilesystem = callPackage({ luaOlder, lua, fetchgit, buildLuarocksPackage }:
+luafilesystem = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luafilesystem";
   version = "1.8.0-1";
@@ -1918,44 +1985,46 @@ buildLuarocksPackage {
   "date": "2020-04-22T22:16:42-03:00",
   "path": "/nix/store/qzjav1cmn4zwclpfs0xzykpbv835d84z-luafilesystem",
   "sha256": "16hpwhj6zgkjns3zilcg3lxfijm3cl71v39y9n5lbjk4b9kkwh54",
+  "hash": "sha256-pEA+Z1pkykWLTT6NHQ5lo8roOh2P0fiHtnK+byTkF5o=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "git://github.com/keplerproject/luafilesystem";
+    homepage = "https://github.com/keplerproject/luafilesystem";
     description = "File System Library for the Lua Programming Language";
     maintainers = with lib.maintainers; [ flosse ];
     license.fullName = "MIT/X11";
   };
 }) {};
 
-lualdap = callPackage({ fetchgit, lua, luaOlder, buildLuarocksPackage }:
+lualdap = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "lualdap";
-  version = "1.3.0-1";
+  version = "1.3.1-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lualdap-1.3.0-1.rockspec";
-    sha256 = "0b51sm0fz4kiim20w538v31k9g20wq3msxdkh17drkr60ab25sc8";
+    url    = "mirror://luarocks/lualdap-1.3.1-1.rockspec";
+    sha256 = "0c0j9dmrphg0dil4yhahcqzzyxhrv525g65jsz0q6iqwyx10bqbp";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lualdap/lualdap",
-  "rev": "be380f5d98f779c813a4fb4ae1400262366fc8d4",
-  "date": "2021-06-05T15:49:42+02:00",
-  "path": "/nix/store/99sy73yz6sidqhkl0kwdsd7r853aw38n-lualdap",
-  "sha256": "133d8br5f24z03ni38m0czrqfz0mr0ksdrc1g73rawpmiqarpps8",
+  "rev": "5c21b3e0d97a07b103f63edc7e649018e0453427",
+  "date": "2023-03-15T09:02:07+01:00",
+  "path": "/nix/store/ah7y5wpp3l0v5bk0gwzdvgzfpczb691k-lualdap",
+  "sha256": "1y3ap9si894xjlbrwx3c6bcfg60y80av802rscldg9scvm984jrg",
+  "hash": "sha256-L0uCUt1Mp9co01kAtBVAHpjn2DJsdJ4XlZ0kFHW6avg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1968,7 +2037,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lualogging = callPackage({ luasocket, buildLuarocksPackage, fetchgit }:
+lualogging = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, luasocket }:
 buildLuarocksPackage {
   pname = "lualogging";
   version = "1.8.2-1";
@@ -1982,12 +2051,13 @@ buildLuarocksPackage {
   "date": "2023-01-27T20:29:41+01:00",
   "path": "/nix/store/pvb3yq11xgqhq6559sjd8rkf1x991rrz-lualogging",
   "sha256": "1mz5iiv9pfikkm4ay7j0q6mk3bmcxylnlg9piwda47xxc1zyb1j4",
+  "hash": "sha256-RIblf2C9H6Iajzc9aqnvrK4xq8FAHq9InTO6m3aM5dc=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ luasocket ];
 
@@ -1998,7 +2068,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaossl = callPackage({ buildLuarocksPackage, lua, fetchzip }:
+luaossl = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua }:
 buildLuarocksPackage {
   pname = "luaossl";
   version = "20220711-0";
@@ -2020,7 +2090,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaposix = callPackage({ bit32, lua, luaOlder, fetchzip, luaAtLeast, buildLuarocksPackage }:
+luaposix = callPackage({ bit32, buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luaposix";
   version = "34.1.1-1";
@@ -2044,7 +2114,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luarepl = callPackage({ buildLuarocksPackage, fetchurl, luaOlder, lua }:
+luarepl = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luarepl";
   version = "0.10-1";
@@ -2067,7 +2137,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luarocks-build-rust-mlua = callPackage({ fetchgit, buildLuarocksPackage }:
+luarocks-build-rust-mlua = callPackage({ buildLuarocksPackage, fetchgit, fetchurl }:
 buildLuarocksPackage {
   pname = "luarocks-build-rust-mlua";
   version = "0.1.2-1";
@@ -2081,41 +2151,44 @@ buildLuarocksPackage {
   "date": "2023-06-29T16:47:41+01:00",
   "path": "/nix/store/n7id28r1m11xd550hayv99xhz96vpdjq-luarocks-build-rust-mlua",
   "sha256": "1zh1p5k7xpczi5db3k0fw0ljw9w0xxk1qjjcfg5rcznqjf48i3x7",
+  "hash": "sha256-p4+IiJPYfpbLc0xKHGbvgCcuKeAOzLFaiZ/dfma5Af4=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
 
   meta = {
     homepage = "https://github.com/khvzak/luarocks-build-rust-mlua";
     description = "A LuaRocks build backend for Lua modules written in Rust using mlua";
+    maintainers = with lib.maintainers; [ mrcjkb ];
     license.fullName = "MIT";
   };
 }) {};
 
-luasec = callPackage({ fetchgit, luaOlder, luasocket, buildLuarocksPackage, lua }:
+luasec = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder, luasocket }:
 buildLuarocksPackage {
   pname = "luasec";
-  version = "1.2.0-1";
+  version = "1.3.2-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/luasec-1.2.0-1.rockspec";
-    sha256 = "0zavdkwd701j8zqyzrpn1n5xd242vziq2l79amjdn5mcw81nrsdf";
+    url    = "mirror://luarocks/luasec-1.3.2-1.rockspec";
+    sha256 = "09nqs60cmbq1bi70cdh7v5xjnlsm2mrxv9pmbbvczijvz184jh33";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/brunoos/luasec",
-  "rev": "d9215ee00f6694a228daad50ee85827a4cd13583",
-  "date": "2022-07-30T08:42:53-03:00",
-  "path": "/nix/store/77m3g768a230h77nxiw23ay73aryq1zh-luasec",
-  "sha256": "1rz2lhf243lrsjsyjwxhijhqr88l8l8sndzzv9w4x1j0zpa9sblb",
+  "rev": "4c06287052d68fdbe7429b8f967cdc8ee94aa44a",
+  "date": "2023-08-31T17:09:53-03:00",
+  "path": "/nix/store/wnl78b5l3dxw52slphmi4rmr1cd8bd3r-luasec",
+  "sha256": "0rrdfbnkd8pgqwh3f0iyd5cxy7g1h0568a88m3sq1z7715js4yx3",
+  "hash": "sha256-o3uiZQnn/ID1qAgpZAqA4R3fWWk+Ajcgx++iNu1yLWc=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua luasocket ];
@@ -2128,7 +2201,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luasocket = callPackage({ fetchgit, lua, luaOlder, buildLuarocksPackage }:
+luasocket = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luasocket";
   version = "3.1.0-1";
@@ -2142,12 +2215,13 @@ buildLuarocksPackage {
   "date": "2022-07-27T10:07:00+03:00",
   "path": "/nix/store/r5pqxqjkdwl80nmjkv400mbls7cfymjc-luasocket",
   "sha256": "13hyf9cvny0kxwyg08929kkl31w74j66fj6zg1myyjr9nh5b795h",
+  "hash": "sha256-sKSzCrQpS+9reN9IZ4wkh4dB50wiIfA87xN4u1lyHo4=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -2159,26 +2233,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-luasql-sqlite3 = callPackage({ lua, buildLuarocksPackage, fetchgit, luaOlder }:
+luasql-sqlite3 = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luasql-sqlite3";
-  version = "2.6.0-1";
+  version = "2.6.0-2";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/luasql-sqlite3-2.6.0-1.rockspec";
-    sha256 = "0w32znsfcaklcja6avqx7daaxbf0hr2v8g8bmz0fysb3401lmp02";
+    url    = "mirror://luarocks/luasql-sqlite3-2.6.0-2.rockspec";
+    sha256 = "1xpbcpl4qhnzpyyszhdsrxhx2qc1dmndh926lv91xwphw7inwdwg";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/keplerproject/luasql.git",
-  "rev": "e2660cbaeb13cb33d8346bb816c6a526241b3c2d",
-  "date": "2022-10-03T18:44:40-03:00",
-  "path": "/nix/store/mxzq779w3l19bgb424aa4cqdzxczmwr3-luasql",
-  "sha256": "052hc174am05plidilzf36vr736sp8vyydfb12qa8xr6mk74f6d1",
+  "rev": "25bf4ffce9323d28cb6f382f7ec9e8951e3084f9",
+  "date": "2023-07-19T14:20:27-03:00",
+  "path": "/nix/store/949886jxp7sx3yx910lc6d1yf3ym9mx5-luasql",
+  "sha256": "00q73j2nzqsm0vmxjkv83qh1dncmr5dgmkrkyxnb5ggygvcbh7w5",
+  "hash": "sha256-hR+42H7+vbJs9zPP+lrJldkWIB5oT9nrBlXjb4UcBwM=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -2191,7 +2266,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luassert = callPackage({ luaOlder, fetchgit, buildLuarocksPackage, lua, say }:
+luassert = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder, say }:
 buildLuarocksPackage {
   pname = "luassert";
   version = "1.9.0-1";
@@ -2205,12 +2280,13 @@ buildLuarocksPackage {
   "date": "2022-08-24T00:00:45+03:00",
   "path": "/nix/store/vfcl25wxps5kvh5prjkkjlj1ga3kgw63-luassert",
   "sha256": "0wlp6qdm9dkwzs8lvnj7zvmid4y12v717ywlhxn2brkbjpvl2dwf",
+  "hash": "sha256-jjdB95Vr5iVsh5T7E84WwZMW6/5H2k2R/ny2VBs2l3I=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua say ];
@@ -2222,7 +2298,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luasystem = callPackage({ buildLuarocksPackage, luaOlder, lua, fetchurl }:
+luasystem = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luasystem";
   version = "0.2.1-0";
@@ -2245,7 +2321,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaunbound = callPackage({ fetchurl, lua, buildLuarocksPackage, luaOlder, luaAtLeast }:
+luaunbound = callPackage({ buildLuarocksPackage, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luaunbound";
   version = "1.0.0-1";
@@ -2268,7 +2344,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luaunit = callPackage({ buildLuarocksPackage, fetchzip, lua, luaAtLeast, luaOlder }:
+luaunit = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luaunit";
   version = "3.4-1";
@@ -2292,7 +2368,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luautf8 = callPackage({ fetchurl, buildLuarocksPackage, lua, luaOlder }:
+luautf8 = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luautf8";
   version = "0.1.5-2";
@@ -2316,7 +2392,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luazip = callPackage({ luaOlder, luaAtLeast, buildLuarocksPackage, lua, fetchgit }:
+luazip = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luazip";
   version = "1.2.7-1";
@@ -2330,12 +2406,13 @@ buildLuarocksPackage {
   "date": "2017-09-05T14:02:52+03:00",
   "path": "/nix/store/idllj442c0iwnx1cpkrifx2afb7vh821-luazip",
   "sha256": "1jlqzqlds3aa3hnp737fm2awcx0hzmwyd87klv0cv13ny5v9f2x4",
+  "hash": "sha256-pAuXdvF2hM3ApvOg5nn9EHTGlajujHMtHEoN3Sj+mMo=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -2347,23 +2424,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-lush-nvim = callPackage({ buildLuarocksPackage, fetchgit, luaAtLeast, luaOlder, lua }:
+lush-nvim = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "lush.nvim";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/rktjmp/lush.nvim",
-  "rev": "b1e8eb1da3fee95ef31515a73c9eff9bf251088d",
-  "date": "2023-01-03T10:45:29+11:00",
-  "path": "/nix/store/wpnvi5bjlp7sl8g2li21qkcd7m1f3d3w-lush.nvim",
-  "sha256": "0q3prq4fm9rpczl7b1lgqnhs0z5jgvpdy0cp45jfpw4bvcy6vkpq",
+  "rev": "966aad1accd47fa11fbe2539234f81f678fef2de",
+  "date": "2023-09-23T12:10:39+10:00",
+  "path": "/nix/store/67046ilc92czfvwc5zdkkxg7iw2xjj45-lush.nvim",
+  "sha256": "0g1xib2k42py9qqccjz11qk52ri0drgdk5rb0ls7wzx4v636k15h",
+  "hash": "sha256-sIRphtmkf340BSuX2V5uIGZRJg7hS8YwTv4KMsWKPTw=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -2376,7 +2454,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luuid = callPackage({ luaOlder, luaAtLeast, buildLuarocksPackage, fetchurl, lua }:
+luuid = callPackage({ buildLuarocksPackage, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "luuid";
   version = "20120509-2";
@@ -2399,7 +2477,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-luv = callPackage({ luaOlder, buildLuarocksPackage, fetchurl, lua }:
+luv = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "luv";
   version = "1.44.2-1";
@@ -2422,7 +2500,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lyaml = callPackage({ buildLuarocksPackage, fetchzip, lua, luaOlder, luaAtLeast }:
+lyaml = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "lyaml";
   version = "6.2.8-1";
@@ -2446,7 +2524,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-magick = callPackage({ fetchgit, buildLuarocksPackage, lua }:
+magick = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua }:
 buildLuarocksPackage {
   pname = "magick";
   version = "1.6.0-1";
@@ -2460,24 +2538,26 @@ buildLuarocksPackage {
   "date": "2022-03-10T20:02:11-08:00",
   "path": "/nix/store/fpl99q09zg3qnk4kagxk1djabl1dm47l-magick",
   "sha256": "01b9qsz27f929rz5z7vapqhazxak74sichdwkjwb219nlhrwfncm",
+  "hash": "sha256-lVnHM6Q2BbG4nLxBFjU5U/WvIL5qn19+TiK5I77GaQU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (lua.luaversion != "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "git://github.com/leafo/magick.git";
+    homepage = "https://github.com/leafo/magick.git";
     description = "Lua bindings to ImageMagick & GraphicsMagick for LuaJIT using FFI";
+    maintainers = with lib.maintainers; [ donovanglover ];
     license.fullName = "MIT";
   };
 }) {};
 
-markdown = callPackage({ buildLuarocksPackage, luaAtLeast, fetchgit, luaOlder, lua }:
+markdown = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "markdown";
   version = "0.33-1";
@@ -2491,12 +2571,13 @@ buildLuarocksPackage {
   "date": "2015-09-27T17:49:28+03:00",
   "path": "/nix/store/akl80hh077hm20bdqj1lksy0fn2285b5-markdown",
   "sha256": "019bk2qprszqncnm8zy6ns6709iq1nwkf7i86nr38f035j4lc11y",
+  "hash": "sha256-PgRGiSwDODSyNSgeN7kNOCZwjLbGf1Qts/jrfLGYKwU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -2508,7 +2589,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-mediator_lua = callPackage({ luaOlder, lua, fetchurl, buildLuarocksPackage }:
+mediator_lua = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "mediator_lua";
   version = "1.1.2-0";
@@ -2531,7 +2612,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-middleclass = callPackage({ luaOlder, buildLuarocksPackage, fetchurl, lua }:
+middleclass = callPackage({ buildLuarocksPackage, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "middleclass";
   version = "4.1.1-0";
@@ -2554,23 +2635,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-moonscript = callPackage({ lpeg, luaOlder, fetchgit, lua, buildLuarocksPackage, argparse, luafilesystem }:
+moonscript = callPackage({ argparse, buildLuarocksPackage, fetchgit, lpeg, lua, luaOlder, luafilesystem }:
 buildLuarocksPackage {
   pname = "moonscript";
   version = "dev-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/leafo/moonscript.git",
-  "rev": "a0108328373d5f3f1aefb98341aa895dd75a1b2a",
-  "date": "2022-11-04T13:38:05-07:00",
-  "path": "/nix/store/js597jw44cdfq154a7bpqba99ninzsqh-moonscript",
-  "sha256": "02ig93c1dzrbs64mz40bkzz3p93fdxm6m0i7gfqwiickybr9wd97",
+  "rev": "fbd8ad48737651114a3d3a672b9f8f8b3a7022b7",
+  "date": "2023-06-23T09:33:37-07:00",
+  "path": "/nix/store/sy1dkcfp3rg7lvazba36sivpk0bs12r5-moonscript",
+  "sha256": "02w6lp5kid73dcd5x71666my7413l05ak0xvva6hp8ixbn6qraqn",
+  "hash": "sha256-FquMjV09oguN2ruDqQqgI5DjqzEmnF4aa+O0OMulhgs=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ argparse lpeg lua luafilesystem ];
@@ -2586,14 +2668,14 @@ buildLuarocksPackage {
 mpack = callPackage({ buildLuarocksPackage, fetchurl }:
 buildLuarocksPackage {
   pname = "mpack";
-  version = "1.0.10-0";
+  version = "1.0.11-0";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/mpack-1.0.10-0.rockspec";
-    sha256 = "sha256-TjeIKGE3/7O+lxGqpz3j6f421zMRtFtZIY5ZRpaPISs=";
+    url    = "mirror://luarocks/mpack-1.0.11-0.rockspec";
+    sha256 = "0alydkccamxldij7ki42imd37630d9qnqg22pndcgkawfclfqzqa";
   }).outPath;
   src = fetchurl {
-    url    = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.10/libmpack-lua-1.0.10.tar.gz";
-    sha256 = "sha256-GOICRzyaJV8dImGwGYdFIqTxxrb5ifgNqT1zNZM+gRk=";
+    url    = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.11/libmpack-lua-1.0.11.tar.gz";
+    sha256 = "15np7603rijavycvrjgjp12y64zs36390lg2hsnr5av790cfrnd2";
   };
 
 
@@ -2604,7 +2686,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-nui-nvim = callPackage( { fetchgit, buildLuarocksPackage }:
+nui-nvim = callPackage({ buildLuarocksPackage, fetchgit, fetchurl }:
 buildLuarocksPackage {
   pname = "nui.nvim";
   version = "0.2.0-1";
@@ -2618,12 +2700,13 @@ buildLuarocksPackage {
   "date": "2023-07-20T10:45:09+06:00",
   "path": "/nix/store/8zdhjgipjjhi9b1y40r2yk5np4lp39as-nui.nvim",
   "sha256": "14a73dwl56kah9h36b40ir6iylvfs261ysz17qvi9vhp63vjq9cx",
+  "hash": "sha256-nSUs9zAX7hQ3PuFrH4zQblMfTY6ALDNggmqaQnkbR5E=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
 
   meta = {
@@ -2634,7 +2717,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-nvim-client = callPackage({ coxpcall, fetchurl, mpack, lua, luaOlder, luv, buildLuarocksPackage }:
+nvim-client = callPackage({ buildLuarocksPackage, coxpcall, fetchurl, lua, luaOlder, luv, mpack }:
 buildLuarocksPackage {
   pname = "nvim-client";
   version = "0.2.4-1";
@@ -2654,23 +2737,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-nvim-cmp = callPackage({ luaAtLeast, lua, fetchgit, buildLuarocksPackage, luaOlder }:
+nvim-cmp = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "nvim-cmp";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/hrsh7th/nvim-cmp",
-  "rev": "7a3b1e76f74934b12fda82158237c6ad8bfd3d40",
-  "date": "2023-02-24T12:23:36+09:00",
-  "path": "/nix/store/s1qark9y2zkbwyl2mzg60z9r0h4hajf4-nvim-cmp",
-  "sha256": "0cy93aj02nkspr83sqsrix12jcnhkl5s2mbpjr5ffhpcrk19vlmx",
+  "rev": "5dce1b778b85c717f6614e3f4da45e9f19f54435",
+  "date": "2023-08-26T15:31:42+00:00",
+  "path": "/nix/store/lvpzc5q7mv66knxh1igvzkrcwkpg8l8q-nvim-cmp",
+  "sha256": "1yl5b680p6vhk1741riiwjnw7a4wn0nimjvcab0ij6mx3kf28rsq",
+  "hash": "sha256-WGck3By9GhnBUmzLGi2wnKjDreQx5kBOmHCbC5BZhfo=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -2682,23 +2766,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-penlight = callPackage({ luafilesystem, luaOlder, fetchgit, buildLuarocksPackage, lua }:
+penlight = callPackage({ buildLuarocksPackage, fetchgit, lua, luaOlder, luafilesystem }:
 buildLuarocksPackage {
   pname = "penlight";
   version = "dev-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lunarmodules/penlight.git",
-  "rev": "7e67bcb1c4d95e7ca817356533419b4a72049b96",
-  "date": "2022-12-28T23:34:46+01:00",
-  "path": "/nix/store/14kax7nswd7in005cgb0f0r8194s9nsd-penlight",
-  "sha256": "17gcfi8hqpdp8m0f1nr9n5p1mzxxpq2qwf8zkqvjkb7qv1zqabj1",
+  "rev": "dc6d19c5c1e1b4ac55b14df17b7645af6b410140",
+  "date": "2023-09-21T10:51:09+02:00",
+  "path": "/nix/store/vbi0d32mbaqcra3jligv8ajq17m1wxa4-penlight",
+  "sha256": "12ppgby8ldh4zxwcr7cknacbdvk30fi92sgyzh1zbgvym4l44g0c",
+  "hash": "sha256-DDxCKKl+v/UD/P5pkaIDY+62mLKTncx4/wQ2ivx694o=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua luafilesystem ];
@@ -2711,23 +2796,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-plenary-nvim = callPackage({ lua, fetchgit, luaOlder, luaAtLeast, luassert, buildLuarocksPackage }:
+plenary-nvim = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder, luassert }:
 buildLuarocksPackage {
   pname = "plenary.nvim";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/nvim-lua/plenary.nvim",
-  "rev": "253d34830709d690f013daf2853a9d21ad7accab",
-  "date": "2023-02-19T10:05:49+01:00",
-  "path": "/nix/store/dnzlin3gqpvd35a8c5g5hwg3fl28vxgs-plenary.nvim",
-  "sha256": "17vvl06jc5vrfrv7gljflkqykshhg84wnhbl9br4pm050ywlg4ng",
+  "rev": "50012918b2fc8357b87cff2a7f7f0446e47da174",
+  "date": "2023-10-11T15:43:47+02:00",
+  "path": "/nix/store/jsgaq274w8pbl4pnmpii3izxafpl346g-plenary.nvim",
+  "sha256": "1sn7vpsbwpyndsjyxb4af8fvz4sfhlbavvw6jjsv3h18sdvkh7nd",
+  "hash": "sha256-zR44d9MowLG1lIbvrRaFTpO/HXKKrO6lbtZfvvTdx+o=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luassert ];
@@ -2739,7 +2825,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-rapidjson = callPackage({ lua, buildLuarocksPackage, luaOlder, fetchgit }:
+rapidjson = callPackage({ buildLuarocksPackage, fetchgit, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "rapidjson";
   version = "0.7.1-1";
@@ -2750,12 +2836,13 @@ buildLuarocksPackage {
   "date": "2021-04-09T19:59:20+08:00",
   "path": "/nix/store/65l71ph27pmipgrq8j4whg6n8h2avvs4-lua-rapidjson",
   "sha256": "1a6srvximxlh6gjkaj5y86d1kf06pc4gby2r6wpdw2pdac8k7xyb",
+  "hash": "sha256-y/czEVPtCt4uN1n49Qi7BrgZmkG+SDXlM5D2GvvO2qg=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -2767,44 +2854,21 @@ buildLuarocksPackage {
   };
 }) {};
 
-readline = callPackage({ buildLuarocksPackage, fetchurl, luaAtLeast, luaOlder, lua, luaposix }:
-buildLuarocksPackage {
-  pname = "readline";
-  version = "3.2-0";
-  knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/readline-3.2-0.rockspec";
-    sha256 = "1r0sgisxm4xd1r6i053iibxh30j7j3rcj4wwkd8rzkj8nln20z24";
-  }).outPath;
-  src = fetchurl {
-    url    = "http://www.pjb.com.au/comp/lua/readline-3.2.tar.gz";
-    sha256 = "1mk9algpsvyqwhnq7jlw4cgmfzj30l7n2r6ak4qxgdxgc39f48k4";
-  };
-
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
-  propagatedBuildInputs = [ lua luaposix ];
-
-  meta = {
-    homepage = "http://pjb.com.au/comp/lua/readline.html";
-    description = "Interface to the readline library";
-    license.fullName = "MIT/X11";
-  };
-}) {};
-
-rest-nvim = callPackage({ lua, luaAtLeast, buildLuarocksPackage, luaOlder, fetchzip, plenary-nvim }:
+rest-nvim = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "rest.nvim";
-  version = "0.1-2";
+  version = "0.2-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/rest.nvim-0.1-2.rockspec";
-    sha256 = "0l8k91483nz75ijgnyfb8r7mynsaps7ikvjkziimf62bv7aks3qh";
+    url    = "mirror://luarocks/rest.nvim-0.2-1.rockspec";
+    sha256 = "1yq8gx585c10j8kybp20swyv9q0i3lm5k0rrv4bgsbwz3ychn0k1";
   }).outPath;
   src = fetchzip {
-    url    = "http://github.com/rest-nvim/rest.nvim/archive/0.1.zip";
-    sha256 = "0yf1a1cjrrzw0wmjgg48g3qn9kfxn7hv38yx88l1sc1r1nsfijrq";
+    url    = "https://github.com/rest-nvim/rest.nvim/archive/0.2.zip";
+    sha256 = "0ycjrrl37z465p71bdkas3q2ky1jmgr2cjnirnskdc6wz14wl09g";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
-  propagatedBuildInputs = [ lua plenary-nvim ];
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
 
   meta = {
     homepage = "https://github.com/rest-nvim/rest.nvim";
@@ -2814,23 +2878,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-say = callPackage({ luaOlder, fetchgit, lua, buildLuarocksPackage }:
+say = callPackage({ buildLuarocksPackage, fetchgit, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "say";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lunarmodules/say.git",
-  "rev": "45a3057e68c52b34ab59ef167efeb2340e356661",
-  "date": "2022-08-27T11:00:01+03:00",
-  "path": "/nix/store/324ryi5hlaisnyp4wpd1hvzcfv508i4s-say",
-  "sha256": "178pdsswwnja2f106701xmdxsdijjl5smm28dhhdcmjyb4mn8cr2",
+  "rev": "3e1f783d0aa496eb21d16e85b2235335cb9332df",
+  "date": "2023-08-13T02:37:27+03:00",
+  "path": "/nix/store/5biavac0k8z0xg4rr3bm8z3kdi8mm8c0-say",
+  "sha256": "04dkf0av6n71vmz0h86i5brklvaf9p91lkldn1xldpdr0qqs0x63",
+  "hash": "sha256-w3SgMQa53UZ7sI1OGtJNTm068yrRIAh+3eFYsxVwsxE=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -2842,7 +2907,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-serpent = callPackage({ fetchgit, luaAtLeast, lua, buildLuarocksPackage, luaOlder }:
+serpent = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "serpent";
   version = "0.30-2";
@@ -2856,12 +2921,13 @@ buildLuarocksPackage {
   "date": "2017-09-01T21:35:14-07:00",
   "path": "/nix/store/z6df44n3p07n4bia7s514vgngbkbpnap-serpent",
   "sha256": "0q80yfrgqgr01qprf0hrp284ngb7fbcq1v9rbzmdkhbm9lpgy8v8",
+  "hash": "sha256-aCP/Lk11wdnqXzntgNlyZz1LkLgZApcvDiA//LLzAGE=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
@@ -2874,7 +2940,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-sqlite = callPackage({ fetchgit, buildLuarocksPackage, luv }:
+sqlite = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, luv }:
 buildLuarocksPackage {
   pname = "sqlite";
   version = "v1.2.2-0";
@@ -2888,12 +2954,13 @@ buildLuarocksPackage {
   "date": "2022-06-17T15:57:13+03:00",
   "path": "/nix/store/637s46bsvsxfnzmy6ygig3y0vqmf3r8p-sqlite.lua",
   "sha256": "0ckifx6xxrannn9szacgiiqjsp4rswghxscdl3s411dhas8djj1m",
+  "hash": "sha256-NUjZkFawhUD0oI3pDh/XmVwtcYyPqa+TtVbl3k13cTI=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ luv ];
 
@@ -2904,7 +2971,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-std-_debug = callPackage({ buildLuarocksPackage, lua, luaOlder, fetchgit, luaAtLeast }:
+std-_debug = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "std._debug";
   version = "git-1";
@@ -2915,12 +2982,13 @@ buildLuarocksPackage {
   "date": "2023-01-31T16:39:35-07:00",
   "path": "/nix/store/i24iz2hvnjp18iz9z8kljsy9iv17m2zl-_debug",
   "sha256": "07z5lz3gy8wzzks79r3v68vckj42i3sybhfmqx7h2s58ld2kn5fd",
+  "hash": "sha256-zRU7RaOoaAFPx9XB5fWIgsjJNjJ75HT0/J8j/8an5R8=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
@@ -2932,23 +3000,24 @@ buildLuarocksPackage {
   };
 }) {};
 
-std-normalize = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, std-_debug, luaOlder }:
+std-normalize = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder, std-_debug }:
 buildLuarocksPackage {
   pname = "std.normalize";
   version = "git-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lua-stdlib/normalize.git",
-  "rev": "ccc697998af22d9d7f675e73f4b27c7a52151b5c",
-  "date": "2022-01-02T16:33:35-08:00",
-  "path": "/nix/store/nvyy1ibp43pzaldj6ark02ypqr45wmy1-normalize",
-  "sha256": "1m6x4lp7xzghvagbqjljyqfcpilh76j25b71da6jd304xc9r0ngy",
+  "rev": "01307e4e6cc3a2d3eba907d3a6758bcf0f3f09e2",
+  "date": "2023-02-03T19:18:59-07:00",
+  "path": "/nix/store/wnvhj9mma8j5j5wmgj5ih2c548gvn5ic-normalize",
+  "sha256": "0bh8sz8lv67yjkzf4i1a75c4ywdx5rsgf063ixxw0fqrc7kazaz5",
+  "hash": "sha256-5auv5mEZO8B7j8MA93QuvXFPWDkqROL+lP6YTdHXCC4=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua std-_debug ];
@@ -2960,7 +3029,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-stdlib = callPackage({ buildLuarocksPackage, luaAtLeast, fetchzip, lua, luaOlder }:
+stdlib = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "stdlib";
   version = "41.2.2-1";
@@ -2984,7 +3053,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-teal-language-server = callPackage({ luafilesystem, buildLuarocksPackage, dkjson, cyan, fetchgit }:
+teal-language-server = callPackage({ buildLuarocksPackage, cyan, dkjson, fetchgit, fetchurl, luafilesystem }:
 buildLuarocksPackage {
   pname = "teal-language-server";
   version = "dev-1";
@@ -2998,12 +3067,13 @@ buildLuarocksPackage {
   "date": "2022-12-21T20:33:53-06:00",
   "path": "/nix/store/qyaz38njm8qgyfxca6m6f8i4lkfcfdb0-teal-language-server",
   "sha256": "12nqarykmdvxxci9l6gq2yhn4pjzzqlxyrl2c8svb97hka68wjvx",
+  "hash": "sha256-fUuOjJrwpLU1YoJm3yn+X15ioRf4GZoi6323On1W2Io=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ cyan dkjson luafilesystem ];
 
@@ -3014,17 +3084,17 @@ buildLuarocksPackage {
   };
 }) {};
 
-telescope-manix = callPackage({ telescope-nvim, buildLuarocksPackage, lua, fetchzip, luaOlder }:
+telescope-manix = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaOlder, telescope-nvim }:
 buildLuarocksPackage {
   pname = "telescope-manix";
-  version = "0.4.0-1";
+  version = "0.5.0-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/telescope-manix-0.4.0-1.rockspec";
-    sha256 = "1kh3dn4aixydxrq01sbl40v7if8bmpsvv30qf7vig7dvl21aqkrp";
+    url    = "mirror://luarocks/telescope-manix-0.5.0-1.rockspec";
+    sha256 = "0i5q9sr0vn0w6yqg530jx2fx52k9jr7rss4ibl49f1x3wv6sckv1";
   }).outPath;
   src = fetchzip {
-    url    = "https://github.com/mrcjkb/telescope-manix/archive/0.4.0.zip";
-    sha256 = "153fqnk8iymyq309kpfiz3xmlqryj02rji3z7air23bgyjkx0gr8";
+    url    = "https://github.com/mrcjkb/telescope-manix/archive/0.5.0.zip";
+    sha256 = "093vkh822ycnc1pri3zmzzqnz235xxam3z1l67zyyqlc1apbarax";
   };
 
   disabled = (luaOlder "5.1");
@@ -3037,7 +3107,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-telescope-nvim = callPackage({ plenary-nvim, buildLuarocksPackage, lua, fetchgit }:
+telescope-nvim = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, plenary-nvim }:
 buildLuarocksPackage {
   pname = "telescope.nvim";
   version = "scm-1";
@@ -3047,16 +3117,17 @@ buildLuarocksPackage {
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/nvim-telescope/telescope.nvim",
-  "rev": "a3f17d3baf70df58b9d3544ea30abe52a7a832c2",
-  "date": "2023-02-26T13:26:12+01:00",
-  "path": "/nix/store/qyzs7im9nqn04h9w9nii4nv12ysgk1fk-telescope.nvim",
-  "sha256": "136pik53kwl2avjdakwfls10d85jqybl7yd0mbzxc5nry8krav22",
+  "rev": "74ce793a60759e3db0d265174f137fb627430355",
+  "date": "2023-10-11T12:29:23+02:00",
+  "path": "/nix/store/7k50qqgamc2ldxdf54jqs8sy8m8vcfzr-telescope.nvim",
+  "sha256": "1m4v097y8ypjm572k1qqii3z56w4x1dsjxd6gp0z24xqyvd4kpa4",
+  "hash": "sha256-RN1J2va4E/HBfaZ1qVvohJvyR4wYhylOqfJ65E8Cm9Q=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (lua.luaversion != "5.1");
   propagatedBuildInputs = [ lua plenary-nvim ];
@@ -3068,26 +3139,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-tl = callPackage({ compat53, luafilesystem, argparse, buildLuarocksPackage, fetchgit }:
+tl = callPackage({ argparse, buildLuarocksPackage, compat53, fetchgit, fetchurl, luafilesystem }:
 buildLuarocksPackage {
   pname = "tl";
-  version = "0.15.1-1";
+  version = "0.15.2-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/tl-0.15.1-1.rockspec";
-    sha256 = "0f9wr91pxcvx43jp9ma4yb6f0r9yrc2fm437nx7xm0dyh7kac9p6";
+    url    = "mirror://luarocks/tl-0.15.2-1.rockspec";
+    sha256 = "1qisdflgikry0jdqvnzdcqib2svbafp10n0gfwm3fcrzqsdxy0xr";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/teal-language/tl",
-  "rev": "a10fb2c69827c1b0f8e1b8a5c848a06d6da5d3be",
-  "date": "2023-01-23T18:14:26-03:00",
-  "path": "/nix/store/x5p9v443g53sz2c8rvxa465gzfiv47wb-tl",
-  "sha256": "0hql1274wxji54cadalv4j3k82vd9xasvi119cdnm16mh85ir70s",
+  "rev": "d2fc36b5ff9a52d7265e63eb74cce70fd1cdbcb2",
+  "date": "2023-04-27T11:28:21-03:00",
+  "path": "/nix/store/ramhj3a29lrn0bblbgyxn4712a7caq8k-tl",
+  "sha256": "1dgldi9pgg23iz3xis4i43bnvkwirh7kkycmr5xp75s2cc85zhg0",
+  "hash": "sha256-4MFfEGNCl3N7yZX5OQ/Mkc9t1yCR6NjHj0O8d1Ns9LU=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ argparse compat53 luafilesystem ];
 
@@ -3099,7 +3171,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-toml = callPackage({ lua, fetchgit, luaOlder, buildLuarocksPackage }:
+toml = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "toml";
   version = "0.3.0-0";
@@ -3113,12 +3185,13 @@ buildLuarocksPackage {
   "date": "2023-02-19T23:00:49-05:00",
   "path": "/nix/store/p6a98sqp9a4jwsw6ghqcwpn9lxmhvkdg-toml.lua",
   "sha256": "05p33bq0ajl41vbsw9bx73shpf0p11n5gb6yy8asvp93zh2m51hq",
+  "hash": "sha256-GIZSBfwj3a0V8t6sV2wIF7gL9Th9Ja7XDoRKBfAa4xY=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -3131,7 +3204,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-toml-edit = callPackage({ luaOlder, luarocks-build-rust-mlua, buildLuarocksPackage, lua, fetchgit }:
+toml-edit = callPackage({ buildLuarocksPackage, fetchgit, fetchurl, lua, luaOlder, luarocks-build-rust-mlua }:
 buildLuarocksPackage {
   pname = "toml-edit";
   version = "0.1.4-1";
@@ -3145,12 +3218,13 @@ buildLuarocksPackage {
   "date": "2023-10-02T16:54:10+02:00",
   "path": "/nix/store/p1368agmqg4jwb1qvf2iff3fdrq9vkdj-toml-edit.lua",
   "sha256": "1aa8znjnmm84392gnl7w0hm069xfv7niym3i8my7kyk0vdgxja06",
+  "hash": "sha256-BijZX9tg+nl8RXFUH+3ZricDKgT8UPtEGgTVaqX9SKk=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua luarocks-build-rust-mlua ];
@@ -3163,7 +3237,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-vstruct = callPackage({ fetchgit, lua, buildLuarocksPackage, luaOlder }:
+vstruct = callPackage({ buildLuarocksPackage, fetchgit, lua, luaOlder }:
 buildLuarocksPackage {
   pname = "vstruct";
   version = "2.1.1-1";
@@ -3174,12 +3248,13 @@ buildLuarocksPackage {
   "date": "2020-05-06T23:13:06-04:00",
   "path": "/nix/store/a4i9k5hx9xiz38bij4hb505dg088jkss-vstruct",
   "sha256": "0sl9v874mckhh6jbxsan48s5xajzx193k4qlphw69sdbf8kr3p57",
+  "hash": "sha256-p9yRJ3Kr6WQ4vBSTOVLoX6peNCJW6b6kgXCySg7aiWo=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -3190,26 +3265,27 @@ buildLuarocksPackage {
   };
 }) {};
 
-vusted = callPackage({ buildLuarocksPackage, fetchgit, busted }:
+vusted = callPackage({ buildLuarocksPackage, busted, fetchgit, fetchurl }:
 buildLuarocksPackage {
   pname = "vusted";
-  version = "2.2.0-1";
+  version = "2.3.1-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/vusted-2.2.0-1.rockspec";
-    sha256 = "1ri96pdwhck1sbdnkqj9ksv9hs86pv8v2f6vl25696v9snp9jkzs";
+    url    = "mirror://luarocks/vusted-2.3.1-1.rockspec";
+    sha256 = "03h7l12xk43rql9vxb5nzfimx9srwaazx2r3j2zm1ba2qz06h0qc";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/notomo/vusted.git",
-  "rev": "f142170d3b802f6cedfcff67b945a260087ecf65",
-  "date": "2023-01-03T11:23:56+09:00",
-  "path": "/nix/store/la7h2a39wnjkdg1fzhkgw3hbrhs4c5kf-vusted",
-  "sha256": "17pdwaqjfkv2b7a801k5fdg2s0s75miiilfdjgmsyv7phighvkvw",
+  "rev": "2bc6818a756e47240d9284f1dfac21b011ca84ea",
+  "date": "2023-10-09T11:47:28+09:00",
+  "path": "/nix/store/jq2yl4adpnyilp3yyw161j1a29bwahqi-vusted",
+  "sha256": "04lxc78n3h1qhby6b4k9x8hb1c3sgqdid71fsvyg4y6j7rb55a8z",
+  "hash": "sha256-H6lSVj7SePL81i6cFht+erCwIOppkmX8gjjAYdFhnRI=",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false
 }
- '') ["date" "path"]) ;
+ '') ["date" "path" "sha256"]) ;
 
   propagatedBuildInputs = [ busted ];
 

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -2977,24 +2977,18 @@ buildLuarocksPackage {
   };
 }) {};
 
-std-normalize = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder, std-_debug }:
+std-normalize = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, lua, luaAtLeast, luaOlder, std-_debug }:
 buildLuarocksPackage {
   pname = "std.normalize";
-  version = "git-1";
-
-  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
-  "url": "https://github.com/lua-stdlib/normalize.git",
-  "rev": "01307e4e6cc3a2d3eba907d3a6758bcf0f3f09e2",
-  "date": "2023-02-03T19:18:59-07:00",
-  "path": "/nix/store/wnvhj9mma8j5j5wmgj5ih2c548gvn5ic-normalize",
-  "sha256": "0bh8sz8lv67yjkzf4i1a75c4ywdx5rsgf063ixxw0fqrc7kazaz5",
-  "hash": "sha256-5auv5mEZO8B7j8MA93QuvXFPWDkqROL+lP6YTdHXCC4=",
-  "fetchLFS": false,
-  "fetchSubmodules": true,
-  "deepClone": false,
-  "leaveDotGit": false
-}
- '') ["date" "path" "sha256"]) ;
+  version = "2.0.3-1";
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/std.normalize-2.0.3-1.rockspec";
+    sha256 = "1l83ikiaw4dch2r69cxpl93b9d4wf54vbjb6fcggnkxxgm0amj3a";
+  }).outPath;
+  src = fetchzip {
+    url    = "http://github.com/lua-stdlib/normalize/archive/v2.0.3.zip";
+    sha256 = "1gyywglxd2y7ck3hk8ap73w0x7hf9irpg6vgs8yc6k9k4c5g3fgi";
+  };
 
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua std-_debug ];

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -386,10 +386,10 @@ with prev;
     ];
   });
 
-  lua-resty-session =  prev.lua-resty-session.overrideAttrs (oa: {
-    # lua_pack and lua-ffi-zlib are unpackaged, causing this package to not evaluate
-    meta.broken = true;
-  });
+  # lua-resty-session =  prev.lua-resty-session.overrideAttrs (oa: {
+  #   # lua_pack and lua-ffi-zlib are unpackaged, causing this package to not evaluate
+  #   meta.broken = true;
+  # });
 
   lua-yajl =  prev.lua-yajl.overrideAttrs (oa: {
     buildInputs = oa.buildInputs ++ [

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -117,12 +117,6 @@ with prev;
       '';
   });
 
-  cyrussasl = prev.cyrussasl.overrideAttrs (drv: {
-    externalDeps = [
-      { name = "LIBSASL"; dep = cyrus_sasl; }
-    ];
-  });
-
   fennel = prev.fennel.overrideAttrs(oa: {
     nativeBuildInputs = oa.nativeBuildInputs ++ [
       installShellFiles

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -322,7 +322,7 @@ with prev;
     externalDeps = [
       { name = "EVENT"; dep = libevent; }
     ];
-    disabled = luaOlder "5.1" || luaAtLeast "5.4";
+    meta.broken = luaOlder "5.1" || luaAtLeast "5.4";
   });
 
   luaexpat = prev.luaexpat.overrideAttrs (_: {
@@ -514,8 +514,21 @@ with prev;
     '';
   });
 
-  readline = prev.readline.overrideAttrs (oa: {
-    propagatedBuildInputs = oa.propagatedBuildInputs ++ [ readline.out ];
+  readline = final.callPackage({ buildLuarocksPackage, fetchurl, luaAtLeast, luaOlder, lua, luaposix }:
+  buildLuarocksPackage ({
+    pname = "readline";
+    version = "3.2-0";
+    knownRockspec = (fetchurl {
+      url    = "mirror://luarocks/readline-3.2-0.rockspec";
+      sha256 = "1r0sgisxm4xd1r6i053iibxh30j7j3rcj4wwkd8rzkj8nln20z24";
+    }).outPath;
+    src = fetchurl {
+      # the rockspec url doesn't work because 'www.' is not covered by the certificate so
+      # I manually removed the 'www' prefix here
+      url    = "http://pjb.com.au/comp/lua/readline-3.2.tar.gz";
+      sha256 = "1mk9algpsvyqwhnq7jlw4cgmfzj30l7n2r6ak4qxgdxgc39f48k4";
+    };
+
     extraVariables = rec {
       READLINE_INCDIR = "${readline.dev}/include";
       HISTORY_INCDIR = READLINE_INCDIR;
@@ -524,9 +537,19 @@ with prev;
       unzip "$curSrc"
       tar xf *.tar.gz
     '';
-    # Without this, source root is wrongly set to ./readline-2.6/doc
-    sourceRoot = "readline-${lib.versions.majorMinor oa.version}";
-  });
+
+    disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+    propagatedBuildInputs = [ lua luaposix
+      readline.out
+    ];
+
+    meta = {
+      homepage = "http://pjb.com.au/comp/lua/readline.html";
+      description = "Interface to the readline library";
+      license.fullName = "MIT/X11";
+    };
+  })) {};
+
 
   sqlite = prev.sqlite.overrideAttrs (drv: {
 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -386,6 +386,11 @@ with prev;
     ];
   });
 
+  lua-resty-session =  prev.lua-resty-session.overrideAttrs (oa: {
+    # lua_pack and lua-ffi-zlib are unpackaged, causing this package to not evaluate
+    meta.broken = true;
+  });
+
   lua-yajl =  prev.lua-yajl.overrideAttrs (oa: {
     buildInputs = oa.buildInputs ++ [
       yajl

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -2,13 +2,13 @@
 
 luarocks.overrideAttrs (old: {
   pname = "luarocks-nix";
-  version = "unstable-2023-02-26";
+  version = "unstable-2023-10-19";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "luarocks-nix";
-    rev = "4cfea3d5d826db4cfbc809ef8bb5f0a9f3a18919";
-    sha256 = "sha256-7L8B+/C7Kzt25Ec+OsM2rliYB2/wyZQ3OT63V7AaOxo=";
+    rev = "4240b25b95d7165cde66fc2acaf5a0f9ad40fd0c";
+    sha256 = "sha256-dqFFYehBgK0RqH0/1GtZXq7XLGCcc3Kfadq8ICYNCWk=";
   };
 
   patches = [ ];

--- a/pkgs/misc/openrussian-cli/default.nix
+++ b/pkgs/misc/openrussian-cli/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ zane ];
     mainProgram = "openrussian";
     platforms   = platforms.unix;
+    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

WIP: bump luarocks package-set . Waiting to fix several luarocks upstream
before starting

- [x] lua-iconv: moved to lunarmodules with fixed rockspecs https://github.com/luarocks/luarocks-site/issues/199#issuecomment-1717484507
- [x] mimetypes: moved to lunarmodules with fixed rockspecs  
- [x] basexx: patch merged, we can use upstream again 
- [x] https://gitlab.com/peterbillam/pjb_lua/-/issues/2 (for now I've just removed it from the generated set and put directly in overrides)
- [x] https://github.com/JorjBauer/lua-cyrussasl/issues/6 wrong source, for now I've dropped it
- luarocks-nix: unstable-2023-02-26 -> unstable-2023-09-08
- [x] generateLuarocksConfig: add defaults to ease its usage
- wip

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
