### PR TITLE
libcue: apply patch for CVE-2023-43641

### DIFF
--- a/pkgs/development/libraries/libcue/default.nix
+++ b/pkgs/development/libraries/libcue/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, bison, flex }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, bison, flex }:
 
 stdenv.mkDerivation rec {
   pname = "libcue";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1iqw4n01rv2jyk9lksagyxj8ml0kcfwk67n79zy1r6zv1xfp5ywm";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-43641.patch";
+      url = "https://github.com/lipnitsk/libcue/commit/fdf72c8bded8d24cfa0608b8e97f2eed210a920e.patch";
+      hash = "sha256-NjnSMUfman/SwLFWDIhtz2jCOLfpXGGGjO3QwRGURNg=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake bison flex ];
 


### PR DESCRIPTION
## Description of changes

https://github.blog/2023-10-09-coordinated-disclosure-1-click-rce-on-gnome-cve-2023-43641/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>33 packages built:</summary>
  <ul>
    <li>audacious</li>
    <li>audacious-plugins</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cinnamon.nemo-fileroller</li>
    <li>cinnamon.nemo-with-extensions</li>
    <li>cmus</li>
    <li>deepin.deepin-music</li>
    <li>dropbox-cli</li>
    <li>dropbox-cli.nautilusExtension</li>
    <li>eiciel</li>
    <li>eiciel.nautilusExtension</li>
    <li>gjay</li>
    <li>gnome-photos</li>
    <li>gnome-photos.installedTests</li>
    <li>gnome.file-roller</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.nautilus</li>
    <li>gnome.nautilus-python</li>
    <li>gnome.nautilus-python.dev</li>
    <li>gnome.nautilus-python.devdoc</li>
    <li>gnome.nautilus-python.doc</li>
    <li>gnome.nautilus.dev</li>
    <li>gnome.nautilus.devdoc</li>
    <li>gnomeExtensions.gtk4-desktop-icons-ng-ding</li>
    <li>libcue</li>
    <li>nautilus-open-any-terminal</li>
    <li>nautilus-open-any-terminal.dist</li>
    <li>pantheon.file-roller-contract</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>tracker-miners</li>
  </ul>
</details>