### PR TITLE
onedriver: init at 0.13.0-2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10828,6 +10828,12 @@
     githubId = 29855073;
     name = "Michael Colicchia";
   };
+  massimogengarelli = {
+    email = "massimo.gengarelli@gmail.com";
+    github = "massix";
+    githubId = 585424;
+    name = "Massimo Gengarelli";
+  };
   matejc = {
     email = "cotman.matej@gmail.com";
     github = "matejc";

--- a/pkgs/by-name/on/onedriver/package.nix
+++ b/pkgs/by-name/on/onedriver/package.nix
@@ -1,0 +1,64 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, pkg-config
+, webkitgtk
+, glib
+, fuse
+, installShellFiles
+}:
+let
+  pname = "onedriver";
+  version = "0.13.0-2";
+
+  src = fetchFromGitHub {
+    owner = "jstaf";
+    repo = "onedriver";
+    rev = "v${version}";
+    hash = "sha256-Bcjgmx9a4pTRhkzR3tbOB6InjvuH71qomv4t+nRNc+w=";
+  };
+in
+buildGoModule {
+  inherit pname version src;
+  vendorHash = "sha256-OOiiKtKb+BiFkoSBUQQfqm4dMfDW3Is+30Kwcdg8LNA=";
+
+  nativeBuildInputs = [ pkg-config installShellFiles ];
+  buildInputs = [ webkitgtk glib fuse ];
+
+  ldflags = [ "-X github.com/jstaf/onedriver/cmd/common.commit=v${version}" ];
+
+  subPackages = [
+    "cmd/onedriver"
+    "cmd/onedriver-launcher"
+  ];
+
+  postInstall = ''
+    echo "Running postInstall"
+    install -Dm644 ./resources/onedriver.svg $out/share/icons/onedriver/onedriver.svg
+    install -Dm644 ./resources/onedriver.png $out/share/icons/onedriver/onedriver.png
+    install -Dm644 ./resources/onedriver-128.png $out/share/icons/onedriver/onedriver-128.png
+
+    install -Dm644 ./resources/onedriver.desktop $out/share/applications/onedriver.desktop
+
+    mkdir -p $out/share/man/man1
+    installManPage ./resources/onedriver.1
+
+    substituteInPlace $out/share/applications/onedriver.desktop \
+      --replace "/usr/bin/onedriver-launcher" "$out/bin/onedriver-launcher" \
+      --replace "/usr/share/icons" "$out/share/icons"
+  '';
+
+  meta = with lib; {
+    description = "A network filesystem for Linux";
+    longDescription = ''
+      onedriver is a network filesystem that gives your computer direct access to your files on Microsoft OneDrive.
+      This is not a sync client. Instead of syncing files, onedriver performs an on-demand download of files when
+      your computer attempts to use them. onedriver allows you to use files on OneDrive as if they were files on
+      your local computer.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.massimogengarelli ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

onedriver is a network filesystem that gives your computer direct access to your files on Microsoft OneDrive. This is not a sync client. Instead of syncing files, onedriver performs an on-demand download of files when your computer attempts to use them. onedriver allows you to use files on OneDrive as if they were files on your local computer.

[Homepage](https://github.com/jstaf/onedriver)

This should also fix #252398

I decided to package version 0.13.0-2 even though there is a newer version 0.14.0 which came out a couple of months ago, the problem is that version 0.14.0 has some major bugs that could lead to corruptions in OneDrive (see [here](https://github.com/jstaf/onedriver/issues/350) for a discussion). I also tried packaging version 0.14.0 with the patch proposed [here](https://github.com/jstaf/onedriver/issues/350) but it is still failing on some cases.

I have been using version 0.13.0-2 for months now without any issue, so I consider this as the stable version of the package.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
