### PR TITLE
webkitgtk: 2.40.5 → 2.42.1

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -27,6 +27,7 @@
 , libxkbcommon
 , libavif
 , libepoxy
+, libjxl
 , at-spi2-core
 , libxml2
 , libsoup
@@ -34,7 +35,6 @@
 , libxslt
 , harfbuzz
 , libpthreadstubs
-, pcre
 , nettle
 , libtasn1
 , p11-kit
@@ -51,7 +51,6 @@
 , openjpeg
 , geoclue2
 , sqlite
-, enableGLES ? true
 , gst-plugins-base
 , gst-plugins-bad
 , woff2
@@ -71,7 +70,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "webkitgtk";
-  version = "2.40.5";
+  version = "2.42.1";
   name = "${finalAttrs.pname}-${finalAttrs.version}+abi=${if lib.versionAtLeast gtk3.version "4.0" then "6.0" else "4.${if lib.versions.major libsoup.version == "2" then "0" else "1"}"}";
 
   outputs = [ "out" "dev" "devdoc" ];
@@ -82,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/webkitgtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-feBRomNmhiHZGmGl6xw3cdGnzskABD1K/vBsMmwWA38=";
+    hash = "sha256-b0H6yZidPuUcCMSN4dQ5ze3ey8dX40thgJh9mbFtJJk=";
   };
 
   patches = lib.optionals stdenv.isLinux [
@@ -132,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     enchant2
     libavif
     libepoxy
+    libjxl
     gnutls
     gst-plugins-bad
     gst-plugins-base
@@ -153,7 +153,6 @@ stdenv.mkDerivation (finalAttrs: {
     nettle
     openjpeg
     p11-kit
-    pcre
     sqlite
     woff2
   ] ++ (with xorg; [
@@ -219,8 +218,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DUSE_GTK4=ON"
   ] ++ lib.optionals (!systemdSupport) [
     "-DENABLE_JOURNALD_LOG=OFF"
-  ] ++ lib.optionals (stdenv.isLinux && enableGLES) [
-    "-DENABLE_GLES2=ON"
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/webkitgtk/fdo-backend-path.patch
+++ b/pkgs/development/libraries/webkitgtk/fdo-backend-path.patch
@@ -3,7 +3,7 @@
 @@ -84,7 +84,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
  
  #if PLATFORM(WAYLAND)
-     if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::Wayland) {
+     if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::Wayland && parameters.dmaBufRendererBufferMode.isEmpty()) {
 -        wpe_loader_init("libWPEBackend-fdo-1.0.so.1");
 +        wpe_loader_init("@wpebackend_fdo@/lib/libWPEBackend-fdo-1.0.so.1");
          if (AcceleratedBackingStoreWayland::checkRequirements()) {


### PR DESCRIPTION
Picked from [GNOME 45 PR](https://github.com/NixOS/nixpkgs/pull/247766), as there is no reason to hold this back.

## Description of changes

https://github.com/WebKit/WebKit/commits/webkitgtk-2.42.1/Source/cmake/OptionsGTK.cmake https://webkitgtk.org/security/WSA-2023-0009.html

JPEG XL is enabled by default.

Remove support for OpenGL API in the web process;
Remove GLX support:

https://github.com/WebKit/WebKit/commit/cfe917fec45bf72c371087ece034feee8454f1b4 https://github.com/WebKit/WebKit/commit/320560f9e53ddcd53954059bd005e0c75eb91abf

Other than ENABLE_GLES2 option can be dropped, it is unclear to me what can actually be dropped so keeping everything around. I assume we keep libGL mainly for egl.

But we don't really need to worry about https://bugzilla.redhat.com/show_bug.cgi?id=2240428 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050777 here, we are applying libgl-path.patch to libepoxy which should load the libGLESv2 thing in a hardcoded path.

Tested yelp, newsflash and the bundled minibrowser and does not experience crash so far.

Dropped pcre as mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=2212686.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
