### PR TITLE
nixos/tests/kubo: various improvements

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -424,7 +424,7 @@ in {
   ksm = handleTest ./ksm.nix {};
   kthxbye = handleTest ./kthxbye.nix {};
   kubernetes = handleTestOn ["x86_64-linux"] ./kubernetes {};
-  kubo = runTest ./kubo.nix;
+  kubo = import ./kubo { inherit recurseIntoAttrs runTest; };
   ladybird = handleTest ./ladybird.nix {};
   languagetool = handleTest ./languagetool.nix {};
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };

--- a/nixos/tests/kubo/default.nix
+++ b/nixos/tests/kubo/default.nix
@@ -1,0 +1,5 @@
+{ recurseIntoAttrs, runTest }:
+recurseIntoAttrs {
+  kubo = runTest ./kubo.nix;
+  kubo-fuse = runTest ./kubo-fuse.nix;
+}

--- a/nixos/tests/kubo/kubo-fuse.nix
+++ b/nixos/tests/kubo/kubo-fuse.nix
@@ -1,0 +1,42 @@
+{ lib, ...} : {
+  name = "kubo-fuse";
+  meta = with lib.maintainers; {
+    maintainers = [ mguentner Luflosi ];
+  };
+
+  nodes.machine = { config, ... }: {
+    services.kubo = {
+      enable = true;
+      autoMount = true;
+    };
+    users.users.alice = {
+      isNormalUser = true;
+      extraGroups = [ config.services.kubo.group ];
+    };
+    users.users.bob = {
+      isNormalUser = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("FUSE mountpoint"):
+        machine.fail("echo a | su bob -l -c 'ipfs add --quieter'")
+        # The FUSE mount functionality is broken as of v0.13.0 and v0.17.0.
+        # See https://github.com/ipfs/kubo/issues/9044.
+        # Workaround: using CID Version 1 avoids that.
+        ipfs_hash = machine.succeed(
+            "echo fnord3 | su alice -l -c 'ipfs add --quieter --cid-version=1'"
+        ).strip()
+
+        machine.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
+
+    with subtest("Unmounting of /ipns and /ipfs"):
+        # Force Kubo to crash and wait for it to restart
+        machine.systemctl("kill --signal=SIGKILL ipfs.service")
+        machine.wait_for_unit("ipfs.service", timeout = 30)
+
+        machine.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
+  '';
+}

--- a/nixos/tests/kubo/kubo.nix
+++ b/nixos/tests/kubo/kubo.nix
@@ -18,20 +18,6 @@
     };
   };
 
-  nodes.fuse = { config, ... }: {
-    services.kubo = {
-      enable = true;
-      autoMount = true;
-    };
-    users.users.alice = {
-      isNormalUser = true;
-      extraGroups = [ config.services.kubo.group ];
-    };
-    users.users.bob = {
-      isNormalUser = true;
-    };
-  };
-
   testScript = ''
     start_all()
 
@@ -63,23 +49,5 @@
     with subtest("Setting dataDir works properly with the hardened systemd unit"):
         machine.succeed("test -e /mnt/ipfs/config")
         machine.succeed("test ! -e /var/lib/ipfs/")
-
-    with subtest("FUSE mountpoint"):
-        fuse.fail("echo a | su bob -l -c 'ipfs add --quieter'")
-        # The FUSE mount functionality is broken as of v0.13.0 and v0.17.0.
-        # See https://github.com/ipfs/kubo/issues/9044.
-        # Workaround: using CID Version 1 avoids that.
-        ipfs_hash = fuse.succeed(
-            "echo fnord3 | su alice -l -c 'ipfs add --quieter --cid-version=1'"
-        ).strip()
-
-        fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
-
-    with subtest("Unmounting of /ipns and /ipfs"):
-        # Force Kubo to crash and wait for it to restart
-        fuse.systemctl("kill --signal=SIGKILL ipfs.service")
-        fuse.wait_for_unit("ipfs.service", timeout = 30)
-
-        fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
   '';
 }

--- a/pkgs/applications/networking/kubo/default.nix
+++ b/pkgs/applications/networking/kubo/default.nix
@@ -2,6 +2,7 @@
 , buildGoModule
 , fetchurl
 , nixosTests
+, callPackage
 }:
 
 buildGoModule rec {
@@ -29,7 +30,10 @@ buildGoModule rec {
 
   subPackages = [ "cmd/ipfs" ];
 
-  passthru.tests.kubo = nixosTests.kubo;
+  passthru.tests = {
+    inherit (nixosTests) kubo;
+    repoVersion = callPackage ./test-repoVersion.nix {};
+  };
 
   vendorHash = null;
 

--- a/pkgs/applications/networking/kubo/test-repoVersion.nix
+++ b/pkgs/applications/networking/kubo/test-repoVersion.nix
@@ -1,0 +1,13 @@
+{ runCommand, kubo }:
+
+runCommand "kubo-test-repoVersion" { } ''
+  export IPFS_PATH="$TMPDIR"
+  "${kubo}/bin/ipfs" init --empty-repo
+  declared_repo_version='${kubo.repoVersion}'
+  actual_repo_version="$(cat "$IPFS_PATH/version")"
+  if [ "$declared_repo_version" != "$actual_repo_version" ]; then
+    echo "kubo.repoVersion is not set correctly. It should be $actual_repo_version but is $declared_repo_version."
+    exit 1
+  fi
+  touch "$out"
+''


### PR DESCRIPTION
## Description of changes
Add new test to check if kubo.passthru.repoVersion is set correctly.
Also split the existing NixOS VM test into two independent parts. The test already used two independent VMs but just one testScript. This made experimenting with just one of the two VMs slower than it needed to be. It should also increase parallelism slightly since both test scripts can now run at the same time.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).