### PR TITLE
vscode: fix using the fhs with overrideAttrs

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -1,27 +1,55 @@
-{ stdenv, lib, makeDesktopItem
-, unzip, libsecret, libXScrnSaver, libxshmfence, buildPackages
-, at-spi2-atk, autoPatchelfHook, alsa-lib, mesa, nss, nspr, xorg
-, systemd, fontconfig, libdbusmenu, glib, buildFHSEnv, wayland
-, libglvnd, libkrb5
+{ stdenv
+, lib
+, makeDesktopItem
+, unzip
+, libsecret
+, libXScrnSaver
+, libxshmfence
+, buildPackages
+, at-spi2-atk
+, autoPatchelfHook
+, alsa-lib
+, mesa
+, nss
+, nspr
+, xorg
+, systemd
+, fontconfig
+, libdbusmenu
+, glib
+, buildFHSEnv
+, wayland
+, libglvnd
+, libkrb5
 
-# Populate passthru.tests
+  # Populate passthru.tests
 , tests
 
-# needed to fix "Save as Root"
-, asar, bash
+  # needed to fix "Save as Root"
+, asar
+, bash
 
-# Attributes inherit from specific versions
-, version, src, meta, sourceRoot, commandLineArgs
-, executableName, longName, shortName, pname, updateScript
+  # Attributes inherit from specific versions
+, version
+, src
+, meta
+, sourceRoot
+, commandLineArgs
+, executableName
+, longName
+, shortName
+, pname
+, updateScript
 , dontFixup ? false
-, rev ? null, vscodeServer ? null
+, rev ? null
+, vscodeServer ? null
 , sourceExecutableName ? executableName
 , useVSCodeRipgrep ? false
 , ripgrep
 }:
 
-  stdenv.mkDerivation (finalAttrs:
-  let
+stdenv.mkDerivation (finalAttrs:
+let
 
   # Vscode and variants allow for users to download and use extensions
   # which often include the usage of pre-built binaries.
@@ -32,7 +60,7 @@
   #
   # buildFHSEnv allows for users to use the existing vscode
   # extension tooling without significant pain.
-  fhs = { additionalPkgs ? pkgs: [] }: buildFHSEnv {
+  fhs = { additionalPkgs ? pkgs: [ ] }: buildFHSEnv {
     # also determines the name of the wrapped command
     name = executableName;
 
@@ -81,142 +109,146 @@
       '';
     };
   };
-  in
-  {
+in
+{
 
-    inherit pname version src sourceRoot dontFixup;
+  inherit pname version src sourceRoot dontFixup;
 
-    passthru = {
-      inherit executableName longName tests updateScript;
-      fhs = fhs {};
-      fhsWithPackages = f: fhs { additionalPkgs = f; };
-    } // lib.optionalAttrs (vscodeServer != null) {
-      inherit rev vscodeServer;
-    };
+  passthru = {
+    inherit executableName longName tests updateScript;
+    fhs = fhs { };
+    fhsWithPackages = f: fhs { additionalPkgs = f; };
+  } // lib.optionalAttrs (vscodeServer != null) {
+    inherit rev vscodeServer;
+  };
 
-    desktopItem = makeDesktopItem {
-      name = executableName;
-      desktopName = longName;
-      comment = "Code Editing. Redefined.";
-      genericName = "Text Editor";
-      exec = "${executableName} %F";
+  desktopItem = makeDesktopItem {
+    name = executableName;
+    desktopName = longName;
+    comment = "Code Editing. Redefined.";
+    genericName = "Text Editor";
+    exec = "${executableName} %F";
+    icon = "vs${executableName}";
+    startupNotify = true;
+    startupWMClass = shortName;
+    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
+    mimeTypes = [ "text/plain" "inode/directory" ];
+    keywords = [ "vscode" ];
+    actions.new-empty-window = {
+      name = "New Empty Window";
+      exec = "${executableName} --new-window %F";
       icon = "vs${executableName}";
-      startupNotify = true;
-      startupWMClass = shortName;
-      categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-      mimeTypes = [ "text/plain" "inode/directory" ];
-      keywords = [ "vscode" ];
-      actions.new-empty-window = {
-        name = "New Empty Window";
-        exec = "${executableName} --new-window %F";
-        icon = "vs${executableName}";
-      };
     };
+  };
 
-    urlHandlerDesktopItem = makeDesktopItem {
-      name = executableName + "-url-handler";
-      desktopName = longName + " - URL Handler";
-      comment = "Code Editing. Redefined.";
-      genericName = "Text Editor";
-      exec = executableName + " --open-url %U";
-      icon = "vs${executableName}";
-      startupNotify = true;
-      categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-      mimeTypes = [ "x-scheme-handler/vscode" ];
-      keywords = [ "vscode" ];
-      noDisplay = true;
-    };
+  urlHandlerDesktopItem = makeDesktopItem {
+    name = executableName + "-url-handler";
+    desktopName = longName + " - URL Handler";
+    comment = "Code Editing. Redefined.";
+    genericName = "Text Editor";
+    exec = executableName + " --open-url %U";
+    icon = "vs${executableName}";
+    startupNotify = true;
+    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
+    mimeTypes = [ "x-scheme-handler/vscode" ];
+    keywords = [ "vscode" ];
+    noDisplay = true;
+  };
 
-    buildInputs = [ libsecret libXScrnSaver libxshmfence ]
-      ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib at-spi2-atk libkrb5 mesa nss nspr systemd xorg.libxkbfile ];
+  buildInputs = [ libsecret libXScrnSaver libxshmfence ]
+    ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib at-spi2-atk libkrb5 mesa nss nspr systemd xorg.libxkbfile ];
 
-    runtimeDependencies = lib.optionals stdenv.isLinux [ (lib.getLib systemd) fontconfig.lib libdbusmenu wayland libsecret ];
+  runtimeDependencies = lib.optionals stdenv.isLinux [ (lib.getLib systemd) fontconfig.lib libdbusmenu wayland libsecret ];
 
-    nativeBuildInputs = [ unzip ]
-      ++ lib.optionals stdenv.isLinux [
-        autoPatchelfHook
-        asar
-        # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
-        (buildPackages.wrapGAppsHook.override { inherit (buildPackages) makeWrapper; })
-      ];
+  nativeBuildInputs = [ unzip ]
+    ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+    asar
+    # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
+    (buildPackages.wrapGAppsHook.override { inherit (buildPackages) makeWrapper; })
+  ];
 
-    dontBuild = true;
-    dontConfigure = true;
-    noDumpEnvVars = true;
+  dontBuild = true;
+  dontConfigure = true;
+  noDumpEnvVars = true;
 
-    installPhase = ''
-      runHook preInstall
-    '' + (if stdenv.isDarwin then ''
-      mkdir -p "$out/Applications/${longName}.app" "$out/bin"
-      cp -r ./* "$out/Applications/${longName}.app"
-      ln -s "$out/Applications/${longName}.app/Contents/Resources/app/bin/${sourceExecutableName}" "$out/bin/${executableName}"
-    '' else ''
-      mkdir -p "$out/lib/vscode" "$out/bin"
-      cp -r ./* "$out/lib/vscode"
+  installPhase = ''
+    runHook preInstall
+  '' + (if stdenv.isDarwin then ''
+    mkdir -p "$out/Applications/${longName}.app" "$out/bin"
+    cp -r ./* "$out/Applications/${longName}.app"
+    ln -s "$out/Applications/${longName}.app/Contents/Resources/app/bin/${sourceExecutableName}" "$out/bin/${executableName}"
+  '' else ''
+    mkdir -p "$out/lib/vscode" "$out/bin"
+    cp -r ./* "$out/lib/vscode"
 
-      ln -s "$out/lib/vscode/bin/${sourceExecutableName}" "$out/bin/${executableName}"
+    ln -s "$out/lib/vscode/bin/${sourceExecutableName}" "$out/bin/${executableName}"
 
-      mkdir -p "$out/share/applications"
-      ln -s "$desktopItem/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
-      ln -s "$urlHandlerDesktopItem/share/applications/${executableName}-url-handler.desktop" "$out/share/applications/${executableName}-url-handler.desktop"
+    mkdir -p "$out/share/applications"
+    ln -s "$desktopItem/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
+    ln -s "$urlHandlerDesktopItem/share/applications/${executableName}-url-handler.desktop" "$out/share/applications/${executableName}-url-handler.desktop"
 
-      # These are named vscode.png, vscode-insiders.png, etc to match the name in upstream *.deb packages.
-      mkdir -p "$out/share/pixmaps"
-      cp "$out/lib/vscode/resources/app/resources/linux/code.png" "$out/share/pixmaps/vs${executableName}.png"
+    # These are named vscode.png, vscode-insiders.png, etc to match the name in upstream *.deb packages.
+    mkdir -p "$out/share/pixmaps"
+    cp "$out/lib/vscode/resources/app/resources/linux/code.png" "$out/share/pixmaps/vs${executableName}.png"
 
-      # Override the previously determined VSCODE_PATH with the one we know to be correct
-      sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}"
-      grep -q "VSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}" # check if sed succeeded
+    # Override the previously determined VSCODE_PATH with the one we know to be correct
+    sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}"
+    grep -q "VSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}" # check if sed succeeded
 
-      # Remove native encryption code, as it derives the key from the executable path which does not work for us.
-      # The credentials should be stored in a secure keychain already, so the benefit of this is questionable
-      # in the first place.
-      rm -rf $out/lib/vscode/resources/app/node_modules/vscode-encrypt
-    '') + ''
-      runHook postInstall
-    '';
+    # Remove native encryption code, as it derives the key from the executable path which does not work for us.
+    # The credentials should be stored in a secure keychain already, so the benefit of this is questionable
+    # in the first place.
+    rm -rf $out/lib/vscode/resources/app/node_modules/vscode-encrypt
+  '') + ''
+    runHook postInstall
+  '';
 
-    preFixup = ''
-      gappsWrapperArgs+=(
-        # Add gio to PATH so that moving files to the trash works when not using a desktop environment
-        --prefix PATH : ${glib.bin}/bin
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
-        --add-flags ${lib.escapeShellArg commandLineArgs}
-      )
-    '';
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Add gio to PATH so that moving files to the trash works when not using a desktop environment
+      --prefix PATH : ${glib.bin}/bin
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+    )
+  '';
 
-    # See https://github.com/NixOS/nixpkgs/issues/49643#issuecomment-873853897
-    # linux only because of https://github.com/NixOS/nixpkgs/issues/138729
-    postPatch = lib.optionalString stdenv.isLinux ''
-      # this is a fix for "save as root" functionality
-      packed="resources/app/node_modules.asar"
-      unpacked="resources/app/node_modules"
-      asar extract "$packed" "$unpacked"
-      substituteInPlace $unpacked/@vscode/sudo-prompt/index.js \
-        --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
-        --replace "/bin/bash" "${bash}/bin/bash"
-      rm -rf "$packed"
+  # See https://github.com/NixOS/nixpkgs/issues/49643#issuecomment-873853897
+  # linux only because of https://github.com/NixOS/nixpkgs/issues/138729
+  postPatch = lib.optionalString stdenv.isLinux ''
+    # this is a fix for "save as root" functionality
+    packed="resources/app/node_modules.asar"
+    unpacked="resources/app/node_modules"
+    asar extract "$packed" "$unpacked"
+    substituteInPlace $unpacked/@vscode/sudo-prompt/index.js \
+      --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
+      --replace "/bin/bash" "${bash}/bin/bash"
+    rm -rf "$packed"
 
-      # without this symlink loading JsChardet, the library that is used for auto encoding detection when files.autoGuessEncoding is true,
-      # fails to load with: electron/js2c/renderer_init: Error: Cannot find module 'jschardet'
-      # and the window immediately closes which renders VSCode unusable
-      # see https://github.com/NixOS/nixpkgs/issues/152939 for full log
-      ln -rs "$unpacked" "$packed"
-    '' + (let
-      vscodeRipgrep = if stdenv.isDarwin then
-        "Contents/Resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg"
-      else
-        "resources/app/node_modules/@vscode/ripgrep/bin/rg";
-    in if !useVSCodeRipgrep then ''
+    # without this symlink loading JsChardet, the library that is used for auto encoding detection when files.autoGuessEncoding is true,
+    # fails to load with: electron/js2c/renderer_init: Error: Cannot find module 'jschardet'
+    # and the window immediately closes which renders VSCode unusable
+    # see https://github.com/NixOS/nixpkgs/issues/152939 for full log
+    ln -rs "$unpacked" "$packed"
+  '' + (
+    let
+      vscodeRipgrep =
+        if stdenv.isDarwin then
+          "Contents/Resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg"
+        else
+          "resources/app/node_modules/@vscode/ripgrep/bin/rg";
+    in
+    if !useVSCodeRipgrep then ''
       rm ${vscodeRipgrep}
       ln -s ${ripgrep}/bin/rg ${vscodeRipgrep}
     '' else ''
       chmod +x ${vscodeRipgrep}
-    '');
+    ''
+  );
 
-    postFixup = lib.optionalString stdenv.isLinux ''
-      patchelf --add-needed ${libglvnd}/lib/libGLESv2.so.2 $out/lib/vscode/${executableName}
-    '';
+  postFixup = lib.optionalString stdenv.isLinux ''
+    patchelf --add-needed ${libglvnd}/lib/libGLESv2.so.2 $out/lib/vscode/${executableName}
+  '';
 
-    inherit meta;
-  })
+  inherit meta;
+})


### PR DESCRIPTION
fixes
```nix
((pkgs.vscode.override { isInsiders = true; }).overrideAttrs (previousAttrs: {
  version = "latest";
  src = (pkgs.fetchurl {
    name = "VSCODE_insiders.tar.gz";
    url = "https://code.visualstudio.com/sha/download?build=insider&os=linux-x64";
    sha256 = "sha256-XcDSCuEMnTq2D75X9sNmGkD+CfPoLRJki9cSDDOeUtc=";
  });
})).fhs
```

NOTE: sha256 isn't stable


Fixes https://github.com/NixOS/nixpkgs/issues/253276

Hide whitespace changes when reviewing
![image](https://github.com/NixOS/nixpkgs/assets/56650223/8b53d886-38ee-4f71-ae74-04109b6bdd2c)


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
