### PR TITLE
by-name: make the way of adding packages clearer

### DIFF
--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -3,6 +3,10 @@
 The structure of this directory maps almost directly to top-level package attributes.
 This is the recommended way to add new top-level packages to Nixpkgs [when possible](#limitations).
 
+Packages found in the named-based structure do not need to be explicitly added to the
+`top-level/all-packages.nix` file unless they require overriding the default value
+of an implicit attribute (see below).
+
 ## Example
 
 The top-level package `pkgs.some-package` may be declared by setting up this file structure:


### PR DESCRIPTION
## Description of changes

It was not clear to me from reading `by-name/README.md` that I could omit adding a new package to `all-packages.nix`.
