### PR TITLE
turso-cli: Install shell completions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6003,6 +6003,15 @@
     githubId = 134872;
     name = "Sergei Lukianov";
   };
+  fryuni = {
+    name = "Luiz Ferraz";
+    email = "luiz@lferraz.com";
+    github = "Fryuni";
+    githubId = 11063910;
+    keys = [{
+      fingerprint = "2109 4B0E 560B 031E F539  62C8 2B56 8731 DB24 47EC";
+    }];
+  };
   fsagbuya = {
     email = "fa@m-labs.ph";
     github = "fsagbuya";

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -1,11 +1,15 @@
 {
   lib,
+  stdenv,
   buildGo121Module,
   fetchFromGitHub,
+  installShellFiles,
 }:
 buildGo121Module rec {
   pname = "turso-cli";
   version = "0.85.3";
+
+  nativeBuildInputs = [ installShellFiles ];
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
@@ -21,6 +25,13 @@ buildGo121Module rec {
   # Include version for `turso --version` reporting
   preBuild = ''
     echo "v${version}" > internal/cmd/version.txt
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd turso \
+      --bash <($out/bin/turso completion bash) \
+      --fish <($out/bin/turso completion fish) \
+      --zsh <($out/bin/turso completion zsh)
   '';
 
   # Test_setDatabasesCache fails due to /homeless-shelter: read-only file system error.

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -42,6 +42,6 @@ buildGo121Module rec {
     homepage = "https://turso.tech";
     mainProgram = "turso";
     license = licenses.mit;
-    maintainers = with maintainers; [ zestsystem kashw2 ];
+    maintainers = with maintainers; [ zestsystem kashw2 fryuni ];
   };
 }

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -9,8 +9,6 @@ buildGo121Module rec {
   pname = "turso-cli";
   version = "0.85.3";
 
-  nativeBuildInputs = [ installShellFiles ];
-
   src = fetchFromGitHub {
     owner = "tursodatabase";
     repo = "turso-cli";
@@ -20,11 +18,17 @@ buildGo121Module rec {
 
   vendorHash = "sha256-Hv4CacBrRX2YT3AkbNzyWrA9Ex6YMDPrPvezukwMkTE=";
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # Build with production code
   tags = ["prod"];
   # Include version for `turso --version` reporting
   preBuild = ''
     echo "v${version}" > internal/cmd/version.txt
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
   '';
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -33,9 +37,6 @@ buildGo121Module rec {
       --fish <($out/bin/turso completion fish) \
       --zsh <($out/bin/turso completion zsh)
   '';
-
-  # Test_setDatabasesCache fails due to /homeless-shelter: read-only file system error.
-  doCheck = false;
 
   meta = with lib; {
     description = "This is the command line interface (CLI) to Turso.";


### PR DESCRIPTION
## Description of changes

- Added shell completions for `turso-cli`
- Added myself as a maintainer

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
