### PR TITLE
slack-term: update from 0.5.0 to latest master

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack-term/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack-term/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "slack-term";
-  version = "0.5.0";
+  version = "0.5.0-master";
 
   src = fetchFromGitHub {
     owner = "erroneousboat";
     repo = "slack-term";
-    rev = "v${version}";
-    sha256 = "1fbq7bdhy70hlkklppimgdjamnk0v059pg73xm9ax1f4616ki1m6";
+    rev = "c19c20a3e5c597d6d60582fcba1a3523415e8fe4";
+    sha256 = "D+3qpRJkADTZyDxQQSFFKZz2WVQIaR8fzS7S90vMlLk=";
   };
   vendorHash = null;
 


### PR DESCRIPTION
Upstream has not cut a release, but current 0.5.0 tag is unusable with "Unsupported block type" errors.

## Description of changes

Upstream has not cut a release, but current 0.5.0 tag is unusable with "Unsupported block type" errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
