### PR TITLE
merkaartor: build with cmake

### DIFF
--- a/pkgs/applications/misc/merkaartor/default.nix
+++ b/pkgs/applications/misc/merkaartor/default.nix
@@ -2,7 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , fetchpatch
-, qmake
+, cmake
+, pkg-config
 , qttools
 , wrapQtAppsHook
 , gdal
@@ -32,9 +33,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/openstreetmap/merkaartor/commit/1e20d2ccd743ea5f8c2358e4ae36fead8b9390fd.patch";
       hash = "sha256-aHjJLKYvqz7V0QwUIg0SbentBe+DaCJusVqy4xRBVWo=";
     })
+    # https://github.com/openstreetmap/merkaartor/pull/290
+    (fetchpatch {
+      url = "https://github.com/openstreetmap/merkaartor/commit/7dede77370d89e8e7586f6ed5af225f9b5bde6cf.patch";
+      hash = "sha256-3oDRPysVNvA50t/b9xOcVQgac3U1lDPrencanl4c6Zk=";
+    })
   ];
 
-  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake pkg-config qttools wrapQtAppsHook ];
 
   buildInputs = [ gdal proj qtsvg qtwebengine ]
     ++ lib.optional withGeoimage exiv2
@@ -42,27 +48,25 @@ stdenv.mkDerivation rec {
     ++ lib.optional withLibproxy libproxy
     ++ lib.optional withZbar zbar;
 
-  preConfigure = ''
-    lrelease src/src.pro
-  '';
-
-  qmakeFlags = [
-    "USEWEBENGINE=1"
-  ] ++ lib.optional withGeoimage "GEOIMAGE=1"
-    ++ lib.optional withGpsdlib "GPSDLIB=1"
-    ++ lib.optional withLibproxy "LIBPROXY=1"
-    ++ lib.optional withZbar "ZBAR=1";
+  cmakeFlags = [
+    (lib.cmakeBool "GEOIMAGE" withGeoimage)
+    (lib.cmakeBool "GPSD" withGpsdlib)
+    (lib.cmakeBool "LIBPROXY" withLibproxy)
+    (lib.cmakeBool "WEBENGINE" true)
+    (lib.cmakeBool "ZBAR" withZbar)
+  ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
-    mkdir -p $out/Applications
-    mv binaries/bin/merkaartor.app $out/Applications
-    mv binaries/bin/plugins $out/Applications/merkaartor.app/Contents
+    mkdir -p $out/{Applications,bin}
+    mv $out/merkaartor.app $out/Applications
+    makeWrapper $out/{Applications/merkaartor.app/Contents/MacOS,bin}/merkaartor
   '';
 
   meta = with lib; {
     description = "OpenStreetMap editor";
     homepage = "http://merkaartor.be/";
     license = licenses.gpl2Plus;
+    mainProgram = "merkaartor";
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
## Description of changes

https://github.com/openstreetmap/merkaartor/blob/0.19.0/Merkaartor.pro

> qmake support is deprecated, please use cmake build system whenever possible. qmake support will be removed in 0.20.0 release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
