### PR TITLE
esdm: 0.6.0 -> 1.0.0

### DIFF
--- a/pkgs/os-specific/linux/esdm/default.nix
+++ b/pkgs/os-specific/linux/esdm/default.nix
@@ -9,67 +9,109 @@
 , ninja
 , libselinux
 , jitterentropy
-  # A more detailed explaination of the following meson build options can be found
-  # in the source code of esdm.
-  # A brief explanation is given:
+, botan3
+, openssl
+, libkcapi
+
+# A more detailed explaination of the following meson build options can be found
+# in the source code of esdm.
+# A brief explanation is given.
+
+# general options
 , selinux ? false # enable selinux support
 , drngHashDrbg ? true  # set the default drng callback
 , drngChaCha20 ? false # set the default drng callback
 , ais2031 ? false # set the seeding strategy to be compliant with AIS 20/31
+, sp80090c ? false # set compliance with NIST SP800-90C
+, cryptoBackend ? "botan" # set backend for hash and drbg operations
 , linuxDevFiles ? true # enable linux /dev/random and /dev/urandom support
 , linuxGetRandom ? true # enable linux getrandom support
-, esJitterRng ? true # enable support for the entropy source: jitter rng
-, esCPU ? true # enable support for the entropy source: cpu-based entropy
-, esKernel ? true # enable support for the entropy source: kernel-based entropy
-, esIRQ ? false # enable support for the entropy source: interrupt-based entropy
-, esSched ? false # enable support for the entropy source: scheduler-based entropy
-, esHwrand ? true # enable support for the entropy source: /dev/hwrng
 , hashSha512 ? false # set the conditioning hash: SHA2-512
 , hashSha3_512 ? true # set the conditioning hash: SHA3-512
+, openSSLRandProvider ? true # build ESDM provider for OpenSSL 3.x
+, botanRng ? true # build ESDM class for Botan 3.x
+
+# client-related options (handle with care, consult source code and meson options)
+# leave as is if in doubt
+, connectTimeoutExponent ? 28 # (1 << EXPONENT nanoseconds)
+, rxTxTimeoutExponent ? 28 # (1 << EXPONENT nanoseconds)
+, reconnectAttempts ? 10 # how often to attempt unix socket connection before giving up
+
+# entropy sources
+, esJitterRng ? true # enable support for the entropy source: jitter rng (running in user space)
+, esJitterRngEntropyRate ? 256 # amount of entropy to account for jitter rng source
+, esJitterRngKernel ? true # enable support for the entropy source: jitter rng (running in kernel space)
+, esJitterRngKernelEntropyRate ? 256 # amount of entropy to account for kernel jitter rng source
+, esCPU ? true # enable support for the entropy source: cpu-based entropy
+, esCPUEntropyRate ? 8 # amount of entropy to account for cpu rng source
+, esKernel ? true # enable support for the entropy source: kernel-based entropy
+, esKernelEntropyRate ? 128 # amount of entropy to account for kernel-based source
+, esIRQ ? false # enable support for the entropy source: interrupt-based entropy
+, esIRQEntropyRate ? 256 # amount of entropy to account for interrupt-based source (only set irq XOR sched != 0)
+, esSched ? false # enable support for the entropy source: scheduler-based entropy
+, esSchedEntropyRate ? 0 # amount of entropy to account for interrupt-based source (only set irq XOR sched != 0)
+, esHwrand ? true # enable support for the entropy source: /dev/hwrng
+, esHwrandEntropyRate ? 128 # amount of entropy to account for /dev/hwrng-based sources
 }:
 
 assert drngHashDrbg != drngChaCha20;
 assert hashSha512 != hashSha3_512;
+assert cryptoBackend == "openssl" || cryptoBackend == "botan" || cryptoBackend == "builtin" "Unsupported ESDM crypto backend";
 
 stdenv.mkDerivation rec {
   pname = "esdm";
-  version = "0.6.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "smuellerDD";
     repo = "esdm";
     rev = "v${version}";
-    sha256 = "sha256-swBKVb5gnND76w2ULT+5hR/jVOqxEe4TAB1gyaLKE9Q=";
+    sha256 = "sha256-q6TGL1agltV9CFfcA6hZszVwGIBBngs22ZqhQgc9FeM=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "arm64.patch";
-      url = "https://github.com/smuellerDD/esdm/commit/86b93a0ddf684448aba152c8f1b3baf40a6d41c0.patch";
-      sha256 = "sha256-gjp13AEsDNj23fcGanAAn2KCbYKA0cphhf4mCxek9Yg=";
-    })
-  ];
-
   nativeBuildInputs = [ meson pkg-config ninja ];
-  buildInputs = [ protobufc fuse3 jitterentropy ]
-    ++ lib.optional selinux libselinux;
+  buildInputs = [ protobufc ]
+    ++ lib.optional (cryptoBackend == "botan" || botanRng) botan3
+    ++ lib.optional (cryptoBackend == "openssl" || openSSLRandProvider) openssl
+    ++ lib.optional selinux libselinux
+    ++ lib.optional esJitterRng jitterentropy
+    ++ lib.optional linuxDevFiles fuse3
+    ++ lib.optional esJitterRngKernel libkcapi;
 
   mesonFlags = [
     (lib.mesonBool "b_lto" false)
+    (lib.mesonBool "fips140" false)
     (lib.mesonBool "ais2031" ais2031)
+    (lib.mesonBool "sp80090c" sp80090c)
+    (lib.mesonEnable "node" true) # multiple DRNGs
+    (lib.mesonOption "threading_max_threads" (toString 64))
+    (lib.mesonOption "crypto_backend" cryptoBackend)
     (lib.mesonEnable "linux-devfiles" linuxDevFiles)
     (lib.mesonEnable "linux-getrandom" linuxGetRandom)
+    (lib.mesonOption "client-connect-timeout-exponent" (toString connectTimeoutExponent))
+    (lib.mesonOption "client-rx-tx-timeout-exponent" (toString rxTxTimeoutExponent))
+    (lib.mesonOption "client-reconnect-attempts" (toString reconnectAttempts))
     (lib.mesonEnable "es_jent" esJitterRng)
+    (lib.mesonOption "es_jent_entropy_rate" (toString esJitterRngEntropyRate))
+    (lib.mesonEnable "es_jent_kernel" esJitterRngKernel)
+    (lib.mesonOption "es_jent_kernel_entropy_rate" (toString esJitterRngKernelEntropyRate))
     (lib.mesonEnable "es_cpu" esCPU)
+    (lib.mesonOption "es_cpu_entropy_rate" (toString esCPUEntropyRate))
     (lib.mesonEnable "es_kernel" esKernel)
+    (lib.mesonOption "es_kernel_entropy_rate" (toString esKernelEntropyRate))
     (lib.mesonEnable "es_irq" esIRQ)
+    (lib.mesonOption "es_irq_entropy_rate" (toString esIRQEntropyRate))
     (lib.mesonEnable "es_sched" esSched)
+    (lib.mesonOption "es_sched_entropy_rate" (toString esSchedEntropyRate))
     (lib.mesonEnable "es_hwrand" esHwrand)
+    (lib.mesonOption "es_hwrand_entropy_rate" (toString esHwrandEntropyRate))
     (lib.mesonEnable "hash_sha512" hashSha512)
     (lib.mesonEnable "hash_sha3_512" hashSha3_512)
     (lib.mesonEnable "selinux" selinux)
     (lib.mesonEnable "drng_hash_drbg" drngHashDrbg)
     (lib.mesonEnable "drng_chacha20" drngChaCha20)
+    (lib.mesonEnable "openssl-rand-provider" openSSLRandProvider)
+    (lib.mesonEnable "botan-rng" botanRng)
   ];
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes

ESDM 1.0.0 contains robustness and feature improvements. Besides support for accelerated crypto operations with Botan or OpenSSL, options which we used in practical deployments were added and/or made explicit.

Changelog: https://github.com/smuellerDD/esdm/blob/master/CHANGES.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
