### PR TITLE
`lib.fileset.unions`: Fix outdated docs

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -258,7 +258,6 @@ If a directory does not recursively contain any file, it is omitted from the sto
   */
   unions =
     # A list of file sets.
-    # Must contain at least 1 element.
     # The elements can also be paths,
     # which get [implicitly coerced to file sets](#sec-fileset-path-coercion).
     filesets:

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -415,7 +415,7 @@ expectFailure 'toSource { root = ./.; fileset = union ./. ./b; }' 'lib.fileset.u
 expectFailure 'toSource { root = ./.; fileset = unions [ ./a ./. ]; }' 'lib.fileset.unions: element 0 \('"$work"'/a\) does not exist.'
 expectFailure 'toSource { root = ./.; fileset = unions [ ./. ./b ]; }' 'lib.fileset.unions: element 1 \('"$work"'/b\) does not exist.'
 
-# unions needs a list with at least 1 element
+# unions needs a list
 expectFailure 'toSource { root = ./.; fileset = unions null; }' 'lib.fileset.unions: Expected argument to be a list, but got a null.'
 
 # The tree of later arguments should not be evaluated if a former argument already includes all files


### PR DESCRIPTION


## Description of changes

Since #257351 `unions` supports empty lists too

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done

- [x] Built the docs