### PR TITLE
mailbase: init at 1.11.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailbase/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailbase/default.nix
@@ -1,0 +1,103 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, alsa-lib
+, coreutils
+, db
+, dpkg
+, glib
+, gtk3
+, wrapGAppsHook
+, libkrb5
+, libsecret
+, nss
+, openssl
+, udev
+, xorg
+, mesa
+, libdrm
+, libappindicator
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mailbase";
+  version = "1.11.1";
+
+  src = fetchurl {
+    url = "https://github.com/CutestNekoAqua/Mailbase/releases/download/v1.11.1/mailspring-1.11.0-amd64.deb";
+    hash = "sha256-wywox5vWzN+5Xp2nyUA6rsFnAuU9rc+YNs2z4WygrRs=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    db
+    glib
+    gtk3
+    libkrb5
+    libsecret
+    nss
+    xorg.libxkbfile
+    xorg.libXdamage
+    xorg.libXScrnSaver
+    xorg.libXtst
+    xorg.libxshmfence
+    mesa
+    libdrm
+  ];
+
+  runtimeDependencies = [
+    coreutils
+    openssl
+    (lib.getLib udev)
+    libappindicator
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg -x $src .
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    cp -ar ./usr/share $out
+
+    substituteInPlace $out/share/mailspring/resources/app.asar.unpacked/mailsync \
+      --replace dirname ${coreutils}/bin/dirname
+
+    ln -s $out/share/mailspring/mailspring $out/bin/mailspring
+    ln -s ${lib.getLib openssl}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
+
+    runHook postInstall
+  '';
+
+  postFixup = /* sh */ ''
+    substituteInPlace $out/share/applications/Mailspring.desktop \
+      --replace Exec=mailspring Exec=$out/bin/mailspring \
+      --replace Name=Mailspring Name=Mailbase
+  '';
+
+  meta = with lib; {
+    description = "A beautiful, fast and maintained fork of Mailspring to fix CVE-2023-4863";
+    longDescription = ''
+      Mailbase is an open-source mail client forked from Mailspring and built with Electron 26.
+      Mailspring's sync engine runs locally, but its source is not open. This fork fixes CVE-2023-4863
+    '';
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aprl ];
+    homepage = "https://github.com/CutestNekoAqua/Mailbase";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34123,6 +34123,8 @@ with pkgs;
 
   nqptp = callPackage ../tools/networking/nqptp { };
 
+  mailbase = callPackage ../applications/networking/mailreaders/mailbase { };
+
   mailspring = callPackage ../applications/networking/mailreaders/mailspring { };
 
   memento = libsForQt5.callPackage ../applications/video/memento { };


### PR DESCRIPTION
## Description of changes
Mailbase is a fork of Mailspring I made, because Mailspring is still stuck on electron 17 which has multiple CVEs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
