### PR TITLE
ocamlPackages.asai: init at 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/asai/default.nix
+++ b/pkgs/development/ocaml-modules/asai/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, algaeff
+, bwd
+, eio
+, eio_main
+, lsp
+, notty
+}:
+
+buildDunePackage rec {
+  pname = "asai";
+  version = "0.1.1";
+  src = fetchFromGitHub {
+    owner = "RedPRL";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Jd90WhSjK4K2amFA5uyGF57NzsgHA8QiccX6qtxO1rQ=";
+  };
+
+  propagatedBuildInputs = [
+    algaeff
+    bwd
+    lsp
+    eio
+    eio_main
+    notty
+  ];
+
+  meta = {
+    description = "A library for constructing and printing compiler diagnostics";
+    homepage = "https://redprl.org/asai/asai/";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -40,6 +40,8 @@ let
 
     arp = callPackage ../development/ocaml-modules/arp { };
 
+    asai = callPackage ../development/ocaml-modules/asai { };
+
     asetmap = callPackage ../development/ocaml-modules/asetmap { };
 
     asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };


### PR DESCRIPTION
## Description of changes

https://redprl.org/asai/asai/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
