### PR TITLE
quarto: added platforms.all

### DIFF
--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (final: {
     changelog = "https://github.com/quarto-dev/quarto-cli/releases/tag/v${version}";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ minijackson mrtarantoga ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
+    platforms = platforms.all;
     sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
   };
 })

--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (final: {
       mv bin/* $out/bin
       mv share/* $out/share
 
-      runHook preInstall
+      runHook postInstall
   '';
 
   passthru.tests = {

--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (final: {
     changelog = "https://github.com/quarto-dev/quarto-cli/releases/tag/v${version}";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ minijackson mrtarantoga ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
     sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
   };
 })

--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -13,6 +13,7 @@
 , python3
 , quarto
 , extraPythonPackages ? ps: with ps; []
+, sysctl
 }:
 
 stdenv.mkDerivation (final: {
@@ -64,7 +65,9 @@ stdenv.mkDerivation (final: {
   '';
 
   passthru.tests = {
-    quarto-check = runCommand "quarto-check" {} ''
+    quarto-check = runCommand "quarto-check" {
+      nativeBuildInputs = lib.optionals stdenv.isDarwin [ sysctl ];
+    } ''
       export HOME="$(mktemp -d)"
       ${quarto}/bin/quarto check
       touch $out


### PR DESCRIPTION
## Description of changes

quarto: added platforms.all

Second attempt at this. I mistakenly erased the branch on which I was working for https://github.com/NixOS/nixpkgs/pull/258043 which closed the PR. 

## Things done

I've added more platforms so that quarto now builds for x86_64-linux, x86_64-darwin, aarch64-linux and aarch64-darwin. 
The same tarball gets used for all platforms, so there was no need to change that. 

I built the package on x86_64-linux, x86_64-darwin and aarch64-linux and was able to run the checks using `quarto check`. I did not personally test it on aarch64-darwin, but  @sagikazarmark has been running it successfully for quite some time now on his own fork. 

I tried to follow contributing.md as much as possible, hope I didn't miss anything this time!

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
