### PR TITLE
ocamlPackages.lwt: 5.6.1 → 5.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/containers/data.nix
+++ b/pkgs/development/ocaml-modules/containers/data.nix
@@ -1,4 +1,5 @@
 { buildDunePackage, containers
+, ocaml
 , dune-configurator
 , gen, iter, qcheck-core
 , mdx
@@ -7,7 +8,9 @@
 buildDunePackage {
   pname = "containers-data";
 
-  inherit (containers) src version doCheck;
+  inherit (containers) src version;
+
+  doCheck = containers.doCheck && ocaml.meta.branch != "5.0";
 
   buildInputs = [ dune-configurator ];
   nativeCheckInputs = [ mdx.bin ];

--- a/pkgs/development/ocaml-modules/kafka/default.nix
+++ b/pkgs/development/ocaml-modules/kafka/default.nix
@@ -5,8 +5,6 @@ buildDunePackage rec {
   pname = "kafka";
   version = "0.5";
 
-  useDune2 = true;
-
   src = fetchurl {
     url = "https://github.com/didier-wenzek/ocaml-kafka/releases/download/${version}/kafka-${version}.tbz";
     sha256 = "0m9212yap0a00hd0f61i4y4fna3141p77qj3mm7jl1h4q60jdhvy";

--- a/pkgs/development/ocaml-modules/kafka/lwt.nix
+++ b/pkgs/development/ocaml-modules/kafka/lwt.nix
@@ -1,13 +1,18 @@
 { buildDunePackage
+, ocaml
+, lib
 , kafka
 , lwt
 , cmdliner
 }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "kafka_lwt is not available for OCaml ${ocaml.version}"
+
 buildDunePackage rec {
   pname = "kafka_lwt";
 
-  inherit (kafka) version useDune2 src;
+  inherit (kafka) version src;
 
   buildInputs = [ cmdliner ];
 

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -4,7 +4,7 @@
 
 buildDunePackage rec {
   pname = "lwt";
-  version = "5.6.1";
+  version = "5.7.0";
 
   minimalOCamlVersion = "4.08";
 
@@ -12,15 +12,8 @@ buildDunePackage rec {
     owner = "ocsigen";
     repo = "lwt";
     rev = version;
-    sha256 = "sha256-XstKs0tMwliCyXnP0Vzi5WC27HKJGnATUYtbbQmH1TE=";
+    hash = "sha256-o0wPK6dPdnsr/LzwcSwbIGcL85wkDjdFuEcAxuS/UEs=";
   };
-
-  postPatch = lib.optionalString (lib.versionAtLeast ocaml.version "5.0") ''
-    substituteInPlace src/core/dune \
-      --replace "(libraries bytes)" ""
-    substituteInPlace src/unix/dune \
-      --replace "libraries bigarray lwt" "libraries lwt"
-  '';
 
   nativeBuildInputs = [ cppo ];
   buildInputs = [ dune-configurator ];


### PR DESCRIPTION
## Description of changes

https://github.com/ocsigen/lwt/releases/tag/5.7.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
