### PR TITLE
dlang-dfmt: init at 0.15.2

### DIFF
--- a/pkgs/by-name/dl/dlang-dfmt/package.nix
+++ b/pkgs/by-name/dl/dlang-dfmt/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ldc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dlang-dfmt";
+  version = "0.15.2";
+
+  src = fetchFromGitHub {
+    owner = "dlang-community";
+    repo = "dfmt";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-9bLoTC88Y/Ud5+iIDPGxjsy5j0Ifk02E9vWcwiGQM+E=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ ldc ];
+
+  buildFlags = [ "ldc" ];
+
+  preBuild = ''
+    mkdir bin
+    echo ${finalAttrs.version} >bin/githash.txt
+  '';
+
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX=/"
+  ];
+
+  meta = {
+    description = "Formatter for D source code";
+    homepage = "https://github.com/dlang-community/dfmt";
+    license = lib.licenses.boost;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ jtbx ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds dfmt, a formatter for D source code. There is already a package called dfmt in nixpkgs, so I named this one dlang-dfmt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
