### PR TITLE
confluent-cli: update 3.17.0 -> 3.37.0, add aarch64 darwin and linux

### DIFF
--- a/pkgs/development/tools/confluent-cli/default.nix
+++ b/pkgs/development/tools/confluent-cli/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "confluent-cli";
-  version = "3.17.0";
+  version = "3.37.0";
 
   # To get the latest version:
   # curl -L https://cnfl.io/cli | sh -s -- -l | grep -v latest | sort -V | tail -n1
   src = fetchurl (if stdenv.hostPlatform.isDarwin then {
       url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_darwin_amd64.tar.gz";
-      sha256 = "03104736f65591a5be9536424460d9b8c8fc8ac8b5eb646e832371397aaf7cef";
+      sha256 = "804401c4286c339097151b1605555c43cf3143637896a908c477d928f10c94e6";
     } else {
       url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_linux_amd64.tar.gz";
-      sha256 = "3243beca4fefd49cf067f9a4df4f5072a8ac5dac91638e9f10ef0b0544d30445";
+      sha256 = "bc907fd2875503ce9f66d461fc283928f0fcabc0901443654738e9238d5439cf";
     });
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];

--- a/pkgs/development/tools/confluent-cli/default.nix
+++ b/pkgs/development/tools/confluent-cli/default.nix
@@ -6,13 +6,24 @@ stdenv.mkDerivation rec {
 
   # To get the latest version:
   # curl -L https://cnfl.io/cli | sh -s -- -l | grep -v latest | sort -V | tail -n1
-  src = fetchurl (if stdenv.hostPlatform.isDarwin then {
-      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_darwin_amd64.tar.gz";
-      sha256 = "804401c4286c339097151b1605555c43cf3143637896a908c477d928f10c94e6";
-    } else {
+  src = {
+    x86_64-linux = fetchurl {
       url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_linux_amd64.tar.gz";
-      sha256 = "bc907fd2875503ce9f66d461fc283928f0fcabc0901443654738e9238d5439cf";
-    });
+      hash = "sha256-vJB/0odVA86fZtRh/Cg5KPD8q8CQFENlRzjpI41UOc8=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_linux_arm64.tar.gz";
+      hash = "sha256-lj7i7oQzX1AfhYfrXDiOjz1/EV4y3/CI4MyPKzNGcss=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_darwin_amd64.tar.gz";
+      hash = "sha256-gEQBxChsM5CXFRsWBVVcQ88xQ2N4lqkIxHfZKPEMlOY";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_darwin_arm64.tar.gz";
+      hash = "sha256-6i5Z3m0gMzPuqWm/SJOuxjO3ioh/Uhk3A9uykksYfPo=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
@@ -38,6 +49,6 @@ stdenv.mkDerivation rec {
     # files in the S3 bucket:
     #
     #   https://s3-us-west-2.amazonaws.com/confluent.cloud?prefix=confluent-cli/archives/1.25.0/&delimiter=/%27
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes
- add arm64 architectures for darwin and linux
- update to version 3.37.0 of confluent-cli package, release notes [here](https://docs.confluent.io/confluent-cli/current/release-notes.html#confluent-cli-v3-37-0-release-notes)

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).