### PR TITLE
simpleitk: improvements and enable SimpleElastix cmake module

### DIFF
--- a/pkgs/development/libraries/simpleitk/default.nix
+++ b/pkgs/development/libraries/simpleitk/default.nix
@@ -1,27 +1,44 @@
-{ lib, stdenv, fetchFromGitHub, cmake, swig4, lua, itk }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, swig4
+, lua
+, itk
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "simpleitk";
   version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "SimpleITK";
     repo = "SimpleITK";
-    rev = "refs/tags/v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-SJSFJEFu1qKowX5/98MslN7GFDS8aF5+EKkQ2983Azg=";
   };
 
-  nativeBuildInputs = [ cmake swig4 ];
-  buildInputs = [ lua itk ];
+  nativeBuildInputs = [
+    cmake
+    swig4
+  ];
+  buildInputs = [
+    lua
+    itk
+  ];
 
   # 2.0.0: linker error building examples
-  cmakeFlags = [ "-DBUILD_EXAMPLES=OFF" "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
 
   meta = with lib; {
     homepage = "https://www.simpleitk.org";
     description = "Simplified interface to ITK";
+    changelog = "https://github.com/SimpleITK/SimpleITK/releases/tag/v${finalAttrs.version}";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.linux;
     license = licenses.asl20;
   };
-}
+})

--- a/pkgs/development/libraries/simpleitk/default.nix
+++ b/pkgs/development/libraries/simpleitk/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , swig4
 , lua
+, elastix
 , itk
 }:
 
@@ -23,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     swig4
   ];
   buildInputs = [
+    elastix
     lua
     itk
   ];
@@ -30,7 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   # 2.0.0: linker error building examples
   cmakeFlags = [
     "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_SHARED_LIBS=OFF"
+    "-DSimpleITK_USE_ELASTIX=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/simpleitk/default.nix
+++ b/pkgs/development/python-modules/simpleitk/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , cmake
 , swig4
+, elastix
 , itk
 , numpy
 , simpleitk
@@ -20,8 +21,17 @@ buildPythonPackage rec {
     make
   '';
 
-  nativeBuildInputs = [ cmake swig4 scikit-build ];
-  propagatedBuildInputs = [ itk simpleitk numpy ];
+  nativeBuildInputs = [
+    cmake
+    swig4
+    scikit-build
+  ];
+  propagatedBuildInputs = [
+    elastix
+    itk
+    simpleitk
+    numpy
+  ];
 
   pythonImportsCheck = [ "SimpleITK" ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25142,7 +25142,7 @@ with pkgs;
 
   simp_le = callPackage ../tools/admin/simp_le { };
 
-  simpleitk = callPackage ../development/libraries/simpleitk { lua = lua5_3; };
+  simpleitk = callPackage ../development/libraries/simpleitk { lua = lua5_4; };
 
   sioclient = callPackage ../development/libraries/sioclient { };
 


### PR DESCRIPTION
## Description of changes

Minor improvements to `simpleitk` and `python311Packages.simpleitk`, in particular enabling the SimpleElastix functionality (which used to be a standalone package not in Nixpkgs but recently was merged into SimpleITK).

Results of `nixpkgs-review` on x86_64-NixOS:

```
25 packages built:
intensity-normalization intensity-normalization.dist python310Packages.pydicom-seg python310Packages.pydicom-seg.dist python310Packages.pymedio python310Packages.pymedio.dist python310Packages.pyradiomics python310Packages.pyradiomics.dist python310Packages.simpleitk python310Packages.simpleitk.dist python310Packages.torchio python310Packages.torchio.dist python311Packages.intensity-normalization python311Packages.intensity-normalization.dist python311Packages.pydicom-seg python311Packages.pydicom-seg.dist python311Packages.pymedio python311Packages.pymedio.dist python311Packages.pyradiomics python311Packages.pyradiomics.dist python311Packages.simpleitk python311Packages.simpleitk.dist python311Packages.torchio python311Packages.torchio.dist simpleitk
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).