### PR TITLE
systemd-stage-1: Default to full systemd build.

### DIFF
--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -102,8 +102,6 @@ with lib;
         jq # for closureInfo
         # For boot.initrd.systemd
         makeInitrdNGTool
-        systemdStage1
-        systemdStage1Network
       ];
 
     boot.swraid.enable = true;

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -2876,8 +2876,6 @@ let
 
     (mkIf cfg.enable {
 
-      systemd.package = mkDefault pkgs.systemdStage1Network;
-
       # For networkctl
       systemd.dbus.enable = mkDefault true;
 

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -135,8 +135,13 @@ in {
       '';
     };
 
-    package = mkPackageOptionMD pkgs "systemd" {
-      default = "systemdStage1";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = config.systemd.package;
+      defaultText = lib.literalExpression "config.systemd.package";
+      description = ''
+        The systemd package to use.
+      '';
     };
 
     extraConfig = mkOption {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28954,20 +28954,6 @@ with pkgs;
     withUkify = false;
     withBootloader = false;
   };
-  systemdStage1 = systemdMinimal.override {
-    pname = "systemd-stage-1";
-    withAcl = true;
-    withCryptsetup = true;
-    withFido2 = true;
-    withKmod = true;
-    withTpm2Tss = true;
-    withRepart = true;
-  };
-  systemdStage1Network = systemdStage1.override {
-    pname = "systemd-stage-1-network";
-    withNetworkd = true;
-    withLibidn2 = true;
-  };
 
 
   udev =


### PR DESCRIPTION
## Description of changes

By building systemd stage 1 with the full systemd build, we get to remove a couple of systemd build variants, and we can stop juggling `boot.initrd.systemd.package` definitions depending on what features an initrd feature depends on. Plus it's nice for the full feature set of systemd to be available by default for users who want to take advantage of them.

The drawback is that initrd increases in size marginally. I've written a nix expression that builds a few different variants of initrd to compare their sizes: https://gist.github.com/ElvishJerricco/ca36d26fd30b78b211aea10604b9885e

Here are the results:

```
11M	initrd
12M	initrd-cryptsetup-luks
12M	initrd-network
13M	initrd-network-cryptsetup-luks
8.8M	initrd-systemd
12M	initrd-systemd-cryptsetup
14M	initrd-systemd-cryptsetup-luks
17M	initrd-systemd-cryptsetup-luks-tpm2
15M	initrd-systemd-cryptsetup-tpm2
14M	initrd-systemd-full-cryptsetup
15M	initrd-systemd-full-cryptsetup-luks
18M	initrd-systemd-full-cryptsetup-luks-tpm2
16M	initrd-systemd-full-cryptsetup-tpm2
16M	initrd-systemd-full-network-cryptsetup
17M	initrd-systemd-full-network-cryptsetup-luks
19M	initrd-systemd-full-network-cryptsetup-luks-tpm2
18M	initrd-systemd-full-network-cryptsetup-tpm2
14M	initrd-systemd-network
15M	initrd-systemd-network-cryptsetup
16M	initrd-systemd-network-cryptsetup-luks
18M	initrd-systemd-network-cryptsetup-luks-tpm2
17M	initrd-systemd-network-cryptsetup-tpm2
```

The increase in size for using the full build is marginal, with the notable exception that disabling `withCryptsetup` significantly reduces the size (but we don't even do this for `systemdStage1` right now).

## Things done

I've run all the nixos tests for systemd stage 1. The only failures were ones that are already failing on master (namely: `hibernate-systemd-stage-1`, `installer-systemd-stage-1.simpleSpecialised`, and `installer-systemd-stage-1.simpleUefiGrubSpecialisation`).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
