### PR TITLE
nload: enable on darwin

### DIFF
--- a/pkgs/applications/networking/nload/default.nix
+++ b/pkgs/applications/networking/nload/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, ncurses }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   version = "0.7.4";
@@ -20,8 +20,23 @@ stdenv.mkDerivation rec {
       name = "nload-0.7.4-Eliminate-flicker-on-some-terminals.patch";
       sha256 = "10yppy5l50wzpcvagsqkbyf1rcan6aj30am4rw8hmkgnbidf4zbq";
     })
+    # Patches configure.in file to make configure compile on macOS.
+    # Patch taken from MacPorts.
+    (fetchpatch {
+      url = "https://github.com/macports/macports-ports/raw/28814c34711e7545929fd391feb6ce079bd73fd4/net/nload/files/patch-configure.in.diff";
+      extraPrefix = "";
+      hash = "sha256-lGbBG5ZOgMVnrwlwXVFGbUZx6RkmQwYSVLB3oqkAWRs=";
+    })
+    # Fixes crash on F2 and garbage in adapter name.
+    # Patch taken from Homebrew.
+    (fetchpatch {
+      url = "https://sourceforge.net/p/nload/bugs/_discuss/thread/c9b68d8e/4a65/attachment/devreader-bsd.cpp.patch";
+      extraPrefix = "";
+      hash = "sha256-umRQDqcRUOGELOx5iB6CPFRkjaD8HXkMCWiKsYdaUa0=";
+    })
   ];
 
+  nativeBuildInputs = lib.optional stdenv.isDarwin autoreconfHook;
   buildInputs = [ ncurses ];
 
   meta = {
@@ -34,7 +49,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.roland-riegel.de/nload/index.html";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.devhell ];
     mainProgram = "nload";
   };


### PR DESCRIPTION
## Description of changes
apply patch from homebrew to build nload under macos

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC: @devhell @NixOS/darwin-maintainers
