### PR TITLE
gtkcord4: 0.0.12 -> 0.0.16-1

### DIFF
--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -59,9 +59,10 @@ buildGoModule rec {
   vendorHash = "sha256-ZQBYi5t6ntukoHP2FtwpZrpFd7b2opPC8tOSU9j3jUM=";
 
   meta = with lib; {
-    description = "GTK4 Discord client in Go, attempt #4.";
+    description = "GTK4 Discord client in Go, attempt #4";
     homepage = "https://github.com/diamondburned/gtkcord4";
     license = licenses.gpl3Only;
+    mainProgram = "gtkcord4";
     maintainers = with maintainers; [ hmenke urandom aleksana ];
   };
 }

--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -18,13 +18,13 @@
 
 buildGoModule rec {
   pname = "gtkcord4";
-  version = "0.0.12";
+  version = "0.0.16-1";
 
   src = fetchFromGitHub {
     owner = "diamondburned";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-x//PST2f501QuxRdPe3cYbpL66/zLJWmscED9SbxsTk=";
+    hash = "sha256-GDQ11X202RIoJUZ2eJ9ukHalhXtKYn9C8lcvAzzaB+4=";
   };
 
   nativeBuildInputs = [
@@ -52,12 +52,11 @@ buildGoModule rec {
   ];
 
   postInstall = ''
-    install -D -m 444 -t $out/share/applications nix/xyz.diamondb.gtkcord4.desktop
-    install -D -m 444 internal/icons/svg/logo.svg $out/share/icons/hicolor/scalable/apps/gtkcord4.svg
-    install -D -m 444 internal/icons/png/logo.png $out/share/icons/hicolor/256x256/apps/gtkcord4.png
+    install -D -m 444 -t $out/share/applications nix/so.libdb.gtkcord4.desktop
+    install -D -m 444 internal/icons/hicolor/scalable/apps/logo.svg $out/share/icons/hicolor/scalable/apps/gtkcord4.svg
   '';
 
-  vendorHash = "sha256-LCLZBcYiexffvCr4vdZdIwNKo0s4mqPc6KxRumRhf1Y=";
+  vendorHash = "sha256-ZQBYi5t6ntukoHP2FtwpZrpFd7b2opPC8tOSU9j3jUM=";
 
   meta = with lib; {
     description = "GTK4 Discord client in Go, attempt #4.";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New upstream releases:
- https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.13 [`v0.0.12...v0.0.13`](https://github.com/diamondburned/gtkcord4/compare/v0.0.12...v0.0.13)
- https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.14 [`v0.0.13...v0.0.14`](https://github.com/diamondburned/gtkcord4/compare/v0.0.13...v0.0.14)
- https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.15 [`v0.0.14...v0.0.15`](https://github.com/diamondburned/gtkcord4/compare/v0.0.14...v0.0.15)
- https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.15-1 [`v0.0.15...v0.0.15-1`](https://github.com/diamondburned/gtkcord4/compare/v0.0.15...v0.0.15-1)
- https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.16 [`v0.0.15-1...v0.0.16`](https://github.com/diamondburned/gtkcord4/compare/v0.0.15-1...v0.0.16)
- https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.16-1 [`v0.0.16...v0.0.16-1`](https://github.com/diamondburned/gtkcord4/compare/v0.0.16...v0.0.16-1)

AppID has been renamed: https://github.com/diamondburned/gtkcord4/issues/156

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
