### PR TITLE
aerc: fix version number and wrap gnupg

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1274,6 +1274,9 @@
     github = "antonmosich";
     githubId = 27223336;
     name = "Anton Mosich";
+    keys = [ {
+      fingerprint = "F401 287C 324F 0A1C B321  657B 9B96 97B8 FB18 7D14";
+    } ];
   };
   antono = {
     email = "self@antono.info";

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -8,6 +8,7 @@
 , w3m
 , dante
 , gawk
+, gnupg
 , testers
 , aerc
 , fetchpatch
@@ -70,7 +71,7 @@ buildGoModule rec {
 
   postFixup = ''
     wrapProgram $out/bin/aerc \
-      --prefix PATH ":" "${lib.makeBinPath [ ncurses ]}"
+      --prefix PATH ":" "${lib.makeBinPath [ ncurses gnupg ]}"
     wrapProgram $out/libexec/aerc/filters/html \
       --prefix PATH ":"  ${lib.makeBinPath [ w3m dante ]}
     wrapProgram $out/libexec/aerc/filters/html-unsafe \

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -8,6 +8,9 @@
 , w3m
 , dante
 , gawk
+, testers
+, aerc
+, fetchpatch
 }:
 
 buildGoModule rec {
@@ -31,6 +34,13 @@ buildGoModule rec {
 
   patches = [
     ./runtime-libexec.patch
+    # Fixes version number for 0.16.0
+    # Remove for the next release
+    (fetchpatch {
+      name = "version.patch";
+      url = "https://git.sr.ht/~rjarry/aerc/commit/d179485eefe50da9d21abdd392cffd865e369509.patch";
+      hash = "sha256-eSCAxUrKGjBf3jYiVdDqi+jFmj5NiFla2IQu6qFO+BA=";
+    })
   ];
 
   postPatch = ''
@@ -67,6 +77,11 @@ buildGoModule rec {
       --prefix PATH ":" ${lib.makeBinPath [ w3m dante ]}
     patchShebangs $out/libexec/aerc/filters
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = aerc;
+    command = "aerc -v";
+  };
 
   meta = with lib; {
     description = "An email client for your terminal";


### PR DESCRIPTION
## Description of changes
In #257771 I recently updated aerc to version 0.16.0. For determining what version to return when calling `aerc -v` aerc uses `git describe` in the build process falling back to a hardcoded string, which did not get updated with the most recent version. I missed that while updating the package. To prevent this from happening in the future I added a test for the version and also added a patch to change the version to the according number.
I also changed aerc such that gnupg is also wrapped because while aerc can be configured to use an external gpg implementation you can not configure which gpg to use and aerc just uses the one on the path. I don't really know whether it's better to not use that wrapper, I'd be happy to drop that commit again in that case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
