### PR TITLE
minimal-bootstrap: hide for yet unsupported platforms

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -6,219 +6,223 @@
 , checkMeta
 }:
 
-lib.makeScope
-  # Prevent using top-level attrs to protect against introducing dependency on
-  # non-bootstrap packages by mistake. Any top-level inputs must be explicitly
-  # declared here.
-  (extra: lib.callPackageWith ({ inherit lib config buildPlatform hostPlatform fetchurl checkMeta; } // extra))
-  (self: with self; {
+let
+  inherit (import ./stage0-posix/platforms.nix { inherit lib hostPlatform; }) platforms;
+in
+lib.optionalAttrs (lib.any (lib.meta.platformMatch hostPlatform) platforms) (
+  lib.makeScope
+    # Prevent using top-level attrs to protect against introducing dependency on
+    # non-bootstrap packages by mistake. Any top-level inputs must be explicitly
+    # declared here.
+    (extra: lib.callPackageWith ({ inherit lib config buildPlatform hostPlatform fetchurl checkMeta; } // extra))
+    (self: with self; {
 
-    bash_2_05 = callPackage ./bash/2.nix { tinycc = tinycc-mes; };
+      bash_2_05 = callPackage ./bash/2.nix { tinycc = tinycc-mes; };
 
-    bash = callPackage ./bash {
-      bootBash = bash_2_05;
-      tinycc = tinycc-musl;
-      coreutils = coreutils-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      bash = callPackage ./bash {
+        bootBash = bash_2_05;
+        tinycc = tinycc-musl;
+        coreutils = coreutils-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    binutils = callPackage ./binutils {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      binutils = callPackage ./binutils {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    bzip2 = callPackage ./bzip2 {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      bzip2 = callPackage ./bzip2 {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    coreutils = callPackage ./coreutils { tinycc = tinycc-mes; };
-    coreutils-musl = callPackage ./coreutils/musl.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      coreutils = callPackage ./coreutils { tinycc = tinycc-mes; };
+      coreutils-musl = callPackage ./coreutils/musl.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    diffutils = callPackage ./diffutils {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      diffutils = callPackage ./diffutils {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    findutils = callPackage ./findutils {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      findutils = callPackage ./findutils {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    gawk-mes = callPackage ./gawk/mes.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-      gnused = gnused-mes;
-    };
+      gawk-mes = callPackage ./gawk/mes.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+        gnused = gnused-mes;
+      };
 
-    gawk = callPackage ./gawk {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-      bootGawk = gawk-mes;
-    };
+      gawk = callPackage ./gawk {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+        bootGawk = gawk-mes;
+      };
 
-    gcc2 = callPackage ./gcc/2.nix {
-      bash = bash_2_05;
-      gcc = gcc2-mes;
-      glibc = glibc22;
-    };
-    gcc2-mes = callPackage ./gcc/2.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-      mesBootstrap = true;
-    };
+      gcc2 = callPackage ./gcc/2.nix {
+        bash = bash_2_05;
+        gcc = gcc2-mes;
+        glibc = glibc22;
+      };
+      gcc2-mes = callPackage ./gcc/2.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+        mesBootstrap = true;
+      };
 
-    gcc46 = callPackage ./gcc/4.6.nix {
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-      # FIXME: not sure why new gawk doesn't work
-      gawk = gawk-mes;
-    };
-    gcc46-cxx = callPackage ./gcc/4.6.cxx.nix {
-      gcc = gcc46;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-      # FIXME: not sure why new gawk doesn't work
-      gawk = gawk-mes;
-    };
+      gcc46 = callPackage ./gcc/4.6.nix {
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+        # FIXME: not sure why new gawk doesn't work
+        gawk = gawk-mes;
+      };
+      gcc46-cxx = callPackage ./gcc/4.6.cxx.nix {
+        gcc = gcc46;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+        # FIXME: not sure why new gawk doesn't work
+        gawk = gawk-mes;
+      };
 
-    inherit (callPackage ./glibc {
-      bash = bash_2_05;
-      gnused = gnused-mes;
-    }) glibc22;
+      inherit (callPackage ./glibc {
+        bash = bash_2_05;
+        gnused = gnused-mes;
+      }) glibc22;
 
-    gnugrep = callPackage ./gnugrep {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-    };
+      gnugrep = callPackage ./gnugrep {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+      };
 
-    gnumake = callPackage ./gnumake { tinycc = tinycc-mes; };
+      gnumake = callPackage ./gnumake { tinycc = tinycc-mes; };
 
-    gnumake-musl = callPackage ./gnumake/musl.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gawk = gawk-mes;
-      gnumakeBoot = gnumake;
-    };
+      gnumake-musl = callPackage ./gnumake/musl.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gawk = gawk-mes;
+        gnumakeBoot = gnumake;
+      };
 
-    gnupatch = callPackage ./gnupatch { tinycc = tinycc-mes; };
+      gnupatch = callPackage ./gnupatch { tinycc = tinycc-mes; };
 
-    gnused = callPackage ./gnused {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnused = gnused-mes;
-    };
-    gnused-mes = callPackage ./gnused/mes.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-    };
+      gnused = callPackage ./gnused {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnused = gnused-mes;
+      };
+      gnused-mes = callPackage ./gnused/mes.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+      };
 
-    gnutar = callPackage ./gnutar/mes.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-      gnused = gnused-mes;
-    };
+      gnutar = callPackage ./gnutar/mes.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+        gnused = gnused-mes;
+      };
 
-    gnutar-musl = callPackage ./gnutar/musl.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnused = gnused-mes;
-    };
+      gnutar-musl = callPackage ./gnutar/musl.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnused = gnused-mes;
+      };
 
-    gzip = callPackage ./gzip {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-      gnused = gnused-mes;
-    };
+      gzip = callPackage ./gzip {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+        gnused = gnused-mes;
+      };
 
-    heirloom = callPackage ./heirloom {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-    };
+      heirloom = callPackage ./heirloom {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+      };
 
-    heirloom-devtools = callPackage ./heirloom-devtools { tinycc = tinycc-mes; };
+      heirloom-devtools = callPackage ./heirloom-devtools { tinycc = tinycc-mes; };
 
-    linux-headers = callPackage ./linux-headers { bash = bash_2_05; };
+      linux-headers = callPackage ./linux-headers { bash = bash_2_05; };
 
-    ln-boot = callPackage ./ln-boot { };
+      ln-boot = callPackage ./ln-boot { };
 
-    mes = lib.recurseIntoAttrs (callPackage ./mes { });
-    mes-libc = callPackage ./mes/libc.nix { };
+      mes = lib.recurseIntoAttrs (callPackage ./mes { });
+      mes-libc = callPackage ./mes/libc.nix { };
 
-    musl11 = callPackage ./musl/1.1.nix {
-      bash = bash_2_05;
-      tinycc = tinycc-mes;
-      gnused = gnused-mes;
-    };
+      musl11 = callPackage ./musl/1.1.nix {
+        bash = bash_2_05;
+        tinycc = tinycc-mes;
+        gnused = gnused-mes;
+      };
 
-    musl = callPackage ./musl {
-      gcc = gcc46;
-      gnumake = gnumake-musl;
-    };
+      musl = callPackage ./musl {
+        gcc = gcc46;
+        gnumake = gnumake-musl;
+      };
 
-    stage0-posix = callPackage ./stage0-posix { };
+      stage0-posix = callPackage ./stage0-posix { };
 
-    inherit (self.stage0-posix) kaem m2libc mescc-tools mescc-tools-extra;
+      inherit (self.stage0-posix) kaem m2libc mescc-tools mescc-tools-extra;
 
-    tinycc-bootstrappable = lib.recurseIntoAttrs (callPackage ./tinycc/bootstrappable.nix { });
-    tinycc-mes = lib.recurseIntoAttrs (callPackage ./tinycc/mes.nix { });
-    tinycc-musl = lib.recurseIntoAttrs (callPackage ./tinycc/musl.nix {
-      bash = bash_2_05;
-      musl = musl11;
-    });
+      tinycc-bootstrappable = lib.recurseIntoAttrs (callPackage ./tinycc/bootstrappable.nix { });
+      tinycc-mes = lib.recurseIntoAttrs (callPackage ./tinycc/mes.nix { });
+      tinycc-musl = lib.recurseIntoAttrs (callPackage ./tinycc/musl.nix {
+        bash = bash_2_05;
+        musl = musl11;
+      });
 
-    xz = callPackage ./xz {
-      bash = bash_2_05;
-      tinycc = tinycc-musl;
-      gnumake = gnumake-musl;
-      gnutar = gnutar-musl;
-    };
+      xz = callPackage ./xz {
+        bash = bash_2_05;
+        tinycc = tinycc-musl;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-musl;
+      };
 
-    inherit (callPackage ./utils.nix { }) derivationWithMeta writeTextFile writeText;
+      inherit (callPackage ./utils.nix { }) derivationWithMeta writeTextFile writeText;
 
-    test = kaem.runCommand "minimal-bootstrap-test" {} ''
-      echo ${bash.tests.get-version}
-      echo ${bash_2_05.tests.get-version}
-      echo ${binutils.tests.get-version}
-      echo ${bzip2.tests.get-version}
-      echo ${coreutils-musl.tests.get-version}
-      echo ${diffutils.tests.get-version}
-      echo ${findutils.tests.get-version}
-      echo ${gawk-mes.tests.get-version}
-      echo ${gawk.tests.get-version}
-      echo ${gcc2.tests.get-version}
-      echo ${gcc2-mes.tests.get-version}
-      echo ${gcc46.tests.get-version}
-      echo ${gcc46-cxx.tests.hello-world}
-      echo ${gnugrep.tests.get-version}
-      echo ${gnused.tests.get-version}
-      echo ${gnused-mes.tests.get-version}
-      echo ${gnutar.tests.get-version}
-      echo ${gnutar-musl.tests.get-version}
-      echo ${gzip.tests.get-version}
-      echo ${heirloom.tests.get-version}
-      echo ${mes.compiler.tests.get-version}
-      echo ${musl.tests.hello-world}
-      echo ${tinycc-mes.compiler.tests.chain}
-      echo ${tinycc-musl.compiler.tests.hello-world}
-      echo ${xz.tests.get-version}
-      mkdir ''${out}
-    '';
-  })
+      test = kaem.runCommand "minimal-bootstrap-test" { } ''
+        echo ${bash.tests.get-version}
+        echo ${bash_2_05.tests.get-version}
+        echo ${binutils.tests.get-version}
+        echo ${bzip2.tests.get-version}
+        echo ${coreutils-musl.tests.get-version}
+        echo ${diffutils.tests.get-version}
+        echo ${findutils.tests.get-version}
+        echo ${gawk-mes.tests.get-version}
+        echo ${gawk.tests.get-version}
+        echo ${gcc2.tests.get-version}
+        echo ${gcc2-mes.tests.get-version}
+        echo ${gcc46.tests.get-version}
+        echo ${gcc46-cxx.tests.hello-world}
+        echo ${gnugrep.tests.get-version}
+        echo ${gnused.tests.get-version}
+        echo ${gnused-mes.tests.get-version}
+        echo ${gnutar.tests.get-version}
+        echo ${gnutar-musl.tests.get-version}
+        echo ${gzip.tests.get-version}
+        echo ${heirloom.tests.get-version}
+        echo ${mes.compiler.tests.get-version}
+        echo ${musl.tests.hello-world}
+        echo ${tinycc-mes.compiler.tests.chain}
+        echo ${tinycc-musl.compiler.tests.hello-world}
+        echo ${xz.tests.get-version}
+        mkdir ''${out}
+      '';
+    }))


### PR DESCRIPTION
Breaks evaluation for other platforms being visible so only
show the package set for supported platforms

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Attempts to resolve #259731

`nix-env -f ./. -u --dry-run -v --show-trace --argstr system x86_64-darwin` passed on x86_64-linux but i'm pretty sure this worked before the change so I'm not convinced this did anything so need to test on a real darwin machine

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
