### PR TITLE
libvmi, tpm2-pkgs11: Remove myself maintainer

### DIFF
--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     '';
     license = with licenses; [ gpl3 lgpl3 ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/misc/tpm2-pkcs11/default.nix
+++ b/pkgs/misc/tpm2-pkcs11/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tpm2-software/tpm2-pkcs11";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "tpm2_ptool";
   };
 }


### PR DESCRIPTION
IIRC I took maintainership of these packages from lschuermann after they left the nixpkgs community, but I see now that I am not able to maintain this in the fashion that I should be able to.

Hence, remove myself as maintainer from these packages.

I'll leave this open for some time so someone can add themselves as maintainer (I would take patches to this PR for adding you, just send them my way)!