### PR TITLE
tree-sitter-grammars: add typst

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -93,6 +93,7 @@
   tree-sitter-tsq = lib.importJSON ./tree-sitter-tsq.json;
   tree-sitter-turtle = lib.importJSON ./tree-sitter-turtle.json;
   tree-sitter-typescript = lib.importJSON ./tree-sitter-typescript.json;
+  tree-sitter-typst = lib.importJSON ./tree-sitter-typst.json;
   tree-sitter-verilog = lib.importJSON ./tree-sitter-verilog.json;
   tree-sitter-vim = lib.importJSON ./tree-sitter-vim.json;
   tree-sitter-vue = lib.importJSON ./tree-sitter-vue.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typst.json
@@ -1,0 +1,12 @@
+{
+  "url": "https://github.com/uben0/tree-sitter-typst",
+  "rev": "b8f3ac3a00247b5be0da2123e6b2d79e3dca4aff",
+  "date": "2023-09-17T16:51:18+02:00",
+  "path": "/nix/store/k4sh7jiqrry4960ygjbs72qvi9amd3s8-tree-sitter-typst",
+  "sha256": "1qihml8jkc32ra1ijmrc1crjmqxspdq163k0hhy9rrq6sqgyh33w",
+  "hash": "sha256-fAzoH9YG55w8hGAOE3C7uuMqMwssVxmDymKwKRGtMOI=",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -143,6 +143,10 @@ let
       repo = "tree-sitter-sql";
       branch = "gh-pages";
     };
+    "tree-sitter-typst" = {
+      orga = "uben0";
+      repo = "tree-sitter-typst";
+    };
     "tree-sitter-vim" = {
       orga = "vigoux";
       repo = "tree-sitter-viml";


### PR DESCRIPTION
## Description of changes

Introducing typst to nixpkgs tree-sitter grammars packages.

Why this specific package? Because the emacs tree-sitter package for typst [typst-ts-mode](https://git.sr.ht/~meow_king/typst-ts-mode) depends on it.


Not entirely sure weather it would be classified as a solution for #235938 due to the existence of many variants of `tree-sitter-typst`. But I figured that it would be worth giving it a mention.

###### Reference

- https://github.com/uben0/tree-sitter-typst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
