### PR TITLE
lomiri.lomiri-url-dispatcher: init at 0.1.3

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -18,6 +18,7 @@ let
     gmenuharness = callPackage ./development/gmenuharness { };
     libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
+    lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
     trust-store = callPackage ./development/trust-store { };
     u1db-qt = callPackage ./development/u1db-qt { };
 
@@ -31,8 +32,8 @@ let
     #### Services
     biometryd = callPackage ./services/biometryd { };
     hfd-service = callPackage ./services/hfd-service { };
-    lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
     lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
+    lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     mediascanner2 = callPackage ./services/mediascanner2 { };
   };
 in

--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -1,0 +1,159 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, dbus
+, dbus-test-runner
+, glib
+, gtest
+, intltool
+, json-glib
+, libapparmor
+, libxkbcommon
+, lomiri-app-launch
+, lomiri-ui-toolkit
+, makeWrapper
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+, qtwayland
+, sqlite
+, systemd
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-url-dispatcher";
+  version = "0.1.3";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-url-dispatcher";
+    rev = finalAttrs.version;
+    hash = "sha256-kde/HzhBHxTeyc2TCUJwpG7IfC8doDd/jNMF8KLM7KU=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Fix case-sensitivity in tests
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-url-dispatcher/-/merge_requests/8 merged & in release
+    (fetchpatch {
+      url = "https://gitlab.com/sunweaver/lomiri-url-dispatcher/-/commit/ebdd31b9640ca243e90bc7b8aca7951085998bd8.patch";
+      hash = "sha256-g4EohB3oDcWK4x62/3r/g6CFxqb7/rdK51+E/Fji1Do=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace "\''${SYSTEMD_USER_UNIT_DIR}" "\''${CMAKE_INSTALL_LIBDIR}/systemd/user"
+
+    substituteInPlace tests/url_dispatcher_testability/CMakeLists.txt \
+      --replace "\''${PYTHON_PACKAGE_DIR}" "$out/${python3.sitePackages}"
+
+    # Update URI handler database whenever new url-handler is installed system-wide
+    substituteInPlace data/lomiri-url-dispatcher-update-system-dir.*.in \
+      --replace '@CMAKE_INSTALL_FULL_DATAROOTDIR@' '/run/current-system/sw/share'
+  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
+    patchShebangs tests/test-sql.sh
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # for gdbus-codegen
+    intltool
+    makeWrapper
+    pkg-config
+    (python3.withPackages (ps: with ps; [
+      setuptools
+    ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
+      python-dbusmock
+    ]))
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cmake-extras
+    dbus-test-runner
+    glib
+    gtest
+    json-glib
+    libapparmor
+    lomiri-app-launch
+    lomiri-ui-toolkit
+    qtdeclarative
+    sqlite
+    systemd
+    libxkbcommon
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    sqlite
+  ];
+
+  cmakeFlags = [
+    "-DLOCAL_INSTALL=ON"
+    "-Denable_mirclient=OFF"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Tests work with an sqlite db, cannot handle >1 test at the same time
+  enableParallelChecking = false;
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    wrapProgram $out/bin/lomiri-url-dispatcher-dump \
+      --prefix PATH : ${lib.makeBinPath [ sqlite ]}
+
+    # Move from qmlscene call in desktop file to easier-to-wrap script
+    guiScript=$out/bin/lomiri-url-dispatcher-gui
+    guiExec=$(grep 'Exec=' $out/share/applications/lomiri-url-dispatcher-gui.desktop | cut -d'=' -f2-)
+
+    cat <<EOF >$guiScript
+    #!/bin/sh
+    $guiExec
+    EOF
+    chmod +x $guiScript
+    sed -i $out/share/applications/lomiri-url-dispatcher-gui.desktop -e "s@Exec=$guiExec@Exec=$guiScript@"
+
+    # Calls qmlscene from PATH, needs Qt plugins & QML components
+    qtWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ qtdeclarative.dev ]}
+    )
+    wrapQtApp $guiScript
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Lomiri operating environment service for requesting URLs to be opened";
+    longDescription = ''
+       Allows applications to request a URL to be opened and handled by another
+       process without seeing the list of other applications on the system or
+       starting them inside its own Application Confinement.
+    '';
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-url-dispatcher";
+    license = with licenses; [ lgpl3Only gpl3Only ];
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "lomiri-url-dispatcher"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -22,6 +22,7 @@
 , qtbase
 , qtdeclarative
 , qtwayland
+, runtimeShell
 , sqlite
 , systemd
 , wrapQtAppsHook
@@ -123,11 +124,12 @@ stdenv.mkDerivation (finalAttrs: {
     guiExec=$(grep 'Exec=' $out/share/applications/lomiri-url-dispatcher-gui.desktop | cut -d'=' -f2-)
 
     cat <<EOF >$guiScript
-    #!/bin/sh
+    #!${runtimeShell}
     $guiExec
     EOF
     chmod +x $guiScript
-    sed -i $out/share/applications/lomiri-url-dispatcher-gui.desktop -e "s@Exec=$guiExec@Exec=$guiScript@"
+    substituteInPlace $out/share/applications/lomiri-url-dispatcher-gui.desktop \
+      --replace "Exec=$guiExec" "Exec=$guiScript"
 
     # Calls qmlscene from PATH, needs Qt plugins & QML components
     qtWrapperArgs+=(

--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -116,6 +116,9 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   preFixup = ''
+    substituteInPlace $out/bin/lomiri-url-dispatcher-dump \
+      --replace '/bin/sh' '${runtimeShell}'
+
     wrapProgram $out/bin/lomiri-url-dispatcher-dump \
       --prefix PATH : ${lib.makeBinPath [ sqlite ]}
 
@@ -128,8 +131,13 @@ stdenv.mkDerivation (finalAttrs: {
     $guiExec
     EOF
     chmod +x $guiScript
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    ln -s $out/share/lomiri-url-dispatcher/gui/lomiri-url-dispatcher-gui.svg $out/share/icons/hicolor/scalable/apps/
+
     substituteInPlace $out/share/applications/lomiri-url-dispatcher-gui.desktop \
-      --replace "Exec=$guiExec" "Exec=$guiScript"
+      --replace "Exec=$guiExec" "Exec=$(basename $guiScript)" \
+      --replace "Icon=$out/share/lomiri-url-dispatcher/gui/lomiri-url-dispatcher-gui.svg" "Icon=lomiri-url-dispatcher-gui"
 
     # Calls qmlscene from PATH, needs Qt plugins & QML components
     qtWrapperArgs+=(


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri URL Dispatcher](https://gitlab.com/ubports/development/core/lomiri-url-dispatcher) takes URL requests and launches whatever applications are registered handlers for them. Examples for (yet-to-be-added) handlers are `alarm://` for `lomiri-clock-app`, `settings://` for `lomiri-system-settings`, the usual `http://` & `https://` for `morph-browser`, `tel://`& `dialer://` for `dialer-app`, etc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
