### PR TITLE
mjpegtools: fix build with clang 16

### DIFF
--- a/pkgs/tools/video/mjpegtools/c++-17-fixes.patch
+++ b/pkgs/tools/video/mjpegtools/c++-17-fixes.patch
@@ -1,0 +1,44 @@
+diff -ur a/mplex/main.cpp b/mplex/main.cpp
+--- a/mplex/main.cpp	2021-09-05 02:14:13.029372000 -0400
++++ b/mplex/main.cpp	2023-09-23 08:47:07.683450627 -0400
+@@ -50,7 +50,7 @@
+ #include "multiplexor.hpp"
+ 
+ 
+-using std::auto_ptr;
++using std::unique_ptr;
+ 
+ 
+ /*************************************************************************
+@@ -138,7 +138,7 @@
+ void 
+ FileOutputStream::NextSegment( )
+ {
+-    auto_ptr<char> prev_filename_buf( new char[strlen(cur_filename)+1] );
++    unique_ptr<char> prev_filename_buf( new char[strlen(cur_filename)+1] );
+     char *prev_filename = prev_filename_buf.get();
+ 	fclose(strm);
+ 	++segment_num;
+diff -ur a/utils/fastintfns.h b/utils/fastintfns.h
+--- a/utils/fastintfns.h	2021-09-05 02:14:13.033372000 -0400
++++ b/utils/fastintfns.h	2023-09-23 08:44:40.147112973 -0400
+@@ -2,12 +2,17 @@
+  *
+  * WARNING: Assumes 2's complement arithmetic.
+  */
+-static inline int intmax( register int x, register int y )
++#ifdef __cplusplus
++#define REGISTER
++#else
++#define REGISTER register
++#endif
++static inline int intmax( REGISTER int x, REGISTER int y )
+ {
+ 	return x < y ? y : x;
+ }
+ 
+-static inline int intmin( register int x, register int y )
++static inline int intmin( REGISTER int x, REGISTER int y )
+ {
+ 	return x < y ? x : y;
+ }

--- a/pkgs/tools/video/mjpegtools/default.nix
+++ b/pkgs/tools/video/mjpegtools/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sYBTbX2ZYLBeACOhl7ANyxAJKaSaq3HRnVX0obIQ9Jo=";
   };
 
+  # Clang 16 defaults to C++17. `std::auto_ptr` has been removed from C++17, and the
+  # `register` type class specifier is no longer allowed.
+  patches = [ ./c++-17-fixes.patch ];
+
   hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## Description of changes

Clang 16 defaults to C++17, causing the build to fail because the following has been removed from C++17:

* `std::auto_ptr`; and
* The `register` type class specifier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
