### PR TITLE
expect: fix build with clang 16

### DIFF
--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -6,18 +6,29 @@ tcl.mkTclDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/expect/Expect/${version}/expect${version}.tar.gz";
-    sha256 = "0d1cp5hggjl93xwc8h1y6adbnrvpkk0ywkd00inz9ndxn21xm9s9";
+    hash = "sha256-Safag7C92fRtBKBN7sGcd2e7mjI+QMR4H4nK92C5LDQ=";
   };
 
   patches = [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/buildroot/buildroot/c05e6aa361a4049eabd8b21eb64a34899ef83fc7/package/expect/0001-enable-cross-compilation.patch";
-      sha256 = "1jwx2l1slidvcpahxbyqs942l81jd62rzbxliyd9lwysk38c8b6b";
+      hash = "sha256-yyzE0Jjac5qaj7Svn4VpMiAqSNLYrw7VZbtFqgMVncs=";
     })
     (substituteAll {
       src = ./fix-cross-compilation.patch;
       tcl = "${buildPackages.tcl}/bin/tclsh";
     })
+    # The following patches fix compilation with clang 15+
+    (fetchpatch {
+      url = "https://sourceforge.net/p/expect/patches/24/attachment/0001-Add-prototype-to-function-definitions.patch";
+      hash = "sha256-X2Vv6VVM3KjmBHo2ukVWe5YTVXRmqe//Kw2kr73OpZs=";
+    })
+    (fetchpatch {
+      url = "https://sourceforge.net/p/expect/patches/_discuss/thread/b813ca9895/6759/attachment/expect-configure-c99.patch";
+      hash = "sha256-PxQQ9roWgVXUoCMxkXEgu+it26ES/JuzHF6oML/nk54=";
+    })
+    # Include `sys/ioctl.h` and `util.h` on Darwin, which are required for `ioctl` and `openpty`.
+    ./fix-darwin-clang16.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/expect/fix-darwin-clang16.patch
+++ b/pkgs/tools/misc/expect/fix-darwin-clang16.patch
@@ -1,0 +1,31 @@
+diff -ur a/exp_win.c b/exp_win.c
+--- a/exp_win.c	2018-02-02 14:15:52.000000000 -0500
++++ b/exp_win.c	2023-10-10 07:47:33.082690432 -0400
+@@ -39,7 +39,8 @@
+ /* Sigh.  On AIX 2.3, termios.h exists but does not define TIOCGWINSZ */
+ /* Instead, it has to come from ioctl.h.  However, As I said above, this */
+ /* can't be cavalierly included on all machines, even when it exists. */
+-#if defined(HAVE_TERMIOS) && !defined(HAVE_TIOCGWINSZ_IN_TERMIOS_H)
++/* Darwin also has termios.h, but it requires ioctl.h for `ioctl`. */
++#if defined(HAVE_TERMIOS) && (defined(__APPLE__) || !defined(HAVE_TIOCGWINSZ_IN_TERMIOS_H))
+ #  include <sys/ioctl.h>
+ #endif
+ 
+diff -ur d/pty_termios.c c/pty_termios.c
+--- d/pty_termios.c	2023-10-10 07:59:23.244452442 -0400
++++ c/pty_termios.c	2023-10-10 08:00:35.303231582 -0400
+@@ -7,7 +7,13 @@
+ 
+ */
+ 
+-#include <pty.h> /* openpty */
++/* openpty */
++#ifdef __APPLE__
++#include <util.h>
++#else /* pty.h is Linux-specific */
++#include <pty.h>
++#endif
++
+ #include <stdio.h>
+ #include <signal.h>
+ 


### PR DESCRIPTION
## Description of changes

* Use patches from upstream issue tracker that fix most compilation issues and the configure script; and
* Modify `exp_win.c` and `pty_termios.c` to build properly on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
