### PR TITLE
gzdoom: 4.10.0 -> 4.11.0

### DIFF
--- a/pkgs/games/doom-ports/gzdoom/default.nix
+++ b/pkgs/games/doom-ports/gzdoom/default.nix
@@ -14,6 +14,7 @@
 , libjpeg
 , libsndfile
 , libvpx
+, libwebp
 , mpg123
 , ninja
 , openal
@@ -25,14 +26,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gzdoom";
-  version = "4.10.0";
+  version = "4.11.0";
 
   src = fetchFromGitHub {
     owner = "ZDoom";
     repo = "gzdoom";
     rev = "g${version}";
     fetchSubmodules = true;
-    hash = "sha256-F3p2X/hjPV9fuaA7T2bQTP6SlKcfc8GniJgv8BcopGw=";
+    hash = "sha256-F3FXV76jpwkOE6QoNi1+TjLOt9x7q3pcZq3hQmRfL5E=";
   };
 
   outputs = [ "out" "doc" ];
@@ -55,6 +56,7 @@ stdenv.mkDerivation rec {
     libjpeg
     libsndfile
     libvpx
+    libwebp
     mpg123
     openal
     vulkan-loader


### PR DESCRIPTION
Among other things fixes build failure against gcc-13:

    $ nix build --impure --expr 'with import ./. {}; gzdoom.override { stdenv = gcc13Stdenv; }' -L
    gzdoom> /build/source/src/common/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h: In function 'void VmaUint32ToStr(char*, size_t, uint32_t)':
    gzdoom> /build/source/src/common/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h:2410:9: error: 'snprintf' was not declared in this scope
    gzdoom>  2410 |         snprintf(outStr, strLen, "%u", static_cast<unsigned int>(num));
    gzdoom>       |         ^~~~~~~~
    gzdoom> /build/source/src/common/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h:2262:1: note: 'snprintf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?

Changes: https://github.com/ZDoom/gzdoom/releases/tag/g4.11.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
