### PR TITLE
nixos/keyd: add `extraConfig` option

### DIFF
--- a/nixos/tests/keyd.nix
+++ b/nixos/tests/keyd.nix
@@ -26,13 +26,13 @@ let
   '';
 
 
-  mkKeyboardTest = name: { settings, test }: with pkgs.lib; makeTest {
+  mkKeyboardTest = name: { default, test }: with pkgs.lib; makeTest {
     inherit name;
 
     nodes.machine = {
       services.keyd = {
         enable = true;
-        keyboards.default = { inherit settings; };
+        keyboards = { inherit default; };
       };
     };
 
@@ -70,13 +70,20 @@ let
 in
 pkgs.lib.mapAttrs mkKeyboardTest {
   swap-ab_and_ctrl-as-shift = {
-    test.press = [ "a" "ctrl-b" "c" ];
-    test.expect = [ "b" "A" "c" ];
+    test.press = [ "a" "ctrl-b" "c" "alt_r-h" ];
+    test.expect = [ "b" "A" "c" "q" ];
 
-    settings.main = {
-      "a" = "b";
-      "b" = "a";
-      "control" = "oneshot(shift)";
+    default = {
+      settings.main = {
+        "a" = "b";
+        "b" = "a";
+        "control" = "oneshot(shift)";
+        "rightalt" = "layer(rightalt)";
+      };
+      extraConfig = ''
+        [rightalt:G]
+        h = q
+      '';
     };
   };
 }


### PR DESCRIPTION
## Description of changes

Successor of https://github.com/NixOS/nixpkgs/pull/258189 which I messed up with force push ([yt](https://youtu.be/aS4Me48wayM?t=4)).

Add the `keyboards.<name>.extraConfig` option, which allows you to create more complex configurations. Especially useful when you need to use composite layers. Ideally, the order of set attributes needs be preserved, which is currently impossible with nix.

Resolves https://github.com/NixOS/nixpkgs/issues/258083

As @jian-lin suggested, I got rid of IFD and changed `types.str` to `types.lines`. Also, the difference from the previous pr is that I changed the test a bit to handle the `extraConfig` option.
I decided not to add myself to the maintainers-list because I probably won't have time to play with nixpkgs until next year.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
