### PR TITLE
nixos/tests: add failing test for dnsmasq+resolved

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -226,6 +226,7 @@ in {
   dnscrypt-proxy2 = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy2.nix {};
   dnscrypt-wrapper = runTestOn ["x86_64-linux"] ./dnscrypt-wrapper;
   dnsdist = handleTest ./dnsdist.nix {};
+  dnsmasq-resolved = handleTest ./dnsmasq-resolved.nix {};
   doas = handleTest ./doas.nix {};
   docker = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker.nix {};
   docker-rootless = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker-rootless.nix {};

--- a/nixos/tests/dnsmasq-resolved.nix
+++ b/nixos/tests/dnsmasq-resolved.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+{
+  name = "dnsmasq-resolved";
+  meta.maintainers = [ lib.maintainers.majiir ];
+
+  nodes = {
+    client = { ... }: {
+      services.dnsmasq.enable = true;
+      services.resolved.enable = true;
+      environment.systemPackages = [ pkgs.dig ];
+    };
+  };
+
+  testScript = ''
+    client.wait_for_unit("dnsmasq.service")
+
+    with subtest("Querying dnsmasq works"):
+      reply = client.succeed("dig +noall +answer client @127.0.0.1")
+      assert (
+          "192.168.1.1" in reply
+      ), f""""
+      The reply does not contain the expected IP address. Reply:
+          {reply}"""
+
+    client.wait_for_unit("systemd-resolved.service")
+
+    with subtest("Querying resolved works"):
+      reply = client.succeed("dig +noall +answer client @127.0.0.53")
+      assert (
+          "192.168.1.1" in reply
+      ), f""""
+      The reply does not contain the expected IP address. Reply:
+          {reply}"""
+  '';
+})


### PR DESCRIPTION
## Description of changes

When both dnsmasq and systemd-resolved are enabled, dnsmasq fails to start because resolved is already listening on port 53. This config allows the test to pass:

```nix
{
  services.dnsmasq.settings.bind-interfaces = true;
}
```

The intent of this test is to prepare for the transition to networkd where systemd-resolved will be enabled by default. See https://github.com/NixOS/nixpkgs/pull/202488 for that broader effort.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
