### PR TITLE
vice: use GTK+-3 UI and use included desktop files

### DIFF
--- a/pkgs/applications/emulators/vice/default.nix
+++ b/pkgs/applications/emulators/vice/default.nix
@@ -6,116 +6,23 @@
 , perl
 , libpng
 , giflib
-, libjpeg
 , alsa-lib
 , readline
 , libGLU
 , libGL
-, libXaw
 , pkg-config
-, gtk2
+, gtk3
+, glew
 , SDL
 , SDL_image
-, autoreconfHook
-, makeDesktopItem
 , dos2unix
+, runtimeShell
 , xa
 , file
+, wrapGAppsHook
+, xdg-utils
 }:
 
-let
-  desktopItems = [
-    (makeDesktopItem {
-      name = "x128";
-      exec = "x128";
-      comment = "VICE: C128 Emulator";
-      desktopName = "VICE: C128 Emulator";
-      genericName = "Commodore 128 emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "x64dtv";
-      exec = "x64dtv";
-      comment = "VICE: C64 DTV Emulator";
-      desktopName = "VICE: C64 DTV Emulator";
-      genericName = "Commodore 64 DTV emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "x64sc";
-      exec = "x64sc";
-      comment = "VICE: C64 Emulator";
-      desktopName = "VICE: C64 Emulator";
-      genericName = "Commodore 64 SC emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "xcbm2";
-      exec = "xcbm2";
-      comment = "VICE: CBM-II B-Model Emulator";
-      desktopName = "VICE: CBM-II B-Model Emulator";
-      genericName = "CBM-II B-Model Emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "xcbm5x0";
-      exec = "xcbm5x0";
-      comment = "VICE: CBM-II P-Model Emulator";
-      desktopName = "VICE: CBM-II P-Model Emulator";
-      genericName = "CBM-II P-Model Emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "xpet";
-      exec = "xpet";
-      comment = "VICE: PET Emulator";
-      desktopName = "VICE: PET Emulator";
-      genericName = "Commodore PET Emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "xplus4";
-      exec = "xplus4";
-      comment = "VICE: PLUS4 Emulator";
-      desktopName = "VICE: PLUS4 Emulator";
-      genericName = "Commodore PLUS4 Emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "xscpu64";
-      exec = "xscpu64";
-      comment = "VICE: SCPU64 Emulator";
-      desktopName = "VICE: SCPU64 Emulator";
-      genericName = "Commodore SCPU64 Emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "xvic";
-      exec = "xvic";
-      comment = "VICE: VIC-20 Emulator";
-      desktopName = "VICE: VIC-20 Emulator";
-      genericName = "Commodore VIC-20 Emulator";
-      categories = [ "System" ];
-    })
-
-    (makeDesktopItem {
-      name = "vsid";
-      exec = "vsid";
-      comment = "VSID: The SID Emulator";
-      desktopName = "VSID: The SID Emulator";
-      genericName = "SID Emulator";
-      categories = [ "System" ];
-    })
-  ];
-in
 stdenv.mkDerivation rec {
   pname = "vice";
   version = "3.7.1";
@@ -126,46 +33,41 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    autoreconfHook
     bison
     dos2unix
     file
     flex
     pkg-config
+    wrapGAppsHook
   ];
 
   buildInputs = [
     alsa-lib
     giflib
-    gtk2
+    gtk3
+    glew
     libGL
     libGLU
-    libXaw
-    libjpeg
     libpng
     perl
     readline
     SDL
     SDL_image
     xa
+    xdg-utils
   ];
   dontDisableStatic = true;
-  configureFlags = [ "--enable-fullscreen" "--enable-gnomeui" "--disable-pdf-docs" ];
+  configureFlags = [ "--enable-sdl2ui" "--enable-gtk3ui" "--enable-desktop-files" "--disable-pdf-docs" "--with-gif" ];
+
+  LIBS = "-lGL";
 
   preBuild = ''
-    for i in src/resid src/resid-dtv
-    do
-      mkdir -pv $i/src
-      ln -sv ../../wrap-u-ar.sh $i/src
-    done
+    sed -i -e 's|#!/usr/bin/env bash|${runtimeShell}/bin/bash|' src/arch/gtk3/novte/box_drawing_generate.sh
   '';
 
   postInstall = ''
-    for app in ${toString desktopItems}
-    do
-        mkdir -p $out/share/applications
-        cp $app/share/applications/* $out/share/applications
-    done
+    mkdir -p $out/share/applications
+    cp src/arch/gtk3/data/unix/vice-org-*.desktop $out/share/applications
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

The GTK+ UI is the recommended UI by the developers. It also fixed the x128 emulator from crashing. Moreover, the GTK+ UI also includes desktop files, so we should use these instead of our own.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
