### PR TITLE
Reinit typora

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12801,6 +12801,12 @@
     githubId = 9939720;
     name = "Philippe Nguyen";
   };
+  npulidomateo = {
+    matrix = "@npulidomateo:matrix.org";
+    github = "npulidomateo";
+    githubId = 13149442;
+    name = "Nico Pulido-Mateo";
+  };
   nrdxp = {
     email = "tim.deh@pm.me";
     matrix = "@timdeh:matrix.org";

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -98,7 +98,7 @@ in stdenv.mkDerivation {
     description = "A markdown editor, a markdown reader";
     homepage = "https://typora.io/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ jensbin npulidomateo ];
+    maintainers = with maintainers; [ npulidomateo ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -1,0 +1,104 @@
+{ stdenv
+, fetchurl
+, dpkg
+, lib
+, glib
+, nss
+, nspr
+, at-spi2-atk
+, cups
+, dbus
+, libdrm
+, gtk3
+, pango
+, cairo
+, xorg
+, libxkbcommon
+, mesa
+, expat
+, alsa-lib
+, buildFHSEnv
+}:
+
+let
+  pname = "typora";
+  version = "1.7.5";
+  src = fetchurl {
+    url = "https://download.typora.io/linux/typora_${version}_amd64.deb";
+    hash = "sha256-4Q+fx1kNu98+nxnI/7hLhE6zOdNsaAiAnW6xVd+hZOI=";
+  };
+
+  typoraBase = stdenv.mkDerivation {
+    inherit pname version src;
+
+    nativeBuildInputs = [ dpkg ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin $out/share
+      mv usr/share $out
+      ln -s $out/share/typora/Typora $out/bin/Typora
+      runHook postInstall
+    '';
+  };
+
+  typoraFHS = buildFHSEnv {
+    name = "typora-fhs";
+    targetPkgs = pkgs: (with pkgs; [
+      typoraBase
+      udev
+      alsa-lib
+      glib
+      nss
+      nspr
+      atk
+      cups
+      dbus
+      gtk3
+      libdrm
+      pango
+      cairo
+      mesa
+      expat
+      libxkbcommon
+    ]) ++ (with pkgs.xorg; [
+      libX11
+      libXcursor
+      libXrandr
+      libXcomposite
+      libXdamage
+      libXext
+      libXfixes
+      libxcb
+    ]);
+    runScript = ''
+      Typora $*
+    '';
+  };
+
+in stdenv.mkDerivation {
+  inherit pname version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    ln -s ${typoraFHS}/bin/typora-fhs $out/bin/typora
+    ln -s ${typoraBase}/share/ $out
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A markdown editor, a markdown reader";
+    homepage = "https://typora.io/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jensbin npulidomateo ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34434,6 +34434,8 @@ with pkgs;
 
   synfigstudio = callPackage ../applications/graphics/synfigstudio { };
 
+  typora = callPackage ../applications/editors/typora { };
+
   taxi = callPackage ../applications/networking/ftp/taxi { };
 
   taxi-cli = with python3Packages; toPythonApplication taxi;


### PR DESCRIPTION
## Description of changes

### Motivation

Typora was removed in pull request #137425 because it refused to run. In issue #250200 it was requested again with a hint that it might run inside an FHS environment. In  #138329 it is said that there is no problem in adding it again if it runs.

closes #250200

### Actual changes 

The derivation of `typora` was re-written from scratch. The `.deb` file is downloaded and unpacked. An FHS environment is created. Typora is run inside the FHS environment.  

I'm adding myself to the maintainers of this package.

*Edit 2023-10-13:* Remove @jensbin from maintainer array.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Output of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` is:
 <details> 
   <summary>1 package built:</summary> 
   <ul> 
    <li>typora</li> 
   </ul> 
 </details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
