### PR TITLE
oreo-cursors-plus: init at unstable-2023-06-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11339,6 +11339,12 @@
     github = "michaelBelsanti";
     githubId = 62124625;
   };
+  michaelBrunner = {
+    email = "michael.brunn3r@gmail.com";
+    name = "Michael Brunner";
+    github = "MichaelBrunn3r";
+    githubId = 19626539;
+  };
   michaelCTS = {
     email = "michael.vogel@cts.co";
     name = "Michael Vogel";

--- a/pkgs/by-name/or/oreo-cursors-plus/package.nix
+++ b/pkgs/by-name/or/oreo-cursors-plus/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  ruby,
+  inkscape,
+  xorg,
+  writeText,
+  cursorsConf ? null, # If set to a string, overwrites contents of './cursors.conf'
+}:
+let
+  newCursorsConf = writeText "oreo-cursors-plus.conf" cursorsConf;
+in
+stdenvNoCC.mkDerivation {
+  pname = "oreo-cursors-plus";
+  version = "unstable-2023-06-05";
+  src = fetchFromGitHub {
+    owner = "Souravgoswami";
+    repo = "oreo-cursors";
+    # At the time of writing, there are no version tags. The author will add them starting with the next version release.
+    # Using the latest commit instead.
+    rev = "9133204d60ca2c54be0df03b836968a1deac6b20";
+    hash = "sha256-6oTyOQK7mkr+jWYbPNBlJ4BpT815lNJvsJjzdTmj+68=";
+  };
+
+  nativeBuildInputs = lib.optionals (cursorsConf != null) [ ruby inkscape xorg.xcursorgen ];
+
+  # './cursors.conf' contains definitions of cursor variations to generate.
+  configurePhase = ''
+    runHook preConfigure
+
+    ${lib.optionalString (cursorsConf != null) ''
+      cp ${newCursorsConf} cursors.conf
+    ''}
+
+    runHook postConfigure
+  '';
+
+  # The repo already contains the default cursors pre-generated in './dist'. Just copy these if './cursors.conf' is not overwritten.
+  # Otherwise firs remove all default variations and build.
+  buildPhase =''
+      runHook preBuild
+
+      ${lib.optionalString (cursorsConf != null) ''
+        rm -r {dist,src/oreo_*}
+        export HOME=$TMP
+        ruby generator/convert.rb
+        make build
+      ''}
+
+      runHook postBuild
+    '';
+
+  installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      mv ./dist $out/share/icons
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Colored Material cursors with cute animations";
+    homepage = "https://github.com/Souravgoswami/oreo-cursors";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [michaelBrunner];
+  };
+}


### PR DESCRIPTION
## Description of changes
Adding new cursor theme package `oreo-cursors-plus` from [https://github.com/Souravgoswami/oreo-cursors](https://github.com/Souravgoswami/oreo-cursors).
This is a fork of an older project but with more features (original: [https://github.com/varlesh/oreo-cursors](https://github.com/varlesh/oreo-cursors)).
Both repos have the same name `oreo-cursors`, thus I opted for the suffix `-plus` for the more recent one. I'm in contact with the author to make sure the name is acceptable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
