### PR TITLE
podman: 4.6.2 -> 4.7.0

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -62,13 +62,13 @@ let
 in
 buildGoModule rec {
   pname = "podman";
-  version = "4.6.2";
+  version = "4.7.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman";
     rev = "v${version}";
-    hash = "sha256-Zxzb7ORyugvN9mhxa0s8r0ch16Ndbm3Z1JCsQcwbF6g=";
+    hash = "sha256-xbU2F/QYtTKeZacTmwKDfIGuUg9VStEO/jkpChK0DyU=";
   };
 
   patches = [

--- a/pkgs/applications/virtualization/podman/rm-podman-mac-helper-msg.patch
+++ b/pkgs/applications/virtualization/podman/rm-podman-mac-helper-msg.patch
@@ -1,16 +1,19 @@
-diff --git a/pkg/machine/qemu/machine.go b/pkg/machine/qemu/machine.go
-index a118285f7..d775f0099 100644
---- a/pkg/machine/qemu/machine.go
-+++ b/pkg/machine/qemu/machine.go
-@@ -1560,11 +1560,6 @@ func (v *MachineVM) waitAPIAndPrintInfo(forwardState machine.APIForwardingState,
- 			case machine.NotInstalled:
- 				fmt.Printf("\nThe system helper service is not installed; the default Docker API socket\n")
- 				fmt.Printf("address can't be used by podman. ")
--				if helper := findClaimHelper(); len(helper) > 0 {
--					fmt.Printf("If you would like to install it run the\nfollowing commands:\n")
--					fmt.Printf("\n\tsudo %s install\n", helper)
--					fmt.Printf("\tpodman machine stop%s; podman machine start%s\n\n", suffix, suffix)
--				}
- 			case machine.MachineLocal:
+diff --git a/pkg/machine/machine_common.go b/pkg/machine/machine_common.go
+index 649748947..a981d93bf 100644
+--- a/pkg/machine/machine_common.go
++++ b/pkg/machine/machine_common.go
+@@ -127,14 +127,6 @@ address can't be used by podman. `
+ 
+ 				if len(helper) < 1 {
+ 					fmt.Print(fmtString)
+-				} else {
+-					fmtString += `If you would like to install it run the\nfollowing commands:
+-
+-        sudo %s install
+-        podman machine stop%[1]s; podman machine start%[1]s
+-
+-                `
+-					fmt.Printf(fmtString, helper, suffix)
+ 				}
+ 			case MachineLocal:
  				fmt.Printf("\nAnother process was listening on the default Docker API socket address.\n")
- 			case machine.ClaimUnsupported:


### PR DESCRIPTION
## Description of changes

Release Notes - https://github.com/containers/podman/releases/tag/v4.7.0
Changes since last tag - https://github.com/containers/podman/compare/v4.6.2...v4.7.0

Due some podman refactoring rm-podman-mac-helper-msg.patch file needed also an update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Did some basic podman commands tests. podman login, image pull, container start stop rm

It's my first contribution and I tried to follow CONTRIBUTING.md.
