### PR TITLE
onedrivegui: init at 1.0.3

### DIFF
--- a/pkgs/by-name/on/onedrivegui/package.nix
+++ b/pkgs/by-name/on/onedrivegui/package.nix
@@ -1,0 +1,87 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, writeText
+, copyDesktopItems
+, makeDesktopItem
+, makeWrapper
+, onedrive
+}:
+
+let
+  version = "1.0.3";
+
+  setupPy = writeText "setup.py" ''
+    from setuptools import setup
+    setup(
+      name='onedrivegui',
+      version='${version}',
+      scripts=[
+        'src/OneDriveGUI.py',
+      ],
+    )
+  '';
+
+in
+python3Packages.buildPythonApplication rec {
+  pname = "onedrivegui";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "bpozdena";
+    repo = "OneDriveGUI";
+    rev = "v${version}";
+    hash = "sha256-HutziAzhIDYP8upNPieL2GNrxPBHUCVs09FFxdSqeBs=";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
+
+  propagatedBuildInputs = with python3Packages; [ pyside6 requests ];
+
+  # wrap manually to avoid having a bash script in $out/bin with a .py extension
+  dontWrapPythonPrograms = true;
+
+  doCheck = false; # No tests defined
+  pythonImportsCheck = [ "OneDriveGUI" ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "OneDriveGUI";
+      exec = "onedrivegui";
+      desktopName = "OneDriveGUI";
+      comment = "OneDrive GUI Client";
+      type = "Application";
+      icon = "OneDriveGUI";
+      terminal = false;
+      categories = [ "Utility" ];
+    })
+  ];
+
+  postPatch = ''
+    # Patch OneDriveGUI.py so DIR_PATH points to shared files location
+    sed -i src/OneDriveGUI.py -e "s@^DIR_PATH =.*@DIR_PATH = '$out/share/OneDriveGUI'@"
+    cp ${setupPy} ${setupPy.name}
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/OneDriveGUI
+    # we do not need the `ui` directory - only resources
+    cp -r src/resources $out/share/OneDriveGUI
+    install -Dm444 -t $/out/share/icons/hicolor/48x48/apps src/resources/images/OneDriveGUI.png
+    # we put our own executable wrapper in place instead
+    rm -r $out/bin/*
+
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/onedrivegui \
+      --prefix PATH : ${lib.makeBinPath [ onedrive ]} \
+      --prefix PYTHONPATH : ${python3Packages.makePythonPath (propagatedBuildInputs ++ [(placeholder "out")])} \
+      --add-flags $out/lib/${python3Packages.python.libPrefix}/site-packages/OneDriveGUI.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/bpozdena/OneDriveGUI";
+    description = "A simple GUI for Linux OneDrive Client, with multi-account support";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ jgarcia ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
onedrivegui init at 1.0.3
OneDriveGUI is a GUI for the linux OneDrive client.
https://github.com/bpozdena/OneDriveGUI

Closes #257520

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
