### PR TITLE
sigrok and friends: Update to nightly

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,45 +1,33 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, cmake, glib, boost, libsigrok
-, libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi1, glibmm
-, pcre, python3, qtsvg, qttools, wrapQtAppsHook, desktopToDarwinBundle
+{ lib, stdenv, fetchgit, pkg-config, cmake, glib, boost, libsigrok
+, libsigrokdecode, libserialport, libzip, libftdi1, hidapi, glibmm
+, pcre, python3, qtsvg, qttools, bluez
+, wrapQtAppsHook, desktopToDarwinBundle
 }:
 
 stdenv.mkDerivation rec {
   pname = "pulseview";
-  version = "0.4.2";
+  version = "0.4.2-unstable-2024-01-26";
 
-  src = fetchurl {
-    url = "https://sigrok.org/download/source/pulseview/pulseview-${version}.tar.gz";
-    hash = "sha256-8EL3ej4bNb8wZmMw427Dj6uNJIw2k8N7fjXUAcO/q8s=";
+  src = fetchgit {
+    url = "git://sigrok.org/pulseview";
+    rev = "9b8b7342725491d626609017292fa9259f7d5e0e";
+    hash = "sha256-UEJunADzc1WRRfchO/n8qqxnyrSo4id1p7gLkD3CKaM=";
   };
 
   nativeBuildInputs = [ cmake pkg-config qttools wrapQtAppsHook ]
     ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
 
   buildInputs = [
-    glib boost libsigrok libsigrokdecode libserialport libzip libusb1 libftdi1 glibmm
+    glib boost libsigrok libsigrokdecode libserialport libzip libftdi1 hidapi glibmm
     pcre python3
     qtsvg
-  ] ++ lib.optional stdenv.isLinux udev;
-
-  patches = [
-    # Allow building with glib 2.68
-    # PR at https://github.com/sigrokproject/pulseview/pull/39
-    (fetchpatch {
-      url = "https://github.com/sigrokproject/pulseview/commit/fb89dd11f2a4a08b73c498869789e38677181a8d.patch";
-      hash = "sha256-0PlE/z4tbN1JFfAUBeZiXc3ENzwuhCaulIBRmXTULh4=";
-    })
-    # Fixes replaced/obsolete Qt methods
-    (fetchpatch {
-      url = "https://github.com/sigrokproject/pulseview/commit/ae726b70a7ada9a4be5808e00f0c951318479684.patch";
-      hash = "sha256-6bFXFAnTO+MBUmslw55gWWSCCPwnejqKGpHeJOoH0e8=";
-    })
-  ];
+  ] ++ lib.optionals stdenv.isLinux [ bluez ];
 
   meta = with lib; {
     description = "Qt-based LA/scope/MSO GUI for sigrok (a signal analysis software suite)";
     homepage = "https://sigrok.org/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ bjornfor ];
+    maintainers = with maintainers; [ bjornfor vifino ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/sm/smuview/package.nix
+++ b/pkgs/by-name/sm/smuview/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, glib
+, boost
+, libsigrok
+, libserialport
+, libzip
+, libftdi1
+, hidapi
+, glibmm
+, python3
+, bluez
+, pcre
+, libsForQt5
+, desktopToDarwinBundle
+, qt5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "smuview";
+  version = "0.0.5-unstable-2023-04-12";
+
+  src = fetchFromGitHub {
+    owner = "knarfS";
+    repo = "smuview";
+    rev = "a5ffb66287b725ebcdecc1eab04a4574c8585f66";
+    hash = "sha256-WH8X75yk0aMivbBBOyODcM1eBWwa5UO/3nTaKV1LCGs=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config qt5.wrapQtAppsHook ]
+    ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
+
+  buildInputs = [
+    glib
+    boost
+    libsigrok
+    libserialport
+    libzip
+    libftdi1
+    hidapi
+    glibmm
+    python3
+    pcre
+    libsForQt5.qwt
+  ] ++ lib.optionals stdenv.isLinux [ bluez ];
+
+  meta = with lib; {
+    description = "A Qt based source measure unit GUI for sigrok";
+    longDescription = "SmuView is a GUI for sigrok that supports power supplies, electronic loads and all sorts of measurement devices like multimeters, LCR meters and so on";
+    homepage = "https://github.com/knarfS/smuview";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vifino ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
-, fetchurl
+, fetchgit
+, autoreconfHook
 , pkg-config
 , libzip
 , glib
@@ -19,16 +20,17 @@
 
 stdenv.mkDerivation rec {
   pname = "libsigrok";
-  version = "0.5.2";
+  version = "0.5.2-unstable-2024-01-03";
 
-  src = fetchurl {
-    url = "https://sigrok.org/download/source/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "0g6fl684bpqm5p2z4j12c62m45j1dircznjina63w392ns81yd2d";
+  src = fetchgit {
+    url = "git://sigrok.org/libsigrok";
+    rev = "b503d24cdf56abf8c0d66d438ccac28969f01670";
+    hash = "sha256-9EW0UCzU6MqBX6rkT5CrBsDkAi6/CLyS9MZHsDV+1IQ=";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ doxygen pkg-config python ];
+  nativeBuildInputs = [ autoreconfHook doxygen pkg-config python ];
   buildInputs = [
     libzip glib libusb1 libftdi1 check libserialport glibmm hidapi
   ] ++ lib.optionals stdenv.isLinux [ libieee1284 bluez ];
@@ -56,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://sigrok.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ bjornfor ];
+    maintainers = with maintainers; [ bjornfor vifino ];
   };
 }

--- a/pkgs/development/tools/libsigrokdecode/default.nix
+++ b/pkgs/development/tools/libsigrokdecode/default.nix
@@ -1,18 +1,14 @@
-{ lib, stdenv, fetchurl, pkg-config, autoreconfHook, glib, python3, check, libxcrypt }:
+{ lib, stdenv, fetchgit, pkg-config, autoreconfHook, glib, python3, check, libxcrypt }:
 
 stdenv.mkDerivation rec {
   pname = "libsigrokdecode";
-  version = "0.5.3";
+  version = "0.5.3-unstable-2023-10-23";
 
-  src = fetchurl {
-    url = "https://sigrok.org/download/source/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "1h1zi1kpsgf6j2z8j8hjpv1q7n49i3fhqjn8i178rka3cym18265";
+  src = fetchgit {
+    url = "git://sigrok.org/libsigrokdecode";
+    rev = "0c35c5c5845d05e5f624c99d58af992d2f004446";
+    hash = "sha256-1kQB7uk2c+6Uriw+1o6brThDcBLoCdPV0MVWAha7ohk=";
   };
-
-  # upstream was rleased before Python 3.9 and thus only checks versions up to 3.8
-  postPatch = ''
-    substituteInPlace configure.ac --replace '[python-3.8-embed]' '[python3-embed]'
-  '';
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ glib python3 libxcrypt ];
@@ -24,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = "https://sigrok.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor vifino ];
   };
 }

--- a/pkgs/development/tools/sigrok-cli/default.nix
+++ b/pkgs/development/tools/sigrok-cli/default.nix
@@ -1,15 +1,16 @@
-{ lib, stdenv, fetchurl, pkg-config, glib, libsigrok, libsigrokdecode }:
+{ lib, stdenv, fetchgit, autoreconfHook, pkg-config, glib, libsigrok, libsigrokdecode }:
 
 stdenv.mkDerivation rec {
   pname = "sigrok-cli";
-  version = "0.7.2";
+  version = "0.7.2-unstable-2023-04-10";
 
-  src = fetchurl {
-    url = "https://sigrok.org/download/source/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-cdBEPzaJe/Vlcy3sIGgw2+oPJ4m2YBzxBTayhtEUCrg=";
+  src = fetchgit {
+    url = "git://sigrok.org/sigrok-cli";
+    rev = "9d9f7b82008e3b3665bda12a63a3339e9f7aabc3";
+    hash = "sha256-B2FJxRkfKELrtqxZDv5QTvntpu9zJnTK15CAUYbf+5M=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ glib libsigrok libsigrokdecode ];
 
   meta = with lib; {
@@ -17,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = "https://sigrok.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor vifino ];
   };
 }

--- a/pkgs/development/tools/sigrok-firmware-fx2lafw/default.nix
+++ b/pkgs/development/tools/sigrok-firmware-fx2lafw/default.nix
@@ -1,21 +1,23 @@
 { lib
 , stdenv
-, fetchurl
+, fetchgit
+, autoreconfHook
 , sdcc
 }:
 
 stdenv.mkDerivation rec {
   pname = "sigrok-firmware-fx2lafw";
-  version = "0.1.7";
+  version = "0.1.7-unstable-2024-02-03";
 
-  src = fetchurl {
-    url = "https://sigrok.org/download/source/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-${version}.tar.gz";
-    sha256 = "sha256-o/RA1qhSpG4sXRmfwcjk2s0Aa8BODVV2KY7lXQVqzjs=";
+  src = fetchgit {
+    url = "git://sigrok.org/sigrok-firmware-fx2lafw";
+    rev = "0f2d3242ffb5582e5b9a018ed9ae9812d517a56e";
+    hash = "sha256-xveVcwAwtqKGD3/UvnBz5ASvTyg/6jAlTedZElhV2HE=";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ sdcc ];
+  nativeBuildInputs = [ autoreconfHook sdcc ];
 
   meta = with lib; {
     description = "Firmware for FX2 logic analyzers";
@@ -30,6 +32,6 @@ stdenv.mkDerivation rec {
 
     sourceProvenance = with sourceTypes; [ fromSource ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ panicgh ];
+    maintainers = with maintainers; [ panicgh vifino ];
   };
 }


### PR DESCRIPTION
## Description of changes

The Sigrok project hasn't had a release in a long time and there is no timeline on when that happens.

However, development is far from stopped.
On the project's site, it is recommended to use the nightly builds.
I asked on IRC about it and it was recommended to package nightly releases until the project publishes releases again.

This advances the packaged version roughly two years or more.
All in one PR, as it doesn't make sense to update one or the other.

In addition, I packaged smuview, which is also "a sigrok project", even though it doesn't use the sigrok.org Git.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
