### PR TITLE
indi-full: wrap indiserver to set correct prefix

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/indi-with-drivers.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-with-drivers.nix
@@ -1,4 +1,4 @@
-{ buildEnv, indilib ? indilib, pname ? "indi-with-drivers", version ? null, extraDrivers ? null }:
+{ buildEnv, makeBinaryWrapper, indilib ? indilib, pname ? "indi-with-drivers", version ? null, extraDrivers ? null }:
 
 buildEnv {
   name = "${pname}-${version}";
@@ -6,5 +6,13 @@ buildEnv {
     indilib
   ]
   ++ extraDrivers;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postBuild = ''
+    makeBinaryWrapper ${indilib}/bin/indiserver $out/bin/indiserver --set-default INDIPREFIX $out
+  '';
+
+
   inherit (indilib) meta;
 }


### PR DESCRIPTION
## Description of changes

Indi drivers from the 3rdparty repo (indi-3rdparty) will look in the indilib prefix for their default config, where they won't find them. The indi-with-drivers buildenv contains all the files but in order to override the path indilib looks for settings per default, the INDIPREFIX env var needs to be set. This is now done for indiserver with a binary wrapper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
