### PR TITLE
man-pages: 5.13 -> 6.05, update build process

### DIFF
--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "man-pages";
-  version = "5.13";
+  version = "6.05";
 
   src = fetchurl {
     url = "mirror://kernel/linux/docs/man-pages/${pname}-${version}.tar.xz";
-    sha256 = "sha256-YU2uPv59/UgJhnY6KiqBeSFQMqWkUmwL5eiZol8Ja4s=";
+    sha256 = "sha256-ibFEXP4uPei9E5dYx48Is3gTz/IXufscjfVf2UB4daY=";
   };
 
   makeFlags = [ "prefix=$(out)" ];

--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -19,6 +19,16 @@ stdenv.mkDerivation rec {
   # Don't build html or pdf for now
   buildFlags = [ "build-catman" ];
 
+  # Append `.*` to share/lint/groff/man.ignore.grep to ignore troff errors
+  preBuild = ''
+    # troff warnings cause the build to fail
+    # (see the `groff_man_ignore_grep` make variable and
+    # the `_CATMAN_MAN_set` build target in share/mk/build/catman.mk)
+
+    # Append .* to man.ignore.grep to effectively ignore groff errors
+    echo ".*" >> share/lint/groff/man.ignore.grep
+  '';
+
   postInstall = ''
     # conflict with shadow-utils
     rm $out/share/man/man5/passwd.5 \

--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, groff, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "man-pages";
@@ -9,7 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ibFEXP4uPei9E5dYx48Is3gTz/IXufscjfVf2UB4daY=";
   };
 
+  buildInputs = [
+    groff
+  ];
+
   makeFlags = [ "prefix=$(out)" ];
+
+  # Only build regular man pages
+  # Don't build html or pdf for now
+  buildFlags = [ "build-catman" ];
+
   postInstall = ''
     # conflict with shadow-utils
     rm $out/share/man/man5/passwd.5 \


### PR DESCRIPTION
## Description of changes

The man-pages project has made many changes to its build system since
man-pages-5.13.  This is a first pass at updating the nixpkgs man-pages
derivation to build it.

* Description of the release in the release commit:
https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tag/?h=man-pages-6.05
* Changes from 6.04 to 6.05:
https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/Changes?h=man-pages-6.05
* Change history, in particular from 5.13 to 6.04
https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/Changes.old?h=man-pages-6.05

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Questions/Comments

1. No applicable tests that I found
2. No binary files to test
3. Should I update release notes?
