### PR TITLE
python311Packages.zope-deprecation: 4.4.0 -> 5.0; rename from zope_deprecation

### DIFF
--- a/pkgs/development/python-modules/deform/default.nix
+++ b/pkgs/development/python-modules/deform/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, chameleon, colander, iso8601, peppercorn, translationstring, zope_deprecation
+, chameleon, colander, iso8601, peppercorn, translationstring, zope-deprecation
 , nose, coverage, beautifulsoup4, flaky, pyramid, pytestCheckHook }:
 
 buildPythonPackage rec {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     iso8601
     peppercorn
     translationstring
-    zope_deprecation
+    zope-deprecation
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyramid-jinja2/default.nix
+++ b/pkgs/development/python-modules/pyramid-jinja2/default.nix
@@ -5,7 +5,7 @@
 , markupsafe
 , jinja2
 , pytestCheckHook
-, zope_deprecation
+, zope-deprecation
 , pyramid
 , pythonOlder
 }:
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     markupsafe
     jinja2
     pyramid
-    zope_deprecation
+    zope-deprecation
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyramid/default.nix
+++ b/pkgs/development/python-modules/pyramid/default.nix
@@ -11,7 +11,7 @@
 , translationstring
 , venusian
 , webob
-, zope_deprecation
+, zope-deprecation
 , zope_interface
 , pythonOlder
 }:
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     translationstring
     venusian
     webob
-    zope_deprecation
+    zope-deprecation
     zope_interface
   ];
 

--- a/pkgs/development/python-modules/zope-component/default.nix
+++ b/pkgs/development/python-modules/zope-component/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , zope_configuration
 , zope-deferredimport
-, zope_deprecation
+, zope-deprecation
 , zope_event
 , zope-hookable
 , zope-i18nmessageid
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     zope_configuration
     zope-deferredimport
-    zope_deprecation
+    zope-deprecation
     zope_event
     zope-hookable
     zope-i18nmessageid

--- a/pkgs/development/python-modules/zope-deprecation/default.nix
+++ b/pkgs/development/python-modules/zope-deprecation/default.nix
@@ -1,19 +1,22 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , setuptools
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-deprecation";
-  version = "4.4.0";
+  version = "5.0";
   pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "zope.deprecation";
     inherit version;
-    sha256 = "0d453338f04bacf91bbfba545d8bcdf529aa829e67b705eac8c1a7fdce66e2df";
+    hash = "sha256-t8MtM5IDayFFxAsxA+cyLbaGYqsJtyZ6/hUyqdk/ZA8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/zope-deprecation/default.nix
+++ b/pkgs/development/python-modules/zope-deprecation/default.nix
@@ -1,12 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, zope_testing
+, setuptools
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-deprecation";
   version = "4.4.0";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "zope.deprecation";
@@ -14,12 +16,27 @@ buildPythonPackage rec {
     sha256 = "0d453338f04bacf91bbfba545d8bcdf529aa829e67b705eac8c1a7fdce66e2df";
   };
 
-  buildInputs = [ zope_testing ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "src/zope/deprecation/tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "zope.deprecation"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/zopefoundation/zope.deprecation";
     description = "Zope Deprecation Infrastructure";
-    license = licenses.zpl20;
+    changelog = "https://github.com/zopefoundation/zope.deprecation/blob/${version}/CHANGES.rst";
+    license = licenses.zpl21;
     maintainers = with maintainers; [ domenkozar ];
   };
 

--- a/pkgs/development/python-modules/zope-deprecation/default.nix
+++ b/pkgs/development/python-modules/zope-deprecation/default.nix
@@ -5,11 +5,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zope.deprecation";
+  pname = "zope-deprecation";
   version = "4.4.0";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "zope.deprecation";
+    inherit version;
     sha256 = "0d453338f04bacf91bbfba545d8bcdf529aa829e67b705eac8c1a7fdce66e2df";
   };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -407,5 +407,6 @@ mapAliases ({
   zc_buildout_nix = throw "zc_buildout_nix was pinned to a version no longer compatible with other modules";
   zope_broken = throw "zope_broken has been removed because it is obsolete and not needed in zodb>=3.10"; # added 2023-07-26
   zope_component = zope-component; # added 2023-07-28
+  zope_deprecation = zope-deprecation; # added 2023-10-07
   zope_i18nmessageid = zope-i18nmessageid; # added 2023-07-29
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15881,7 +15881,7 @@ self: super: with self; {
 
   zope-deferredimport = callPackage ../development/python-modules/zope-deferredimport { };
 
-  zope_deprecation = callPackage ../development/python-modules/zope_deprecation { };
+  zope-deprecation = callPackage ../development/python-modules/zope-deprecation { };
 
   zope_dottedname = callPackage ../development/python-modules/zope_dottedname { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/zopefoundation/zope.deprecation/blob/5.0/CHANGES.rst

part of #245383

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
