### PR TITLE
nixos/network-interfaces-systemd: fix WakeOnLan

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -61,8 +61,6 @@ let
           MACAddress = i.macAddress;
         } // optionalAttrs (i.mtu != null) {
           MTUBytes = toString i.mtu;
-        } // optionalAttrs (i.wakeOnLan.enable == true) {
-          WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
         };
       };
     in listToAttrs (map createNetworkLink interfaces);

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -389,6 +389,16 @@ in
         };
       })))
       vlanNetworks
+      {
+        systemd.network.links = pipe interfaces [
+          (filter (i: i.wakeOnLan.enable))
+          (map (i: nameValuePair "40-${i.name}" {
+            matchConfig.OriginalName = i.name;
+            linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
+          }))
+          listToAttrs
+        ];
+      }
     ];
 
     # We need to prefill the slaved devices with networking options

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -389,16 +389,6 @@ in
         };
       })))
       vlanNetworks
-      {
-        systemd.network.links = pipe interfaces [
-          (filter (i: i.wakeOnLan.enable))
-          (map (i: nameValuePair "40-${i.name}" {
-            matchConfig.OriginalName = i.name;
-            linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
-          }))
-          listToAttrs
-        ];
-      }
     ];
 
     # We need to prefill the slaved devices with networking options

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1460,6 +1460,16 @@ in
       ]
       ++ bridgeStp;
 
+    # Wake-on-LAN configuration is shared by the scripted and networkd backends.
+    systemd.network.links = pipe interfaces [
+      (filter (i: i.wakeOnLan.enable))
+      (map (i: nameValuePair "40-${i.name}" {
+        matchConfig.OriginalName = i.name;
+        linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
+      }))
+      listToAttrs
+    ];
+
     # The network-interfaces target is kept for backwards compatibility.
     # New modules must NOT use it.
     systemd.targets.network-interfaces =


### PR DESCRIPTION
## Description of changes

`WakeOnLan=` was configured when using the scripted backend but not the networkd backend. The other link options are set in the `.network` file when using networkd, but `WakeOnLan=` is only available in a `.link` file.

I tried to write a test for this, but the network adapter in the test VM doesn't support wake-on-LAN. I tested this change by building a system configuration with wake-on-LAN enabled using both the scripted backend and networkd, and manually verified the config generated config files.

Since both backends need the same link configuration for wake-on-LAN, the second commit combines them into a shared configuration.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
