### PR TITLE
blobwars: fix build against glibc-2.38

### DIFF
--- a/pkgs/games/blobwars/blobwars-2.00-glibc-2.38.patch
+++ b/pkgs/games/blobwars/blobwars-2.00-glibc-2.38.patch
@@ -1,0 +1,11 @@
+--- a/src/headers.h
++++ b/src/headers.h
+@@ -56,7 +56,7 @@ extern DECLSPEC int SDLCALL SDL_GetGamma(float *red, float *green, float *blue);
+ #define textdomain(x) while(false)
+ #endif
+ 
+-#if !defined(OpenBSD) && !defined(FreeBSD) && !defined(__APPLE__)
++#if !defined(OpenBSD) && !defined(FreeBSD) && !defined(__APPLE__) && !(defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 38)
+ static inline void strlcat(char *dest, const char *src, size_t n) { strncat(dest, src, n - 1); }
+ static inline void strlcpy(char *dest, const char *src, size_t n) { strncpy(dest, src, n); dest[n - 1] = 0; }
+ #endif

--- a/pkgs/games/blobwars/default.nix
+++ b/pkgs/games/blobwars/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "c406279f6cdf2aed3c6edb8d8be16efeda0217494acd525f39ee2bd3e77e4a99";
   };
 
+  patches = [ ./blobwars-2.00-glibc-2.38.patch ];
+
   nativeBuildInputs = [ pkg-config gettext ];
   buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_net SDL2_ttf zlib ];
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error" ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
