### PR TITLE
add pkg/moon-phases

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -30,6 +30,14 @@ in mkLicense lset) ({
     fullName = "Abstyles License";
   };
 
+  acsl14 = {
+    fullName = "Anti-Capitalist Software License v1.4";
+    url = "https://anticapitalist.software/";
+    /* restrictions on corporations apply for both use and redistribution */
+    free = false;
+    redistributable = false;
+  };
+
   afl20 = {
     spdxId = "AFL-2.0";
     fullName = "Academic Free License v2.0";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11560,6 +11560,15 @@
     githubId = 1776903;
     name = "Andrew Abbott";
   };
+  mirrorwitch = {
+    email = "mirrorwitch@transmom.love";
+    github = "mirrorwitch";
+    githubId = 146672255;
+    name = "mirrorwitch";
+    keys = [{
+        fingerprint = "C3E7 F8C4 9CBC 9320 D360  B117 8516 D0FA 7D8F 58FC";
+    }];
+  };
   Misaka13514 = {
     name = "Misaka13514";
     email = "Misaka13514@gmail.com";

--- a/pkgs/tools/misc/moon-phases/default.nix
+++ b/pkgs/tools/misc/moon-phases/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchCrate, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "moon-phases";
+  version = "0.3.3";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-8ZdtM246aqc49Q3ygMGk51LIzRA8RIdlaistbKUj3yY=";
+  };
+
+  cargoSha256 = "sha256-5JKM+GnigkpuX4qeGQAjDz/X48ZxXtCfYVwGco13YRM=";
+
+  meta = with lib; {
+    description = "Command-line/WM bar tool to display the moon phase at a certain date";
+    homepage = "https://github.com/mirrorwitch/moon-phases";
+    license = licenses.acsl14;
+    maintainers = with maintainers; [ mirrorwitch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6031,6 +6031,8 @@ with pkgs;
 
   moodle-dl = callPackage ../tools/networking/moodle-dl { };
 
+  moon-phases = callPackage ../tools/misc/moon-phases { };
+
   moonraker = callPackage ../servers/moonraker { };
 
   morsel = callPackage ../tools/text/morsel { };


### PR DESCRIPTION
A fast CLI tool in Rust to print the moon phase, intended for use in things like shell prompts or the sway/i3/etc. bar.

Able to show the phase in a variety of formats, including different types of emojis, for a date-time in human format.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
