### PR TITLE
borgbackup: fix build by reverting msgpack bump

### DIFF
--- a/pkgs/development/python-modules/msgpack/default.nix
+++ b/pkgs/development/python-modules/msgpack/default.nix
@@ -4,6 +4,7 @@
 , pytestCheckHook
 , pythonOlder
 , setuptools
+, borgbackup
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,12 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "msgpack"
   ];
+
+  passthru.tests = {
+    # borgbackup is sensible to msgpack versions: https://github.com/borgbackup/borg/issues/3753
+    # please be mindful before bumping versions.
+    inherit borgbackup;
+  };
 
   meta = with lib;  {
     description = "MessagePack serializer implementation";

--- a/pkgs/development/python-modules/msgpack/default.nix
+++ b/pkgs/development/python-modules/msgpack/default.nix
@@ -1,29 +1,25 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pytestCheckHook
 , pythonOlder
 , setuptools
-, cython_3
 }:
 
 buildPythonPackage rec {
   pname = "msgpack";
-  version = "1.0.7";
-  pyproject = true;
+  version = "1.0.5";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.6";
 
-  src = fetchFromGitHub {
-    owner = "msgpack";
-    repo = "msgpack-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-ayEyvKiTYPdhy4puUjtyGIR+jsTXd2HRINaAYxQGTZM=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-wHVUQoTq3Fzdxw9HVzMdmdy8FrK71ISdFfiq5M820xw=";
   };
 
   nativeBuildInputs = [
     setuptools
-    cython_3
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

This reverts commit 378fbaf, reversing
changes made to 4b786de.

As they caused breakage for borgbackup which is quite a ubiquitious
software for backupping and stopping all updates on the
nixos-unstable-small channel as it is hard to remove such software from
your configuration.

Thankfully, 1.0.6 and 1.0.7 changelog:

https://github.com/msgpack/msgpack-python/releases/tag/v1.0.6
https://github.com/msgpack/msgpack-python/releases/tag/v1.0.7

are not security updates, this should not cause issues.

Also adds a reverse dependency test for msgpack in general.
cc @NickCao

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
