### PR TITLE
xpipe: init at 1.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3811,6 +3811,12 @@
     githubId = 6821729;
     github = "criyle";
   };
+  crschnick = {
+    email = "crschnick@xpipe.io";
+    name = "Christopher Schnick";
+    github = "crschnick";
+    githubId = 72509152;
+  };
   CRTified = {
     email = "carl.schneider+nixos@rub.de";
     matrix = "@schnecfk:ruhr-uni-bochum.de";

--- a/pkgs/applications/networking/xpipe/default.nix
+++ b/pkgs/applications/networking/xpipe/default.nix
@@ -1,0 +1,132 @@
+{ stdenvNoCC
+, lib
+, fetchzip
+, makeDesktopItem
+, autoPatchelfHook
+, zlib
+, fontconfig
+, udev
+, gtk3
+, freetype
+, alsa-lib
+, makeShellWrapper
+, libX11
+, libXext
+, libXdamage
+, libXfixes
+, libxcb
+, libXcomposite
+, libXcursor
+, libXi
+, libXrender
+, libXtst
+, libXxf86vm
+}:
+
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  arch = {
+    x86_64-linux = "x86_64";
+    aarch64-linux = "arm64";
+  }.${system} or throwSystem;
+
+  hash = {
+    x86_64-linux = "sha256-/cumOKaWPdAruMLZP2GMUdocIhsbo59dc4Q3ngc/JOc=";
+    aarch64-linux = "sha256-xMV+9etnuFwRGIHdaXNViKd4FMOuVtugGDS1xyMwEnM=";
+  }.${system} or throwSystem;
+
+  displayname = "XPipe";
+
+in stdenvNoCC.mkDerivation rec {
+  pname = "xpipe";
+  version = "1.7.3";
+
+  src = fetchzip {
+    url = "https://github.com/xpipe-io/xpipe/releases/download/${version}/xpipe-portable-linux-${arch}.tar.gz";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeShellWrapper
+  ];
+
+  # Ignore libavformat dependencies as we don't need them
+  autoPatchelfIgnoreMissingDeps = true;
+
+  buildInputs = [
+      fontconfig
+      zlib
+      udev
+      freetype
+      gtk3
+      alsa-lib
+      libX11
+      libX11
+      libXext
+      libXdamage
+      libXfixes
+      libxcb
+      libXcomposite
+      libXcursor
+      libXi
+      libXrender
+      libXtst
+      libXxf86vm
+    ];
+
+  desktopItem = makeDesktopItem {
+    categories = [ "Network" ];
+    comment = "Your entire server infrastructure at your fingertips";
+    desktopName = displayname;
+    exec = "/opt/${pname}/cli/bin/xpipe open %U";
+    genericName = "Shell connection hub";
+    icon = "/opt/${pname}/logo.png";
+    name = displayname;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    pkg="${pname}"
+    mkdir -p $out/opt/$pkg
+    cp -r ./ $out/opt/$pkg
+
+    mkdir -p "$out/bin"
+    ln -s "$out/opt/$pkg/cli/bin/xpipe" "$out/bin/$pkg"
+
+    mkdir -p "$out/share/applications"
+    cp -r "${desktopItem}/share/applications/" "$out/share/"
+
+    mkdir -p "$out/etc/bash_completion.d"
+    ln -s "$out/opt/$pkg/cli/xpipe_completion" "$out/etc/bash_completion.d/$pkg"
+
+    substituteInPlace $out/share/applications/${displayname}.desktop --replace "Exec=" "Exec=$out"
+    substituteInPlace $out/share/applications/${displayname}.desktop --replace "Icon=" "Icon=$out"
+
+    mv "$out/opt/xpipe/app/bin/xpiped" "$out/opt/xpipe/app/bin/xpiped_raw"
+    mv "$out/opt/xpipe/app/lib/app/xpiped.cfg" "$out/opt/xpipe/app/lib/app/xpiped_raw.cfg"
+    mv "$out/opt/xpipe/app/scripts/xpiped_debug.sh" "$out/opt/xpipe/app/scripts/xpiped_debug_raw.sh"
+
+    makeShellWrapper "$out/opt/xpipe/app/bin/xpiped_raw" "$out/opt/xpipe/app/bin/xpiped" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fontconfig gtk3 udev ]}"
+    makeShellWrapper "$out/opt/xpipe/app/scripts/xpiped_debug_raw.sh" "$out/opt/xpipe/app/scripts/xpiped_debug.sh" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fontconfig gtk3 udev ]}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A cross-platform shell connection hub and remote file manager";
+    homepage = "https://github.com/xpipe-io/${pname}";
+    downloadPage = "https://github.com/xpipe-io/${pname}/releases/latest";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    changelog = "https://github.com/xpipe-io/${pname}/releases/tag/${version}";
+    license = [ licenses.asl20 licenses.unfree ];
+    maintainers = with maintainers; [ crschnick ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = pname;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41564,6 +41564,8 @@ with pkgs;
 
   xpad = callPackage ../applications/misc/xpad { };
 
+  xpipe = callPackage ../applications/networking/xpipe { };
+
   xsane = callPackage ../applications/graphics/sane/xsane.nix { };
 
   xsser = python3Packages.callPackage ../tools/security/xsser { };


### PR DESCRIPTION
## Description of changes

New package for https://github.com/xpipe-io/xpipe

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
