### PR TITLE
mozillavpn: 2.16.1 → 2.19.0

### DIFF
--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -26,13 +26,13 @@
 
 let
   pname = "mozillavpn";
-  version = "2.16.1";
+  version = "2.17.1";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-UMWBn3DoEU1fG7qh6F0GOhOqod+grPwp15wSSdP0eCo=";
+    hash = "sha256-sxkah+tVCbw62A57ia0JnOgmdqojL7inoSStilEhoMg=";
   };
   patches = [ ];
 
@@ -46,19 +46,19 @@ let
     inherit src patches;
     name = "${pname}-${version}-extension-bridge";
     preBuild = "cd extension/bridge";
-    hash = "sha256-1wYTRc+NehiHwAd/2CmsJNv/TV6wH5wXwNiUdjzEUIk=";
+    hash = "sha256-3sncaaeUdCQd8yZHu9z54BaXEvNOqn7sqsUREIOIxDY=";
   };
   signatureDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-signature";
     preBuild = "cd signature";
-    hash = "sha256-oaKkQWMYkAy1c2biVt+GyjHBeYb2XkuRvFrWQJJIdPw=";
+    hash = "sha256-E/DutZai+Jq/5pq5wQ4haZUkb4Roq2Loh0epZNGxOtw=";
   };
   qtgleanDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-qtglean";
     preBuild = "cd qtglean";
-    hash = "sha256-cqfiOBS8xFC2BbYp6BJWK6NHIU0tILSgu4eo3Ik4YqY=";
+    hash = "sha256-1uGAP/OLo/lr4PHEBS+R4odkpNJl7oSIYx9cfCQKsC4=";
   };
 
 in
@@ -110,7 +110,7 @@ stdenv.mkDerivation {
   dontCargoSetupPostUnpack = true;
 
   postPatch = ''
-    substituteInPlace src/apps/vpn/cmake/linux.cmake \
+    substituteInPlace src/cmake/linux.cmake \
       --replace '/etc/xdg/autostart' "$out/etc/xdg/autostart" \
       --replace '/usr/share/dbus-1' "$out/share/dbus-1" \
       --replace '${"$"}{SYSTEMD_UNIT_DIR}' "$out/lib/systemd/system"

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -26,13 +26,13 @@
 
 let
   pname = "mozillavpn";
-  version = "2.17.1";
+  version = "2.18.0";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-sxkah+tVCbw62A57ia0JnOgmdqojL7inoSStilEhoMg=";
+    hash = "sha256-DCYRzq5b1rzmrT5r5BgBJ6bWSxvOA6hQBU0vhhBfT1s=";
   };
   patches = [ ];
 
@@ -46,19 +46,19 @@ let
     inherit src patches;
     name = "${pname}-${version}-extension-bridge";
     preBuild = "cd extension/bridge";
-    hash = "sha256-3sncaaeUdCQd8yZHu9z54BaXEvNOqn7sqsUREIOIxDY=";
+    hash = "sha256-PK4Vdw9I+XJmMARHJkPsRv1MSkiHwOgCA+DWasXouV8=";
   };
   signatureDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-signature";
     preBuild = "cd signature";
-    hash = "sha256-E/DutZai+Jq/5pq5wQ4haZUkb4Roq2Loh0epZNGxOtw=";
+    hash = "sha256-PEB/O25KrGk8U79bkIISqa3TrpPM346TxvuiJ5NsFFM=";
   };
   qtgleanDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-qtglean";
     preBuild = "cd qtglean";
-    hash = "sha256-1uGAP/OLo/lr4PHEBS+R4odkpNJl7oSIYx9cfCQKsC4=";
+    hash = "sha256-ma2PkkvZyHEMrE6W/y9SeYOQAWKZP5hTLkgRQt4hwEQ=";
   };
 
 in

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -26,13 +26,13 @@
 
 let
   pname = "mozillavpn";
-  version = "2.18.0";
+  version = "2.18.1";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-DCYRzq5b1rzmrT5r5BgBJ6bWSxvOA6hQBU0vhhBfT1s=";
+    hash = "sha256-BURs6NU4LFozG+mdklu3k4CzljSLJBsnsaA68b47oxE=";
   };
   patches = [ ];
 
@@ -46,19 +46,19 @@ let
     inherit src patches;
     name = "${pname}-${version}-extension-bridge";
     preBuild = "cd extension/bridge";
-    hash = "sha256-PK4Vdw9I+XJmMARHJkPsRv1MSkiHwOgCA+DWasXouV8=";
+    hash = "sha256-Sz6zqDhC82MYqRZG4M0XLlzo2WM9mqqPSbh7OEOqqlw=";
   };
   signatureDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-signature";
     preBuild = "cd signature";
-    hash = "sha256-PEB/O25KrGk8U79bkIISqa3TrpPM346TxvuiJ5NsFFM=";
+    hash = "sha256-Of8qk+Yy4/t/VNOrbFJxHLVlDhMSSNS1vi5rOr/ydCw=";
   };
   qtgleanDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-qtglean";
     preBuild = "cd qtglean";
-    hash = "sha256-ma2PkkvZyHEMrE6W/y9SeYOQAWKZP5hTLkgRQt4hwEQ=";
+    hash = "sha256-QIgTTKqujqv5t8lWkpU6ttX//3oHRGwj+CtLTX73oAI=";
   };
 
 in

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -26,13 +26,13 @@
 
 let
   pname = "mozillavpn";
-  version = "2.18.1";
+  version = "2.19.0";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-BURs6NU4LFozG+mdklu3k4CzljSLJBsnsaA68b47oxE=";
+    hash = "sha256-aXfxUtGm+vq8U3jYTxYhOP7UXL6ukCJgmGQO2Wsqobo=";
   };
   patches = [ ];
 
@@ -46,19 +46,19 @@ let
     inherit src patches;
     name = "${pname}-${version}-extension-bridge";
     preBuild = "cd extension/bridge";
-    hash = "sha256-Sz6zqDhC82MYqRZG4M0XLlzo2WM9mqqPSbh7OEOqqlw=";
+    hash = "sha256-23GTXsbjL8qfGA5NdPlrbdaA8rg8vOZsZCXvevi7Chc=";
   };
   signatureDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-signature";
     preBuild = "cd signature";
-    hash = "sha256-Of8qk+Yy4/t/VNOrbFJxHLVlDhMSSNS1vi5rOr/ydCw=";
+    hash = "sha256-TB172hVIilDTl+y0shNp55if+FhrXjWSaGNF7K6GSH8=";
   };
   qtgleanDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-qtglean";
     preBuild = "cd qtglean";
-    hash = "sha256-QIgTTKqujqv5t8lWkpU6ttX//3oHRGwj+CtLTX73oAI=";
+    hash = "sha256-tfQ2ogSDDXNPeygBy+el+71iwcafSfY78hvYPHurKPE=";
   };
 
 in


### PR DESCRIPTION
## Description of changes

Upgrade the Mozilla VPN client from 2.16.1 to 2.19.0.

https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.17.0
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.17.1
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.18.0
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.18.1
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.19.0
https://github.com/mozilla-mobile/mozilla-vpn-client/compare/v2.16.1...v2.19.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
