### PR TITLE
ft2-clone: 1.69 -> 1.71

### DIFF
--- a/pkgs/applications/audio/ft2-clone/default.nix
+++ b/pkgs/applications/audio/ft2-clone/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , nixosTests
 , alsa-lib
@@ -14,29 +13,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ft2-clone";
-  version = "1.69";
+  version = "1.71";
 
   src = fetchFromGitHub {
     owner = "8bitbubsy";
     repo = "ft2-clone";
     rev = "v${version}";
-    sha256 = "sha256-tm0yTh46UKnsjH9hv3cMW0YL2x3OTRL+14x4c7w124U=";
+    hash = "sha256-c2gFq+TgTMI+Eld0z8hryLew3XkrQ7XAfq2s+zdEkBQ=";
   };
-
-  patches = [
-    # Adapt CMake script to be Darwin-compatible
-    # https://github.com/8bitbubsy/ft2-clone/pull/30
-    (fetchpatch {
-      name = "0001-ft2-clone-Make-CMake-script-macOS-compatible.patch";
-      url = "https://github.com/8bitbubsy/ft2-clone/pull/30/commits/0033a567abf7ddbdb2bc59c7f730d22f986010aa.patch";
-      hash = "sha256-fhA+T6RI+Qmhr7mbG9lEA7esWskgK8+DkWzol0J2lUo=";
-    })
-    (fetchpatch {
-      name = "0002-ft2-clone-Fix-__MACOSX_CORE__-typo.patch";
-      url = "https://github.com/8bitbubsy/ft2-clone/pull/30/commits/fe50aff9233130150a6631875611c7db67a2d705.patch";
-      hash = "sha256-X4AVuJ0iRlpH1N/YzjdVk5+yv7eiDNoZkk0mhOizgOg=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ SDL2 ]
@@ -63,4 +47,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.littleEndian;
   };
 }
-


### PR DESCRIPTION

## Description of changes

Drops the patches that have been integrated upstream

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
