### PR TITLE
ocamlPackages.pp: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/pp/default.nix
+++ b/pkgs/development/ocaml-modules/pp/default.nix
@@ -1,16 +1,13 @@
-{ buildDunePackage
-, fetchurl
-, ppx_expect
-, lib
-}:
+{ buildDunePackage, fetchurl, ppx_expect, lib }:
 
 buildDunePackage rec {
   pname = "pp";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-dune/pp/releases/download/${version}/pp-${version}.tbz";
-    hash = "sha256-5KTpjZaxu3aVD81tpOk4yG2YnfTX5I8C96RFlfWvHVY=";
+    url =
+      "https://github.com/ocaml-dune/pp/releases/download/${version}/pp-${version}.tbz";
+    hash = "sha256-pegiVzxVr7Qtsp7FbqzR8qzY9lzy3yh44pHeN0zmkJw=";
   };
 
   duneVersion = "3";
@@ -20,7 +17,8 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = with lib; {
-    description = "A an alternative pretty printing library to the Format module of the OCaml standard library";
+    description =
+      "A an alternative pretty printing library to the Format module of the OCaml standard library";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];


### PR DESCRIPTION
## Description of changes

Dune 3.11.0 broke `dune-rpc` and `stdune` because the vendored copy of pp was bumped. I don't know why we didn't see this in the dune 3.11 PR.

We bump the copy of pp here used to build stdune and dune-rpc, hopefully fixing these issues.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
