### PR TITLE
ocamlPackages.zmq: 5.1.5 → 5.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -2,18 +2,14 @@
 
 buildDunePackage rec {
   pname = "zmq";
-  version = "5.1.5";
-
-  duneVersion = "3";
+  version = "5.2.1";
 
   src = fetchurl {
-    url = "https://github.com/issuu/ocaml-zmq/releases/download/${version}/zmq-lwt-${version}.tbz";
-    sha256 = "sha256-mUfRPatLPFeSzWDwCIoFaVl85VkvDch4i6pOn3Kme1Y=";
+    url = "https://github.com/issuu/ocaml-zmq/releases/download/${version}/zmq-${version}.tbz";
+    hash = "sha256-hVKfaTrUFqEBsv5hFB7JwsR630M0DKnqhB0QHpxcHKc=";
   };
 
   buildInputs = [ czmq dune-configurator ];
-
-  propagatedBuildInputs = [ stdint ];
 
   meta = {
     description = "ZeroMQ bindings for OCaml";

--- a/pkgs/development/ocaml-modules/zmq/lwt.nix
+++ b/pkgs/development/ocaml-modules/zmq/lwt.nix
@@ -1,9 +1,8 @@
-{ buildDunePackage, zmq, ocaml_lwt }:
+{ buildDunePackage, zmq, lwt }:
 
 buildDunePackage {
   pname = "zmq-lwt";
   inherit (zmq) version src meta;
-  duneVersion = "3";
 
-  propagatedBuildInputs = [ zmq ocaml_lwt ];
+  propagatedBuildInputs = [ zmq lwt ];
 }


### PR DESCRIPTION
## Description of changes

https://github.com/issuu/ocaml-zmq/blob/5.2.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
