### PR TITLE
lomiri.lomiri-thumbnailer: init at 3.0.2

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -40,6 +40,7 @@ let
     history-service = callPackage ./services/history-service { };
     lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
     lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
+    lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
     lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     mediascanner2 = callPackage ./services/mediascanner2 { };
   };

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -1,0 +1,233 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, boost
+, cmake
+, cmake-extras
+, doxygen
+, gst_all_1
+, gdk-pixbuf
+, gtest
+, makeFontsConf
+, libapparmor
+, libexif
+, libqtdbustest
+, librsvg
+, lomiri-api
+, persistent-cache-cpp
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+, shared-mime-info
+, taglib
+, validatePkgConfig
+, wrapGAppsHook
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-thumbnailer";
+  version = "3.0.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-thumbnailer";
+    rev = finalAttrs.version;
+    hash = "sha256-AZoXTE4ix/NDBSwPJcod+cMNnfrCxFj5IzxCWxh6uq0=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  patches = [
+    # Remove when version > 3.0.2
+    (fetchpatch {
+      name = "0001-lomiri-thumbnailer-Stop-using-qt5_use_modules.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/a0d81863f3f48717507cfa181030a8ffb0c4e881.patch";
+      hash = "sha256-B0935Hve5zYA3aUqr0RUtJsOAsfDAF/L7/20F4I+5s0=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/19 merged & in release
+    (fetchpatch {
+      name = "0002-lomiri-thumbnailer-Add-more-better-GNUInstallDirs-variables-usage.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/0b9795a6313fd025d5646f2628a2cbb3104b0ebc.patch";
+      hash = "sha256-br99n2nDLjUfnjbjhOsWlvP62VmVjYeZ6yPs1dhPN/s=";
+    })
+
+    # Remove when version > 3.0.2
+    (fetchpatch {
+      name = "0003-lomiri-thumbnailer-Fix-check-for-No-such-file-or-directory-error.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/de8f9175830581e9180ed789b92dffbb08dfe436.patch";
+      hash = "sha256-JHoYTATbR8NTsVU2+8+R2sCSU6ZDLyKgmdbt4VZPv3Q=";
+    })
+
+    # Remove when version > 3.0.2
+    (fetchpatch {
+      name = "0004-lomiri-thumbnailer-tests-headers-CMakelists.txt-Remove-extra-slash-in-include-paths.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/3598fdc84ded8241f273c89c95371d4675690e38.patch";
+      hash = "sha256-Sonjc/a6hfuXhaus2scfmPfgIYWxsRD/1/IIACLqsBA=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/22 merged & in release
+    (fetchpatch {
+      name = "0005-lomiri-thumbnailer-Make-tests-optional.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/df7a3d1689f875d207a90067b957e888160491b9.patch";
+      hash = "sha256-gVxigpSL/3fXNdJBjh8Ex3/TYmQUiwRji/NmLW/uhE4=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/23 merged & in release
+    (fetchpatch {
+      name = "0006-lomiri-thumbnailer-doc-liblomiri-thumbnailer-qt-Honour-CMAKE_INSTALL_DOCDIR.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/930a3b57e899f6eb65a96d096edaea6a6f6b242a.patch";
+      hash = "sha256-klYycUoQqA+Dfk/4fRQgdS4/G4o0sC1k98mbtl0iHkE=";
+    })
+    (fetchpatch {
+      name = "0007-lomiri-thumbnailer-Re-enable-documentation.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/2f9186f71fdd25e8a0852073f1da59ba6169cf3f.patch";
+      hash = "sha256-youaJfCeYVpLmruHMupuUdl0c/bSDPWqKPLgu5plBrw=";
+    })
+    (fetchpatch {
+      name = "0008-lomiri-thumbnailer-doc-liblomiri-thumbnailer-qt-examples-Drop-qt5_use_modules-usage.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/9e5cf09de626e73e6b8f180cbc1160ebd2f169e7.patch";
+      hash = "sha256-vfNCN7tqq6ngzNmb3qqHDHaDx/kI8/UXyyv7LqUWya0=";
+    })
+    (fetchpatch {
+      name = "0009-lomiri-thumbnailer-Re-enable-coverge-reporting.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/6a48831f042cd3ad34200f32800393d4eec2f84b.patch";
+      hash = "sha256-HZd4K0R1W6adOjKy7tODfQAD+9IKPcK0DnH1uKNd/Ak=";
+    })
+    (fetchpatch {
+      name = "0010-lomiri-thumbnailer-Make-GTest-available-to-example-test.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/657be3bd1aeb227edc04e26b597b2fe97b2dc51a.patch";
+      hash = "sha256-XEvdWV3JJujG16+87iewYor0jFK7NTeE5459iT96SkU=";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs tools/{parse-settings.py,run-xvfb.sh} tests/{headers,whitespace,server}/*.py
+
+    substituteInPlace tests/thumbnailer-admin/thumbnailer-admin_test.cpp \
+      --replace '/usr/bin/test' 'test'
+
+    substituteInPlace plugins/*/Thumbnailer*/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+
+    # I think this variable fails to be populated because of our toolchain, while upstream uses Debian / Ubuntu where this works fine
+    # https://cmake.org/cmake/help/v3.26/variable/CMAKE_LIBRARY_ARCHITECTURE.html
+    # > If the <LANG> compiler passes to the linker an architecture-specific system library search directory such as
+    # > <prefix>/lib/<arch> this variable contains the <arch> name if/as detected by CMake.
+    substituteInPlace tests/qml/CMakeLists.txt \
+      --replace 'CMAKE_LIBRARY_ARCHITECTURE' 'CMAKE_SYSTEM_PROCESSOR' \
+      --replace 'powerpc-linux-gnu' 'ppc' \
+      --replace 's390x-linux-gnu' 's390x'
+
+    # Tests run in parallel to other builds, don't suck up cores
+    substituteInPlace tests/headers/compile_headers.py \
+      --replace 'max_workers=multiprocessing.cpu_count()' "max_workers=1"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    gdk-pixbuf # setup hook
+    pkg-config
+    (python3.withPackages (ps: with ps; lib.optionals finalAttrs.doCheck [
+      python-dbusmock
+      tornado
+    ]))
+    validatePkgConfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    boost
+    cmake-extras
+    gdk-pixbuf
+    libapparmor
+    libexif
+    librsvg
+    lomiri-api
+    persistent-cache-cpp
+    qtbase
+    qtdeclarative
+    shared-mime-info
+    taglib
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    # maybe add ugly to cover all kinds of formats?
+  ]);
+
+  nativeCheckInputs = [
+    shared-mime-info
+    xvfb-run
+  ];
+
+  checkInputs = [
+    gtest
+    libqtdbustest
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+    # error: use of old-style cast to 'std::remove_reference<_GstElement*>::type' {aka 'struct _GstElement*'}
+    (lib.cmakeBool "Werror" false)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
+      # QSignalSpy tests in QML suite always fail, pass when running interactively
+      "-E" "^qml"
+    ]))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  enableParallelChecking = false;
+
+  preCheck = ''
+    # Fontconfig warnings breaks some tests
+    export FONTCONFIG_FILE=${makeFontsConf { fontDirectories = []; }}
+    export HOME=$TMPDIR
+
+    # Some tests need Qt plugins
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+
+    # QML tests need QML modules
+    export QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : ${lib.makeSearchPath "share" [ shared-mime-info ]}
+    )
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "D-Bus service for out of process thumbnailing";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/blob/${finalAttrs.version}/ChangeLog";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "liblomiri-thumbnailer-qt"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Thumbnailer](https://gitlab.com/ubports/development/core/lomiri-thumbnailer) is a background service for generating thumbnails to media. Used by Lomiri itself, and most of its media-related apps (music app, gallery app, file manager, messaging app...?).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
