### PR TITLE
hishtory: enable hishtory backend

### DIFF
--- a/pkgs/shells/hishtory/default.nix
+++ b/pkgs/shells/hishtory/default.nix
@@ -16,13 +16,14 @@ buildGoModule rec {
 
   vendorHash = "sha256-aXHqPk8iBMbe0NlsY3ZR7iozBGCAKlOOQ23FAD/5hL8=";
 
-  ldflags = [ "-X github.com/ddworken/hishtory/client/lib.Version=${version}" ];
+  ldflags = [ "-X github.com/ddworken/hishtory/client/lib.Version=${version}" "-X main.ReleaseVersion=${version}"];
 
-  excludedPackages = [ "backend/server" ];
+  excludedPackages = [];
 
   postInstall = ''
     mkdir -p $out/share/hishtory
     cp client/lib/config.* $out/share/hishtory
+    mv $out/bin/server $out/bin/hishtory-server
   '';
 
   doCheck = false;


### PR DESCRIPTION
hishtory has a client and a server for self-host purpose. Server is currently not built. This commit enables it

## Description of changes

Hishtory has a client and a server for self-host purpose. Server is currently not built. This commit enables it

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
