### PR TITLE
freeswitch: patch CVE-2023-5217 and CVE-2023-44488

### DIFF
--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -1,12 +1,28 @@
-{ fetchFromGitHub, stdenv, lib, pkg-config, autoreconfHook
-, ncurses, gnutls, readline
-, openssl, perl, sqlite, libjpeg, speex, pcre, libuuid
-, ldns, libedit, yasm, which, libsndfile, libtiff, libxcrypt
-
+{ fetchFromGitHub
+, fetchpatch
+, stdenv
+, lib
+, pkg-config
+, autoreconfHook
+, ncurses
+, gnutls
+, readline
+, openssl
+, perl
+, sqlite
+, libjpeg
+, speex
+, pcre
+, libuuid
+, ldns
+, libedit
+, yasm
+, which
+, libsndfile
+, libtiff
+, libxcrypt
 , callPackage
-
 , SystemConfiguration
-
 , modules ? null
 , nixosTests
 }:
@@ -109,6 +125,20 @@ stdenv.mkDerivation rec {
       } > $f
     done
   '';
+
+  ## TODO Validate with the next upstream release
+  patches = [
+    (fetchpatch {
+       name = "CVE-2023-44488.patch";
+       url = "https://github.com/signalwire/freeswitch/commit/f1fb05214e4f427dcf922f531431ab649cf0622b.patch";
+       hash = "sha256-6GMebE6O2EBx60NE2LSRVljaiLm9T4zTrkIpwGvaB08=";
+     })
+    (fetchpatch {
+       name = "CVE-2023-5217.patch";
+       url = "https://github.com/signalwire/freeswitch/commit/6f9e72c585265d8def8a613b36cd4f524c201980.patch";
+       hash = "sha256-l64mBpyq/TzRM78n73kbuD0UNsk5zIH5QNJlMKdPfr4=";
+     })
+  ];
 
   strictDeps = true;
   nativeBuildInputs = [ pkg-config autoreconfHook perl which yasm ];


### PR DESCRIPTION
## Description of changes

Applies the security patch because no upstream release has been made yet, and it looks like they have a slow release cycle. To see the pr, used for the patch, look [here](https://github.com/signalwire/freeswitch/pull/2266)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
