### PR TITLE
lib/options: mkPackageOption: document better, add pkgsText and usePname options, refactor

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -227,8 +227,14 @@ checkConfigOutput '^false$' config.enableAlias ./alias-with-priority-can-overrid
 
 # Check mkPackageOption
 checkConfigOutput '^"hello"$' config.package.pname ./declare-mkPackageOption.nix
+checkConfigOutput '^"hello"$' config.namedPackage.pname ./declare-mkPackageOption.nix
+checkConfigOutput '^".*Hello.*"$' options.namedPackage.description ./declare-mkPackageOption.nix
+checkConfigOutput '^"hello"$' config.pathPackage.pname ./declare-mkPackageOption.nix
+checkConfigOutput '^"pkgs\.hello\.override \{ stdenv = pkgs\.clangStdenv; \}"$' options.packageWithExample.example.text ./declare-mkPackageOption.nix
+checkConfigOutput '^".*Example extra description\..*"$' options.packageWithExtraDescription.description ./declare-mkPackageOption.nix
 checkConfigError 'The option .undefinedPackage. is used but not defined' config.undefinedPackage ./declare-mkPackageOption.nix
 checkConfigOutput '^null$' config.nullablePackage ./declare-mkPackageOption.nix
+checkConfigOutput '^"null or package"$' options.nullablePackageWithDefault.type.description ./declare-mkPackageOption.nix
 
 # submoduleWith
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -235,6 +235,8 @@ checkConfigOutput '^".*Example extra description\..*"$' options.packageWithExtra
 checkConfigError 'The option .undefinedPackage. is used but not defined' config.undefinedPackage ./declare-mkPackageOption.nix
 checkConfigOutput '^null$' config.nullablePackage ./declare-mkPackageOption.nix
 checkConfigOutput '^"null or package"$' options.nullablePackageWithDefault.type.description ./declare-mkPackageOption.nix
+checkConfigOutput '^"myPkgs\.hello"$' options.packageWithPkgsText.defaultText.text ./declare-mkPackageOption.nix
+checkConfigOutput '^"hello-other"$' options.packageFromOtherSet.default.pname ./declare-mkPackageOption.nix
 
 # submoduleWith
 

--- a/lib/tests/modules/declare-mkPackageOption.nix
+++ b/lib/tests/modules/declare-mkPackageOption.nix
@@ -41,5 +41,13 @@ in {
     nullablePackageWithDefault = lib.mkPackageOption pkgs "hello" {
       nullable = true;
     };
+
+    packageWithPkgsText = lib.mkPackageOption pkgs "hello" {
+      pkgsText = "myPkgs";
+    };
+
+    packageFromOtherSet = let myPkgs = {
+      hello = pkgs.hello // { pname = "hello-other"; };
+    }; in lib.mkPackageOption myPkgs "hello" { };
   };
 }

--- a/lib/tests/modules/declare-mkPackageOption.nix
+++ b/lib/tests/modules/declare-mkPackageOption.nix
@@ -7,6 +7,28 @@ in {
   options = {
     package = lib.mkPackageOption pkgs "hello" { };
 
+    namedPackage = lib.mkPackageOption pkgs "Hello" {
+      default = [ "hello" ];
+    };
+
+    namedPackageSingletonDefault = lib.mkPackageOption pkgs "Hello" {
+      default = "hello";
+    };
+
+    pathPackage = lib.mkPackageOption pkgs [ "hello" ] { };
+
+    packageWithExample = lib.mkPackageOption pkgs "hello" {
+      example = "pkgs.hello.override { stdenv = pkgs.clangStdenv; }";
+    };
+
+    packageWithPathExample = lib.mkPackageOption pkgs "hello" {
+      example = [ "hello" ];
+    };
+
+    packageWithExtraDescription = lib.mkPackageOption pkgs "hello" {
+      extraDescription = "Example extra description.";
+    };
+
     undefinedPackage = lib.mkPackageOption pkgs "hello" {
       default = null;
     };
@@ -14,6 +36,10 @@ in {
     nullablePackage = lib.mkPackageOption pkgs "hello" {
       nullable = true;
       default = null;
+    };
+
+    nullablePackageWithDefault = lib.mkPackageOption pkgs "hello" {
+      nullable = true;
     };
   };
 }


### PR DESCRIPTION
## Description of changes

I have noticed that changes to `mkPackageOption` have left the documentation behind. I have updated the documentation.

I also noticed the documentation encourages users to pass alternative package sets to the function,
but as it is implemented, this would lead to end-user confusion. I have added a parameter that alleviates this.

I added another parameter that could be useful in niche cases, which has necessitated a refactor,
but I think the refactor leaves the function easier to read anyways. However, for this change in particular I request feedback.

I have only done rudimentary tests by inspecting the output of the function in `nix repl`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
