### PR TITLE
percona-server_8_0: init at 8.0.34

### DIFF
--- a/nixos/tests/mysql/common.nix
+++ b/nixos/tests/mysql/common.nix
@@ -3,5 +3,8 @@
   mysqlPackages = {
     inherit (pkgs) mysql80;
   };
+  perconaPackages = {
+    inherit (pkgs) percona-server_8_0;
+  };
   mkTestName = pkg: "mariadb_${builtins.replaceStrings ["."] [""] (lib.versions.majorMinor pkg.version)}";
 }

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (import ./common.nix { inherit pkgs lib; }) mkTestName mariadbPackages mysqlPackages;
+  inherit (import ./common.nix { inherit pkgs lib; }) mkTestName mariadbPackages mysqlPackages perconaPackages;
 
   makeTest = import ./../make-test-python.nix;
   # Setup common users
@@ -78,9 +78,6 @@ let
             };
           };
         };
-
-      mariadb =        {
-        };
     };
 
     testScript = ''
@@ -147,3 +144,8 @@ in
   // (lib.mapAttrs (_: package: makeMySQLTest {
     inherit package;
   }) mariadbPackages)
+  // (lib.mapAttrs (_: package: makeMySQLTest {
+    inherit package;
+    name = "percona_8_0";
+    hasMroonga = false; useSocketAuth = false;
+  }) perconaPackages)

--- a/pkgs/servers/sql/percona-server/8.0.x.nix
+++ b/pkgs/servers/sql/percona-server/8.0.x.nix
@@ -1,0 +1,96 @@
+{ lib, stdenv, fetchurl, bison, cmake, pkg-config
+, boost, icu, libedit, libevent, lz4, ncurses, openssl, perl, protobuf, re2, readline, zlib, zstd, libfido2
+, numactl, cctools, CoreServices, developer_cmds, libtirpc, rpcsvc-proto, curl, DarwinTools, nixosTests
+# Percona-specific deps
+, coreutils, cyrus_sasl, gnumake, openldap
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "percona-server";
+  version = "8.0.34-26";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${finalAttrs.version}/source/tarball/percona-server-${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-xOaXfnh/lg/TutanwGt+EmxG4UA8oTPdil2nvU3NZXQ=";
+  };
+
+  nativeBuildInputs = [ bison cmake pkg-config ]
+    ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
+
+  patches = [
+    ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+  ];
+
+  ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
+  postPatch = ''
+    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
+    substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+    # The rocksdb setup script is called with `env -i` and cannot find anything in PATH.
+    patchShebangs storage/rocksdb/get_rocksdb_files.sh
+    substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace mktemp ${coreutils}/bin/mktemp
+    substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace "rm $MKFILE" "${coreutils}/bin/rm $MKFILE"
+    substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace "make --" "${gnumake}/bin/make --"
+  '';
+
+  buildInputs = [
+    boost (curl.override { inherit openssl; }) icu libedit libevent lz4 ncurses openssl protobuf re2 readline zlib
+    zstd libfido2 openldap perl cyrus_sasl
+  ] ++ lib.optionals stdenv.isLinux [
+    numactl libtirpc
+  ] ++ lib.optionals stdenv.isDarwin [
+    cctools CoreServices developer_cmds DarwinTools
+  ];
+
+  outputs = [ "out" "static" ];
+
+  cmakeFlags = [
+    # Percona-specific flags.
+    "-DPORTABLE=1"
+    "-DWITH_LDAP=system"
+    "-DROCKSDB_DISABLE_AVX2=1"
+    "-DROCKSDB_DISABLE_MARCH_NATIVE=1"
+
+    # Flags taken from mysql package.
+    "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
+    "-DWITH_ROUTER=OFF" # It may be packaged separately.
+    "-DWITH_SYSTEM_LIBS=ON"
+    "-DWITH_UNIT_TESTS=OFF"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_MYSQLTESTDIR="
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  postInstall = ''
+    moveToOutput "lib/*.a" $static
+    so=${stdenv.hostPlatform.extensions.sharedLibrary}
+    ln -s libmysqlclient$so $out/lib/libmysqlclient_r$so
+  '';
+
+  passthru = {
+    client = finalAttrs.finalPackage;
+    connector-c = finalAttrs.finalPackage;
+    server = finalAttrs.finalPackage;
+    mysqlVersion = lib.versions.majorMinor finalAttrs.version;
+    tests = nixosTests.mysql.percona-server_8_0;
+  };
+
+  meta = with lib; {
+    homepage = "https://www.percona.com/software/mysql-database/percona-server";
+    description = ''
+      A free, fully compatible, enhanced, open source drop-in replacement for
+      MySQL® that provides superior performance, scalability and instrumentation.
+    '';
+    license = licenses.gpl2;
+    maintainers = teams.flyingcircus.members;
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/servers/sql/percona-server/no-force-outline-atomics.patch
+++ b/pkgs/servers/sql/percona-server/no-force-outline-atomics.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 727d66011f9..acae1aada57 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1338,19 +1338,6 @@ IF(UNIX AND MY_COMPILER_IS_GNU_OR_CLANG
+   ENDIF()
+ ENDIF()
+ 
+-# For aarch64 some sub-architectures support LSE atomics and some don't. Thus,
+-# compiling for the common denominator (-march=armv8-a) means LSE is not used.
+-# The -moutline-atomics switch enables run-time detection of LSE support.
+-# There are compilers (gcc 9.3.1 for example) which support this switch, but
+-# do not enable it by default, even though it seems to help. So, we force it.
+-IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+-  MY_CHECK_CXX_COMPILER_FLAG( "-moutline-atomics" HAVE_OUTLINE_ATOMICS)
+-  IF(HAVE_OUTLINE_ATOMICS)
+-    STRING_APPEND(CMAKE_C_FLAGS   " -moutline-atomics")
+-    STRING_APPEND(CMAKE_CXX_FLAGS " -moutline-atomics")
+-  ENDIF()
+-ENDIF()
+-
+ IF(LINUX)
+   OPTION(LINK_RANDOMIZE "Randomize the order of all symbols in the binary" OFF)
+   SET(LINK_RANDOMIZE_SEED "mysql"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11862,6 +11862,13 @@ with pkgs;
 
   perceptualdiff = callPackage ../tools/graphics/perceptualdiff { };
 
+  percona-server_8_0 = callPackage ../servers/sql/percona-server/8.0.x.nix {
+    inherit (darwin) cctools developer_cmds DarwinTools;
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+    boost = boost177; # Configure checks for specific version.
+    icu = icu69;
+    protobuf = protobuf3_21;
+  };
   percona-xtrabackup = percona-xtrabackup_8_0;
   percona-xtrabackup_8_0 = callPackage ../tools/backup/percona-xtrabackup/8_0.nix {
     boost = boost177;


### PR DESCRIPTION
## Description of changes

Add another MySQL variant, based on the existing `mysql80` package. 

Percona Server for MySQL is mostly a drop-in replacement for MySQL and can be used with the NixOS module as `services.mysql.package = pkgs.percona-server_8_0`.

The generic MySQL NixOS test is now also used for the Percona variant. I removed the empty `mariadb` node definition from the test which seems to serve no purpose anymore.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (ran --help for every executable that supports it and skimmed the output, for Darwin and Linux)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).