### PR TITLE
{nickel,nls}: make nls an output of nickel

### DIFF
--- a/pkgs/development/interpreters/nickel/default.nix
+++ b/pkgs/development/interpreters/nickel/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , python3
 , nix-update-script
-, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,11 +28,18 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  cargoBuildFlags = [ "-p nickel-lang-cli" ];
+  cargoBuildFlags = [ "-p nickel-lang-cli" "-p nickel-lang-lsp" ];
 
   nativeBuildInputs = [
     python3
   ];
+
+  outputs = [ "out" "nls" ];
+
+  postInstall = ''
+    mkdir -p $nls/bin
+    mv $out/bin/nls $nls/bin/nls
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/tools/language-servers/nls/default.nix
+++ b/pkgs/development/tools/language-servers/nls/default.nix
@@ -1,27 +1,13 @@
-{ lib
-, rustPlatform
+{ symlinkJoin
 , nickel
-, stdenv
 }:
 
-rustPlatform.buildRustPackage {
+symlinkJoin {
+  name = "nls-${nickel.version}";
   pname = "nls";
+  inherit (nickel) version;
 
-  inherit (nickel) src version nativeBuildInputs;
-
-  cargoLock = {
-    lockFile = ./Cargo.lock;
-    outputHashes = {
-      "topiary-0.2.3" = "sha256-DcmrQ8IuvUBDCBKKSt13k8rU8DJZWFC8MvxWB7dwiQM=";
-      "tree-sitter-bash-0.20.3" = "sha256-zkhCk19kd/KiqYTamFxui7KDE9d+P9pLjc1KVTvYPhI=";
-      "tree-sitter-facade-0.9.3" = "sha256-M/npshnHJkU70pP3I4WMXp3onlCSWM5mMIqXP45zcUs=";
-      "tree-sitter-nickel-0.0.1" = "sha256-aYsEx1Y5oDEqSPCUbf1G3J5Y45ULT9OkD+fn6stzrOU=";
-      "tree-sitter-query-0.1.0" = "sha256-5N7FT0HTK3xzzhAlk3wBOB9xlEpKSNIfakgFnsxEi18=";
-      "web-tree-sitter-sys-1.3.0" = "sha256-9rKB0rt0y9TD/HLRoB9LjEP9nO4kSWR9ylbbOXo2+2M=";
-    };
-  };
-
-  cargoBuildFlags = [ "-p nickel-lang-lsp" ];
+  paths = [ nickel.nls ];
 
   meta = {
     inherit (nickel.meta) homepage changelog license maintainers;


### PR DESCRIPTION
## Description of changes

This PR makes `nls` an output of `nickel` (`nickel.nls`). These two packages are released in lockstep so it's easier to just build them as part of the same derivation. It also saves on build time as they share the same dependencies. For backwards compatibility and discoverability I aliased `nls` to `nickel.nls` using `symlinkJoin`. This intentionally doesn't use `aliases.nix` as I feel the package still deserves its own entry / metadata. 

Fixes: https://github.com/NixOS/nixpkgs/issues/259532

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
