### PR TITLE
Fix to apply the selected flavour and accent

### DIFF
--- a/pkgs/data/themes/catppuccin-kde/default.nix
+++ b/pkgs/data/themes/catppuccin-kde/default.nix
@@ -1,14 +1,14 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
-, flavour ? [ "frappe" ]
-, accents ? [ "blue" ]
+, flavour ? [ "Frappe" ]
+, accents ? [ "Blue" ]
 , winDecStyles ? [ "modern" ]
 }:
 
 let
-  validFlavours = [ "mocha" "macchiato" "frappe" "latte" ];
-  validAccents = [ "rosewater" "flamingo" "pink" "mauve" "red" "maroon" "peach" "yellow" "green" "teal" "sky" "sapphire" "blue" "lavender" ];
+  validFlavours = [ "Mocha" "Macchiato" "Frappe" "Latte" ];
+  validAccents = [ "Rosewater" "Flamingo" "Pink" "Mauve" "Red" "Maroon" "Peach" "Yellow" "Green" "Teal" "Sky" "Sapphire" "Blue" "Lavender" ];
   validWinDecStyles = [ "modern" "classic" ];
 
   installScript = ./install.sh;


### PR DESCRIPTION
The shell script checks for strings that start with an uppercase letter https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/data/themes/catppuccin-kde/install.sh#L18