### PR TITLE
lomiri.lomiri-settings-components: init at 1.1.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -18,6 +18,9 @@ let
     libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
 
+    #### QML / QML-related
+    lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
+
     #### Services
     biometryd = callPackage ./services/biometryd { };
   };

--- a/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, cmake
+, cmake-extras
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-settings-components";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-settings-components";
+    rev = finalAttrs.version;
+    hash = "sha256-Ybg+qyecvhPUDoIoq+0194u57imx7SxDMEmufGN22jM=";
+  };
+
+  postPatch = ''
+    patchShebangs tests/imports/check_imports.py
+
+    substituteInPlace CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" '${placeholder "out"}/${qtbase.qtQmlPrefix}'
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    sed -i CMakeLists.txt \
+      -e '/add_subdirectory(tests)/d'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    python3
+  ];
+
+  # No apps, just QML components
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "QML settings components for the Lomiri Desktop Environment";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-settings-components";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-settings-components";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-settings-components";
     rev = finalAttrs.version;
-    hash = "sha256-Ybg+qyecvhPUDoIoq+0194u57imx7SxDMEmufGN22jM=";
+    hash = "sha256-13uxUBM+uOmt8X0uLGWNP8YbwCdb2QCChB8IP3td5a4=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Settings Components](https://gitlab.com/ubports/development/core/lomiri-settings-components), QML settings components for Lomiri. Required by Lomiri and the system settings app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
