### PR TITLE
gromacs: use multiple outputs

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -27,6 +27,10 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-vOFIByfksruQBBO3XZmjJm81B4d9pPWy1JHfeY+fza4=";
   };
 
+  patches = [ ./pkgconfig.patch ];
+
+  outputs = [ "out" "dev" "man" ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
@@ -64,10 +68,8 @@ in stdenv.mkDerivation rec {
      ]
   ) ++ lib.optional enableCuda "-DGMX_GPU=CUDA";
 
-  postFixup = ''
-    substituteInPlace "$out"/lib/pkgconfig/*.pc \
-      --replace '=''${prefix}//' '=/' \
-      --replace "$out/$out/" "$out/"
+  postInstall = ''
+    moveToOutput share/cmake $dev
   '';
 
   meta = with lib; {

--- a/pkgs/applications/science/molecular-dynamics/gromacs/pkgconfig.patch
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/pkgconfig.patch
@@ -1,0 +1,24 @@
+diff --git a/src/external/muparser/muparser.pc.in b/src/external/muparser/muparser.pc.in
+index 646787cb53..9b97ad57f7 100644
+--- a/src/external/muparser/muparser.pc.in
++++ b/src/external/muparser/muparser.pc.in
+@@ -1,7 +1,5 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: @PACKAGE_NAME@
+ Description: Mathematical expressions parser library
+diff --git a/src/gromacs/libgromacs.pc.cmakein b/src/gromacs/libgromacs.pc.cmakein
+index ec1ed6684e..ca1105474a 100644
+--- a/src/gromacs/libgromacs.pc.cmakein
++++ b/src/gromacs/libgromacs.pc.cmakein
+@@ -1,4 +1,4 @@
+-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: libgromacs@GMX_LIBS_SUFFIX@
+ Description: Gromacs library


### PR DESCRIPTION
## Description of changes
The Gromacs library can be used build extensions.  However the header files not needed at runtime.
Also split the man pages into `man`.
Fix patching of pkgconfig files (replace with proper patch).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
