### PR TITLE
lomiri.qtmir: init at 0.7.2-unstable-2024-01-08

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -22,6 +22,7 @@ let
     libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
     lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
+    qtmir = callPackage ./development/qtmir { };
     trust-store = callPackage ./development/trust-store { };
     u1db-qt = callPackage ./development/u1db-qt { };
 

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -1,0 +1,160 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, testers
+, cmake
+, cmake-extras
+, pkg-config
+, wrapQtAppsHook
+, gsettings-qt
+, gtest
+, libqtdbustest
+, libqtdbusmock
+, libuuid
+, lomiri-api
+, lomiri-app-launch
+, lomiri-url-dispatcher
+, lttng-ust
+, mir
+, process-cpp
+, qtbase
+, qtdeclarative
+, qtsensors
+, valgrind
+, protobuf
+, glm
+, boost
+, properties-cpp
+, glib
+, validatePkgConfig
+, wayland
+, xwayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  # Not regular qtmir, experimental support for Mir 2.x
+  # Currently following https://gitlab.com/ubports/development/core/qtmir/-/tree/personal/mariogrip/desktop-development
+  pname = "qtmir-mir2";
+  version = "0.7.2-unstable-2024-01-08";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/qtmir";
+    rev = "ae0d87415d5c9ed2c4fd2284ba0807d23d564bb0";
+    hash = "sha256-fE8ttCC0FNavs91pASGGG7k7nKVg2lD3JK0WTmCA3gM=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Mir 2.15 compatibility patch
+    # Remove when https://gitlab.com/ubports/development/core/qtmir/-/merge_requests/70 merged into branch
+    (fetchpatch {
+      name = "0001-qtmir-Update-for-Mir-2.15-removals.patch";
+      url = "https://gitlab.com/ubports/development/core/qtmir/-/commit/ead5cacd4d69094ab956627f4dd94ecaff1fd69e.patch";
+      hash = "sha256-hUUUnYwhNH3gm76J21M8gA5okaRd/Go03ZFJ4qn0JUo=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/qtmir/-/merge_requests/72 merged in branch
+    (fetchpatch {
+      name = "0002-qtmir-Add-more-better-GNUInstallDirs-variables-usage.patch";
+      url = "https://gitlab.com/ubports/development/core/qtmir/-/commit/87e2cd31052ce15e9625c1327807a320ee5d12af.patch";
+      hash = "sha256-MTE9tHw+xJhraEO1up7dLg0UIcmfHXgWOeuyYrVu2wc=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/qtmir/-/merge_requests/73 merged in branch
+    (fetchpatch {
+      name = "0003-qtmir-CMakeLists-Only-require-test-dependencies-when-building-tests.patch";
+      url = "https://gitlab.com/ubports/development/core/qtmir/-/commit/b7144e67bcbb4cfbd2283d5d05146fb22b7d8cd4.patch";
+      hash = "sha256-Afbj40MopztchDnk6fphTYk86YrQkiK8L1e/oXiL1Mw=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/qtmir/-/merge_requests/74 merged in branch
+    (fetchpatch {
+      name = "0004-qtmir-CMakeLists-Drop-call-of-Qt-internal-macro.patch";
+      url = "https://gitlab.com/ubports/development/core/qtmir/-/commit/8f9c599a4dbc4cf35e289157fd0c82df55b9f8d9.patch";
+      hash = "sha256-SMAErXnlMtVleWRPgO4xuUI7gAAy6W18LxtgXgetRA4=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
+      --replace "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/plugins/platforms" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}/platforms" \
+
+    substituteInPlace data/xwayland.qtmir.desktop \
+      --replace '/usr/bin/Xwayland' 'Xwayland'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # glib-compile-schemas
+    pkg-config
+    validatePkgConfig
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cmake-extras
+    boost
+    gsettings-qt
+    libuuid
+    lomiri-api
+    lomiri-app-launch
+    lomiri-url-dispatcher
+    lttng-ust
+    mir
+    process-cpp
+    protobuf
+    qtbase
+    qtdeclarative
+    qtsensors
+    valgrind
+
+    glm # included by mir header
+    wayland # mirwayland asks for this
+    properties-cpp # included by l-a-l header
+  ];
+
+  propagatedBuildInputs = [
+    # Needs Xwayland on PATH for desktop file, else launching X11 applications crashes qtmir
+    xwayland
+  ];
+
+  checkInputs = [
+    gtest
+    libqtdbustest
+    libqtdbusmock
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
+    (lib.cmakeBool "WITH_MIR2" true)
+  ];
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  # Tests currently unavailable when building with Mir2
+  doCheck = false;
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    description = "QPA plugin to make Qt a Mir server";
+    homepage = "https://gitlab.com/ubports/development/core/qtmir";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "qtmirserver"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[QtMir](https://gitlab.com/ubports/development/core/qtmir) (AFAICT) is a Qt Platform Abstraction (QPA) plugin to make Qt a compositor for Mir (as in, the non-Wayland platform). It is used by Lomiri itself to start & communicate with Mir for graphics & desktop interactions.

QtMir only supports Mir 1.x officially. Mir 1.x *can* be packaged, but it has some problems. Upstream is aiming to convert QtMir from Mir 1.x (a Mir-only server) and MirAL to Mir 2.x (a Wayland compositor framework) and Miroil. We're going to do the same thing Debian has done in their Lomiri effort and package an upstream branch with the Mir 2.x migration instead of going with the regular QtMir. I have thus opted to change the `pname` and add some comments about this situation.

Upstream tests have not been made Mir 2.x compatible yet, so there's sadly no testing for this. Launching the `qtmir-demo-client` on top of my Miriway session (I assume any Wayland compositor will do) works, as does the entire Lomiri ecosystem on my WIP branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
