### PR TITLE
nixos/sway: add enableRealtime option

### DIFF
--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -42,6 +42,11 @@ in {
       <https://github.com/swaywm/sway/wiki> and
       "man 5 sway" for more information'');
 
+    enableRealtime = mkEnableOption (lib.mdDoc ''
+      add CAP_SYS_NICE capability on `sway` binary for realtime scheduling
+      privileges. This may improve latency and reduce stuttering, specially in
+      high load scenarios'') // { default = true; };
+
     package = mkOption {
       type = with types; nullOr package;
       default = defaultSwayPackage;
@@ -147,6 +152,14 @@ in {
             '';
           } // optionalAttrs (cfg.package != null) {
             "sway/config".source = mkOptionDefault "${cfg.package}/etc/sway/config";
+          };
+        };
+        security.wrappers = mkIf (cfg.enableRealtime && cfg.package != null) {
+          sway = {
+            owner = "root";
+            group = "root";
+            source = "${cfg.package}/bin/sway";
+            capabilities = "cap_sys_nice+ep";
           };
         };
         # To make a Sway session available if a display manager like SDDM is enabled:

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Use /run/current-system/sw/share and /etc instead of /nix/store
     # references:
     ./sway-config-nixos-paths.patch
+    # Drop ambient capabilities after getting SCHED_RR
+    ./drop_ambient_capabilities.patch
   ];
 
   strictDeps = true;

--- a/pkgs/applications/window-managers/sway/drop_ambient_capabilities.patch
+++ b/pkgs/applications/window-managers/sway/drop_ambient_capabilities.patch
@@ -1,0 +1,41 @@
+From e7d9098e81289ae99d07ec3eac1fec1d303b8fe4 Mon Sep 17 00:00:00 2001
+From: Thiago Kenji Okada <thiagokokada@gmail.com>
+Date: Thu, 5 Oct 2023 15:23:35 +0100
+Subject: [PATCH] drop ambient capabilities
+
+Within NixOS the only possibility to gain cap_sys_nice is using the
+security.wrapper infrastructure. However to pass the capabilities to the
+wrapped program, they are raised to the ambient set. To fix this we make
+sure to drop the ambient capabilities during sway startup and realtime
+setup. Otherwise all programs started by sway also gain cap_sys_nice,
+which is not something we want.
+
+Co-authored-by: Rouven Czerwinski <rouven@czerwinskis.de>
+---
+ sway/realtime.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sway/realtime.c b/sway/realtime.c
+index 11154af0..06f872a8 100644
+--- a/sway/realtime.c
++++ b/sway/realtime.c
+@@ -3,6 +3,7 @@
+ #include <unistd.h>
+ #include <pthread.h>
+ #include "sway/server.h"
++#include "sys/prctl.h"
+ #include "log.h"
+ 
+ static void child_fork_callback(void) {
+@@ -10,6 +11,8 @@ static void child_fork_callback(void) {
+ 
+ 	param.sched_priority = 0;
+ 
++	prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0);
++
+ 	int ret = pthread_setschedparam(pthread_self(), SCHED_OTHER, &param);
+ 	if (ret != 0) {
+ 		sway_log(SWAY_ERROR, "Failed to reset scheduler policy on fork");
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

This option wraps the `sway` binary to allow it to request realtime scheduling (SCHED_RR). This allow for possible lower latency, specially when the system is under high load.

Available since Sway 1.8. See:
- https://github.com/swaywm/sway/pull/6994
- https://github.com/swaywm/sway/releases/tag/1.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
