### PR TITLE
nsc: disable check phase on darwin

### DIFF
--- a/pkgs/tools/system/nsc/default.nix
+++ b/pkgs/tools/system/nsc/default.nix
@@ -39,12 +39,22 @@ buildGoModule rec {
     export HOME=$(mktemp -d)
   '';
 
+  # Tests currently fail on darwin because of a test in nsc which
+  # expects command output to contain a specific path. However
+  # the test strips table formatting from the command output in a naive way
+  # that removes all the table characters, including '-'.
+  # The nix build directory looks something like:
+  # /private/tmp/nix-build-nsc-2.8.1.drv-0/nsc_test2000598938/keys
+  # Then the `-` are removed from the path unintentionally and the test fails.
+  # This should be fixed upstream to avoid mangling the path when
+  # removing the table decorations from the command output.
+  doCheck = !stdenv.isDarwin;
+
   meta = {
     description = "A tool for creating NATS account and user access configurations";
     homepage = "https://github.com/nats-io/nsc";
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ cbrewster ];
     mainProgram = "nsc";
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

nsc is currently marked as broken on darwin because it's check phase does not pass. However, it builds and works fine.

The check phase failure is due to a test in nsc stripping `-` from some test output to remove some table formatting. This accidentally removes `-` in a filesystem path and makes a test fail that expects the output to contain a specific path.

This should be fixed upstream in nsc, but no need to mark darwin as broken when it actually does build and work okay. So I've disabled the check phase if the platform is darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
