### PR TITLE
hci: Improve closure size

### DIFF
--- a/pkgs/development/tools/continuous-integration/hci/default.nix
+++ b/pkgs/development/tools/continuous-integration/hci/default.nix
@@ -1,8 +1,24 @@
-{ haskell, haskellPackages, lib, makeWrapper, runc, stdenv }:
+{ haskell, haskellPackages, lib, makeWrapper, runc, stdenv, emptyDirectory }:
 let
-  inherit (haskell.lib.compose) overrideCabal addBuildTools justStaticExecutables;
+  inherit (haskell.lib.compose) overrideCabal addBuildTools justStaticExecutables appendConfigureFlags;
   inherit (lib) makeBinPath;
   bundledBins = lib.optional stdenv.isLinux runc;
+
+  overrides = old: {
+    hercules-ci-agent =
+      overrideCabal
+        (o: {
+          isLibrary = true;
+          isExecutable = false;
+          postInstall = ""; # ignore completions
+          enableSharedExecutables = false;
+          buildTarget = "lib:hercules-ci-agent hercules-ci-agent-unit-tests";
+          configureFlags = o.configureFlags or [ ] ++ [
+            "--bindir=${emptyDirectory}/hercules-ci-built-without-binaries/no-bin"
+          ];
+        })
+        old.hercules-ci-agent;
+  };
 
   pkg =
     # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
@@ -15,7 +31,7 @@ let
           makeWrapper $out/libexec/hci $out/bin/hci --prefix PATH : ${lib.escapeShellArg (makeBinPath bundledBins)}
         '';
       })
-      (addBuildTools [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-cli));
+      (addBuildTools [ makeWrapper ] (justStaticExecutables (haskellPackages.hercules-ci-cli.override overrides)));
 in pkg // {
     meta = pkg.meta // {
       position = toString ./default.nix + ":1";


### PR DESCRIPTION
## Description of changes

Improve the closure size of the Hercules CI command line.

Mirrors https://github.com/hercules-ci/hercules-ci-agent/pull/538
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
