### PR TITLE
koodo-reader: init at 1.6.6

### DIFF
--- a/pkgs/by-name/ko/koodo-reader/fix-isdev.patch
+++ b/pkgs/by-name/ko/koodo-reader/fix-isdev.patch
@@ -1,0 +1,13 @@
+diff --git a/main.js b/main.js
+index a4b5c8ef..743d63ca 100644
+--- a/main.js
++++ b/main.js
+@@ -8,7 +8,7 @@ const {
+   nativeTheme,
+ } = require("electron");
+ const path = require("path");
+-const isDev = require("electron-is-dev");
++const isDev = false;
+ const Store = require("electron-store");
+ const store = new Store();
+ const fs = require("fs");

--- a/pkgs/by-name/ko/koodo-reader/mime-types.xml
+++ b/pkgs/by-name/ko/koodo-reader/mime-types.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+<mime-type type="application/epub+zip">
+  <glob pattern="*.epub"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/pdf">
+  <glob pattern="*.pdf"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="image/vnd.djvu">
+  <glob pattern="*.djvu"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-mobipocket-ebook">
+  <glob pattern="*.mobi"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/vnd.amazon.ebook">
+  <glob pattern="*.azw3"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/vnd.amazon.ebook">
+  <glob pattern="*.azw"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-cbz">
+  <glob pattern="*.cbz"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-cbr">
+  <glob pattern="*.cbr"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-cbt">
+  <glob pattern="*.cbt"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-cb7">
+  <glob pattern="*.cb7"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-fictionbook+xml">
+  <glob pattern="*.fb2"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+</mime-info>

--- a/pkgs/by-name/ko/koodo-reader/package.json
+++ b/pkgs/by-name/ko/koodo-reader/package.json
@@ -1,0 +1,312 @@
+{
+  "name": "koodo-reader",
+  "main": "main.js",
+  "version": "1.6.6",
+  "description": "A cross-platform ebook reader",
+  "author": {
+    "name": "App by Troye",
+    "email": "support@960960.xyz"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=6.0.0"
+  },
+  "repository": "https://github.com/koodo-reader/koodo-reader",
+  "private": false,
+  "resolutions": {
+    "//": "See https://github.com/facebook/create-react-app/issues/11773",
+    "react-error-overlay": "6.0.9"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.485.0",
+    "adm-zip": "^0.5.2",
+    "axios": "^0.19.2",
+    "buffer": "^6.0.3",
+    "copy-text-to-clipboard": "^2.2.0",
+    "dompurify": "^3.0.1",
+    "electron-is-dev": "^1.1.0",
+    "electron-store": "^8.0.1",
+    "font-list": "^1.4.5",
+    "fs-extra": "^9.1.0",
+    "ftp": "^0.3.10",
+    "howler": "^2.2.3",
+    "iconv-lite": "^0.6.3",
+    "qs": "^6.11.2",
+    "react-hot-toast": "^2.1.1",
+    "react-tooltip": "^5.26.3",
+    "ssh2-sftp-client": "^9.1.0",
+    "webdav": "^3.6.2",
+    "wink-lemmatizer": "^3.0.4",
+    "ws": "^8.13.0",
+    "zip-a-folder": "^0.0.12"
+  },
+  "devDependencies": {
+    "@types/i18next": "^13.0.0",
+    "@types/iconv-lite": "^0.0.1",
+    "@types/node": "^13.13.2",
+    "@types/react": "17.0.2",
+    "@types/react-dom": "17.0.2",
+    "@types/react-i18next": "^8.1.0",
+    "@types/react-lottie": "^1.2.5",
+    "@types/react-redux": "^7.1.7",
+    "@types/react-router-dom": "^5.1.6",
+    "@types/spark-md5": "^3.0.2",
+    "@types/ws": "^8.5.5",
+    "classnames": "^2.2.6",
+    "concurrently": "^5.0.1",
+    "cross-env": "^6.0.3",
+    "electron": "14.1.1",
+    "electron-builder": "^23.6.0",
+    "hard-source-webpack-plugin": "^0.13.1",
+    "html-react-parser": "^0.13.0",
+    "i18next": "^20.2.4",
+    "node-sass": "^9.0.0",
+    "nodemon": "^2.0.6",
+    "rc-color-picker": "^1.2.6",
+    "react": "^17.0.2",
+    "react-device-detect": "^1.12.1",
+    "react-dom": "^17.0.2",
+    "react-dropzone": "^11.3.0",
+    "react-i18next": "^13.2.2",
+    "react-lottie": "^1.2.3",
+    "react-redux": "^7.2.0",
+    "react-router-dom": "^5.2.0",
+    "react-scripts": "^5.0.1",
+    "redux": "^4.0.5",
+    "redux-thunk": "^2.3.0",
+    "sass-loader": "^13.3.2",
+    "source-map-explorer": "^2.5.2",
+    "spark-md5": "^3.0.1",
+    "typescript": "3.8.3",
+    "wait-on": "^7.0.1"
+  },
+  "scripts": {
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "ele": "electron .",
+    "dev": "concurrently \"cross-env BROWSER=none npm start\" \"wait-on http://127.0.0.1:3000/ && nodemon --watch main.js --exec electron .\"",
+    "release": "electron-builder",
+    "prerelease": "react-scripts build"
+  },
+  "homepage": "./",
+  "build": {
+    "appId": "xyz.960960.koodo",
+    "productName": "Koodo Reader",
+    "copyright": "Copyright (c) 2021-2022 ${author}",
+    "files": [
+      "build/**/*",
+      "node_modules/**/*",
+      "package.json",
+      "main.js",
+      "edge-tts.js"
+    ],
+    "directories": {
+      "buildResources": "assets"
+    },
+    "publish": {
+      "provider": "github",
+      "repo": "koodo-reader",
+      "owner": "koodo-reader"
+    },
+    "buildDependenciesFromSource": false,
+    "nodeGypRebuild": false,
+    "fileAssociations": [
+      {
+        "ext": "epub",
+        "icon": "assets/icons/epub",
+        "role": "Viewer",
+        "mimeType": "application/epub+zip"
+      },
+      {
+        "ext": "pdf",
+        "icon": "assets/icons/pdf",
+        "role": "Viewer",
+        "mimeType": "application/pdf"
+      },
+      {
+        "ext": "mobi",
+        "icon": "assets/icons/mobi",
+        "role": "Viewer",
+        "mimeType": "application/x-mobipocket-ebook"
+      },
+      {
+        "ext": "azw3",
+        "icon": "assets/icons/azw3",
+        "role": "Viewer",
+        "mimeType": "application/vnd.amazon.ebook"
+      },
+      {
+        "ext": "azw",
+        "icon": "assets/icons/azw3",
+        "role": "Viewer",
+        "mimeType": "application/vnd.amazon.ebook"
+      },
+      {
+        "ext": "cbz",
+        "icon": "assets/icons/comic",
+        "role": "Viewer",
+        "mimeType": "application/x-cbz"
+      },
+      {
+        "ext": "cbr",
+        "icon": "assets/icons/comic",
+        "role": "Viewer",
+        "mimeType": "application/x-cbr"
+      },
+      {
+        "ext": "cbt",
+        "icon": "assets/icons/comic",
+        "role": "Viewer",
+        "mimeType": "application/x-cbt"
+      },
+      {
+        "ext": "cb7",
+        "icon": "assets/icons/comic",
+        "role": "Viewer",
+        "mimeType": "application/x-cb7"
+      },
+      {
+        "ext": "fb2",
+        "icon": "assets/icons/fb2",
+        "role": "Viewer",
+        "mimeType": "application/x-fictionbook+xml"
+      }
+    ],
+    "extends": null,
+    "dmg": {
+      "contents": [
+        {
+          "x": 410,
+          "y": 150,
+          "type": "link",
+          "path": "/Applications"
+        },
+        {
+          "x": 130,
+          "y": 150,
+          "type": "file"
+        }
+      ]
+    },
+    "mac": {
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ],
+      "icon": "assets/icons/icon.icns",
+      "category": "public.app-category.productivity",
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "ia32",
+            "arm64"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "icon": "assets/icons/icon.ico",
+      "artifactName": "${productName}-${version}-${arch}-Win.${ext}",
+      "publisherName": "App by Troye"
+    },
+    "linux": {
+      "icon": "assets/icons",
+      "category": "Office",
+      "target": [
+        {
+          "target": "snap",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "arm64",
+            "ia32",
+            "x64"
+          ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "AppImage",
+          "arch": [
+            "arm64",
+            "ia32",
+            "x64"
+          ]
+        }
+      ],
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "portable": {
+      "artifactName": "${productName}-${version}-Portable.${ext}"
+    },
+    "nsis": {
+      "artifactName": "${productName}-${version}.${ext}",
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "include": "assets/windows/installer.nsh"
+    },
+    "snap": {
+      "publish": [
+        {
+          "provider": "github"
+        }
+      ]
+    }
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "babel": {
+    "presets": [
+      "react-app"
+    ],
+    "plugins": [
+      [
+        "react-hot-loader/babel"
+      ]
+    ]
+  }
+}

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  mkYarnPackage,
+  fetchFromGitHub,
+  applyPatches,
+  fetchYarnDeps,
+  makeDesktopItem,
+  copyDesktopItems,
+  wrapGAppsHook,
+  electron,
+}:
+
+mkYarnPackage rec {
+  pname = "koodo-reader";
+  version = "1.6.6";
+
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "troyeguo";
+      repo = "koodo-reader";
+      rev = "v${version}";
+      hash = "sha256-g2bVm8LFeEIPaWlaxzMI0SrpM+79zQFzJ7Vs5CbWBT4=";
+    };
+    patches = [ ./update-react-i18next.patch ]; # Could be upstreamed
+  };
+
+  # should be copied from `koodo-reader.src`
+  packageJSON = ./package.json;
+
+  patches = [ ./fix-isdev.patch ];
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-VvYkotVb74zR9+/IWiQwOX/6RJf+xukpi7okRovfVzc=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapGAppsHook
+  ];
+
+  dontWrapGApps = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -r $node_modules node_modules
+    chmod +w node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+    yarn --offline build
+    yarn --offline run electron-builder --dir \
+      -c.electronDist=${electron}/libexec/electron \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 assets/icons/256x256.png $out/share/icons/hicolor/256x256/apps/koodo-reader.png
+    install -Dm644 ${./mime-types.xml} $out/share/mime/packages/koodo-reader.xml
+
+    mkdir -p $out/share/lib/koodo-reader
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/lib/koodo-reader
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/koodo-reader \
+      --add-flags $out/share/lib/koodo-reader/resources/app.asar \
+      "''${gappsWrapperArgs[@]}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
+  '';
+
+  doDist = false;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "koodo-reader";
+      desktopName = "Koodo Reader";
+      exec = "koodo-reader %U";
+      icon = "koodo-reader";
+      comment = meta.description;
+      categories = [ "Office" ];
+      mimeTypes = [
+        "application/epub+zip"
+        "application/pdf"
+        "image/vnd.djvu"
+        "application/x-mobipocket-ebook"
+        "application/vnd.amazon.ebook"
+        "application/vnd.amazon.ebook"
+        "application/x-cbz"
+        "application/x-cbr"
+        "application/x-cbt"
+        "application/x-cb7"
+        "application/x-fictionbook+xml"
+      ];
+      startupWMClass = "Koodo Reader";
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    broken = stdenv.isDarwin;
+    changelog = "https://github.com/troyeguo/koodo-reader/releases/tag/v${version}";
+    description = "A cross-platform ebook reader";
+    longDescription = ''
+      A modern ebook manager and reader with sync and backup capacities
+      for Windows, macOS, Linux and Web
+    '';
+    homepage = "https://github.com/troyeguo/koodo-reader";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "koodo-reader";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = electron.meta.platforms;
+  };
+}

--- a/pkgs/by-name/ko/koodo-reader/update-react-i18next.patch
+++ b/pkgs/by-name/ko/koodo-reader/update-react-i18next.patch
@@ -1,0 +1,58 @@
+diff --git a/package.json b/package.json
+index c71b04a1..a4b4b3ef 100644
+--- a/package.json
++++ b/package.json
+@@ -67,7 +67,7 @@
+     "react-device-detect": "^1.12.1",
+     "react-dom": "^17.0.2",
+     "react-dropzone": "^11.3.0",
+-    "react-i18next": "^11.8.15",
++    "react-i18next": "^13.2.2",
+     "react-lottie": "^1.2.3",
+     "react-redux": "^7.2.0",
+     "react-router-dom": "^5.2.0",
+diff --git a/yarn.lock b/yarn.lock
+index 881db5b2..2df4d362 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -1828,7 +1828,7 @@
+   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
+   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
+ 
+-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
++"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+   version "7.21.0"
+   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+@@ -1842,6 +1842,13 @@
+   dependencies:
+     regenerator-runtime "^0.14.0"
+ 
++"@babel/runtime@^7.22.5":
++  version "7.23.1"
++  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
++  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
++  dependencies:
++    regenerator-runtime "^0.14.0"
++
+ "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
+   version "7.20.7"
+   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
+@@ -10951,12 +10958,12 @@ react-i18next@*:
+     "@babel/runtime" "^7.20.6"
+     html-parse-stringify "^3.0.1"
+ 
+-react-i18next@^11.8.15:
+-  version "11.18.6"
+-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.18.6.tgz#e159c2960c718c1314f1e8fcaa282d1c8b167887"
+-  integrity sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==
++react-i18next@^13.2.2:
++  version "13.2.2"
++  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-13.2.2.tgz#b1e78ed66a54f4bc819616f68b98221e1b1a1936"
++  integrity sha512-+nFUkbRByFwnrfDcYqvzBuaeZb+nACHx+fAWN/pZMddWOCJH5hoc21+Sa/N/Lqi6ne6/9wC/qRGOoQhJa6IkEQ==
+   dependencies:
+-    "@babel/runtime" "^7.14.5"
++    "@babel/runtime" "^7.22.5"
+     html-parse-stringify "^3.0.1"
+ 
+ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/259589

This PR adds 1 package: `koodo-reader`

This is an Electron app.

There is a patch which bumps a node dependency version
(This was the encountered issue: https://github.com/i18next/react-i18next/issues/1543)

There's another patch which just hard-codes `isDev` to false, as `electron-is-dev` wasn't working.

The package provides MIME types. When packaging as `.deb`, `electron-builder` would generate an `.xml` file listing them, and would create a `.desktop` file supporting them.
I couldn't find a way to generate these when building as an `.asar` file, so I copied the `.xml` file from the `.deb` release. I also manually set the `desktopItem`'s `mimeTypes` attribute.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
