### PR TITLE
quassel: add ldap support for core

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -6,7 +6,7 @@
 
 , lib, stdenv, fetchFromGitHub, cmake, makeWrapper, dconf
 , mkDerivation, qtbase, boost, zlib, qtscript
-, phonon, libdbusmenu, qca-qt5
+, phonon, libdbusmenu, qca-qt5, openldap
 
 , withKDE ? true # enable KDE integration
 , extra-cmake-modules
@@ -47,7 +47,7 @@ in (if !buildClient then stdenv.mkDerivation else mkDerivation) rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ qtbase boost zlib ]
-    ++ lib.optionals buildCore [qtscript qca-qt5 ]
+    ++ lib.optionals buildCore [qtscript qca-qt5 openldap]
     ++ lib.optionals buildClient [libdbusmenu phonon]
     ++ lib.optionals (buildClient && withKDE) [
       extra-cmake-modules kconfigwidgets kcoreaddons
@@ -62,6 +62,7 @@ in (if !buildClient then stdenv.mkDerivation else mkDerivation) rec {
     ++ edf static "STATIC"
     ++ edf monolithic "WANT_MONO"
     ++ edf enableDaemon "WANT_CORE"
+    ++ edf enableDaemon "WITH_LDAP"
     ++ edf client "WANT_QTCLIENT"
     ++ edf withKDE "WITH_KDE";
 


### PR DESCRIPTION
## Description of changes

allows using ldap as an authentication backend for the quassel core.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
