### PR TITLE
ocamlPackages.algaeff: 0.2.1 → 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/algaeff/default.nix
+++ b/pkgs/development/ocaml-modules/algaeff/default.nix
@@ -1,21 +1,25 @@
 { lib
 , buildDunePackage
 , fetchFromGitHub
+, alcotest
+, qcheck-core
 }:
 
 buildDunePackage rec {
   pname = "algaeff";
-  version = "0.2.1";
+  version = "1.1.0";
 
   minimalOCamlVersion = "5.0";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "RedPRL";
     repo = pname;
     rev = version;
-    hash = "sha256-jpnJhF+LN2ef6QPLcCHxcMg3Fr3GSLOnJkZ9ZUIOrlY=";
+    hash = "sha256-7kwQmoT8rpQWPHc+BZQi9fcZhgHxS99158ebXAXlpQ8=";
   };
+
+  doCheck = true;
+  checkInputs = [ alcotest qcheck-core ];
 
   meta = {
     description = "Reusable Effects-Based Components";


### PR DESCRIPTION
## Description of changes

https://github.com/RedPRL/algaeff/blob/1.1.0/CHANGELOG.markdown

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
