### PR TITLE
perl-debug-adapter: init at 1.0.5

### DIFF
--- a/pkgs/by-name/pe/perl-debug-adapter/package.nix
+++ b/pkgs/by-name/pe/perl-debug-adapter/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, fetchpatch
+, makeWrapper
+, perl
+# Needed if you want to use it for a perl script with dependencies.
+, extraPerlPackages ? []
+}:
+
+let
+  perlInterpreter = perl.withPackages(ps: [
+    ps.PadWalker
+  ] ++ extraPerlPackages);
+in buildNpmPackage rec {
+  pname = "perl-debug-adapter";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "Nihilus118";
+    repo = "perl-debug-adapter";
+    rev = version;
+    hash = "sha256-IXXKhk4rzsWSPA0RT0L3CZuKlgTWtweZ4dQtruTigRs=";
+  };
+
+  npmDepsHash = "sha256-iw7+YC4qkrTVEJuZ9lnjNlUopTCp+fMNoIjFLutmrMw=";
+
+  npmBuildScript = "compile";
+
+  makeWrapperArgs = [
+    "--prefix" "PATH" ":" (lib.makeBinPath [ perlInterpreter ])
+  ];
+  passthru = {
+    inherit perlInterpreter;
+  };
+
+  meta = {
+    description = "Debug adapter, invokes perl -d and handles communication with VS Code or other editors";
+    homepage = "https://github.com/Nihilus118/perl-debug-adapter";
+    changelog = "https://github.com/Nihilus118/perl-debug-adapter/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "perl-debug-adapter";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
