### PR TITLE
k0s: init at 1.30.4+k0s.0

### DIFF
--- a/pkgs/applications/networking/cluster/k0s/1_30.nix
+++ b/pkgs/applications/networking/cluster/k0s/1_30.nix
@@ -1,0 +1,17 @@
+{
+  version = "1.30.4+k0s.0";
+  srcs = {
+    armv7l-linux = {
+      url = "https://github.com/k0sproject/k0s/releases/download/v1.30.4+k0s.0/k0s-v1.30.4+k0s.0-arm";
+      hash = "sha256-e9YpqLUVxlnabdjdaA4q963Li0BURCQ/Xa3oxTeh7Bo=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/k0sproject/k0s/releases/download/v1.30.4+k0s.0/k0s-v1.30.4+k0s.0-arm64";
+      hash = "sha256-N1dhnQkgyUczDO0RRvEIoRbFXO4gpUuvuLayjb6eTdA=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/k0sproject/k0s/releases/download/v1.30.4+k0s.0/k0s-v1.30.4+k0s.0-amd64";
+      hash = "sha256-cOPWukAEOiSFtmZQ7JLgHjfq9dkYyCKMtdvXcBKNKfk=";
+    };
+  };
+}

--- a/pkgs/applications/networking/cluster/k0s/default.nix
+++ b/pkgs/applications/networking/cluster/k0s/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  pkgs,
+  buildPackages,
+  fetchurl,
+  installShellFiles,
+  testers,
+}:
+let
+  releases = {
+    k0s_1_30 = import ./1_30.nix;
+  };
+in
+builtins.mapAttrs (
+  name: release:
+  stdenv.mkDerivation rec {
+    pname = "k0s";
+    inherit (release) version;
+
+    src = fetchurl {
+      inherit
+        (release.srcs."${stdenv.hostPlatform.system}"
+          or (throw "Missing source for host system: ${stdenv.hostPlatform.system}")
+        )
+        url
+        hash
+        ;
+    };
+
+    nativeBuildInputs = [ installShellFiles ];
+
+    phases = [ "installPhase" ];
+
+    installPhase =
+      let
+        k0s =
+          if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+            placeholder "out"
+          else
+            buildPackages."${name}";
+      in
+      ''
+        install -m 755 -D -- "$src" "$out"/bin/k0s
+
+        # Generate shell completions
+        installShellCompletion --cmd k0s \
+          --bash <(${k0s}/bin/k0s completion bash) \
+          --fish <(${k0s}/bin/k0s completion fish) \
+          --zsh <(${k0s}/bin/k0s completion zsh)
+      '';
+
+    passthru.tests.version = testers.testVersion {
+      package = pkgs."${name}";
+      command = "k0s version";
+      version = "v${version}";
+    };
+
+    passthru.updateScript = ./update-script.bash;
+
+    meta = with lib; {
+      description = "k0s - The Zero Friction Kubernetes";
+      homepage = "https://k0sproject.io";
+      license = licenses.asl20;
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      mainProgram = "k0s";
+      maintainers = with maintainers; [ twz123 ];
+      platforms = builtins.attrNames release.srcs;
+    };
+  }
+) releases

--- a/pkgs/applications/networking/cluster/k0s/update-script.bash
+++ b/pkgs/applications/networking/cluster/k0s/update-script.bash
@@ -1,0 +1,90 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils go gh nix-prefetch
+
+set -euo pipefail
+
+list_k0s_releases() {
+  #shellcheck disable=SC2016
+  local query='.[] | select(.prerelease == false and .draft == false) | .tag_name | select(startswith($ENV.VERSION_PREFIX))'
+  VERSION_PREFIX="v$1" gh api -X GET /repos/k0sproject/k0s/releases -F per_page=100 --paginate --jq "$query"
+}
+
+k0s_sort() {
+  go run github.com/k0sproject/version/cmd/k0s_sort@v0.6.0
+}
+
+latest_release() {
+  list_k0s_releases "$1" | k0s_sort | tail -1
+}
+
+hash_file() {
+  local sha256
+  sha256=$(nix-prefetch-url --quiet "$1")
+  nix hash to-sri --type sha256 "$sha256"
+}
+
+main() {
+  k0sMajorMinor=$(echo "$UPDATE_NIX_OLD_VERSION" | cut -d . -f1,2)
+  [ -n "$k0sMajorMinor" ] || {
+    echo Failed to determine k0s minor version >&2
+    exit 1
+  }
+
+  latestRelease=$(latest_release "$k0sMajorMinor")
+  latestRelease=${latestRelease#v}
+  [ -n "$latestRelease" ] || {
+    echo Failed to find latest k0s release >&2
+    exit 1
+  }
+
+  [ "$latestRelease" != "$UPDATE_NIX_OLD_VERSION" ] || {
+    # already up to date
+    exit 0
+  }
+
+  local -A archs
+  archs['x86_64-linux']=amd64
+  archs['aarch64-linux']=arm64
+  archs['armv7l-linux']=arm
+
+  local -A urls hashes
+  for arch in "${archs[@]}"; do
+    urls[$arch]="https://github.com/k0sproject/k0s/releases/download/v$latestRelease/k0s-v$latestRelease-$arch"
+    hashes[$arch]=$(hash_file "${urls[$arch]}")
+  done
+
+  packagePath=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+  outFile="$packagePath/${k0sMajorMinor/./_}.nix"
+
+  {
+    cat <<EOF
+{
+  version = "$latestRelease";
+  srcs = {
+EOF
+    for arch in "${!archs[@]}"; do
+      cat <<EOF
+    $arch = {
+      url = "${urls[${archs[$arch]}]}";
+      hash = "${hashes[${archs[$arch]}]}";
+    };
+EOF
+    done
+    cat <<EOF
+  };
+}
+EOF
+
+  } >"$outFile"
+
+  cat <<EOF
+[{
+  "attrPath": "$UPDATE_NIX_ATTR_PATH",
+  "oldVersion": "$UPDATE_NIX_OLD_VERSION",
+  "newVersion": "$latestRelease",
+  "files": [ "$outFile" ]
+}]
+EOF
+}
+
+main

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30703,6 +30703,11 @@ with pkgs;
 
   jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };
 
+  inherit (callPackage ../applications/networking/cluster/k0s { })
+    k0s_1_30
+  ;
+  k0s = k0s_1_30;
+
   inherit (callPackage ../applications/networking/cluster/k3s { })
     k3s_1_28
     k3s_1_29


### PR DESCRIPTION
## Description of changes

This adds the upstream binary release. The k0s build process is a bit too bespoke and convoluted (relies heavily on Docker) to be replicated here.

Fixes #247158.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A k0s
/nix/store/bsp511n0ij8dy2x051fc3d6gmkjs6126-k0s-1.30.4+k0s.0

$  find /nix/store/bsp511n0ij8dy2x051fc3d6gmkjs6126-k0s-1.30.4+k0s.0 -type f
/nix/store/bsp511n0ij8dy2x051fc3d6gmkjs6126-k0s-1.30.4+k0s.0/bin/k0s
/nix/store/bsp511n0ij8dy2x051fc3d6gmkjs6126-k0s-1.30.4+k0s.0/share/bash-completion/completions/k0s.bash
/nix/store/bsp511n0ij8dy2x051fc3d6gmkjs6126-k0s-1.30.4+k0s.0/share/fish/vendor_completions.d/k0s.fish
/nix/store/bsp511n0ij8dy2x051fc3d6gmkjs6126-k0s-1.30.4+k0s.0/share/zsh/site-functions/_k0s

$ nix-build --attr pkgs.k0s.passthru.tests
this derivation will be built:
  /nix/store/hgib9vgbyjv291nx3lqyzc3i2qsf4gsg-k0s-1.30.4+k0s.0-test-version.drv
building '/nix/store/hgib9vgbyjv291nx3lqyzc3i2qsf4gsg-k0s-1.30.4+k0s.0-test-version.drv'...
v1.30.4+k0s.0
/nix/store/7fqg2kfa4rssdvi30glw78a94bbqc4fx-k0s-1.30.4+k0s.0-test-version

$ nix-build --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' -A k0s
/nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0

$  find /nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0 -type f
/nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0/bin/k0s
/nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0/share/bash-completion/completions/k0s.bash
/nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0/share/fish/vendor_completions.d/k0s.fish
/nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0/share/zsh/site-functions/_k0s

$ file /nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0/bin/k0s
/nix/store/z3jkflzxx3f59vw6i066xq99bfcsnfyq-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0/bin/k0s: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=wXTCmC4Xikze-LVzKwIz/Kj9ZY3j_LIsTtdti16M-/GygUeaCPhscsfDmWc2T8/EbpR-JL9pTvitwFk2shC, BuildID[sha1]=57482c8c8e50c789c19e2f031e12c219fb945628, stripped

$  nix-build --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' --attr pkgs.k0s.passthru.tests
this derivation will be built:
  /nix/store/6f6c2vd0b7kxw4b5jhdf8q4w23dasawr-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0-test-version.drv
this path will be fetched (0.02 MiB download, 0.06 MiB unpacked):
  /nix/store/ykw0rzx117mdgx86anzn5zcha6vjgkpb-stdenv-linux
copying path '/nix/store/ykw0rzx117mdgx86anzn5zcha6vjgkpb-stdenv-linux' from 'https://cache.nixos.org'...
building '/nix/store/6f6c2vd0b7kxw4b5jhdf8q4w23dasawr-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0-test-version.drv'...
v1.30.4+k0s.0
/nix/store/dx21am9da2qjfc73z5pwbyv5iz80zf9x-k0s-aarch64-unknown-linux-gnu-1.30.4+k0s.0-test-version
```