### PR TITLE
nixos/security/wrappers: don't force PIE hardening

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -5,7 +5,6 @@ stdenv.mkDerivation {
   name = "security-wrapper";
   buildInputs = [ linuxHeaders ];
   dontUnpack = true;
-  hardeningEnable = [ "pie" ];
   CFLAGS = [
     ''-DSOURCE_PROG="${sourceProg}"''
   ] ++ (if debug then [


### PR DESCRIPTION
## Description of changes

PIE causes problems with static binaries on ARM (see 76552e9). It is enabled by default on other platforms anyway when musl is used, so we don't need to specify it manually.

Without this PR, the wrapper fails to build on `armv7l-linux`:
```
/nix/store/4lxj7pm6qa6fznja0bwk4c68rd90k6gn-armv7l-unknown-linux-musleabihf-binutils-2.40/bin/armv7l-unknown-linux-musleabihf-ld: /nix/store/cppxlcnd0anv12l2dy79cgpc2qwq3lyq-armv7l-unknown-linux-musleabihf-stage-final-gcc-12.3.0/lib/gcc/armv7l-unknown-linux-musleabihf/12.3.0/crtbeginT.o: relocation R_ARM_MOVW_ABS_NC against `a local symbol' can not be used when making a shared object; recompile with -fPIC
/nix/store/cppxlcnd0anv12l2dy79cgpc2qwq3lyq-armv7l-unknown-linux-musleabihf-stage-final-gcc-12.3.0/lib/gcc/armv7l-unknown-linux-musleabihf/12.3.0/crtbeginT.o:(.fini_array+0x0): dangerous relocation: unsupported relocation
/nix/store/cppxlcnd0anv12l2dy79cgpc2qwq3lyq-armv7l-unknown-linux-musleabihf-stage-final-gcc-12.3.0/lib/gcc/armv7l-unknown-linux-musleabihf/12.3.0/crtbeginT.o:(.init_array+0x0): dangerous relocation: unsupported relocation
collect2: error: ld returned 1 exit status
```

Additionally, on `armv6l-linux`, you get a dynamically linked binary that segfaults, rather than a statically linked one. I have confirmed that this PR fixes both of these issues.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux (cross)
  - [x] armv6l-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
