### PR TITLE
obs-studio: symlink libcef instead of copy

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -118,12 +118,12 @@ stdenv.mkDerivation rec {
   postUnpack = ''
     mkdir -p cef/Release cef/Resources cef/libcef_dll_wrapper/
     for i in ${libcef}/share/cef/*; do
-      cp -r $i cef/Release/
-      cp -r $i cef/Resources/
+      ln -s $i cef/Release/
+      ln -s $i cef/Resources/
     done
-    cp -r ${libcef}/lib/libcef.so cef/Release/
-    cp -r ${libcef}/lib/libcef_dll_wrapper.a cef/libcef_dll_wrapper/
-    cp -r ${libcef}/include cef/
+    ln -s ${libcef}/lib/libcef.so cef/Release/
+    ln -s ${libcef}/lib/libcef_dll_wrapper.a cef/libcef_dll_wrapper/
+    ln -s ${libcef}/include cef/
   '';
 
   cmakeFlags = [
@@ -145,6 +145,9 @@ stdenv.mkDerivation rec {
       blackmagic-desktop-video
     ];
   in ''
+    #Remove libcef before patchelf, otherwise it will fail
+    rm  $out/lib/obs-plugins/libcef.so
+
     qtWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"
       ''${gappsWrapperArgs[@]}
@@ -154,6 +157,9 @@ stdenv.mkDerivation rec {
   postFixup = lib.optionalString stdenv.isLinux ''
     addOpenGLRunpath $out/lib/lib*.so
     addOpenGLRunpath $out/lib/obs-plugins/*.so
+
+    #Link libcef again after patchelf for other libs
+    ln -s ${libcef}/lib/libcef.so $out/lib/obs-plugins/libcef.so
   '';
 
   meta = with lib; {

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -146,7 +146,7 @@ stdenv.mkDerivation rec {
     ];
   in ''
     # Remove libcef before patchelf, otherwise it will fail
-    rm  $out/lib/obs-plugins/libcef.so
+    rm $out/lib/obs-plugins/libcef.so
 
     qtWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation rec {
       blackmagic-desktop-video
     ];
   in ''
-    #Remove libcef before patchelf, otherwise it will fail
+    # Remove libcef before patchelf, otherwise it will fail
     rm  $out/lib/obs-plugins/libcef.so
 
     qtWrapperArgs+=(
@@ -158,7 +158,7 @@ stdenv.mkDerivation rec {
     addOpenGLRunpath $out/lib/lib*.so
     addOpenGLRunpath $out/lib/obs-plugins/*.so
 
-    #Link libcef again after patchelf for other libs
+    # Link libcef again after patchelfing other libs
     ln -s ${libcef}/lib/libcef.so $out/lib/obs-plugins/libcef.so
   '';
 


### PR DESCRIPTION
## Description of changes
Use symlink instead of copy for libcef. For issue https://github.com/NixOS/nixpkgs/issues/259165
Reduces space used by obs.

```bash
#before symlink
du -sh /nix/store/4q8l345f1d9h2bx81lzjrj15w0rr8147-obs-studio-29.1.3
426M    /nix/store/4q8l345f1d9h2bx81lzjrj15w0rr8147-obs-studio-29.1.3

#after symlink
du -sh /nix/store/bsqq89vrif4xb8gm2fxprq200iqd0md0-obs-studio-29.1.3
45M     /nix/store/bsqq89vrif4xb8gm2fxprq200iqd0md0-obs-studio-29.1.3
```
## Things done
Changed copy to symlink in post unpack phase.
Small change to pre and post fixup phase, remove and re link libcef so patchelfing will not fail. (Is there a better way like dontPatchELF for single path/lib?)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
