### PR TITLE
gnome.gnome-flashback: Fix x-d-p-gnome launch

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -311,7 +311,9 @@ in
         (gnome-panel-with-modules.override {
           panelModulePackages = cfg.flashback.panelModulePackages;
         })
-      ];
+      ]
+      # For /share/applications/${wmName}.desktop
+      ++ (map (wm: gnome-flashback.mkWmApplication { inherit (wm) wmName wmLabel wmCommand; }) flashbackWms);
     })
 
     (mkIf serviceCfg.core-os-services.enable {

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -294,7 +294,7 @@ in
           map
             (wm:
               pkgs.gnome.gnome-flashback.mkSessionForWm {
-                inherit (wm) wmName wmLabel wmCommand enableGnomePanel;
+                inherit (wm) wmName wmLabel wmCommand;
               }
             ) flashbackWms;
 
@@ -313,7 +313,9 @@ in
         })
       ]
       # For /share/applications/${wmName}.desktop
-      ++ (map (wm: gnome-flashback.mkWmApplication { inherit (wm) wmName wmLabel wmCommand; }) flashbackWms);
+      ++ (map (wm: gnome-flashback.mkWmApplication { inherit (wm) wmName wmLabel wmCommand; }) flashbackWms)
+      # For /share/gnome-session/sessions/gnome-flashback-${wmName}.session
+      ++ (map (wm: gnome-flashback.mkGnomeSession { inherit (wm) wmName wmLabel enableGnomePanel; }) flashbackWms);
     })
 
     (mkIf serviceCfg.core-os-services.enable {

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -229,7 +229,7 @@ in
         panelModulePackages = mkOption {
           default = [ pkgs.gnome.gnome-applets ];
           defaultText = literalExpression "[ pkgs.gnome.gnome-applets ]";
-          type = types.listOf types.path;
+          type = types.listOf types.package;
           description = lib.mdDoc ''
             Packages containing modules that should be made available to `gnome-panel` (usually for applets).
 
@@ -295,7 +295,6 @@ in
             (wm:
               pkgs.gnome.gnome-flashback.mkSessionForWm {
                 inherit (wm) wmName wmLabel wmCommand enableGnomePanel;
-                inherit (cfg.flashback) panelModulePackages;
               }
             ) flashbackWms;
 
@@ -309,6 +308,9 @@ in
 
       environment.systemPackages = with pkgs.gnome; [
         gnome-flashback
+        (gnome-panel-with-modules.override {
+          panelModulePackages = cfg.flashback.panelModulePackages;
+        })
       ];
     })
 

--- a/nixos/tests/gnome-flashback.nix
+++ b/nixos/tests/gnome-flashback.nix
@@ -32,14 +32,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
     xauthority = "/run/user/${uid}/gdm/Xauthority";
   in ''
       with subtest("Login to GNOME Flashback with GDM"):
-          # wait_for_x() checks graphical-session.target, which is expected to be
-          # inactive on gnome-flashback before #228946 (i.e. systemd managed
-          # gnome-session) is done.
-          # https://github.com/NixOS/nixpkgs/pull/208060
-          #
-          # Previously this was unconditionally touched by xsessionWrapper but was
-          # changed in #233981 (we have GNOME-Flashback:GNOME in XDG_CURRENT_DESKTOP).
-          # machine.wait_for_x()
+          machine.wait_for_x()
           machine.wait_until_succeeds('journalctl -t gnome-session-binary --grep "Entering running state"')
           # Wait for alice to be logged in"
           machine.wait_for_unit("default.target", "${user.name}")

--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -240,6 +240,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gnome-panel = callPackage ./misc/gnome-panel { };
 
+  gnome-panel-with-modules = callPackage ./misc/gnome-panel/wrapper.nix { };
+
   gnome-tweaks = callPackage ./misc/gnome-tweaks { };
 
   gpaste = callPackage ./misc/gpaste { };

--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -238,9 +238,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gnome-flashback = callPackage ./misc/gnome-flashback { };
 
-  gnome-panel = callPackage ./misc/gnome-panel {
-    autoreconfHook = pkgs.autoreconfHook269;
-  };
+  gnome-panel = callPackage ./misc/gnome-panel { };
 
   gnome-tweaks = callPackage ./misc/gnome-tweaks { };
 

--- a/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
@@ -128,25 +128,26 @@ let
         versionPolicy = "odd-unstable";
       };
 
+      mkWmApplication = { wmName, wmLabel, wmCommand }:
+        writeTextFile {
+          name = "gnome-flashback-${wmName}-wm";
+          destination = "/share/applications/${wmName}.desktop";
+          text = ''
+            [Desktop Entry]
+            Type=Application
+            Encoding=UTF-8
+            Name=${wmLabel}
+            Exec=${wmCommand}
+            NoDisplay=true
+            X-GNOME-WMName=${wmLabel}
+            X-GNOME-Autostart-Phase=WindowManager
+            X-GNOME-Provides=windowmanager
+            X-GNOME-Autostart-Notify=false
+          '';
+        };
+
       mkSessionForWm = { wmName, wmLabel, wmCommand, enableGnomePanel }:
         let
-          wmApplication = writeTextFile {
-            name = "gnome-flashback-${wmName}-wm";
-            destination = "/share/applications/${wmName}.desktop";
-            text = ''
-              [Desktop Entry]
-              Type=Application
-              Encoding=UTF-8
-              Name=${wmLabel}
-              Exec=${wmCommand}
-              NoDisplay=true
-              X-GNOME-WMName=${wmLabel}
-              X-GNOME-Autostart-Phase=WindowManager
-              X-GNOME-Provides=windowmanager
-              X-GNOME-Autostart-Notify=false
-            '';
-          };
-
           gnomeSession = writeTextFile {
             name = "gnome-flashback-${wmName}-gnome-session";
             destination = "/share/gnome-session/sessions/gnome-flashback-${wmName}.session";
@@ -174,7 +175,7 @@ let
               makeWrapper ${gnome-session}/bin/gnome-session $out \
                 --add-flags "--session=gnome-flashback-${wmName} --builtin" \
                 --set-default XDG_CURRENT_DESKTOP 'GNOME-Flashback:GNOME' \
-                --prefix XDG_DATA_DIRS : '${lib.makeSearchPath "share" [ wmApplication gnomeSession gnome-flashback ]}'
+                --prefix XDG_DATA_DIRS : '${lib.makeSearchPath "share" [ gnomeSession gnome-flashback ]}'
             '';
           };
 

--- a/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
@@ -146,18 +146,19 @@ let
           '';
         };
 
-      mkSessionForWm = { wmName, wmLabel, wmCommand, enableGnomePanel }:
-        let
-          gnomeSession = writeTextFile {
-            name = "gnome-flashback-${wmName}-gnome-session";
-            destination = "/share/gnome-session/sessions/gnome-flashback-${wmName}.session";
-            text = ''
-              [GNOME Session]
-              Name=GNOME Flashback (${wmLabel})
-              ${requiredComponents wmName enableGnomePanel}
-            '';
-          };
+      mkGnomeSession = { wmName, wmLabel, enableGnomePanel }:
+        writeTextFile {
+          name = "gnome-flashback-${wmName}-gnome-session";
+          destination = "/share/gnome-session/sessions/gnome-flashback-${wmName}.session";
+          text = ''
+            [GNOME Session]
+            Name=GNOME Flashback (${wmLabel})
+            ${requiredComponents wmName enableGnomePanel}
+          '';
+        };
 
+      mkSessionForWm = { wmName, wmLabel, wmCommand }:
+        let
           executable = stdenv.mkDerivation {
             name = "gnome-flashback-${wmName}";
 
@@ -175,7 +176,7 @@ let
               makeWrapper ${gnome-session}/bin/gnome-session $out \
                 --add-flags "--session=gnome-flashback-${wmName} --builtin" \
                 --set-default XDG_CURRENT_DESKTOP 'GNOME-Flashback:GNOME' \
-                --prefix XDG_DATA_DIRS : '${lib.makeSearchPath "share" [ gnomeSession gnome-flashback ]}'
+                --prefix XDG_DATA_DIRS : '${lib.makeSearchPath "share" [ gnome-flashback ]}'
             '';
           };
 

--- a/pkgs/desktops/gnome/misc/gnome-panel/wrapper.nix
+++ b/pkgs/desktops/gnome/misc/gnome-panel/wrapper.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, lib
+, buildEnv
+, gnome-panel
+, gnome-flashback
+, xorg
+, glib
+, wrapGAppsHook
+, panelModulePackages ? [ ]
+}:
+
+let
+  # We always want to find the built-in panel applets.
+  selectedPanelModulePackages = [ gnome-panel gnome-flashback ] ++ panelModulePackages;
+
+  panelModulesEnv = buildEnv {
+    name = "gnome-panel-modules-env";
+    paths = selectedPanelModulePackages;
+    pathsToLink = [ "/lib/gnome-panel/modules" ];
+  };
+in
+stdenv.mkDerivation {
+  pname = "${gnome-panel.pname}-with-modules";
+  inherit (gnome-panel) version;
+
+  nativeBuildInputs = [
+    glib
+    wrapGAppsHook
+  ];
+
+  buildInputs = selectedPanelModulePackages ++
+    lib.forEach selectedPanelModulePackages (x: x.buildInputs or [ ]);
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    ${xorg.lndir}/bin/lndir -silent ${gnome-panel} $out
+
+    rm -r $out/lib/gnome-panel/modules
+    ${xorg.lndir}/bin/lndir -silent ${panelModulesEnv} $out
+
+    rm $out/share/applications/gnome-panel.desktop
+
+    substitute ${gnome-panel}/share/applications/gnome-panel.desktop \
+      $out/share/applications/gnome-panel.desktop --replace \
+      "Exec=${gnome-panel}/bin/gnome-panel" "Exec=$out/bin/gnome-panel"
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set NIX_GNOME_PANEL_MODULESDIR "$out/lib/gnome-panel/modules"
+    )
+  '';
+
+  meta = gnome-panel.meta // { outputsToInstall = [ "out" ]; };
+}


### PR DESCRIPTION
## Description of changes

... which is part of graphical-session.target, in the end we still need to look at the builtin thing

So you don't need to wait for ~30s for app to startup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
