### PR TITLE
jetporch init at unstable-2023-10-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6954,6 +6954,12 @@
       fingerprint = "4304 6B43 8D83 078E 3DF7  10D6 DEB0 E15C 6D2A 5A7C";
     }];
   };
+  heywoodlh = {
+    email = "nixpkgs@heywoodlh.io";
+    github = "heywoodlh";
+    githubId = 18178614;
+    name = "Spencer Heywood";
+  };
   hh = {
     email = "hh@m-labs.hk";
     github = "HarryMakes";

--- a/pkgs/by-name/je/jetporch/package.nix
+++ b/pkgs/by-name/je/jetporch/package.nix
@@ -1,0 +1,44 @@
+{ lib,
+  rustPlatform,
+  fetchFromSourcehut,
+  openssl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jetporch";
+  version = "unstable-2023-10-16";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  src = fetchFromSourcehut {
+    owner = "~mpdehaan";
+    repo = "jetporch";
+    rev = "6ca8a26c0514a31c359bad081ef55980dd509912";
+    hash = "sha256-ih3ZUBWPVrpg8NVDvj+bp4R8horUwB05SzoUMYPFN/E=";
+  };
+
+  preBuild = ''
+    echo "pub const GIT_VERSION: &str  = \"${version}\";" >> src/cli/version.rs
+    echo "pub const GIT_BRANCH: &str  = \"nixpkgs\";" >> src/cli/version.rs
+    echo "pub const BUILD_TIME: &str  = \"Thu Jan  1 00:00:00 UTC 1970\";" >> src/cli/version.rs
+  '';
+
+  cargoHash = "sha256-agByCEpqD8z6jQGsKAZgB0X+I4umgNd3dyhIFlUS/vQ=";
+
+  meta = with lib; {
+    homepage = "https://www.jetporch.com";
+    description = "Jet is a general-purpose, community-driven IT automation platform for configuration, deployment, orchestration, patching, and arbitrary task execution workflows";
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [
+      heywoodlh
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Initial commit of [JetPorch](https://www.jetporch.com/) version unstable-2023-10-16 [rev 6ca8a26c0514a31c359bad081ef55980dd509912](https://git.sr.ht/~mpdehaan/jetporch/tree/6ca8a26c0514a31c359bad081ef55980dd509912).

## Things done

~Plan to build on Linux later, just wanted to get the PR put together.~

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
