### PR TITLE
wireshark: 4.0.8 -> 4.0.10 + refactor

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -52,7 +52,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.0.8";
+  version = "4.0.10";
 
   outputs = [ "out" "dev" ];
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-bNg0yhNb1GRsTclNWWO+Bamm2wOnUjVKU+JftJu+LTo=";
+    hash = "sha256-R8CoatIZC7vkKn4UZ3G7h5qBexfKMdJJ0swi+IxAjG0=";
   };
 
   patches = [

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,60 +1,59 @@
 { lib
 , stdenv
-, buildPackages
 , fetchFromGitLab
-, pkg-config
-, pcre2
-, perl
-, flex
+
+, ApplicationServices
+, asciidoctor
+, bcg729
 , bison
-, gettext
-, libpcap
-, libnl
+, buildPackages
 , c-ares
+, cmake
+, flex
+, gettext
+, glib
+, gmp
 , gnutls
+, libcap
 , libgcrypt
 , libgpg-error
-, libmaxminddb
-, libopus
-, bcg729
-, spandsp3
 , libkrb5
-, speexdsp
+, libmaxminddb
+, libnl
+, libopus
+, libpcap
 , libsmi
-, lz4
-, snappy
-, zstd
-, minizip
-, sbc
-, openssl
-, lua5
-, python3
-, libcap
-, glib
 , libssh
-, nghttp2
-, zlib
-, cmake
-, ninja
+, lua5
+, lz4
 , makeWrapper
+, minizip
+, nghttp2
+, ninja
+, openssl
+, pcre2
+, perl
+, pkg-config
+, python3
+, sbc
+, snappy
+, spandsp3
+, speexdsp
+, SystemConfiguration
 , wrapGAppsHook
+, zlib
+, zstd
+
 , withQt ? true
 , qt6 ? null
-, ApplicationServices
-, SystemConfiguration
-, gmp
-, asciidoctor
 }:
 
 assert withQt -> qt6 != null;
 
-let
+stdenv.mkDerivation rec {
+  pname = "wireshark-${if withQt then "qt" else "cli"}";
   version = "4.0.8";
-  variant = if withQt then "qt" else "cli";
-in
-stdenv.mkDerivation {
-  pname = "wireshark-${variant}";
-  inherit version;
+
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitLab {
@@ -64,25 +63,28 @@ stdenv.mkDerivation {
     hash = "sha256-bNg0yhNb1GRsTclNWWO+Bamm2wOnUjVKU+JftJu+LTo=";
   };
 
-  cmakeFlags = [
-    "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
-    "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
-    # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DLEMON_C_COMPILER=cc"
-    "-DUSE_qt6=ON"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "-DHAVE_C99_VSNPRINTF_EXITCODE=0"
-    "-DHAVE_C99_VSNPRINTF_EXITCODE__TRYRUN_OUTPUT="
+  patches = [
+    ./wireshark-lookup-dumpcap-in-path.patch
   ];
 
-  # Avoid referencing -dev paths because of debug assertions.
-  env.NIX_CFLAGS_COMPILE = toString [ "-DQT_NO_DEBUG" ];
+  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    buildPackages.stdenv.cc
+  ];
 
-  nativeBuildInputs = [ asciidoctor bison cmake ninja flex makeWrapper pkg-config python3 perl ]
-    ++ lib.optionals withQt [ qt6.wrapQtAppsHook wrapGAppsHook ];
-
-  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [
+    asciidoctor
+    bison
+    cmake
+    flex
+    makeWrapper
+    ninja
+    perl
+    pkg-config
+    python3
+  ] ++ lib.optionals withQt [
+    qt6.wrapQtAppsHook
+    wrapGAppsHook
+  ];
 
   buildInputs = [
     gettext
@@ -109,14 +111,49 @@ stdenv.mkDerivation {
     c-ares
     glib
     zlib
-  ] ++ lib.optionals withQt (with qt6; [ qtbase qtmultimedia qtsvg qttools qt5compat ])
-  ++ lib.optionals (withQt && stdenv.isLinux) [ qt6.qtwayland ]
-  ++ lib.optionals stdenv.isLinux [ libcap libnl sbc ]
-  ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ];
+  ] ++ lib.optionals withQt (with qt6; [
+    qt5compat
+    qtbase
+    qtmultimedia
+    qtsvg
+    qttools
+  ]) ++ lib.optionals (withQt && stdenv.isLinux) [
+    qt6.qtwayland
+  ] ++ lib.optionals stdenv.isLinux [
+    libcap
+    libnl
+    sbc
+  ] ++ lib.optionals stdenv.isDarwin [
+    ApplicationServices
+    gmp
+    SystemConfiguration
+  ];
 
   strictDeps = true;
 
-  patches = [ ./wireshark-lookup-dumpcap-in-path.patch ];
+  cmakeFlags = [
+    "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
+    "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
+    # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DLEMON_C_COMPILER=cc"
+    "-DUSE_qt6=ON"
+  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "-DHAVE_C99_VSNPRINTF_EXITCODE=0"
+    "-DHAVE_C99_VSNPRINTF_EXITCODE__TRYRUN_OUTPUT="
+  ];
+
+  # Avoid referencing -dev paths because of debug assertions.
+  env.NIX_CFLAGS_COMPILE = toString [ "-DQT_NO_DEBUG" ];
+
+  dontFixCmake = true;
+  # Prevent double-wrapping, inject wrapper args manually instead.
+  dontWrapGApps = true;
+
+  shellHook = ''
+    # to be able to run the resulting binary
+    export WIRESHARK_RUN_FROM_BUILD_DIRECTORY=1
+  '';
 
   postPatch = ''
     sed -i -e '1i cmake_policy(SET CMP0025 NEW)' CMakeLists.txt
@@ -151,31 +188,20 @@ stdenv.mkDerivation {
       cp ../wsutil/wmem/*.h $dev/include/wsutil/wmem/
     '');
 
-  dontFixCmake = true;
-
-  # Prevent double-wrapping, inject wrapper args manually instead.
-  dontWrapGApps = true;
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  shellHook = ''
-    # to be able to run the resulting binary
-    export WIRESHARK_RUN_FROM_BUILD_DIRECTORY=1
-  '';
-
   meta = with lib; {
-    homepage = "https://www.wireshark.org/";
-    changelog = "https://www.wireshark.org/docs/relnotes/wireshark-${version}.html";
     description = "Powerful network protocol analyzer";
-    license = licenses.gpl2Plus;
-
     longDescription = ''
       Wireshark (formerly known as "Ethereal") is a powerful network
       protocol analyzer developed by an international team of networking
       experts. It runs on UNIX, macOS and Windows.
     '';
-
+    homepage = "https://www.wireshark.org";
+    changelog = "https://www.wireshark.org/docs/relnotes/wireshark-${version}.html";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz paveloom ];
     mainProgram = if withQt then "wireshark" else "tshark";


### PR DESCRIPTION
## Description of changes

https://www.wireshark.org/docs/relnotes/wireshark-4.0.9.html
https://www.wireshark.org/docs/relnotes/wireshark-4.0.10.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
