### PR TITLE
python310Packages.jupyter-server: disable failing test_copy_big_dir on all linux

### DIFF
--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -5,12 +5,10 @@
 , pythonOlder
 , hatch-jupyter-builder
 , hatchling
-, pandoc
 , pytestCheckHook
 , pytest-console-scripts
 , pytest-jupyter
 , pytest-timeout
-, pytest-tornasync
 , argon2-cffi
 , jinja2
 , tornado
@@ -102,7 +100,8 @@ buildPythonPackage rec {
     "test_authorized_requests"
     # Insufficient access privileges for operation
     "test_regression_is_hidden"
-  ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+  ] ++ lib.optionals stdenv.isLinux [
+    # Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
     "test_copy_big_dir"
   ];
 


### PR DESCRIPTION
## Description of changes

```
jupyter-server> tests/services/contents/test_api.py .................................... [ 51%]
jupyter-server> ........................................................................ [ 60%]
jupyter-server> ........................................................................ [ 68%]
jupyter-server> ......................................................                   [ 75%]
jupyter-server> tests/services/contents/test_checkpoints.py ............                 [ 76%]
jupyter-server> tests/services/contents/test_config.py .....                             [ 77%]
jupyter-server> tests/services/contents/test_fileio.py ......                            [ 78%]
jupyter-server> tests/services/contents/test_largefilemanager.py ..............          [ 79%]
jupyter-server> tests/services/contents/test_manager.py ................................ [ 83%]
jupyter-server> ...................................................FFF.................. [ 92%]
jupyter-server> ..                                                                       [ 92%]
jupyter-server> tests/services/events/test_api.py .........                              [ 93%]
jupyter-server> tests/services/events/test_extension.py .                                [ 94%]
jupyter-server> tests/services/kernels/test_config.py ...                                [ 94%]
jupyter-server> tests/services/kernels/test_connection.py .                              [ 94%]
jupyter-server> tests/services/kernels/test_cull.py .                                    [ 94%]
jupyter-server> tests/services/kernels/test_events.py ............                       [ 96%]
jupyter-server> tests/services/kernelspecs/test_api.py ......                            [ 96%]
jupyter-server> tests/services/nbconvert/test_api.py .                                   [ 96%]
jupyter-server> tests/services/sessions/test_manager.py ................                 [ 98%]
jupyter-server> tests/unix_sockets/test_api.py ..                                        [ 99%]
jupyter-server> tests/unix_sockets/test_serverapp_integration.py sssssss                 [100%]
jupyter-server>
jupyter-server> =================================== FAILURES ===================================
jupyter-server> ___________________ test_copy_big_dir[jp_contents_manager1] ____________________
jupyter-server>
jupyter-server> jp_contents_manager = <jupyter_server.services.contents.filemanager.FileContentsManager object at 0x7ffff1c08460>
jupyter-server>
jupyter-server>     async def test_copy_big_dir(jp_contents_manager):
jupyter-server>         # this tests how the Content API limits preventing copying folders that are more than
jupyter-server>         # the size limit specified in max_copy_folder_size_mb trait
jupyter-server>         cm = jp_contents_manager
jupyter-server>         destDir = "Untitled Folder 1"
jupyter-server>         sourceDir = "Morningstar Notebooks"
jupyter-server>         cm.max_copy_folder_size_mb = 5
jupyter-server>         _make_dir(cm, destDir)
jupyter-server>         _make_big_dir(contents_manager=cm, api_path=sourceDir)
jupyter-server> >       with pytest.raises(HTTPError) as exc_info:
jupyter-server> E       Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
jupyter-server>
jupyter-server> tests/services/contents/test_manager.py:896: Failed
jupyter-server> ___________________ test_copy_big_dir[jp_contents_manager2] ____________________
jupyter-server>
jupyter-server> jp_contents_manager = <jupyter_server.services.contents.filemanager.AsyncFileContentsManager object at 0x7ffff1dcb2b0>
jupyter-server>
jupyter-server>     async def test_copy_big_dir(jp_contents_manager):
jupyter-server>         # this tests how the Content API limits preventing copying folders that are more than
jupyter-server>         # the size limit specified in max_copy_folder_size_mb trait
jupyter-server>         cm = jp_contents_manager
jupyter-server>         destDir = "Untitled Folder 1"
jupyter-server>         sourceDir = "Morningstar Notebooks"
jupyter-server>         cm.max_copy_folder_size_mb = 5
jupyter-server>         _make_dir(cm, destDir)
jupyter-server>         _make_big_dir(contents_manager=cm, api_path=sourceDir)
jupyter-server> >       with pytest.raises(HTTPError) as exc_info:
jupyter-server> E       Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
jupyter-server>
jupyter-server> tests/services/contents/test_manager.py:896: Failed
jupyter-server> ___________________ test_copy_big_dir[jp_contents_manager3] ____________________
jupyter-server>
jupyter-server> jp_contents_manager = <jupyter_server.services.contents.filemanager.AsyncFileContentsManager object at 0x7ffff1d40160>
jupyter-server>
jupyter-server>     async def test_copy_big_dir(jp_contents_manager):
jupyter-server>         # this tests how the Content API limits preventing copying folders that are more than
jupyter-server>         # the size limit specified in max_copy_folder_size_mb trait
jupyter-server>         cm = jp_contents_manager
jupyter-server>         destDir = "Untitled Folder 1"
jupyter-server>         sourceDir = "Morningstar Notebooks"
jupyter-server>         cm.max_copy_folder_size_mb = 5
jupyter-server>         _make_dir(cm, destDir)
jupyter-server>         _make_big_dir(contents_manager=cm, api_path=sourceDir)
jupyter-server> >       with pytest.raises(HTTPError) as exc_info:
jupyter-server> E       Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
jupyter-server>
jupyter-server> tests/services/contents/test_manager.py:896: Failed
jupyter-server> =============================== warnings summary ===============================
jupyter-server> tests/auth/test_authorizer.py::test_authorized_requests[False-GET-/api/contents-None]
jupyter-server>   /nix/store/8gzy5wqmr0la63dh95nas76kb3bchnca-python3.10-tornado-6.3.3/lib/python3.10/site-packages/tornado/routing.py:626: ResourceWarning: unclosed <socket.socket fd=20, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 53450), raddr=('127.0.0.1', 45263)>
jupyter-server>     for fragment in pattern.split("("):
jupyter-server>   Enable tracemalloc to get traceback where the object was allocated.
jupyter-server>   See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
jupyter-server>
jupyter-server> -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
jupyter-server> ===Flaky Test Report===
jupyter-server>
jupyter-server> test_culling_config passed 1 out of the required 1 times. Success!
jupyter-server> test_culling passed 1 out of the required 1 times. Success!
jupyter-server>
jupyter-server> ===End Flaky Test Report===
jupyter-server> ============================= slowest 10 durations =============================
jupyter-server> 12.12s call     tests/test_terminal.py::test_culling
jupyter-server> 5.03s call     tests/test_terminal.py::test_terminal_create_with_cwd
jupyter-server> 3.17s call     tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager2]
jupyter-server> 3.11s call     tests/services/sessions/test_manager.py::test_pending_kernel
jupyter-server> 2.85s call     tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager3]
jupyter-server> 2.84s call     tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager1]
jupyter-server> 1.41s call     tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager0]
jupyter-server> 1.12s teardown tests/auth/test_authorizer.py::test_authorized_requests[True-GET-/api/kernels/{kernel_id}/channels-None]
jupyter-server> 1.12s teardown tests/services/kernels/test_connection.py::test_websocket_connection
jupyter-server> 1.11s call     tests/extension/test_serverextension.py::test_help_output
jupyter-server> =========================== short test summary info ============================
jupyter-server> SKIPPED [1] tests/test_terminal.py:161: Not yet working
jupyter-server> SKIPPED [1] tests/test_terminal.py:198: Not yet working
jupyter-server> SKIPPED [7] tests/conftest.py:37: Skipping this test because it's marked 'integration_test'. Run integration tests using the `--integration_tests` flag.
jupyter-server> FAILED tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager1] - Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
jupyter-server> FAILED tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager2] - Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
jupyter-server> FAILED tests/services/contents/test_manager.py::test_copy_big_dir[jp_contents_manager3] - Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
jupyter-server> = 3 failed, 811 passed, 9 skipped, 3 deselected, 1 warning in 97.40s (0:01:37) =
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
