### PR TITLE
rstudio: fix server node patching

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -145,6 +145,9 @@ in
         --replace '@node@' ${nodejs} \
         --replace './lib/quarto' ${quartoSrc}
 
+      substituteInPlace src/cpp/conf/rsession-dev.conf \
+        --replace '@node@' ${nodejs}
+
       substituteInPlace src/cpp/core/libclang/LibClang.cpp \
         --replace '@libclang@' ${llvmPackages.libclang.lib} \
         --replace '@libclang.so@' ${llvmPackages.libclang.lib}/lib/libclang.so

--- a/pkgs/applications/editors/rstudio/use-system-node.patch
+++ b/pkgs/applications/editors/rstudio/use-system-node.patch
@@ -1,5 +1,33 @@
+diff --git a/src/cpp/conf/rsession-dev.conf b/src/cpp/conf/rsession-dev.conf
+index d18362b..98cdd4c 100644
+--- a/src/cpp/conf/rsession-dev.conf
++++ b/src/cpp/conf/rsession-dev.conf
+@@ -39,7 +39,7 @@ external-mathjax-path=${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}
+ external-pandoc-path=${RSTUDIO_DEPENDENCIES_PANDOC_DIR}
+ external-quarto-path=${RSTUDIO_DEPENDENCIES_QUARTO_DIR}
+ external-libclang-path=${RSTUDIO_DEPENDENCIES_DIR}/common/libclang
+-external-node-path=${RSTUDIO_DEPENDENCIES_DIR}/common/node/16.14.0/bin/node
++external-node-path=@node@/bin/node
+ 
+ # enable copilot
+ copilot-enabled=1
+diff --git a/src/cpp/server/CMakeLists.txt b/src/cpp/server/CMakeLists.txt
+index 30dd638..cb4a645 100644
+--- a/src/cpp/server/CMakeLists.txt
++++ b/src/cpp/server/CMakeLists.txt
+@@ -250,10 +250,6 @@ if (UNIX AND NOT APPLE)
+            DESTINATION ${RSERVER_SYSTEMD_DIR})
+ 
+    # install node
+-   install(
+-      DIRECTORY "${RSTUDIO_DEPENDENCIES_DIR}/common/node/${RSTUDIO_NODE_VERSION}/"
+-      DESTINATION "${RSTUDIO_INSTALL_BIN}/node"
+-      USE_SOURCE_PERMISSIONS)
+ 
+ elseif(APPLE)
+ 
 diff --git a/src/gwt/build.xml b/src/gwt/build.xml
-index 83e9433..f1ee63d 100644
+index 033d605..f1ee63d 100644
 --- a/src/gwt/build.xml
 +++ b/src/gwt/build.xml
 @@ -87,29 +87,7 @@


### PR DESCRIPTION
## Description of changes

Rstudio server failed to build due to missing node vendoring. This removes
the vendoring and configures use of nixpkgs' nodejs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
