### PR TITLE
veyon: init at 4.9.6.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1380,6 +1380,7 @@
   ./services/networking/v2raya.nix
   ./services/networking/vdirsyncer.nix
   ./services/networking/veilid.nix
+  ./services/networking/veyon.nix
   ./services/networking/vsftpd.nix
   ./services/networking/vwifi.nix
   ./services/networking/wasabibackend.nix

--- a/nixos/modules/services/networking/veyon.nix
+++ b/nixos/modules/services/networking/veyon.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.veyon;
+in
+{
+  options = {
+    services.veyon = {
+      enable = lib.mkEnableOption "Veyon";
+      package = lib.mkPackageOption pkgs "veyon" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.dbus.enable = true;
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+    systemd.services.veyon.wantedBy = [ "multi-user.target" ];
+  };
+
+  meta.maintainers = pkgs.veyon.meta.maintainers;
+}

--- a/pkgs/by-name/ve/veyon/fix-install-perms.patch
+++ b/pkgs/by-name/ve/veyon/fix-install-perms.patch
@@ -1,0 +1,10 @@
+diff --git a/plugins/platform/linux/auth-helper/CMakeLists.txt b/plugins/platform/linux/auth-helper/CMakeLists.txt
+index 46840492c..d09b2d529 100644
+--- a/plugins/platform/linux/auth-helper/CMakeLists.txt
++++ b/plugins/platform/linux/auth-helper/CMakeLists.txt
+@@ -11,4 +11,4 @@ set_default_target_properties(veyon-auth-helper)
+ target_include_directories(veyon-auth-helper PRIVATE ${PAM_INCLUDE_DIR})
+ target_link_libraries(veyon-auth-helper PRIVATE ${PAM_LIBRARY} Qt${QT_MAJOR_VERSION}::Core)
+ 
+-install(TARGETS veyon-auth-helper RUNTIME DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE SETUID GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install(TARGETS veyon-auth-helper RUNTIME DESTINATION bin)

--- a/pkgs/by-name/ve/veyon/package.nix
+++ b/pkgs/by-name/ve/veyon/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  writeText,
+
+  cmake,
+  pkg-config,
+  qt6Packages,
+
+  lzo,
+  openldap,
+  cyrus_sasl,
+  pam,
+  procps,
+  libXtst,
+  libXrandr,
+  libXinerama,
+  libXdamage,
+  libXcursor,
+  libvncserver,
+  libfakekey,
+}:
+
+let
+  # Replace CONTRIBUTOR list with link to upstream
+  # This avoids generating contibutor list at build-time
+  contributors = writeText "CONTRIBUTORS" ''
+    https://github.com/veyon/veyon/contributors
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "veyon";
+  version = "4.9.6.1";
+
+  src = fetchFromGitHub {
+    owner = "veyon";
+    repo = "veyon";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/s2t89lOeJPwhUEtXp5llFEdsUF6roa8xUZqehdl8mA=";
+    fetchSubmodules = true; # kldap, x11vnc and qthttpserver get built from source
+  };
+
+  patches = [ ./fix-install-perms.patch ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6Packages.qtbase
+    qt6Packages.qt5compat
+    qt6Packages.qttools
+    qt6Packages.qthttpserver
+    qt6Packages.qca
+
+    lzo
+    openldap
+    cyrus_sasl
+    pam
+    procps
+    libXtst
+    libXrandr
+    libXinerama
+    libXdamage
+    libXcursor
+    libvncserver
+    libfakekey
+  ];
+
+  cmakeFlags = [
+    # cmake's setup hook makes it so that this is absolute by default
+    # veyon's build steps only work if this is relative
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "SYSTEMD_SERVICE_INSTALL_DIR" "lib/systemd/system")
+    (lib.cmakeFeature "CONTRIBUTORS" "${contributors}")
+  ];
+
+  # Some executables need to access the other ones
+  qtWrapperArgs = [ "--prefix PATH : ${placeholder "out"}/bin" ];
+
+  meta = {
+    changelog = "https://github.com/veyon/veyon/releases/tag/v${finalAttrs.version}";
+    description = "A free and open source software for monitoring and controlling computers across multiple platforms";
+    homepage = "https://veyon.io";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "veyon-master";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes
Closes https://github.com/NixOS/nixpkgs/issues/257501

This PR adds 1 package: `veyon`
It also adds a `nixos` module for the systemd service provided by the package.

The privileged authentication for `veyon-configurator` doesn't seem to be working properly, so you'll have to use `sudo` manually. Not sure why this is.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
