### PR TITLE
matomo: 4.14.2 -> 4.15.1, matomo-beta: 4.14.3-b6 -> 5.0.0-rc3

### DIFF
--- a/pkgs/servers/web-apps/matomo/change-path-geoip2-4.x.patch
+++ b/pkgs/servers/web-apps/matomo/change-path-geoip2-4.x.patch
@@ -8,4 +8,3 @@
 +    'path.geoip2' => PIWIK_USER_PATH . '/misc/',
      'geopip2.ispEnabled' => true
  ];
-\ Pas de fin de ligne à la fin du fichier

--- a/pkgs/servers/web-apps/matomo/change-path-geoip2-5.x.patch
+++ b/pkgs/servers/web-apps/matomo/change-path-geoip2-5.x.patch
@@ -1,0 +1,10 @@
+--- a/plugins/GeoIp2/config/config.php
++++ b/plugins/GeoIp2/config/config.php
+@@ -1,6 +1,6 @@
+ <?php
+ 
+ return [
+-    'path.geoip2' => Piwik\DI::string('{path.root}/misc/'),
++    'path.geoip2' => PIWIK_USER_PATH . '/misc/',
+     'geopip2.ispEnabled' => true
+ ];

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,8 +3,8 @@
 let
   versions = {
     matomo = {
-      version = "4.14.2";
-      hash = "sha256-jPs/4bgt7VqeSoeLnwHr+FI426hAhwiP8RciQDNwCpo=";
+      version = "4.15.1";
+      hash = "sha256-XnfiprGLqFQqPk30gcAVLdBZ3pYMSdBPfnicm7V1PSc=";
     };
     matomo-beta = {
       version = "4.14.3";
@@ -108,7 +108,7 @@ let
           license = licenses.gpl3Plus;
           homepage = "https://matomo.org/";
           platforms = platforms.all;
-          maintainers = with maintainers; [ florianjacob kiwi sebbel twey boozedog ];
+          maintainers = with maintainers; [ florianjacob kiwi sebbel twey boozedog ] ++ teams.flyingcircus.members;
         };
       };
 in

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -7,11 +7,11 @@ let
       hash = "sha256-XnfiprGLqFQqPk30gcAVLdBZ3pYMSdBPfnicm7V1PSc=";
     };
     matomo-beta = {
-      version = "4.14.3";
+      version = "5.0.0";
       # `beta` examples: "b1", "rc1", null
       # when updating: use null if stable version is >= latest beta or release candidate
-      beta = "b6";
-      hash = "sha256-WGyGoTugxHgB2by1F57PQhyqQRjoKBCvwFBZvpsHwZg=";
+      beta = "rc3";
+      hash = "sha256-Q5GB4i0ew6+tr8Bsm9PYkzJ8U6DmVPwG2QCi8CTge5E=";
     };
   };
   common = pname: { version, hash, beta ? null }:
@@ -39,10 +39,11 @@ let
           # TODO: is upstream interested in this?
           # -> discussion at https://github.com/matomo-org/matomo/issues/12646
           ./make-localhost-default-database-host.patch
-
           # This changes the default config for path.geoip2 so that it doesn't point
           # to the nix store.
-          ./change-path-geoip2.patch
+          (if lib.versionOlder version "5.0"
+           then ./change-path-geoip2-4.x.patch
+           else ./change-path-geoip2-5.x.patch)
         ];
 
         # this bootstrap.php adds support for getting PIWIK_USER_PATH

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, php }:
+{ lib, stdenv, fetchurl, makeWrapper, php, nixosTests }:
 
 let
   versions = {
@@ -102,6 +102,10 @@ let
           done
           popd > /dev/null
         '';
+
+        passthru = {
+          tests = nixosTests.matomo."${pname}";
+        };
 
         meta = with lib; {
           description = "A real-time web analytics application";


### PR DESCRIPTION
## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
