### PR TITLE
lutris-humble-cookies: init

### DIFF
--- a/pkgs/applications/misc/lutris-humble-cookies/default.nix
+++ b/pkgs/applications/misc/lutris-humble-cookies/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  python3,
+  fetchFromGitHub,
+}: let
+  runtimePython = python3.withPackages (pythonPackages:
+    with pythonPackages; [
+      click
+    ]);
+in
+  stdenvNoCC.mkDerivation rec {
+    pname = "lutris-humble-cookies";
+    version = "unreleased";
+
+    src = fetchFromGitHub {
+      owner = "rcrit";
+      repo = pname;
+      rev = "cc1dd6c50cc7181370f64848642be9681b87a1d8";
+      hash = "sha256-AsANi5KjohVV+Iv3sN3AlMq3f+hDOWmotY4+Ku+t358=";
+    };
+
+    patchPhase = ''
+      substituteInPlace extract_cookies.py --replace '/usr/bin/python3' '${runtimePython.interpreter}'
+   '';
+
+    doCheck = false;
+
+    installPhase = ''
+      install -Dm755 extract_cookies.py $out/bin/extract_cookies.py
+    '';
+
+    meta = with lib; {
+      mainProgram = "extract_cookies.py";
+      description = "Helper script to transfer Humble Bundle cookie from Firefox to Lutris";
+      homepage = "https://github.com/rcrit/lutris-humble-cookies";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [wamserma];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33695,6 +33695,8 @@ with pkgs;
     steamSupport = false;
   };
 
+  lutris-humble-cookies = callPackage ../applications/misc/lutris-humble-cookies/default.nix { };
+
   lv2bm = callPackage ../applications/audio/lv2bm { };
 
   lv2lint = callPackage ../applications/audio/lv2lint/default.nix { };


### PR DESCRIPTION
## Description of changes

This is a small helper script to transfer a session cookie for Humble Bundle from Firefox to Lutris.
While it is easy to directly download the script from GitHub and running it with Python, the script would have to be reviewed before each execution to ensure it has not been altered in a malicious way. Packaging adds the benefit of recording a hash of the script.

Usage: `nix run nixpkgs#lutris-humble-cookies > ~/.cache/lutris/.humblebundle.auth`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
