### PR TITLE
caddy: Allow adding external plugins

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -501,6 +501,26 @@ The module update takes care of the new config syntax and the data itself (user 
 
   If you use this feature, updates to CoreDNS may require updating `vendorHash` by following these steps again.
 
+- Caddy can now be built with external plugins by overriding `externalPlugins` and `vendorHash` arguments like this:
+
+  ```
+  services.caddy = {
+    enable = true;
+    package = pkgs.caddy.override {
+      externalPlugins = [
+        {name = "coraza"; repo = "github.com/corazawaf/coraza-caddy/v2"; version = "v2.0.0-rc.3";}
+        {name = "cache-handler"; repo = "github.com/caddyserver/cache-handler"; version = "v0.9.0";}
+        {name = "ratelimit"; repo = "github.com/mholt/caddy-ratelimit"; version = "2dc0d586f0b87e983757c403bc0929ddeb84a537";}
+      ];
+      vendorHash = "<SRI hash>";
+    };
+  };
+  ```
+
+  To get the necessary SRI hash, set `vendorHash = "";`. The build will fail and produce the correct `vendorHash` in the error message.
+
+  If you use this feature, updates to Caddy may require updating `vendorHash` by following these steps again.
+
 - `postgresql_11` has been removed since it'll stop receiving fixes on November 9 2023.
 
 - `ffmpeg` default upgraded from `ffmpeg_5` to `ffmpeg_6`.

--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -1,23 +1,30 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, gnused
 , nixosTests
 , caddy
 , testers
 , installShellFiles
+, externalPlugins ? []
+, vendorHash ? "sha256-YNcQtjPGQ0XMSog+sWlH4lG/QdbdI0Lyh/fUGqQUFaY="
 }:
+
 let
+  attrsToModules = attrs:
+    builtins.map ({name, repo, version}: "${repo}") attrs;
+  attrsToSources = attrs:
+    builtins.map ({name, repo, version}: "${repo}@${version}") attrs;
+in buildGoModule rec {
+  pname = "caddy";
   version = "2.7.5";
+
   dist = fetchFromGitHub {
     owner = "caddyserver";
     repo = "dist";
     rev = "v${version}";
     hash = "sha256-aZ7hdAZJH1PvrX9GQLzLquzzZG3LZSKOvt7sWQhTiR8=";
   };
-in
-buildGoModule {
-  pname = "caddy";
-  inherit version;
 
   src = fetchFromGitHub {
     owner = "caddyserver";
@@ -26,7 +33,7 @@ buildGoModule {
     hash = "sha256-0IZZ7mkEzZI2Y8ed//m0tbBQZ0YcCXA0/b10ntNIXUk=";
   };
 
-  vendorHash = "sha256-YNcQtjPGQ0XMSog+sWlH4lG/QdbdI0Lyh/fUGqQUFaY=";
+  inherit vendorHash;
 
   subPackages = [ "cmd/caddy" ];
 
@@ -35,7 +42,34 @@ buildGoModule {
     "-X github.com/caddyserver/caddy/v2.CustomVersion=${version}"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ gnused installShellFiles ];
+
+  modBuildPhase = ''
+    for module in ${builtins.toString (attrsToModules externalPlugins)}; do
+      sed -i "/standard/a _ \"$module\"" ./cmd/caddy/main.go
+    done
+    for plugin in ${builtins.toString (attrsToSources externalPlugins)}; do
+      go get $plugin
+    done
+
+    go generate
+    go mod vendor
+  '';
+
+  modInstallPhase = ''
+    mv -t vendor go.mod go.sum
+    cp -r --reflink=auto vendor "$out"
+  '';
+
+  preBuild = ''
+    chmod -R u+w vendor
+    [ -f vendor/go.mod ] && mv -t . vendor/go.{mod,sum}
+    go generate
+
+    for module in ${builtins.toString (attrsToModules externalPlugins)}; do
+      sed -i "/standard/a _ \"$module\"" ./cmd/caddy/main.go
+    done
+  '';
 
   postInstall = ''
     install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system


### PR DESCRIPTION
## Description of changes

Solves: #14671

Caddy has support for plugins that are added at compile time. This exposes an argument `externalPlugins` that will build caddy with the specified plugins.

Example:
```
caddy-custom = pkgs.caddy.override {
  externalPlugins = [
    {name = "coraza"; repo = "github.com/corazawaf/coraza-caddy/v2"; version = "v2.0.0-rc.3";}
    {name = "cache-handler"; repo = "github.com/caddyserver/cache-handler"; version = "v0.9.0";}
    {name = "ratelimit"; repo = "github.com/mholt/caddy-ratelimit"; version = "2dc0d586f0b87e983757c403bc0929ddeb84a537";}
  ];
  vendorHash = "<SRI hash>";
};
```

Adapted from Brendan Taylor's CoreDNS change in commit 95e66809debf42dbe1e4935fd31c8c275914d2eb.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).