### PR TITLE
properties-cpp: 0.0.1 -> 0.0.3

### DIFF
--- a/pkgs/development/libraries/properties-cpp/default.nix
+++ b/pkgs/development/libraries/properties-cpp/default.nix
@@ -1,35 +1,63 @@
-{ lib, stdenv
-, fetchurl
+{ lib
+, stdenv
+, fetchFromGitLab
+, gitUpdater
+, testers
 , cmake
 , pkg-config
 , gtest
 , doxygen
 , graphviz
-, lcov
+, lomiri
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "properties-cpp";
-  version = "0.0.1";
+  version = "0.0.3";
 
-  src = let srcver = "${version}+14.10.20140730"; in
-    fetchurl {
-      url = "https://launchpad.net/ubuntu/+archive/primary/+files/${pname}_${srcver}.orig.tar.gz";
-      sha256 = "08vjyv7ibn6jh2ikj5v48kjpr3n6hlkp9qlvdn8r0vpiwzah0m2w";
-    };
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lib-cpp/properties-cpp";
+    rev = finalAttrs.version;
+    hash = "sha256-C/BDEuKNMQHOjATO5aWBptjIlgfv6ykzjFAsHb6uP3Q=";
+  };
 
-  postPatch = ''
+  postPatch = lib.optionalString (!finalAttrs.doCheck) ''
     sed -i "/add_subdirectory(tests)/d" CMakeLists.txt
   '';
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  strictDeps = true;
 
-  buildInputs = [ gtest doxygen graphviz lcov ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+    pkg-config
+  ];
+
+  buildInputs = [
+    lomiri.cmake-extras
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
 
   meta = with lib; {
-    homepage = "https://launchpad.net/properties-cpp";
+    homepage = "https://gitlab.com/ubports/development/core/lib-cpp/properties-cpp";
     description = "A very simple convenience library for handling properties and signals in C++11";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ edwtjo ];
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "properties-cpp"
+    ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

The [changelog notes on launchpad](https://launchpad.net/ubuntu/+source/properties-cpp/0.0.3-1) sounds like they're not the actual upstream for this project (possibly the lib-cpp projects in general), the [debian directory tarball](https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/properties-cpp/0.0.3-1/properties-cpp_0.0.3-1.debian.tar.xz) on there says the upstream is https://gitlab.com/ubports/development/core/lib-cpp/properties-cpp.

- Changed upstream to the UBports / Lomiri GitLab
- Cleaned up / updated expression
  - Corrected inputs splitting
  - Removed dependency on coverage reporter (doesn't matter for us)
  - Added `meta.platforms`
  - Moved from `rec` attrset to `finalAttrs` function style
- Enabled tests
- Added pkg-config modules details & test
- Added update script

This is potentially something that the Lomiri team should maintain (related to #99090) and [there are more projects that belong to the lib-cpp collection of projects](https://gitlab.com/ubports/development/core/lib-cpp), but I opted to not change anything about the maintenance details yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [Kinda] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  My current hardware is too weak for `nixpkgs-review`, but tested building `anbox`, `ubports-click` & `process-cpp`.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
