### PR TITLE
soundconverter: 4.0.3 -> 4.0.4

### DIFF
--- a/pkgs/applications/audio/soundconverter/default.nix
+++ b/pkgs/applications/audio/soundconverter/default.nix
@@ -7,11 +7,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "soundconverter";
-  version = "4.0.3";
+  version = "4.0.4";
 
   src = fetchurl {
     url = "https://launchpad.net/soundconverter/trunk/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "sha256-hzIG/4LD3705erPYvXb7uoRwF9LtKKIKB3jrhpYMsZ0=";
+    hash = "sha256-15TeNxFQzE6pzADuBN8jEzpPPna4pt0x4GXsaxi0gr4=";
   };
 
   buildInputs = [
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication rec {
     # FIXME: Fails due to weird Gio.file_parse_name() behavior.
     sed -i '49 a\    @unittest.skip("Gio.file_parse_name issues")' tests/testcases/names.py
   '' + lib.optionalString (!faacSupport) ''
-    substituteInPlace tests/testcases/integration.py --replace \
+    substituteInPlace tests/testcases/gui_integration.py --replace \
       "for encoder in ['fdkaacenc', 'faac', 'avenc_aac']:" \
       "for encoder in ['fdkaacenc', 'avenc_aac']:"
   '';
@@ -65,6 +65,10 @@ python3Packages.buildPythonApplication rec {
     runHook preCheck
     xvfb-run python tests/test.py
     runHook postCheck
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/soundconverter --prefix PYTHONPATH : "$PYTHONPATH"
   '';
 
   # Necessary to set GDK_PIXBUF_MODULE_FILE.


### PR DESCRIPTION
## Description of changes

https://github.com/kassoulet/soundconverter/releases/tag/4.0.4

Resolves:
* https://github.com/NixOS/nixpkgs/issues/259338

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).