### PR TITLE
macvim: 8.2.3455 -> 178

### DIFF
--- a/pkgs/applications/editors/vim/macvim-configurable.nix
+++ b/pkgs/applications/editors/vim/macvim-configurable.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, callPackage, vimUtils, buildEnv, makeWrapper }:
 
 let
-  macvim = callPackage ./macvim.nix { inherit stdenv; };
-
   makeCustomizable = macvim: macvim // {
     # configure expects the same args as vimUtils.vimrcFile.
     # This is the same as the value given to neovim.override { configure = … }
@@ -62,5 +60,4 @@ let
     override = f: makeCustomizable (macvim.override f);
     overrideAttrs = f: makeCustomizable (macvim.overrideAttrs f);
   };
-in
-  makeCustomizable macvim
+in { inherit makeCustomizable; }

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -6,14 +6,22 @@
 , gettext
 , pkg-config
 , cscope
-, ruby
+, ruby_3_2
 , tcl
-, perl
+, perl536
 , luajit
 , darwin
 , libiconv
 , python3
 }:
+
+# Try to match MacVim's documented script interface compatibility
+let
+  # Perl 5.30 - closest we get is 5.36. 5.38 is currently failing
+  perl = perl536;
+  # Ruby 3.2
+  ruby = ruby_3_2;
+in
 
 let
   # Building requires a few system tools to be in PATH.
@@ -26,16 +34,16 @@ let
   '';
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "macvim";
 
-  version = "8.2.3455";
+  version = "178";
 
   src = fetchFromGitHub {
     owner = "macvim-dev";
     repo = "macvim";
-    rev = "snapshot-172";
-    sha256 = "sha256-LLLQ/V1vyKTuSXzHW3SOlOejZD5AV16NthEdMoTnfko=";
+    rev = "release-${finalAttrs.version}";
+    hash = "sha256-JYh5fyaYuME/Lk67vrf1hYOIcAkEbwtslcnI9KRzHa8=";
   };
 
   enableParallelBuilding = true;
@@ -48,26 +56,26 @@ stdenv.mkDerivation {
   patches = [ ./macvim.patch ];
 
   configureFlags = [
-      "--enable-cscope"
-      "--enable-fail-if-missing"
-      "--with-features=huge"
-      "--enable-gui=macvim"
-      "--enable-multibyte"
-      "--enable-nls"
-      "--enable-luainterp=dynamic"
-      "--enable-python3interp=dynamic"
-      "--enable-perlinterp=dynamic"
-      "--enable-rubyinterp=dynamic"
-      "--enable-tclinterp=yes"
-      "--without-local-dir"
-      "--with-luajit"
-      "--with-lua-prefix=${luajit}"
-      "--with-python3-command=${python3}/bin/python3"
-      "--with-ruby-command=${ruby}/bin/ruby"
-      "--with-tclsh=${tcl}/bin/tclsh"
-      "--with-tlib=ncurses"
-      "--with-compiledby=Nix"
-      "--disable-sparkle"
+    "--enable-cscope"
+    "--enable-fail-if-missing"
+    "--with-features=huge"
+    "--enable-gui=macvim"
+    "--enable-multibyte"
+    "--enable-nls"
+    "--enable-luainterp=dynamic"
+    "--enable-python3interp=dynamic"
+    "--enable-perlinterp=dynamic"
+    "--enable-rubyinterp=dynamic"
+    "--enable-tclinterp=yes"
+    "--without-local-dir"
+    "--with-luajit"
+    "--with-lua-prefix=${luajit}"
+    "--with-python3-command=${python3}/bin/python3"
+    "--with-ruby-command=${ruby}/bin/ruby"
+    "--with-tclsh=${tcl}/bin/tclsh"
+    "--with-tlib=ncurses"
+    "--with-compiledby=Nix"
+    "--disable-sparkle"
   ];
 
   # Remove references to Sparkle.framework from the project.
@@ -78,37 +86,45 @@ stdenv.mkDerivation {
     sed -e '/Sparkle\.framework/d' -i src/MacVim/MacVim.xcodeproj/project.pbxproj
   '';
 
-  # This is unfortunate, but we need to use the same compiler as Xcode,
-  # but Xcode doesn't provide a way to configure the compiler.
-  preConfigure = ''
-    CC=/usr/bin/clang
+  # This is unfortunate, but we need to use the same compiler as Xcode, but Xcode doesn't provide a
+  # way to configure the compiler. We also need to pull in lib/include paths for some of our build
+  # inputs since we don't have cc-wrapper to do that for us.
+  preConfigure =
+    let
+      # ideally we'd recurse, but we don't need that right now
+      inputs = [ ncurses ] ++ perl.propagatedBuildInputs;
+      ldflags = map (drv: "-L${lib.getLib drv}/lib") inputs;
+      cppflags = map (drv: "-isystem ${lib.getDev drv}/include") inputs;
+    in
+    ''
+      CC=/usr/bin/clang
 
-    DEV_DIR=$(/usr/bin/xcode-select -print-path)/Platforms/MacOSX.platform/Developer
-    configureFlagsArray+=(
-      --with-developer-dir="$DEV_DIR"
-      LDFLAGS="-L${ncurses}/lib"
-      CPPFLAGS="-isystem ${ncurses.dev}/include"
-      CFLAGS="-Wno-error=implicit-function-declaration"
-    )
-  ''
-  # For some reason having LD defined causes PSMTabBarControl to fail at link-time as it
-  # passes arguments to ld that it meant for clang.
-  + ''
-    unset LD
-  ''
-  # When building with nix-daemon, we need to pass -derivedDataPath or else it tries to use
-  # a folder rooted in /var/empty and fails. Unfortunately we can't just pass -derivedDataPath
-  # by itself as this flag requires the use of -scheme or -xctestrun (not sure why), but MacVim
-  # by default just runs `xcodebuild -project src/MacVim/MacVim.xcodeproj`, relying on the default
-  # behavior to build the first target in the project. Experimentally, there seems to be a scheme
-  # called MacVim, so we'll explicitly select that. We also need to specify the configuration too
-  # as the scheme seems to have the wrong default.
-  + ''
-    configureFlagsArray+=(
-      XCODEFLAGS="-scheme MacVim -derivedDataPath $NIX_BUILD_TOP/derivedData"
-      --with-xcodecfg="Release"
-    )
-  ''
+      DEV_DIR=$(/usr/bin/xcode-select -print-path)/Platforms/MacOSX.platform/Developer
+      configureFlagsArray+=(
+        --with-developer-dir="$DEV_DIR"
+        LDFLAGS=${lib.escapeShellArg ldflags}
+        CPPFLAGS=${lib.escapeShellArg cppflags}
+        CFLAGS="-Wno-error=implicit-function-declaration"
+      )
+    ''
+    # For some reason having LD defined causes PSMTabBarControl to fail at link-time as it
+    # passes arguments to ld that it meant for clang.
+    + ''
+      unset LD
+    ''
+    # When building with nix-daemon, we need to pass -derivedDataPath or else it tries to use
+    # a folder rooted in /var/empty and fails. Unfortunately we can't just pass -derivedDataPath
+    # by itself as this flag requires the use of -scheme or -xctestrun (not sure why), but MacVim
+    # by default just runs `xcodebuild -project src/MacVim/MacVim.xcodeproj`, relying on the default
+    # behavior to build the first target in the project. Experimentally, there seems to be a scheme
+    # called MacVim, so we'll explicitly select that. We also need to specify the configuration too
+    # as the scheme seems to have the wrong default.
+    + ''
+      configureFlagsArray+=(
+        XCODEFLAGS="-scheme MacVim -derivedDataPath $NIX_BUILD_TOP/derivedData"
+        --with-xcodecfg="Release"
+      )
+    ''
   ;
 
   # Because we're building with system clang, this means we're building against Xcode's SDK and
@@ -124,7 +140,7 @@ stdenv.mkDerivation {
   # Xcode project or pass it as a flag to xcodebuild as well.
   postConfigure = ''
     substituteInPlace src/auto/config.mk \
-      --replace "PERL_CFLAGS	=" "PERL_CFLAGS	= -I${darwin.libutil}/include" \
+      --replace "PERL_CFLAGS${"\t"}=" "PERL_CFLAGS${"\t"}= -I${darwin.libutil}/include" \
       --replace " -L${stdenv.cc.libc}/lib" "" \
       --replace " -L${darwin.libobjc}/lib" "" \
       --replace " -L${darwin.libunwind}/lib" "" \
@@ -143,17 +159,25 @@ stdenv.mkDerivation {
     substituteInPlace src/MacVim/vimrc --subst-var-by CSCOPE ${cscope}/bin/cscope
   '';
 
+  # Note that $out/MacVim.app has a misnamed set of binaries in the Contents/bin folder (the V is
+  # capitalized) and is missing a bunch of them. This is why we're grabbing the version from the
+  # build folder.
   postInstall = ''
     mkdir -p $out/Applications
     cp -r src/MacVim/build/Release/MacVim.app $out/Applications
     rm -rf $out/MacVim.app
 
-    rm $out/bin/*
-
-    cp src/vimtutor $out/bin
-    for prog in mvim ex vi vim vimdiff view rvim rvimdiff rview; do
+    mkdir -p $out/bin
+    for prog in ex vi {,g,m,r}vi{m,mdiff,ew}; do
       ln -s $out/Applications/MacVim.app/Contents/bin/mvim $out/bin/$prog
     done
+    for prog in {,g}vimtutor xxd; do
+      ln -s $out/Applications/MacVim.app/Contents/bin/$prog $out/bin/$prog
+    done
+    ln -s $out/Applications/MacVim.app/Contents/bin/gvimtutor $out/bin/mvimtutor
+
+    mkdir -p $out/share
+    ln -s $out/Applications/MacVim.app/Contents/man $out/share/man
 
     # Fix rpaths
     exe="$out/Applications/MacVim.app/Contents/MacOS/Vim"
@@ -165,7 +189,7 @@ stdenv.mkDerivation {
     install_name_tool -add_rpath ${ruby}/lib $exe
 
     # Remove manpages from tools we aren't providing
-    find $out/share/man \( -name eVim.1 -or -name xxd.1 \) -delete
+    find $out/Applications/MacVim.app/Contents/man -name evim.1 -delete
   '';
 
   # We rely on the user's Xcode install to build. It may be located in an arbitrary place, and
@@ -179,10 +203,10 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Vim - the text editor - for macOS";
-    homepage    = "https://github.com/macvim-dev/macvim";
+    homepage = "https://macvim.org/";
     license = licenses.vim;
     maintainers = with maintainers; [ lilyball ];
-    platforms   = platforms.darwin;
+    platforms = platforms.darwin;
     hydraPlatforms = []; # hydra can't build this as long as we rely on Xcode and sandboxProfile
   };
-}
+})

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -1,50 +1,60 @@
 diff --git a/src/MacVim/vimrc b/src/MacVim/vimrc
-index 32c89b387..c2af70127 100644
+index 162af04..4322049 100644
 --- a/src/MacVim/vimrc
 +++ b/src/MacVim/vimrc
-@@ -9,35 +9,5 @@ set nocompatible
+@@ -9,45 +9,7 @@ set nocompatible
  " more sensible value.  Add "set backspace&" to your ~/.vimrc to reset it.
  set backspace+=indent,eol,start
  
 -" Python2
--" MacVim is configured by default to use the pre-installed System python2
--" version. However, following code tries to find a Homebrew, MacPorts or
--" an installation from python.org:
+-" MacVim is configured by default in the binary release to use the
+-" pre-installed System python2 version. However, following code tries to
+-" find a Homebrew, MacPorts or an installation from python.org:
 -if exists("&pythondll") && exists("&pythonhome")
+-  " Homebrew python 2.7
 -  if filereadable("/usr/local/Frameworks/Python.framework/Versions/2.7/Python")
--    " Homebrew python 2.7
 -    set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python
+-
+-  " MacPorts python 2.7
 -  elseif filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
--    " MacPorts python 2.7
 -    set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+-
+-  " https://www.python.org/downloads/mac-osx/
 -  elseif filereadable("/Library/Frameworks/Python.framework/Versions/2.7/Python")
--    " https://www.python.org/downloads/mac-osx/
 -    set pythondll=/Library/Frameworks/Python.framework/Versions/2.7/Python
 -  endif
 -endif
 -
 -" Python3
--" MacVim is configured by default to use Homebrew python3 version
--" If this cannot be found, following code tries to find a MacPorts
--" or an installation from python.org:
+-" MacVim is configured by default in the binary release to set
+-" pythonthreedll to Homebrew python3. If it cannot be found, the following
+-" code tries to find Python3 from other popular locations.  Note that we are
+-" using "Current" for the version, because Vim supports the stable ABI and
+-" therefore any new version of Python3 will work.
 -if exists("&pythonthreedll") && exists("&pythonthreehome") &&
 -      \ !filereadable(&pythonthreedll)
--  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python")
--    " MacPorts python 3.9
--    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python
--  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.9/Python")
--    " https://www.python.org/downloads/mac-osx/
--    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.9/Python
+-  " MacPorts python
+-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/Current/Python")
+-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/Current/Python
+-
+-  " macOS default Python, installed by 'xcode-select --install'
+-  elseif filereadable("/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/Current/Python3")
+-    set pythonthreedll=/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/Current/Python3
+-
+-  " https://www.python.org/downloads/mac-osx/
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/Current/Python")
+-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/Current/Python
 -  endif
 -endif
--
 +" Default cscopeprg to the Nix-installed path
 +set cscopeprg=@CSCOPE@
+ 
+ " vim: sw=2 ts=2 et
 diff --git a/src/Makefile b/src/Makefile
-index c4a3ada37..06ee3de44 100644
+index 5b4cdff..72fee3a 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -1402,7 +1402,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
+@@ -1290,7 +1290,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
  		  MacVim/MacVim.m
  MACVIMGUI_OBJ	= objects/gui.o objects/gui_beval.o \
  		  objects/gui_macvim.o objects/MMBackend.o objects/MacVim.o
@@ -54,10 +64,10 @@ index c4a3ada37..06ee3de44 100644
  MACVIMGUI_LIBS_DIR =
  MACVIMGUI_LIBS1	=
 diff --git a/src/auto/configure b/src/auto/configure
-index 39ef81449..d8fa7ec2f 100755
+index ecf10c4..4b691d0 100755
 --- a/src/auto/configure
 +++ b/src/auto/configure
-@@ -5896,10 +5896,7 @@ $as_echo "not found" >&6; }
+@@ -6247,10 +6247,7 @@ printf "%s\n" "not found" >&6; }
  
      for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do
        if test "X$path" != "X"; then
@@ -69,7 +79,7 @@ index 39ef81449..d8fa7ec2f 100755
  	  MZSCHEME_LIBS="${path}/libmzscheme3m.a"
  	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
  	elif test -f "${path}/libracket3m.a"; then
-@@ -6287,23 +6284,6 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
+@@ -6646,23 +6643,6 @@ printf "%s\n" ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
    fi
  
    if test "x$MACOS_X" = "xyes"; then
@@ -93,7 +103,7 @@ index 39ef81449..d8fa7ec2f 100755
                  PERL_LIBS=`echo "$PERL_LIBS" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
      PERL_CFLAGS=`echo "$PERL_CFLAGS" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
    fi
-@@ -6526,13 +6506,6 @@ __:
+@@ -6902,13 +6882,7 @@ __:
  eof
  	    	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
  	    rm -f -- "${tmp_mkf}"
@@ -104,10 +114,11 @@ index 39ef81449..d8fa7ec2f 100755
 -		  vi_cv_path_python_plibs="-F${python_PYTHONFRAMEWORKPREFIX} -framework Python"
 -	      fi
 -	    else
++
  	      vi_cv_path_python_plibs="-L${PYTHON_CONFDIR} -lpython${vi_cv_var_python_version}"
  	      	      	      	      if test -n "${python_LINKFORSHARED}" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
  	        python_link_symbol=`echo ${python_LINKFORSHARED} | sed 's/\([^ \t][^ \t]*[ \t][ \t]*[^ \t][^ \t]*\)[ \t].*/\1/'`
-@@ -6547,7 +6520,6 @@ eof
+@@ -6923,7 +6897,6 @@ eof
  	      fi
  	      vi_cv_path_python_plibs="${vi_cv_path_python_plibs} ${python_BASEMODLIBS} ${python_LIBS} ${python_SYSLIBS} ${python_LINKFORSHARED}"
  	      	      vi_cv_path_python_plibs=`echo $vi_cv_path_python_plibs | sed s/-ltermcap//`
@@ -115,8 +126,8 @@ index 39ef81449..d8fa7ec2f 100755
  
  fi
  
-@@ -6626,13 +6598,6 @@ rm -f core conftest.err conftest.$ac_objext \
- $as_echo "no" >&6; }
+@@ -7004,13 +6977,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
+ printf "%s\n" "no" >&6; }
  	fi
  
 -                                if test -n "$MACSDK"; then
@@ -126,13 +137,13 @@ index 39ef81449..d8fa7ec2f 100755
 -          PYTHON_GETPATH_CFLAGS=
 -        fi
 -
- 			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compile and link flags for Python are sane" >&5
- $as_echo_n "checking if compile and link flags for Python are sane... " >&6; }
+ 			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if compile and link flags for Python are sane" >&5
+ printf %s "checking if compile and link flags for Python are sane... " >&6; }
  	cflags_save=$CFLAGS
-@@ -7557,11 +7522,7 @@ $as_echo "$tclver - OK" >&6; };
+@@ -8060,11 +8026,7 @@ printf "%s\n" "$tclver - OK" >&6; };
  
-       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of Tcl include" >&5
- $as_echo_n "checking for location of Tcl include... " >&6; }
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for location of Tcl include" >&5
+ printf %s "checking for location of Tcl include... " >&6; }
 -      if test "x$MACOS_X" != "xyes"; then
  	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
 -      else
@@ -141,10 +152,10 @@ index 39ef81449..d8fa7ec2f 100755
        TCL_INC=
        for try in $tclinc; do
  	if test -f "$try/tcl.h"; then
-@@ -7579,13 +7540,8 @@ $as_echo "<not found>" >&6; }
+@@ -8082,13 +8044,8 @@ printf "%s\n" "<not found>" >&6; }
        if test -z "$SKIP_TCL"; then
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of tclConfig.sh script" >&5
- $as_echo_n "checking for location of tclConfig.sh script... " >&6; }
+ 	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for location of tclConfig.sh script" >&5
+ printf %s "checking for location of tclConfig.sh script... " >&6; }
 -	if test "x$MACOS_X" != "xyes"; then
  	  tclcnf=`echo $tclinc | sed s/include/lib/g`
  	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
@@ -154,8 +165,8 @@ index 39ef81449..d8fa7ec2f 100755
 -	fi
  	for try in $tclcnf; do
  	  if test -f "$try/tclConfig.sh"; then
- 	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $try/tclConfig.sh" >&5
-@@ -7774,10 +7730,6 @@ $as_echo "$rubyhdrdir" >&6; }
+ 	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $try/tclConfig.sh" >&5
+@@ -8285,10 +8242,6 @@ printf "%s\n" "$rubyhdrdir" >&6; }
  	rubylibdir=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG['libdir'])"`
  	if test -f "$rubylibdir/$librubya" || expr "$librubyarg" : "-lruby"; then
  	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
@@ -167,10 +178,10 @@ index 39ef81449..d8fa7ec2f 100755
  
  	if test "X$librubyarg" != "X"; then
 diff --git a/src/vim.h b/src/vim.h
-index 4ff59f201..f91cb9836 100644
+index 6e33142..6185f45 100644
 --- a/src/vim.h
 +++ b/src/vim.h
-@@ -244,17 +244,6 @@
+@@ -270,17 +270,6 @@
  # define SUN_SYSTEM
  #endif
  
@@ -189,10 +200,10 @@ index 4ff59f201..f91cb9836 100644
  # include "os_amiga.h"
  #endif
 diff --git a/src/vimtutor b/src/vimtutor
-index 3b154f288..e89f26060 100755
+index 3b154f2..e89f260 100755
 --- a/src/vimtutor
 +++ b/src/vimtutor
-@@ -16,6 +16,6 @@ seq="vim vim81 vim80 vim8 vim74 vim73 vim72 vim71 vim70 vim7 vim6 vi"
+@@ -16,7 +16,7 @@ seq="vim vim81 vim80 vim8 vim74 vim73 vim72 vim71 vim70 vim7 vim6 vi"
  if test "$1" = "-g"; then
      # Try to use the GUI version of Vim if possible, it will fall back
      # on Vim if Gvim is not installed.
@@ -200,3 +211,4 @@ index 3b154f288..e89f26060 100755
 +    seq="mvim gvim gvim81 gvim80 gvim8 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
      shift
  fi
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35086,7 +35086,11 @@ with pkgs;
 
   vimiv-qt = callPackage ../applications/graphics/vimiv-qt { };
 
-  macvim = callPackage ../applications/editors/vim/macvim-configurable.nix { stdenv = clangStdenv; };
+  macvim = let
+    macvimUtils = callPackage ../applications/editors/vim/macvim-configurable.nix { };
+  in macvimUtils.makeCustomizable (callPackage ../applications/editors/vim/macvim.nix {
+    stdenv = clangStdenv;
+  });
 
   vim-full = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/full.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa Foundation CoreData;


### PR DESCRIPTION
## Description of changes

This updates MacVim to the latest release. I've been running these changes locally for a while now, on both macOS Ventura and macOS Sonoma. It also fixes the ability to override macvim (previously it would override the `macvim-configurable.nix` file instead). The version is now listed as `178` as MacVim has switched to reporting its own version as its release number.

MacVim release notes:
[Release 173](https://github.com/macvim-dev/macvim/releases/tag/snapshot-173) (Vim 9.0.0065)
[Release 174](https://github.com/macvim-dev/macvim/releases/tag/release-174) (Vim 9.0.472)
(Release 175 was pulled)
[Release 176](https://github.com/macvim-dev/macvim/releases/tag/release-176) (Vim 9.0.1276)
[r177](https://github.com/macvim-dev/macvim/releases/tag/release-177) (Vim 9.0.1677)
[r178](https://github.com/macvim-dev/macvim/releases/tag/release-178) (Vim 9.0.1897)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
