### PR TITLE
sway: generalize wrapper

### DIFF
--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -17,22 +17,22 @@ with lib;
 
 let
   sway = sway-unwrapped.overrideAttrs (oa: { inherit isNixOS enableXWayland; });
-  baseWrapper = writeShellScriptBin "sway" ''
+  baseWrapper = writeShellScriptBin sway.meta.mainProgram ''
      set -o errexit
      if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then
-       export XDG_CURRENT_DESKTOP=sway
+       export XDG_CURRENT_DESKTOP=${sway.meta.mainProgram}
        ${extraSessionCommands}
        export _SWAY_WRAPPER_ALREADY_EXECUTED=1
      fi
      if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
        export DBUS_SESSION_BUS_ADDRESS
-       exec ${sway}/bin/sway "$@"
+       exec ${lib.getExe sway} "$@"
      else
-       exec ${lib.optionalString dbusSupport "${dbus}/bin/dbus-run-session"} ${sway}/bin/sway "$@"
+       exec ${lib.optionalString dbusSupport "${dbus}/bin/dbus-run-session"} ${lib.getExe sway} "$@"
      fi
    '';
 in symlinkJoin {
-  name = "sway-${sway.version}";
+  name = "${sway.meta.mainProgram}-${sway.version}";
 
   paths = (optional withBaseWrapper baseWrapper)
     ++ [ sway ];
@@ -49,14 +49,14 @@ in symlinkJoin {
   postBuild = ''
     ${optionalString withGtkWrapper "gappsWrapperArgsHook"}
 
-    wrapProgram $out/bin/sway \
+    wrapProgram $out/bin/${sway.meta.mainProgram} \
       ${optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
       ${optionalString (extraOptions != []) "${concatMapStrings (x: " --add-flags " + x) extraOptions}"}
   '';
 
   passthru = {
     inherit (sway.passthru) tests;
-    providedSessions = [ "sway" ];
+    providedSessions = [ sway.meta.mainProgram ];
   };
 
   inherit (sway) meta;


### PR DESCRIPTION
## Description of changes

Generalize the sway wrapper so it can be used by sway derivatives, like volare.

The idea is that with this change, we could package volare as a flake outside of nixpkgs, but avoid duplicating a lot of the wrapper logic. This is much more complex if you try to do it just with overrides.

Keeping as draft for now since I haven't actually fully tested it yet (currently testing it on a nixpkgs branch, moving to a flake is still on my list)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
