### PR TITLE
libhttpserver: init at 0.19.0

### DIFF
--- a/pkgs/by-name/li/libhttpserver/package.nix
+++ b/pkgs/by-name/li/libhttpserver/package.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, gnutls
+, libmicrohttpd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libhttpserver";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "etr";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Pc3Fvd8D4Ymp7dG9YgU58mDceOqNfhWE1JtnpVaNx/Y=";
+  };
+
+  nativeBuildInputs = [ autoconf automake libtool ];
+
+  buildInputs = [ gnutls libmicrohttpd ];
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs ./bootstrap
+  '';
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  configureFlags = [ "--enable-same-directory-build" ];
+
+  meta = with lib; {
+    description = "C++ library for creating an embedded Rest HTTP server (and more)";
+    homepage = "https://github.com/etr/libhttpserver";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ pongo1231 ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin; # configure: error: cannot find required auxiliary files: ltmain.sh
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

C++ library for creating an embedded Rest HTTP server (and more)

https://github.com/etr/libhttpserver

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
