### PR TITLE
nixos/x11: refactor XKB options into a single attrset

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -45,8 +45,8 @@ services.xserver.displayManager.gdm.enable = true;
 You can set the keyboard layout (and optionally the layout variant):
 
 ```nix
-services.xserver.layout = "de";
-services.xserver.xkbVariant = "neo";
+services.xserver.xkb.layout = "de";
+services.xserver.xkb.variant = "neo";
 ```
 
 The X server is started automatically at boot time. If you don't want
@@ -266,7 +266,7 @@ Once the configuration is applied, and you did a logout/login cycle, the
 layout should be ready to use. You can try it by e.g. running
 `setxkbmap us-greek` and then type `<alt>+a` (it may not get applied in
 your terminal straight away). To change the default, the usual
-`services.xserver.layout` option can still be used.
+`services.xserver.xkb.layout` option can still be used.
 
 A layout can have several other components besides `xkb_symbols`, for
 example we will define new keycodes for some multimedia key and bind

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -269,6 +269,8 @@
   order, or relying on `mkBefore` and `mkAfter`, but may impact users calling
   `mkOrder n` with n ≤ 400.
 
+- X keyboard extension (XKB) options have been reorganized into a single attribute set, `services.xserver.xkb`. Specifically, `services.xserver.layout` is now `services.xserver.xkb.layout`, `services.xserver.xkbModel` is now `services.xserver.xkb.model`, `services.xserver.xkbOptions` is now `services.xserver.xkb.options`, `services.xserver.xkbVariant` is now `services.xserver.xkb.variant`, and `services.xserver.xkbDir` is now `services.xserver.xkb.dir`.
+
 - `networking.networkmanager.firewallBackend` was removed as NixOS is now using iptables-nftables-compat even when using iptables, therefore Networkmanager now uses the nftables backend unconditionally.
 
 - [`lib.lists.foldl'`](https://nixos.org/manual/nixpkgs/stable#function-library-lib.lists.foldl-prime) now always evaluates the initial accumulator argument first.
@@ -442,4 +444,3 @@ The module update takes care of the new config syntax and the data itself (user 
 - The `electron` packages now places its application files in `$out/libexec/electron` instead of `$out/lib/electron`. Packages using electron-builder will fail to build and need to be adjusted by changing `lib` to `libexec`.
 
 - `teleport` has been upgraded from major version 12 to major version 14. Please see upstream [upgrade instructions](https://goteleport.com/docs/management/operations/upgrading/) and release notes for versions [13](https://goteleport.com/docs/changelog/#1300-050823) and [14](https://goteleport.com/docs/changelog/#1400-092023). Note that Teleport does not officially support upgrades across more than one major version at a time. If you're running Teleport server components, it is recommended to first upgrade to an intermediate 13.x version by setting `services.teleport.package = pkgs.teleport_13`. Afterwards, this option can be removed to upgrade to the default version (14).
-

--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -127,8 +127,8 @@ in
               ${optionalString (config.environment.sessionVariables ? XKB_CONFIG_ROOT)
                 "-I${config.environment.sessionVariables.XKB_CONFIG_ROOT}"
               } \
-              -model '${xkbModel}' -layout '${layout}' \
-              -option '${xkbOptions}' -variant '${xkbVariant}' > "$out"
+              -model '${xkb.model}' -layout '${xkb.layout}' \
+              -option '${xkb.options}' -variant '${xkb.variant}' > "$out"
           '');
     }
 

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -163,15 +163,15 @@ in
         # console = {
         #   font = "Lat2-Terminus16";
         #   keyMap = "us";
-        #   useXkbConfig = true; # use xkbOptions in tty.
+        #   useXkbConfig = true; # use xkb.options in tty.
         # };
 
       $xserverConfig
 
       $desktopConfiguration
         # Configure keymap in X11
-        # services.xserver.layout = "us";
-        # services.xserver.xkbOptions = "eurosign:e,caps:escape";
+        # services.xserver.xkb.layout = "us";
+        # services.xserver.xkb.options = "eurosign:e,caps:escape";
 
         # Enable CUPS to print documents.
         # services.printing.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -90,7 +90,7 @@ in
         };
     };
 
-    environment.etc."X11/xkb".source = xcfg.xkbDir;
+    environment.etc."X11/xkb".source = xcfg.xkb.dir;
 
     fonts.packages = [ pkgs.dejavu_fonts pkgs.ubuntu_font_family ];
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -309,7 +309,7 @@ in
         "/share"
       ];
 
-      environment.etc."X11/xkb".source = xcfg.xkbDir;
+      environment.etc."X11/xkb".source = xcfg.xkb.dir;
 
       environment.sessionVariables = {
         PLASMA_USE_QT_SCALING = mkIf cfg.useQtScaling "1";

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -204,10 +204,10 @@ in
                 left-handed = xcfg.libinput.mouse.leftHanded;
               };
               keyboard = {
-                keymap_model = xcfg.xkbModel;
-                keymap_layout = xcfg.layout;
-                keymap_variant = xcfg.xkbVariant;
-                keymap_options = xcfg.xkbOptions;
+                keymap_model = xcfg.xkb.model;
+                keymap_layout = xcfg.xkb.layout;
+                keymap_variant = xcfg.xkb.variant;
+                keymap_options = xcfg.xkb.options;
               };
             }; in "${pkgs.weston}/bin/weston --shell=fullscreen-shell.so -c ${westonIni}";
           description = lib.mdDoc "Command used to start the selected compositor";

--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -121,11 +121,11 @@ in
     environment.sessionVariables = {
       # runtime override supported by multiple libraries e. g. libxkbcommon
       # https://xkbcommon.org/doc/current/group__include-path.html
-      XKB_CONFIG_ROOT = config.services.xserver.xkbDir;
+      XKB_CONFIG_ROOT = config.services.xserver.xkb.dir;
     };
 
     services.xserver = {
-      xkbDir = "${xkb_patched}/etc/X11/xkb";
+      xkb.dir = "${xkb_patched}/etc/X11/xkb";
       exportConfiguration = config.services.xserver.displayManager.startx.enable
         || config.services.xserver.displayManager.sx.enable;
     };

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -175,6 +175,31 @@ in
         "Use services.xserver.fontPath instead of useXFS")
       (mkRemovedOptionModule [ "services" "xserver" "useGlamor" ]
         "Option services.xserver.useGlamor was removed because it is unnecessary. Drivers that uses Glamor will use it automatically.")
+      (lib.mkRenamedOptionModuleWith {
+        sinceRelease = 2311;
+        from = [ "services" "xserver" "layout" ];
+        to = [ "services" "xserver" "xkb" "layout" ];
+      })
+      (lib.mkRenamedOptionModuleWith {
+        sinceRelease = 2311;
+        from = [ "services" "xserver" "xkbModel" ];
+        to = [ "services" "xserver" "xkb" "model" ];
+      })
+      (lib.mkRenamedOptionModuleWith {
+        sinceRelease = 2311;
+        from = [ "services" "xserver" "xkbOptions" ];
+        to = [ "services" "xserver" "xkb" "options" ];
+      })
+      (lib.mkRenamedOptionModuleWith {
+        sinceRelease = 2311;
+        from = [ "services" "xserver" "xkbVariant" ];
+        to = [ "services" "xserver" "xkb" "variant" ];
+      })
+      (lib.mkRenamedOptionModuleWith {
+        sinceRelease = 2311;
+        from = [ "services" "xserver" "xkbDir" ];
+        to = [ "services" "xserver" "xkb" "dir" ];
+      })
     ];
 
 
@@ -339,48 +364,55 @@ in
         '';
       };
 
-      layout = mkOption {
-        type = types.str;
-        default = "us";
-        description = lib.mdDoc ''
-          Keyboard layout, or multiple keyboard layouts separated by commas.
-        '';
-      };
+      xkb = mkOption {
+        description = "X keyboard extension (XKB) configuration";
+        type = types.submodule {
+          options = {
+            layout = mkOption {
+              type = types.str;
+              default = "us";
+              description = lib.mdDoc ''
+                Keyboard layout, or multiple keyboard layouts separated by commas.
+              '';
+            };
 
-      xkbModel = mkOption {
-        type = types.str;
-        default = "pc104";
-        example = "presario";
-        description = lib.mdDoc ''
-          Keyboard model.
-        '';
-      };
+            model = mkOption {
+              type = types.str;
+              default = "pc104";
+              example = "presario";
+              description = lib.mdDoc ''
+                Keyboard model.
+              '';
+            };
 
-      xkbOptions = mkOption {
-        type = types.commas;
-        default = "terminate:ctrl_alt_bksp";
-        example = "grp:caps_toggle,grp_led:scroll";
-        description = lib.mdDoc ''
-          X keyboard options; layout switching goes here.
-        '';
-      };
+            options = mkOption {
+              type = types.commas;
+              default = "terminate:ctrl_alt_bksp";
+              example = "grp:caps_toggle,grp_led:scroll";
+              description = lib.mdDoc ''
+                X keyboard options; layout switching goes here.
+              '';
+            };
 
-      xkbVariant = mkOption {
-        type = types.str;
-        default = "";
-        example = "colemak";
-        description = lib.mdDoc ''
-          X keyboard variant.
-        '';
-      };
+            variant = mkOption {
+              type = types.str;
+              default = "";
+              example = "colemak";
+              description = lib.mdDoc ''
+                X keyboard variant.
+              '';
+            };
 
-      xkbDir = mkOption {
-        type = types.path;
-        default = "${pkgs.xkeyboard_config}/etc/X11/xkb";
-        defaultText = literalExpression ''"''${pkgs.xkeyboard_config}/etc/X11/xkb"'';
-        description = lib.mdDoc ''
-          Path used for -xkbdir xserver parameter.
-        '';
+            dir = mkOption {
+              type = types.path;
+              default = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+              defaultText = literalExpression ''"''${pkgs.xkeyboard_config}/etc/X11/xkb"'';
+              description = lib.mdDoc ''
+                Path used for -xkbdir xserver parameter.
+              '';
+            };
+          };
+        };
       };
 
       config = mkOption {
@@ -667,7 +699,7 @@ in
         {
           "X11/xorg.conf".source = "${configFile}";
           # -xkbdir command line option does not seems to be passed to xkbcomp.
-          "X11/xkb".source = "${cfg.xkbDir}";
+          "X11/xkb".source = "${cfg.xkb.dir}";
         })
       # localectl looks into 00-keyboard.conf
       //{
@@ -675,10 +707,10 @@ in
             Section "InputClass"
               Identifier "Keyboard catchall"
               MatchIsKeyboard "on"
-              Option "XkbModel" "${cfg.xkbModel}"
-              Option "XkbLayout" "${cfg.layout}"
-              Option "XkbOptions" "${cfg.xkbOptions}"
-              Option "XkbVariant" "${cfg.xkbVariant}"
+              Option "XkbModel" "${cfg.xkb.model}"
+              Option "XkbLayout" "${cfg.xkb.layout}"
+              Option "XkbOptions" "${cfg.xkb.options}"
+              Option "XkbVariant" "${cfg.xkb.variant}"
             EndSection
           '';
         }
@@ -759,7 +791,7 @@ in
 
     services.xserver.displayManager.xserverArgs =
       [ "-config ${configFile}"
-        "-xkbdir" "${cfg.xkbDir}"
+        "-xkbdir" "${cfg.xkb.dir}"
       ] ++ optional (cfg.display != null) ":${toString cfg.display}"
         ++ optional (cfg.tty     != null) "vt${toString cfg.tty}"
         ++ optional (cfg.dpi     != null) "-dpi ${toString cfg.dpi}"
@@ -777,14 +809,14 @@ in
       ];
 
     system.checks = singleton (pkgs.runCommand "xkb-validated" {
-      inherit (cfg) xkbModel layout xkbVariant xkbOptions;
+      inherit (cfg.xkb) model layout variant options;
       nativeBuildInputs = with pkgs.buildPackages; [ xkbvalidate ];
       preferLocalBuild = true;
     } ''
       ${optionalString (config.environment.sessionVariables ? XKB_CONFIG_ROOT)
         "export XKB_CONFIG_ROOT=${config.environment.sessionVariables.XKB_CONFIG_ROOT}"
       }
-      xkbvalidate "$xkbModel" "$layout" "$xkbVariant" "$xkbOptions"
+      xkbvalidate "$model" "$layout" "$variant" "$options"
       touch "$out"
     '');
 

--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -31,7 +31,7 @@ let
 
     nodes.machine.console.keyMap = mkOverride 900 layout;
     nodes.machine.services.xserver.desktopManager.xterm.enable = false;
-    nodes.machine.services.xserver.layout = mkOverride 900 layout;
+    nodes.machine.services.xserver.xkb.layout = mkOverride 900 layout;
     nodes.machine.imports = [ ./common/x11.nix extraConfig ];
 
     testScript = ''
@@ -116,7 +116,7 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "fr";
-    extraConfig.services.xserver.layout = "fr";
+    extraConfig.services.xserver.xkb.layout = "fr";
   };
 
   bone = {
@@ -130,8 +130,8 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "bone";
-    extraConfig.services.xserver.layout = "de";
-    extraConfig.services.xserver.xkbVariant = "bone";
+    extraConfig.services.xserver.xkb.layout = "de";
+    extraConfig.services.xserver.xkb.variant = "bone";
   };
 
   colemak = {
@@ -141,8 +141,8 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "colemak";
-    extraConfig.services.xserver.layout = "us";
-    extraConfig.services.xserver.xkbVariant = "colemak";
+    extraConfig.services.xserver.xkb.layout = "us";
+    extraConfig.services.xserver.xkb.variant = "colemak";
   };
 
   dvorak = {
@@ -154,8 +154,8 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "dvorak";
-    extraConfig.services.xserver.layout = "us";
-    extraConfig.services.xserver.xkbVariant = "dvorak";
+    extraConfig.services.xserver.xkb.layout = "us";
+    extraConfig.services.xserver.xkb.variant = "dvorak";
   };
 
   dvorak-programmer = {
@@ -170,8 +170,8 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "dvorak-programmer";
-    extraConfig.services.xserver.layout = "us";
-    extraConfig.services.xserver.xkbVariant = "dvp";
+    extraConfig.services.xserver.xkb.layout = "us";
+    extraConfig.services.xserver.xkb.variant = "dvp";
   };
 
   neo = {
@@ -185,8 +185,8 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "neo";
-    extraConfig.services.xserver.layout = "de";
-    extraConfig.services.xserver.xkbVariant = "neo";
+    extraConfig.services.xserver.xkb.layout = "de";
+    extraConfig.services.xserver.xkb.variant = "neo";
   };
 
   qwertz = {
@@ -199,7 +199,7 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.keyMap = "de";
-    extraConfig.services.xserver.layout = "de";
+    extraConfig.services.xserver.xkb.layout = "de";
   };
 
   custom = {
@@ -212,7 +212,7 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
     };
 
     extraConfig.console.useXkbConfig = true;
-    extraConfig.services.xserver.layout = "us-greek";
+    extraConfig.services.xserver.xkb.layout = "us-greek";
     extraConfig.services.xserver.extraLayouts.us-greek =
       { description = "US layout with alt-gr greek";
         languages   = [ "eng" ];

--- a/pkgs/tools/X11/xkbvalidate/xkbvalidate.c
+++ b/pkgs/tools/X11/xkbvalidate/xkbvalidate.c
@@ -121,10 +121,10 @@ int main(int argc, char **argv)
 
     rdef = malloc(sizeof(struct xkb_rule_names));
 
-    TRY_KEYMAP(model,   argv[1], "xkbModel");
-    TRY_KEYMAP(layout,  argv[2], "layout");
-    TRY_KEYMAP(variant, argv[3], "xkbVariant");
-    TRY_KEYMAP(options, argv[4], "xkbOptions");
+    TRY_KEYMAP(model,   argv[1], "xkb.model");
+    TRY_KEYMAP(layout,  argv[2], "xkb.layout");
+    TRY_KEYMAP(variant, argv[3], "xkb.variant");
+    TRY_KEYMAP(options, argv[4], "xkb.options");
 
     free_logs();
     rdef->model = argv[1];


### PR DESCRIPTION
[Motivation](https://github.com/NixOS/nixpkgs/issues/257817#issuecomment-1741705042):

- Having all the XKB options in the same attribute set clarifies their relation better than using a common option name prefix ("xkb").
- `services.xserver.layout` is an XKB option, but this is not obvious from its name. Putting it with the other XKB options clarifies this.

## Description of changes

X keyboard extension (XKB) options have been reorganized into a single attribute set, `services.xserver.xkb`. Specifically, `services.xserver.layout` is now `services.xserver.xkb.layout`, `services.xserver.xkbModel` is now `services.xserver.xkb.model`, `services.xserver.xkbOptions` is now `services.xserver.xkb.options`, `services.xserver.xkbVariant` is now `services.xserver.xkb.variant`, and `services.xserver.xkbDir` is now `services.xserver.xkb.dir`.

@Artturin 

## Things done

- Built on platform(s)
  - [x] x86_64-linux (`nix-build --attr pkgs.xkbvalidate --attr pkgs.gnome.gnome-shell --attr pkgs.enlightenment.enlightenment`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (`nix-build --attr nixosTests.keymap`)
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).