### PR TITLE
nixos/tt-rss: supply --force-yes to update-schema

### DIFF
--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -596,7 +596,7 @@ let
         description = "Tiny Tiny RSS feeds update daemon";
 
         preStart = ''
-          ${pkgs.php81}/bin/php ${cfg.root}/www/update.php --update-schema
+          ${pkgs.php81}/bin/php ${cfg.root}/www/update.php --update-schema --force-yes
         '';
 
         serviceConfig = {


### PR DESCRIPTION
This commit fixes the service failing to start for the first time since the update-schema operation requires human interaction (typing 'yes') in order to actually perform the schema upgrade.

## Description of changes

This module does not seem to have a NixOS test, so here's a little test I've done:

- Status quo

Service fails to start because it requires human interaction:
```
Oct 07 16:47:03 cobalt systemd[1]: Starting Tiny Tiny RSS feeds update daemon...
<...>
Oct 07 16:47:04 cobalt tt-rss[2323512]: [16:47:04/2323512] Lock: update.lock
# Human interaction required here
Oct 07 16:47:04 cobalt tt-rss[2323512]: [16:47:04/2323512] Type 'yes' to continue.
Oct 07 16:47:04 cobalt systemd[1]: tt-rss.service: Control process exited, code=exited, status=1/FAILURE
```

- This commit
Human interaction is skipped by supplying the `--force-yes` flag:
```
# sudo -u tt_rss /nix/store/b2samp9wri1221ymplzcabz7mdfqbnzf-php-with-extensions-8.1.24/bin/php /var/lib/tt-rss/www/update.php --update-schema --force-yes
[16:51:43/2332896] Lock: update.lock
[16:51:43/2332896] Proceeding to update without confirmation.
[16:51:43/2332896] Loading base database schema...
[16:51:45/2332896] Migration finished, current version: 147
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
