### PR TITLE
[23.05] woodpecker-*: 0.15.8 -> 0.15.11, mark knownVulnerabilities CVE-2023-40034

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,17 +1,17 @@
 { lib, fetchFromGitHub }:
 let
   version = "0.15.8";
-  srcSha256 = "sha256-7CTRx7I47VEKfPvkWhmpyHV3hkeLyHymFMrkyYQ1wl8=";
-  yarnSha256 = "sha256-PY0BIBbjyi2DG+n5x/IPc0AwrFSwII4huMDU+FeZ/Sc=";
+  srcHash = "sha256-7CTRx7I47VEKfPvkWhmpyHV3hkeLyHymFMrkyYQ1wl8=";
+  yarnHash = "sha256-PY0BIBbjyi2DG+n5x/IPc0AwrFSwII4huMDU+FeZ/Sc=";
 in
 {
-  inherit version yarnSha256;
+  inherit version yarnHash;
 
   src = fetchFromGitHub {
     owner = "woodpecker-ci";
     repo = "woodpecker";
     rev = "v${version}";
-    sha256 = srcSha256;
+    hash = srcHash;
   };
 
   postBuild = ''

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub }:
 let
-  version = "0.15.8";
-  srcHash = "sha256-7CTRx7I47VEKfPvkWhmpyHV3hkeLyHymFMrkyYQ1wl8=";
+  version = "0.15.11";
+  srcHash = "sha256-iDcEkaR1ZvH7Q68sxbwOiP1WKbkiDhCOtkuipbjXHKM=";
   yarnHash = "sha256-PY0BIBbjyi2DG+n5x/IPc0AwrFSwII4huMDU+FeZ/Sc=";
 in
 {

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -32,5 +32,8 @@ in
     homepage = "https://woodpecker-ci.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [ ambroisie techknowlogick ];
+    knownVulnerabilities = [
+      "CVE-2023-40034"
+    ];
   };
 }

--- a/pkgs/development/tools/continuous-integration/woodpecker/frontend.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/frontend.nix
@@ -11,7 +11,7 @@ mkYarnPackage {
   packageJSON = ./woodpecker-package.json;
   offlineCache = fetchYarnDeps {
     yarnLock = "${common.src}/web/yarn.lock";
-    sha256 = common.yarnSha256;
+    hash = common.yarnHash;
   };
 
   buildPhase = ''

--- a/pkgs/development/tools/continuous-integration/woodpecker/update.sh
+++ b/pkgs/development/tools/continuous-integration/woodpecker/update.sh
@@ -28,7 +28,7 @@ fi
 version="${version#v}"
 
 # Woodpecker repository
-src_hash=$(nix-prefetch-github woodpecker-ci woodpecker --rev "v${version}" | jq -r .sha256)
+src_hash=$(nix-prefetch-github woodpecker-ci woodpecker --rev "v${version}" | jq -r .hash)
 
 # Front-end dependencies
 woodpecker_src="https://raw.githubusercontent.com/woodpecker-ci/woodpecker/v$version"
@@ -42,9 +42,8 @@ yarn_hash=$(prefetch-yarn-deps yarn.lock)
 popd
 
 # Use friendlier hashes
-src_hash=$(nix hash to-sri --type sha256 "$src_hash")
 yarn_hash=$(nix hash to-sri --type sha256 "$yarn_hash")
 
 sed -i -E -e "s#version = \".*\"#version = \"$version\"#" common.nix
-sed -i -E -e "s#srcSha256 = \".*\"#srcSha256 = \"$src_hash\"#" common.nix
-sed -i -E -e "s#yarnSha256 = \".*\"#yarnSha256 = \"$yarn_hash\"#" common.nix
+sed -i -E -e "s#srcHash = \".*\"#srcHash = \"$src_hash\"#" common.nix
+sed -i -E -e "s#yarnHash = \".*\"#yarnHash = \"$yarn_hash\"#" common.nix


### PR DESCRIPTION
## Description of changes
The bump addresses CVE-2022-23471, CVE-2023-25153, CVE-2023-25173, CVE-2023-28840, CVE-2023-28841, CVE-2023-28842, GHSA-vp35-85q5-9f25, CVE-2023-24535, GHSA-hw7c-3rfg-p46j, CVE-2023-26125 and CVE-2023-29401 in vendored dependencies.

Not sure patching CVE-2023-40034 is a great idea, and users should probably be encouraged to upgrade as there are also some other minor security issues addressed in 1.0+

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
