### PR TITLE
liblinphone: add back QR support

### DIFF
--- a/pkgs/development/libraries/liblinphone/backport-cpp17.patch
+++ b/pkgs/development/libraries/liblinphone/backport-cpp17.patch
@@ -1,0 +1,98 @@
+From 9ece6e77dcf6545c3b8104068302c6243e3a5e88 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micka=C3=ABl=20Turnel?=
+ <mickael.turnel@belledonne-communications.com>
+Date: Wed, 1 Mar 2023 09:14:53 +0100
+Subject: [PATCH] Set c++ version 17 and fix compilation errors
+
+Backported-by: Lorenz Brun <lorenz@brun.one>
+
+---
+ CMakeLists.txt                           |  2 +-
+ daemon/daemon.cc                         |  2 +-
+ libxsd/xsd/cxx/config.hxx                |  2 +-
+ src/conference/session/streams-group.cpp | 10 +++++-----
+ 4 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 475ff16a8..a771e4595 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,7 +92,7 @@ cmake_dependent_option(ENABLE_QRCODE "Enable QRCode support" YES "ENABLE_VIDEO"
+ # * DISABLE_BC_PACKAGE_SEARCH: skip find_package() for every BC package (bctoolbox, ortp, etc.)
+ # * DISABLE_SOCI_PACKAGE_SEARCH: skip find_package() for Soci.
+ 
+-set(CMAKE_CXX_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_EXTENSIONS NO)
+ 
+ if(NOT CMAKE_BUILD_TYPE)
+diff --git a/daemon/daemon.cc b/daemon/daemon.cc
+index 197fc22ef..fd09edb26 100644
+--- a/daemon/daemon.cc
++++ b/daemon/daemon.cc
+@@ -628,7 +628,7 @@ void Daemon::execCommand(const string &command) {
+ 	ist.get(argsbuf);
+ 	string args = argsbuf.str();
+ 	if (!args.empty() && (args[0] == ' ')) args.erase(0, 1);
+-	list<DaemonCommand*>::iterator it = find_if(mCommands.begin(), mCommands.end(), bind2nd(mem_fun(&DaemonCommand::matches), name));
++	list<DaemonCommand*>::iterator it = find_if(mCommands.begin(), mCommands.end(), [&name](const DaemonCommand *dc) { return dc->matches(name); });
+ 	if (it != mCommands.end()) {
+ 		ms_mutex_lock(&mMutex);
+ 		(*it)->exec(this, args);
+diff --git a/libxsd/xsd/cxx/config.hxx b/libxsd/xsd/cxx/config.hxx
+index 076b107f5..385841731 100644
+--- a/libxsd/xsd/cxx/config.hxx
++++ b/libxsd/xsd/cxx/config.hxx
+@@ -19,7 +19,7 @@
+ #  endif
+ #else
+ #  if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+-#    ifdef __GNUC__
++#    if defined(__GNUC__) && !defined(__clang__)
+ #      if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __GNUC__ > 4
+ #        define XSD_CXX11_NULLPTR
+ #      endif
+diff --git a/src/conference/session/streams-group.cpp b/src/conference/session/streams-group.cpp
+index bff739dda..84277a6b7 100644
+--- a/src/conference/session/streams-group.cpp
++++ b/src/conference/session/streams-group.cpp
+@@ -447,11 +447,11 @@ float StreamsGroup::computeOverallQuality(_functor func){
+ }
+ 
+ float StreamsGroup::getAverageQuality(){
+-	return computeOverallQuality(mem_fun(&Stream::getAverageQuality));
++	return computeOverallQuality(mem_fn(&Stream::getAverageQuality));
+ }
+ 
+ float StreamsGroup::getCurrentQuality(){
+-	return computeOverallQuality(mem_fun(&Stream::getCurrentQuality));
++	return computeOverallQuality(mem_fn(&Stream::getCurrentQuality));
+ }
+ 
+ int StreamsGroup::getAvpfRrInterval()const{
+@@ -481,11 +481,11 @@ bool StreamsGroup::avpfEnabled() const{
+ }
+ 
+ void StreamsGroup::refreshSockets(){
+-	forEach<Stream>(mem_fun(&Stream::refreshSockets));
++	forEach<Stream>(mem_fn(&Stream::refreshSockets));
+ }
+ 
+ void StreamsGroup::computeAndReportBandwidth(){
+-	forEach<Stream>(mem_fun(&Stream::updateBandwidthReports));
++	forEach<Stream>(mem_fn(&Stream::updateBandwidthReports));
+ 	
+ 	if (!bctbx_log_level_enabled(BCTBX_LOG_DOMAIN, BCTBX_LOG_MESSAGE)) return;
+ 	
+@@ -540,7 +540,7 @@ void StreamsGroup::finish(){
+ 	mIceService->finish(); // finish ICE first, as it has actions on the streams.
+ 	for (auto & ss : mSharedServices) ss.second->checkDestroy();
+ 	mSharedServices.clear();
+-	forEach<Stream>(mem_fun(&Stream::finish));
++	forEach<Stream>(mem_fn(&Stream::finish));
+ 	mFinished = true;
+ }
+ 
+-- 
+2.41.0
+

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -13,6 +13,7 @@
 , sqlite
 , stdenv
 , xercesc
+, zxing-cpp
 }:
 
 stdenv.mkDerivation rec {
@@ -28,6 +29,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-kQZePMa7MTaSJLEObM8khfSFYLqhlgTcVyKfTPLwKYU=";
   };
 
+  patches = [
+    # zxing-cpp 2.0+ requires C++ 17
+    # Manual backport as upstream ran formatters in the meantime
+    ./backport-cpp17.patch
+  ];
+
   postPatch = ''
     substituteInPlace src/CMakeLists.txt \
       --replace "jsoncpp_object" "jsoncpp" \
@@ -38,7 +45,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_STATIC=NO" # Do not build static libraries
     "-DENABLE_UNIT_TESTS=NO" # Do not build test executables
     "-DENABLE_STRICT=NO" # Do not build with -Werror
-    "-DENABLE_QRCODE=NO" # Does not build with zxing-cpp 2
   ];
 
   buildInputs = [
@@ -56,6 +62,7 @@ stdenv.mkDerivation rec {
     (python3.withPackages (ps: [ ps.pystache ps.six ]))
     sqlite
     xercesc
+    zxing-cpp
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
liblinphone was broken by 1769609dc0f5bb4bab18d2245e28b052f66b7a71 as zxing-cpp 2.0 and later require C++ 17 [1]. The version of liblinphone in nixpkgs does however only build with C++ 14. This was then fixed in c42909d342e2bad6739a31e608f41ad62d545ce1 by disabling QR code support. Its master branch does however build with C++ 17, so backport that commit. Due to upstream running formatters on their code in the meantime, the backport had to be done manually and the commit cannot be picked.

[1] https://github.com/zxing-cpp/zxing-cpp/releases/tag/v2.0.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
