### PR TITLE
nixos/release: don't block on firefox tests

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -67,8 +67,15 @@ in rec {
         (onSystems ["x86_64-linux"] "nixos.tests.docker")
         (onFullSupported "nixos.tests.ecryptfs")
         (onFullSupported "nixos.tests.env")
-        (onFullSupported "nixos.tests.firefox-esr")
-        (onFullSupported "nixos.tests.firefox")
+
+        # Way too many manual retries required on Hydra.
+        #  Apparently it's hard to track down the cause.
+        #  So let's depend just on the packages for now.
+        #(onFullSupported "nixos.tests.firefox-esr")
+        #(onFullSupported "nixos.tests.firefox")
+        (onFullSupported "nixpkgs.firefox-esr")
+        (onFullSupported "nixpkgs.firefox")
+
         (onFullSupported "nixos.tests.firewall")
         (onFullSupported "nixos.tests.fontconfig-default-fonts")
         (onFullSupported "nixos.tests.gnome")


### PR DESCRIPTION
I can't recall when these tests last discovered a real problem. Having to do many manual restarts is annoying, e.g.
  https://hydra.nixos.org/build/237622614#tabs-buildsteps

_Usual checklist does not apply here._