### PR TITLE
blueman: fix cross-compilation

### DIFF
--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ bluez gtk3 pythonPackages.python librsvg
-                  gnome.adwaita-icon-theme iproute2 networkmanager ]
+                  gnome.adwaita-icon-theme networkmanager ]
                 ++ pythonPath
                 ++ lib.optional withPulseAudio libpulseaudio;
 
@@ -36,6 +36,8 @@ in stdenv.mkDerivation rec {
   configureFlags = [
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+    # Don't check for runtime dependency `ip` during the configure
+    "--disable-runtime-deps-check"
     (lib.enableFeature withPulseAudio "pulseaudio")
   ];
 


### PR DESCRIPTION
## Description of changes

blueman needs `iproute2` as native build dependency, not as target dependency.

Fixes the following error when cross-compiling (in this case, to aarch64):
<details>

```
error: builder for '/nix/store/kzrxxlk0vpsz6hwhl4rgf0ankfp3639h-blueman-aarch64-unknown-linux-gnu-2.3.5.drv' failed with exit code 1;
       last 10 log lines:
       > checking for python version... 3.10
       > checking for python platform... linux
       > checking for GNU default python prefix... ${prefix}
       > checking for GNU default python exec_prefix... ${exec_prefix}
       > checking for python script directory (pythondir)... ${PYTHON_PREFIX}/lib/python3.10/site-packages
       > checking for python extension module directory (pyexecdir)... ${PYTHON_EXEC_PREFIX}/lib/python3.10/site-packages
       > checking for python-3.10... yes
       > checking for ifconfig... no
       > checking for ip... no
       > configure: error: ifconfig or ip not found, install net-tools or iproute2
       For full logs, run 'nix log /nix/store/kzrxxlk0vpsz6hwhl4rgf0ankfp3639h-blueman-aarch64-unknown-linux-gnu-2.3.5.drv'.
error: building '/nix/store/kzrxxlk0vpsz6hwhl4rgf0ankfp3639h-blueman-aarch64-unknown-linux-gnu-2.3.5.drv' failed

```
</details>

A minimal reproducer (flake), buildable using `nix build .#images.reproducer`:
<details>
<summary><code>flake.nix</code></summary>

```nix
{
  description = "blueman cross-compilation reproducer";
  inputs.nixpkgs.url = "github:christoph-heiss/nixpkgs/fix/blueman-cross";
  outputs = { nixpkgs, ... }: rec {
    nixosConfigurations.reproducer = nixpkgs.lib.nixosSystem {
      modules = [
        "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
        {
          nixpkgs = {
            config.allowUnsupportedSystem = true;
            hostPlatform.system = "aarch64-linux";
            buildPlatform.system = "x86_64-linux";
          };

          system.stateVersion = "23.11";

          hardware.bluetooth.enable = true;
          services.blueman.enable = true;
        }
      ];
    };

    images.reproducer =
      nixosConfigurations.reproducer.config.system.build.sdImage;
  };
}
```

</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
