### PR TITLE
qgis: Enable mapserver

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -32,6 +32,14 @@ in symlinkJoin rec {
     wrapProgram $out/bin/qgis \
       --prefix PATH : $program_PATH \
       --set PYTHONPATH $program_PYTHONPATH
+
+    wrapProgram $out/bin/qgis_mapserver \
+      --prefix PATH : $program_PATH \
+      --set PYTHONPATH $program_PYTHONPATH
+
+    wrapProgram $out/bin/qgis_mapserv.fcgi \
+      --prefix PATH : $program_PATH \
+      --set PYTHONPATH $program_PYTHONPATH
   '';
 
   passthru = {

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -32,6 +32,14 @@ in symlinkJoin rec {
     wrapProgram $out/bin/qgis \
       --prefix PATH : $program_PATH \
       --set PYTHONPATH $program_PYTHONPATH
+
+    wrapProgram $out/bin/qgis_mapserver \
+      --prefix PATH : $program_PATH \
+      --set PYTHONPATH $program_PYTHONPATH
+
+    wrapProgram $out/bin/qgis_mapserv.fcgi \
+      --prefix PATH : $program_PATH \
+      --set PYTHONPATH $program_PYTHONPATH
   '';
 
   passthru = {

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -141,6 +141,7 @@ in mkDerivation rec {
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "WITH_SERVER" true)
     (lib.cmakeBool "WITH_3D" true)
     (lib.cmakeBool "WITH_PDAL" true)
     (lib.cmakeBool "ENABLE_TESTS" false)

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -141,11 +141,11 @@ in mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DWITH_3D=True"
-    "-DWITH_PDAL=TRUE"
-    "-DENABLE_TESTS=False"
-  ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
-    ++ lib.optional withGrass (let
+    (lib.cmakeBool "WITH_3D" true)
+    (lib.cmakeBool "WITH_PDAL" true)
+    (lib.cmakeBool "ENABLE_TESTS" false)
+    (lib.cmakeBool "WITH_QTWEBKIT" withWebKit)
+  ] ++ lib.optional withGrass (let
         gmajor = lib.versions.major grass.version;
         gminor = lib.versions.minor grass.version;
       in "-DGRASS_PREFIX${gmajor}=${grass}/grass${gmajor}${gminor}"

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -150,6 +150,7 @@ in mkDerivation rec {
   '';
 
   cmakeFlags = [
+    (lib.cmakeBool "WITH_SERVER" true)
     (lib.cmakeBool "WITH_3D" true)
     (lib.cmakeBool "WITH_PDAL" true)
     (lib.cmakeBool "ENABLE_TESTS" false)

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -150,11 +150,11 @@ in mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DWITH_3D=True"
-    "-DWITH_PDAL=TRUE"
-    "-DENABLE_TESTS=False"
-  ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
-    ++ lib.optional withGrass (let
+    (lib.cmakeBool "WITH_3D" true)
+    (lib.cmakeBool "WITH_PDAL" true)
+    (lib.cmakeBool "ENABLE_TESTS" false)
+    (lib.cmakeBool "WITH_QTWEBKIT" withWebKit)
+  ] ++ lib.optional withGrass (let
         gmajor = lib.versions.major grass.version;
         gminor = lib.versions.minor grass.version;
       in "-DGRASS_PREFIX${gmajor}=${grass}/grass${gmajor}${gminor}"


### PR DESCRIPTION

## Description of changes

Here we enable QGis's internal [tileserver] implementation. I have found this useful and the size of the binary itself is negligible (around 300kB).

[tileserver]: https://docs.qgis.org/3.28/en/docs/server_manual


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
