### PR TITLE
nushellPlugins: fixes

### DIFF
--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -15,7 +15,9 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit Foundation ];
   cargoBuildFlags = [ "--package nu_plugin_formats" ];
-  doCheck = false;
+  checkPhase = ''
+    cargo test --manifest-path crates/nu_plugin_formats/Cargo.toml
+  '';
   meta = with lib; {
     description = "A formats plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats";

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage {
   '';
   meta = with lib; {
     description = "A formats plugin for Nushell";
-    homepage = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats";
+    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_formats";
     license = licenses.mpl20;
     maintainers = with maintainers; [ viraptor ];
     platforms = with platforms; all;

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -12,13 +12,17 @@ rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_formats";
   inherit (nushell) version src;
   cargoHash = "sha256-WS8VRpJnn/VWS7GUkGowFf51ifUx0SbEZzcoTfx2dp0=";
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit Foundation ];
   cargoBuildFlags = [ "--package nu_plugin_formats" ];
+
   checkPhase = ''
     cargo test --manifest-path crates/nu_plugin_formats/Cargo.toml
   '';
+
   passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "A formats plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_formats";

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -7,10 +7,9 @@
 , Foundation
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_formats";
-  version = "0.85.0";
-  src = nushell.src;
+  inherit (nushell) version src;
   cargoHash = "sha256-WS8VRpJnn/VWS7GUkGowFf51ifUx0SbEZzcoTfx2dp0=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit Foundation ];

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -7,11 +7,8 @@
 , Foundation
 }:
 
-let
-  pname = "nushell_plugin_formats";
-in
 rustPlatform.buildRustPackage {
-  inherit pname;
+  pname = "nushell_plugin_formats";
   version = "0.85.0";
   src = nushell.src;
   cargoHash = "sha256-WS8VRpJnn/VWS7GUkGowFf51ifUx0SbEZzcoTfx2dp0=";

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , IOKit
 , Foundation
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -17,6 +18,7 @@ rustPlatform.buildRustPackage rec {
   checkPhase = ''
     cargo test --manifest-path crates/nu_plugin_formats/Cargo.toml
   '';
+  passthru.updateScript = nix-update-script { };
   meta = with lib; {
     description = "A formats plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_formats";

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "A formats plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_formats";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ viraptor ];
+    maintainers = with maintainers; [ viraptor aidalgol ];
     platforms = with platforms; all;
   };
 }

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -21,7 +21,10 @@ rustPlatform.buildRustPackage rec {
     cargo test --manifest-path crates/nu_plugin_formats/Cargo.toml
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    # Skip the version check and only check the hash because we inherit version from nushell.
+    extraArgs = [ "--version=skip" ];
+  };
 
   meta = with lib; {
     description = "A formats plugin for Nushell";

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -7,11 +7,8 @@
 , Security
 }:
 
-let
-  pname = "nushell_plugin_gstat";
-in
 rustPlatform.buildRustPackage {
-  inherit pname;
+  pname = "nushell_plugin_gstat";
   version = "0.85.0";
   src = nushell.src;
   cargoHash = "sha256-6luY3SIRRd9vaY9KIJcj8Q974FW0LtAvRjVpdpzkdLo=";

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -12,13 +12,17 @@ rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_gstat";
   inherit (nushell) version src;
   cargoHash = "sha256-6luY3SIRRd9vaY9KIJcj8Q974FW0LtAvRjVpdpzkdLo=";
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
   cargoBuildFlags = [ "--package nu_plugin_gstat" ];
+
   checkPhase = ''
     cargo test --manifest-path crates/nu_plugin_gstat/Cargo.toml
   '';
+
   passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "A git status plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_gstat";

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -7,10 +7,9 @@
 , Security
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_gstat";
-  version = "0.85.0";
-  src = nushell.src;
+  inherit (nushell) version src;
   cargoHash = "sha256-6luY3SIRRd9vaY9KIJcj8Q974FW0LtAvRjVpdpzkdLo=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -15,7 +15,9 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
   cargoBuildFlags = [ "--package nu_plugin_gstat" ];
-  doCheck = false; # some tests fail
+  checkPhase = ''
+    cargo test --manifest-path crates/nu_plugin_gstat/Cargo.toml
+  '';
   meta = with lib; {
     description = "A git status plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat";

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage {
   '';
   meta = with lib; {
     description = "A git status plugin for Nushell";
-    homepage = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat";
+    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_gstat";
     license = licenses.mpl20;
     maintainers = with maintainers; [ mrkkrp ];
     platforms = with platforms; all;

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -5,6 +5,7 @@
 , nushell
 , pkg-config
 , Security
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -17,6 +18,7 @@ rustPlatform.buildRustPackage rec {
   checkPhase = ''
     cargo test --manifest-path crates/nu_plugin_gstat/Cargo.toml
   '';
+  passthru.updateScript = nix-update-script { };
   meta = with lib; {
     description = "A git status plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_gstat";

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "A git status plugin for Nushell";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_gstat";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ mrkkrp ];
+    maintainers = with maintainers; [ mrkkrp aidalgol ];
     platforms = with platforms; all;
   };
 }

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -21,7 +21,10 @@ rustPlatform.buildRustPackage rec {
     cargo test --manifest-path crates/nu_plugin_gstat/Cargo.toml
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    # Skip the version check and only check the hash because we inherit version from nushell.
+    extraArgs = [ "--version=skip" ];
+  };
 
   meta = with lib; {
     description = "A git status plugin for Nushell";

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
     description = "A Nushell plugin to query JSON, XML, and various web data";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_query";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ happysalada ];
+    maintainers = with maintainers; [ happysalada aidalgol ];
     platforms = with platforms; all;
   };
 }

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
 
   meta = with lib; {
     description = "A Nushell plugin to query JSON, XML, and various web data";
-    homepage = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query";
+    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_query";
     license = licenses.mpl20;
     maintainers = with maintainers; [ happysalada ];
     platforms = with platforms; all;

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -13,16 +13,13 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-xyty3GfI+zNkuHs7LYHBctqXUHZ4/MNNcnnfYvI18do=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit CoreFoundation ];
-
   cargoBuildFlags = [ "--package nu_plugin_query" ];
 
   checkPhase = ''
     cargo test --manifest-path crates/nu_plugin_query/Cargo.toml
   '';
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A Nushell plugin to query JSON, XML, and various web data";

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -19,8 +19,9 @@ rustPlatform.buildRustPackage {
 
   cargoBuildFlags = [ "--package nu_plugin_query" ];
 
-  # compilation fails with a missing symbol
-  doCheck = false;
+  checkPhase = ''
+    cargo test --manifest-path crates/nu_plugin_query/Cargo.toml
+  '';
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -9,10 +9,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "nushell_plugin_query";
-  version = "0.85.0";
-
-  src = nushell.src;
-
+  inherit (nushell) version src;
   cargoHash = "sha256-xyty3GfI+zNkuHs7LYHBctqXUHZ4/MNNcnnfYvI18do=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit CoreFoundation ];

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -19,7 +19,10 @@ rustPlatform.buildRustPackage {
     cargo test --manifest-path crates/nu_plugin_query/Cargo.toml
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    # Skip the version check and only check the hash because we inherit version from nushell.
+    extraArgs = [ "--version=skip" ];
+  };
 
   meta = with lib; {
     description = "A Nushell plugin to query JSON, XML, and various web data";


### PR DESCRIPTION
## Description of changes
* Fix the check phase of each plugin package.
* Fix incorrect `meta.homepage` URLs.
* Inherit `src` *and* `version` from `nushell`.
* Add `passthru.updateScript`.
* Code style housekeeping.
* Add myself to the maintainers list for each plugin package.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
