### PR TITLE
mov-cli: unstable-2022-06-30 -> 1.5.4

### DIFF
--- a/pkgs/applications/video/mov-cli/default.nix
+++ b/pkgs/applications/video/mov-cli/default.nix
@@ -1,24 +1,34 @@
 { lib
 , python3
 , fetchFromGitHub
+, mpv
 }:
 
 python3.pkgs.buildPythonPackage rec {
   pname = "mov-cli";
-  version = "unstable-2022-06-30";
+  version = "1.5.4";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "mov-cli";
     repo = "mov-cli";
-    rev = "b89e807e8ffc830b0b18c8e98712441c03774b8e";
-    sha256 = "sha256-D+OeXcLdkbG4ASbPQYIWf7J1CRZ9jH3UXxfTL4WleY0=";
+    rev = version;
+    sha256 = "sha256-WhoP4FcoO9+O9rfpC3oDQkVIpVOqxfdLRygHgf1O01g=";
   };
+  makeWrapperArgs = [
+    "--prefix" "PATH" ":" "${lib.getBin mpv}/bin"
+  ];
 
-  propagatedBuildInputs = with python3.pkgs; [ setuptools httpx click beautifulsoup4 colorama ];
-
-  postPatch = ''
-    substituteInPlace setup.py --replace "bs4" "beautifulsoup4"
-  '';
+  propagatedBuildInputs = with python3.pkgs; [
+    poetry-core
+    krfzf-py
+    pycrypto
+    setuptools
+    httpx
+    click
+    beautifulsoup4
+    colorama
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/mov-cli/mov-cli";

--- a/pkgs/development/python-modules/krfzf-py/default.nix
+++ b/pkgs/development/python-modules/krfzf-py/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, poetry-core
+}:
+
+buildPythonPackage rec {
+  pname = "krfzf-py";
+  version = "0.0.6";
+  format = "pyproject";
+
+  src = fetchPypi {
+    pname = "krfzf_py";
+    inherit version;
+    hash = "sha256-/M9Atu9MLAGmnEdx6tknMJAit2o4Xt971uQ7pb0CBCk=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [ "fzf" ];
+
+  meta = with lib; {
+    description = "A Pythonic Fzf Wrapper";
+    downloadPage = "https://github.com/justfoolingaround/fzf.py";
+    homepage = "https://pypi.org/project/krfzf-py/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5930,6 +5930,8 @@ self: super: with self; {
 
   krakenex = callPackage ../development/python-modules/krakenex { };
 
+  krfzf-py = callPackage ../development/python-modules/krfzf-py { };
+
   kubernetes = callPackage ../development/python-modules/kubernetes { };
 
   l18n = callPackage ../development/python-modules/l18n { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
