### PR TITLE
fastcdr: 1.1.1 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/fastcdr/default.nix
+++ b/pkgs/development/libraries/fastcdr/default.nix
@@ -6,17 +6,18 @@
 , withDocs ? true
 , doxygen
 , graphviz-nox
+, nix-update-script
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fastcdr";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "eProsima";
     repo = "Fast-CDR";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Pe1h8dHS+wWql0oimfPlLHvXbgLEo2kiRNKMD8EvNZ0=";
+    hash = "sha256-tYDVQ3165k1L0tJZxZtm/en6pn9m1MvuDHgs0KBsfnY=";
   };
 
   patches = [
@@ -40,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   checkInputs = [ gtest ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/eProsima/Fast-CDR";

--- a/pkgs/development/libraries/fastcdr/default.nix
+++ b/pkgs/development/libraries/fastcdr/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fastcdr";
-  version = "1.1.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "eProsima";
     repo = "Fast-CDR";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ZJQnm3JN56y2v/XIShfZxkEEu1AKMJxt8wpRqSn9HWk=";
+    hash = "sha256-Pe1h8dHS+wWql0oimfPlLHvXbgLEo2kiRNKMD8EvNZ0=";
   };
 
   patches = [
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = lib.optional (stdenv.hostPlatform.isStatic) "-DBUILD_SHARED_LIBS=OFF"
-  # fastcdr doesn't respect BUILD_TESTING
-  ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "-DEPROSIMA_BUILD_TESTS=ON"
+  # upstream turns BUILD_TESTING=OFF by default and doesn't honor cmake's default (=ON)
+  ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "-DBUILD_TESTING=ON"
   ++ lib.optional withDocs "-DBUILD_DOCUMENTATION=ON";
 
   outputs = [ "out" ] ++ lib.optional withDocs "doc";


### PR DESCRIPTION
## Description of changes

https://github.com/eProsima/Fast-CDR/releases/tag/v2.0.0
https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.0

Closes #258838

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
