### PR TITLE
libsForQt5.applet-window-appmenu: init at unstable-2022-06-27

### DIFF
--- a/pkgs/development/libraries/applet-window-appmenu/default.nix
+++ b/pkgs/development/libraries/applet-window-appmenu/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, kcoreaddons
+, kdeclarative
+, kdecoration
+, plasma-framework
+, plasma-workspace
+, libSM
+, qtx11extras
+, kwindowsystem
+, libdbusmenu
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation {
+  pname = "applet-window-appmenu";
+  version = "unstable-2022-06-27";
+
+  src = fetchFromGitHub {
+    owner = "psifidotos";
+    repo = "applet-window-appmenu";
+    rev = "1de99c93b0004b80898081a1acfd1e0be807326a";
+    hash = "sha256-PLlZ2qgdge8o1mZOiPOXSmTQv1r34IUmWTmYFGEzNTI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    kdeclarative
+    kdecoration
+    kwindowsystem
+    plasma-framework
+    plasma-workspace
+    libSM
+    qtx11extras
+    libdbusmenu
+  ];
+
+  meta = with lib; {
+    description = "Plasma 5 applet in order to show window menu in your panels";
+    homepage = "https://github.com/psifidotos/applet-window-appmenu";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ greydot ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -72,6 +72,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   alkimia = callPackage ../development/libraries/alkimia { };
 
+  applet-window-appmenu = callPackage ../development/libraries/applet-window-appmenu { };
+
   applet-window-buttons = callPackage ../development/libraries/applet-window-buttons { };
 
   appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };


### PR DESCRIPTION
## Description of changes
Add applet-window-appmenu package. This library adds global menu similar to the stock KDE one, but with more options. From latte-dock author.

The last release doesn't build work with KDE 5.27, but this code does.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
