### PR TITLE
nixos/synapse: doc: suggest LoadCredential before nixops/sops

### DIFF
--- a/nixos/modules/services/matrix/synapse.md
+++ b/nixos/modules/services/matrix/synapse.md
@@ -150,17 +150,23 @@ in an additional file like this:
     ```
     registration_shared_secret: your-very-secret-secret
     ```
-  - Deploy the file with a secret-manager such as
+  - Get systemd LoadCredential to read the file somewhere the service can access
+    ```
+    {
+      systemd.services.matrix-synapse.serviceConfig.LoadCredential =
+        "matrix-shared-secret:/etc/nixos/secrets/matrix-shared-secret";
+    }
+    ```
+    Alternatively, you can deploy the file with a secret-manager such as
     [{option}`deployment.keys`](https://nixops.readthedocs.io/en/latest/overview.html#managing-keys)
-    from {manpage}`nixops(1)` or [sops-nix](https://github.com/Mic92/sops-nix/) to
-    e.g. {file}`/run/secrets/matrix-shared-secret` and ensure that it's readable
-    by `matrix-synapse`.
+    from {manpage}`nixops(1)` or [sops-nix](https://github.com/Mic92/sops-nix/)
+    and ensure that it's readable by `matrix-synapse` manually.
   - Include the file like this in your configuration:
 
     ```
     {
       services.matrix-synapse.extraConfigFiles = [
-        "/run/secrets/matrix-shared-secret"
+        "/run/credentials/matrix-synapse.service/matrix-shared-secret"
       ];
     }
     ```


### PR DESCRIPTION
## Description of changes

This is a bit selfish, but that's what I was looking for in the .md when I wanted to quickly add a user without adding the password in the store on a local machine. Happy to reword or try another way of describing it.

----
nixops and similar are great, but require an upfront cost that is no longer necessary now systemd can read root-only files for restricted services through `LoadCredential`

Suggest the native method first in the service readme for simplicity

-----

Note: it'd make more sense to set `$CREDENTIALS_DIRECTORY/matrix-shared-secret` instead of hardcoding `/run/credentials/<service>`, but that doesn't pass types.path check. The service name is made explicit when setting LoadCredential anyway, so this constant should be safe to use.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Cc @ma27 @fadenb @mguentner @ralith @sumnerevans @NickCao @dali99 (matrix team)