### PR TITLE
treewide: test eval fixes

### DIFF
--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -30,13 +30,15 @@ let
             })
           ({ options, ... }: {
             key = "nodes.nix-pkgs";
-            config = mkIf (!options.nixpkgs.pkgs.isDefined) {
-              # Ensure we do not use aliases. Ideally this is only set
-              # when the test framework is used by Nixpkgs NixOS tests.
-              nixpkgs.config.allowAliases = false;
-              # TODO: switch to nixpkgs.hostPlatform and make sure containers-imperative test still evaluates.
-              nixpkgs.system = hostPkgs.stdenv.hostPlatform.system;
-            };
+            config = optionalAttrs (!config.node.pkgsReadOnly) (
+              mkIf (!options.nixpkgs.pkgs.isDefined) {
+                # Ensure we do not use aliases. Ideally this is only set
+                # when the test framework is used by Nixpkgs NixOS tests.
+                nixpkgs.config.allowAliases = false;
+                # TODO: switch to nixpkgs.hostPlatform and make sure containers-imperative test still evaluates.
+                nixpkgs.system = hostPkgs.stdenv.hostPlatform.system;
+              }
+            );
           })
           testModuleArgs.config.extraBaseModules
         ];

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -154,5 +154,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ erictapen bbenno joscha ];
+  meta.maintainers = with lib.maintainers; [ erictapen bbenno ];
 }

--- a/nixos/modules/services/network-filesystems/orangefs/server.nix
+++ b/nixos/modules/services/network-filesystems/orangefs/server.nix
@@ -192,7 +192,7 @@ in {
     # orangefs daemon will run as user
     users.users.orangefs = {
       isSystemUser = true;
-      group = "orangfs";
+      group = "orangefs";
     };
     users.groups.orangefs = {};
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -331,7 +331,6 @@ in {
   graylog = handleTest ./graylog.nix {};
   grocy = handleTest ./grocy.nix {};
   grub = handleTest ./grub.nix {};
-  guacamole-client = handleTest ./guacamole-client.nix {};
   guacamole-server = handleTest ./guacamole-server.nix {};
   gvisor = handleTest ./gvisor.nix {};
   hadoop = import ./hadoop { inherit handleTestOn; package=pkgs.hadoop; };

--- a/nixos/tests/dconf.nix
+++ b/nixos/tests/dconf.nix
@@ -14,8 +14,8 @@ import ./make-test-python.nix
         profiles.user.databases = [
           {
             settings = {
-              "test/not/locked" = mkInt32 1;
-              "test/is/locked" = "locked";
+              "test/not".locked = mkInt32 1;
+              "test/is".locked = "locked";
             };
             locks = [
               "/test/is/locked"

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -28,7 +28,7 @@ import ./make-test-python.nix ({ pkgs, ... } : {
         };
       };
       boot.extraModulePackages =
-        optional (versionOlder config.boot.kernelPackages.kernel.version "5.6")
+        pkgs.lib.optional (pkgs.lib.versionOlder config.boot.kernelPackages.kernel.version "5.6")
           config.boot.kernelPackages.wireguard;
       boot.kernelModules = [ "wireguard" ];
     };

--- a/nixos/tests/legit.nix
+++ b/nixos/tests/legit.nix
@@ -8,7 +8,7 @@ in
   meta.maintainers = [ lib.maintainers.ratsclub ];
 
   nodes = {
-    server = { config, pkgs }: {
+    server = { config, pkgs, ... }: {
       services.legit = {
         enable = true;
         settings = {

--- a/nixos/tests/litestream.nix
+++ b/nixos/tests/litestream.nix
@@ -44,14 +44,22 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       };
       services.grafana = {
         enable = true;
-        security = {
-          adminUser = "admin";
-          adminPassword = "admin";
-        };
-        addr = "localhost";
-        port = 3000;
-        extraOptions = {
-          DATABASE_URL = "sqlite3:///var/lib/grafana/data/grafana.db?cache=private&mode=rwc&_journal_mode=WAL";
+        settings = {
+          security = {
+            admin_user = "admin";
+            admin_password = "admin";
+          };
+
+          server = {
+            http_addr = "localhost";
+            http_port = 3000;
+          };
+
+          database = {
+            type = "sqlite3";
+            path = "/var/lib/grafana/data/grafana.db";
+            wal = true;
+          };
         };
       };
       users.users.foo = {

--- a/nixos/tests/lxd-image-server.nix
+++ b/nixos/tests/lxd-image-server.nix
@@ -8,8 +8,8 @@ let
     };
   };
 
-  lxd-image-metadata = lxd-image.lxdMeta.${pkgs.stdenv.hostPlatform.system};
-  lxd-image-rootfs = lxd-image.lxdImage.${pkgs.stdenv.hostPlatform.system};
+  lxd-image-metadata = lxd-image.lxdContainerMeta.${pkgs.stdenv.hostPlatform.system};
+  lxd-image-rootfs = lxd-image.lxdContainerImage.${pkgs.stdenv.hostPlatform.system};
 
 in {
   name = "lxd-image-server";

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -27,7 +27,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
   in {
     name = "mongodb";
     meta = with pkgs.lib.maintainers; {
-      maintainers = [ bluescreen303 offline cstrahan rvl phile314 ];
+      maintainers = [ bluescreen303 offline rvl phile314 ];
     };
 
     nodes = {

--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -36,7 +36,7 @@ in
       machine.succeed("echo 'SELECT address FROM etc_hosts LIMIT 1;' | osqueryi | tee /dev/console | grep -q '127.0.0.1'")
 
       # osquery binaries respect configuration from the Nix config option.
-      machine.succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"utc\";' | osqueryi | tee /dev/console | grep -q ${boolToString utc}")
+      machine.succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"utc\";' | osqueryi | tee /dev/console | grep -q ${lib.boolToString utc}")
 
       # osquery binaries respect configuration from the Nix flags option.
       machine.succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"config_refresh\";' | osqueryi | tee /dev/console | grep -q ${config_refresh}")

--- a/nixos/tests/sftpgo.nix
+++ b/nixos/tests/sftpgo.nix
@@ -52,7 +52,7 @@ let
       # inside the dataprovider they will be automatically created.
       # You have to create the folder on the filesystem yourself
       virtual_folders =
-        lib.optional (lib.isMemberOf config sharedFolderName user) {
+        lib.optional (isMemberOf config sharedFolderName user) {
           name = sharedFolderName;
           mapped_path = "${config.services.sftpgo.dataDir}/${sharedFolderName}";
           virtual_path = "/${sharedFolderName}";
@@ -63,7 +63,7 @@ let
         lib.recursiveUpdate {
           "/" = [ "list" ];     # read-only top level directory
           "/private" = [ "*" ]; # private subdirectory, not shared with others
-        } (lib.optionalAttrs (lib.isMemberOf config "shared" user) {
+        } (lib.optionalAttrs (isMemberOf config "shared" user) {
           "/shared" = [ "*" ];
         });
 
@@ -89,7 +89,7 @@ let
   # of users and folders to import to SFTPGo.
   loadDataJson = config: pkgs.writeText "users-and-folders.json" (builtins.toJSON {
     users =
-      lib.mapAttrsToList (name: user: lib.generateUserAttrSet config user) (normalUsers config);
+      lib.mapAttrsToList (name: user: generateUserAttrSet config user) (normalUsers config);
 
     folders = [
       {

--- a/nixos/tests/sftpgo.nix
+++ b/nixos/tests/sftpgo.nix
@@ -17,7 +17,7 @@ let
 
   # Returns an attributeset of users who are not system users.
   normalUsers = config:
-    filterAttrs (name: user: user.isNormalUser) config.users.users;
+    lib.filterAttrs (name: user: user.isNormalUser) config.users.users;
 
   # Returns true if a user is a member of the given group
   isMemberOf =
@@ -26,7 +26,7 @@ let
     groupName:
     # users.users attrset
     user:
-      any (x: x == user.name) config.users.groups.${groupName}.members;
+      lib.any (x: x == user.name) config.users.groups.${groupName}.members;
 
   # Generates a valid SFTPGo user configuration for a given user
   # Will be converted to JSON and loaded on application startup.
@@ -144,7 +144,7 @@ in
 {
   name = "sftpgo";
 
-  meta.maintainers = with maintainers; [ yayayayaka ];
+  meta.maintainers = with lib.maintainers; [ yayayayaka ];
 
   nodes = {
     server = { nodes, ... }: {
@@ -228,7 +228,7 @@ in
           # Created shared folder directories
           "d ${statePath}/${sharedFolderName} 2770 ${sftpgoUser} ${sharedFolderName}   -"
         ]
-        ++ mapAttrsToList (name: user:
+        ++ lib.mapAttrsToList (name: user:
           # Create private user directories
           ''
             d ${statePath}/users/${user.name} 0700 ${sftpgoUser} ${sftpgoGroup} -
@@ -273,12 +273,12 @@ in
           networking.firewall.allowedTCPPorts = [ 22 80 ];
           services.sftpgo = {
             settings = {
-              sftpd.bindings = mkForce [{
+              sftpd.bindings = lib.mkForce [{
                 address = "";
                 port = 22;
               }];
 
-              httpd.bindings = mkForce [{
+              httpd.bindings = lib.mkForce [{
                 address = "";
                 port = 80;
               }];

--- a/nixos/tests/tracee.nix
+++ b/nixos/tests/tracee.nix
@@ -43,6 +43,10 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             mv $GOPATH/tracee-integration $out/bin/
           '';
           doInstallCheck = false;
+
+          meta = oa.meta // {
+            outputsToInstall = [];
+          };
         }))
       ];
     };


### PR DESCRIPTION
## Description of changes

This gets us back to all of nixosTests being able to at least evaluate (if not succeed), except things explicitly marked broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
