### PR TITLE
uhd: 4.4.0.0 -> 4.5.0.0

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -49,8 +49,10 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uhd";
-  # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
-  # and xxx.yyy.zzz. Hrmpf... style keeps changing
+  # NOTE: Use the following command to update the package, and the uhdImageSrc attribute:
+  #
+  #     nix-shell maintainers/scripts/update.nix --argstr package uhd --argstr commit true
+  #
   version = "4.4.0.0";
 
   outputs = [ "out" "dev" ];
@@ -59,14 +61,24 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "EttusResearch";
     repo = "uhd";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-khVOHlvacZc4EMg4m55rxEqPvLY1xURpAfOW905/3jg=";
+    # The updateScript relies on the `src` using `hash`, and not `sha256. To
+    # update the correct hash for the `src` vs the `uhdImagesSrc`
+    hash = "sha256-khVOHlvacZc4EMg4m55rxEqPvLY1xURpAfOW905/3jg=";
   };
   # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
     url = "https://github.com/EttusResearch/uhd/releases/download/v${finalAttrs.version}/uhd-images_${finalAttrs.version}.tar.xz";
+    # Please don't convert this to a hash, in base64, see comment near src's
+    # hash.
     sha256 = "V8ldW8bvYWbrDAvpWpHcMeLf9YvF8PIruDAyNK/bru4=";
   };
-  # TODO: Add passthru.updateScript that will update both of the above hashes...
+  passthru = {
+    updateScript = [
+      ./update.sh
+      # Pass it this file name as argument
+      (builtins.unsafeGetAttrPos "pname" finalAttrs.finalPackage).file
+    ];
+  };
 
   cmakeFlags = [
     "-DENABLE_LIBUHD=ON"

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   #
   #     nix-shell maintainers/scripts/update.nix --argstr package uhd --argstr commit true
   #
-  version = "4.4.0.0";
+  version = "4.5.0.0";
 
   outputs = [ "out" "dev" ];
 
@@ -63,14 +63,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     # The updateScript relies on the `src` using `hash`, and not `sha256. To
     # update the correct hash for the `src` vs the `uhdImagesSrc`
-    hash = "sha256-khVOHlvacZc4EMg4m55rxEqPvLY1xURpAfOW905/3jg=";
+    hash = "sha256-0EqMBaQiNr8PE542YNkPvX3o1HhnhrO0Kz1euphY6Ps=";
   };
   # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
     url = "https://github.com/EttusResearch/uhd/releases/download/v${finalAttrs.version}/uhd-images_${finalAttrs.version}.tar.xz";
     # Please don't convert this to a hash, in base64, see comment near src's
     # hash.
-    sha256 = "V8ldW8bvYWbrDAvpWpHcMeLf9YvF8PIruDAyNK/bru4=";
+    sha256 = "13cn41wv7vldk4vx7vy3jbb3wb3a5vpfg3ay893klpi6vzxc1dly";
   };
   passthru = {
     updateScript = [

--- a/pkgs/applications/radio/uhd/update.sh
+++ b/pkgs/applications/radio/uhd/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq nix nix-prefetch-github
+
+set -euo pipefail
+echoerr() { echo "$@" 1>&2; }
+
+fname="$1"
+echoerr got fname $fname
+shift
+latest_release=$(curl --silent https://api.github.com/repos/EttusResearch/uhd/releases/latest)
+version=$(jq -r '.tag_name' <<<"$latest_release" | cut -c2-)
+# Update version, if needed
+if grep -q 'version = "'$version $fname; then
+    echoerr Current version $version is the latest available
+    exit 0;
+fi
+echoerr got version $version
+sed -i -E 's/(version = ").*(";)/\1'$version'\2/g' $fname
+# Verify the sed command above did not fail
+grep -q $version $fname
+# Update srcHash
+srcHash="$(nix-prefetch-github EttusResearch uhd --rev v${version} | jq --raw-output .hash)"
+sed -i -E 's#(hash = ").*(";)#\1'$srcHash'\2#g' $fname
+grep -q $srcHash $fname
+imageHash="$(nix-prefetch-url https://github.com/EttusResearch/uhd/releases/download/v${version}/uhd-images_${version}.tar.xz)"
+sed -i -E 's#(sha256 = ").*(";)#\1'$imageHash'\2#g' $fname
+grep -q $imageHash $fname


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
