### PR TITLE
nixos/systemd-lock-handler: init with corresponding package at 2.4.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -67,6 +67,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [RustDesk](https://rustdesk.com), a full-featured open source remote control alternative for self-hosting and security with minimal configuration. Alternative to TeamViewer.
 
+- [systemd-lock-handler](https://git.sr.ht/~whynothugo/systemd-lock-handler/), a bridge between logind D-Bus events and systemd targets. Available as [services.systemd-lock-handler.enable](#opt-services.systemd-lock-handler.enable).
+
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1236,6 +1236,7 @@
   ./services/system/saslauthd.nix
   ./services/system/self-deploy.nix
   ./services/system/systembus-notify.nix
+  ./services/system/systemd-lock-handler.nix
   ./services/system/uptimed.nix
   ./services/system/zram-generator.nix
   ./services/torrent/deluge.nix

--- a/nixos/modules/services/system/systemd-lock-handler.md
+++ b/nixos/modules/services/system/systemd-lock-handler.md
@@ -1,0 +1,47 @@
+# systemd-lock-handler {#module-services-systemd-lock-handler}
+
+The `systemd-lock-handler` module provides a service that bridges
+D-Bus events from `logind` to user-level systemd targets:
+
+  - `lock.target` started by `loginctl lock-session`,
+  - `unlock.target` started by `loginctl unlock-session` and
+  - `sleep.target` started by `systemctl suspend`.
+
+You can create a user service that starts with any of these targets.
+
+For example, to create a service for `swaylock`:
+
+```nix
+{
+  services.systemd-lock-handler.enable = true;
+
+  systemd.user.services.swaylock = {
+    description = "Screen locker for Wayland";
+    documentation = ["man:swaylock(1)"];
+
+    # If swaylock exits cleanly, unlock the session:
+    onSuccess = ["unlock.target"];
+
+    # When lock.target is stopped, stops this too:
+    partOf = ["lock.target"];
+
+    # Delay lock.target until this service is ready:
+    before = ["lock.target"];
+    wantedBy = ["lock.target"];
+
+    serviceConfig = {
+      # systemd will consider this service started when swaylock forks...
+      Type = "forking";
+
+      # ... and swaylock will fork only after it has locked the screen.
+      ExecStart = "${lib.getExe pkgs.swaylock} -f";
+
+      # If swaylock crashes, always restart it immediately:
+      Restart = "on-failure";
+      RestartSec = 0;
+    };
+  };
+}
+```
+
+See [upstream documentation](https://sr.ht/~whynothugo/systemd-lock-handler) for more information.

--- a/nixos/modules/services/system/systemd-lock-handler.nix
+++ b/nixos/modules/services/system/systemd-lock-handler.nix
@@ -1,0 +1,27 @@
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  cfg = config.services.systemd-lock-handler;
+  inherit (lib) mkIf mkEnableOption mkPackageOption;
+in
+{
+  options.services.systemd-lock-handler = {
+    enable = mkEnableOption (lib.mdDoc "systemd-lock-handler");
+    package = mkPackageOption pkgs "systemd-lock-handler" { };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+
+    # https://github.com/NixOS/nixpkgs/issues/81138
+    systemd.user.services.systemd-lock-handler.wantedBy = [ "default.target" ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ liff ];
+    doc = ./systemd-lock-handler.md;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -856,6 +856,7 @@ in {
   systemd-journal = handleTest ./systemd-journal.nix {};
   systemd-journal-gateway = handleTest ./systemd-journal-gateway.nix {};
   systemd-journal-upload = handleTest ./systemd-journal-upload.nix {};
+  systemd-lock-handler = runTestOn ["aarch64-linux" "x86_64-linux"] ./systemd-lock-handler.nix;
   systemd-machinectl = handleTest ./systemd-machinectl.nix {};
   systemd-networkd = handleTest ./systemd-networkd.nix {};
   systemd-networkd-dhcpserver = handleTest ./systemd-networkd-dhcpserver.nix {};

--- a/nixos/tests/systemd-lock-handler.nix
+++ b/nixos/tests/systemd-lock-handler.nix
@@ -1,0 +1,56 @@
+{ lib, ... }: {
+  name = "systemd-lock-handler";
+
+  meta.maintainers = with lib.maintainers; [ liff ];
+
+  enableOCR = true;
+
+  nodes.machine = { config, pkgs, lib, ... }:
+    let
+      touch = "${lib.getBin pkgs.coreutils}/bin/touch";
+    in
+    {
+      imports = [ common/wayland-cage.nix ];
+
+      services.systemd-lock-handler.enable = true;
+
+      systemd.user.services = {
+        test-lock = {
+          partOf = [ "lock.target" ];
+          onSuccess = [ "unlock.target" ];
+          before = [ "lock.target" ];
+          wantedBy = [ "lock.target" ];
+          serviceConfig.ExecStart = "${touch} /tmp/lock.target.activated";
+        };
+        test-unlock = {
+          partOf = [ "unlock.target" ];
+          after = [ "unlock.target" ];
+          wantedBy = [ "unlock.target" ];
+          serviceConfig.ExecStart = "${touch} /tmp/unlock.target.activated";
+        };
+        test-sleep = {
+          partOf = [ "sleep.target" ];
+          before = [ "sleep.target" ];
+          wantedBy = [ "sleep.target" ];
+          serviceConfig.ExecStart = "${touch} /tmp/sleep.target.activated";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit('graphical.target')
+    machine.wait_for_text('alice@machine')
+
+    machine.send_chars('loginctl lock-session\n')
+    machine.wait_for_file('/tmp/lock.target.activated')
+    machine.wait_for_file('/tmp/unlock.target.activated')
+
+    machine.send_chars('systemctl suspend\n')
+    # wait_for_file won’t complete before the machine is asleep,
+    # so we’ll watch the log instead.
+    machine.wait_for_console_text('Started test-sleep.service.')
+
+    # The VM is asleep, regular shutdown won’t work.
+    machine.crash()
+  '';
+}

--- a/pkgs/by-name/sy/systemd-lock-handler/package.nix
+++ b/pkgs/by-name/sy/systemd-lock-handler/package.nix
@@ -2,6 +2,7 @@
 , fetchFromSourcehut
 , buildGoModule
 , nix-update-script
+, nixosTests
 }:
 
 buildGoModule rec {
@@ -17,7 +18,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-dWzojV3tDA5lLdpAQNC9NaADGyvV7dNOS3x8mfgNNtA=";
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = nixosTests.systemd-lock-handler;
+  };
 
   # The Makefile expects to find the binary in the source root. Make
   # the one built by `buildGoModule` available so that `make install`

--- a/pkgs/by-name/sy/systemd-lock-handler/package.nix
+++ b/pkgs/by-name/sy/systemd-lock-handler/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromSourcehut
+, buildGoModule
+, nix-update-script
+}:
+
+buildGoModule rec {
+  pname = "systemd-lock-handler";
+  version = "2.4.2";
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = "systemd-lock-handler";
+    rev = "v${version}";
+    hash = "sha256-sTVAabwWtyvHuDp/+8FKNbfej1x/egoa9z1jLIMJuBg=";
+  };
+
+  vendorHash = "sha256-dWzojV3tDA5lLdpAQNC9NaADGyvV7dNOS3x8mfgNNtA=";
+
+  passthru.updateScript = nix-update-script { };
+
+  # The Makefile expects to find the binary in the source root. Make
+  # the one built by `buildGoModule` available so that `make install`
+  # doesn’t try to build it again.
+  postBuild = ''
+    cp -a $GOPATH/bin/* .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace systemd-lock-handler.service \
+      --replace /usr/lib/ $out/lib/
+
+    make install DESTDIR= PREFIX=$out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~whynothugo/systemd-lock-handler";
+    description = "Translates systemd-system lock/sleep signals into systemd-user target activations";
+    license = licenses.isc;
+    maintainers = with maintainers; [ liff ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a package and a module for [systemd-lock-handler](https://git.sr.ht/~whynothugo/systemd-lock-handler).

This is a possible future replacement for logind integration if swaywm/swayidle#133 moves forward.

There is another PR, #228063, for this package but it has not seen any updates in a while.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
