### PR TITLE
floorp: init at 11.5.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -284,6 +284,7 @@ in {
   firewall-nftables = handleTest ./firewall.nix { nftables = true; };
   fish = handleTest ./fish.nix {};
   flannel = handleTestOn ["x86_64-linux"] ./flannel.nix {};
+  floorp = handleTest ./firefox.nix { firefoxPackage = pkgs.floorp; };
   fluentd = handleTest ./fluentd.nix {};
   fluidd = handleTest ./fluidd.nix {};
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,5 +1,6 @@
 { pname
 , version
+, packageVersion ? version
 , meta
 , updateScript ? null
 , binaryName ? "firefox"
@@ -206,7 +207,7 @@ in
 
 buildStdenv.mkDerivation {
   pname = "${pname}-unwrapped";
-  inherit version;
+  version = packageVersion;
 
   inherit src unpackPhase meta;
 
@@ -557,7 +558,6 @@ buildStdenv.mkDerivation {
   passthru = {
     inherit application extraPatches;
     inherit updateScript;
-    inherit version;
     inherit alsaSupport;
     inherit binaryName;
     inherit jackSupport;
@@ -569,6 +569,7 @@ buildStdenv.mkDerivation {
     inherit tests;
     inherit gtk3;
     inherit wasiSysRoot;
+    version = packageVersion;
   } // extraPassthru;
 
   hardeningDisable = [ "format" ]; # -Werror=format-security

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildMozillaMach
+, nixosTests
+}:
+
+((buildMozillaMach rec {
+  pname = "floorp";
+  packageVersion = "11.5.0";
+  applicationName = "Floorp";
+  binaryName = "floorp";
+  version = "155.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Floorp-Projects";
+    repo = "Floorp";
+    fetchSubmodules = true;
+    rev = "v${packageVersion}";
+    hash = "sha256-adK3LAu3cDh6d+GvtnkWmSnxansnSZoIgtA9TAqIMyA=";
+  };
+
+  extraConfigureFlags = [
+    "--with-app-name=${pname}"
+    "--with-app-basename=${applicationName}"
+    "--with-branding=browser/branding/official"
+    "--with-distribution-id=app.floorp.Floorp"
+    "--with-unsigned-addon-scopes=app,system"
+    "--allow-addon-sideload"
+  ];
+
+  meta = {
+    description = "A fork of Firefox, focused on keeping the Open, Private and Sustainable Web alive, built in Japan";
+    homepage = "https://floorp.app/";
+    maintainers = with lib.maintainers; [ christoph-heiss ];
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.darwin;
+    broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+                                           # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
+    maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
+    license = lib.licenses.mpl20;
+  };
+  tests = [ nixosTests.floorp ];
+}).override {
+  privacySupport = true;
+  enableOfficialBranding = false;
+}).overrideAttrs (prev: {
+  MOZ_REQUIRE_SIGNING = "";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32173,6 +32173,10 @@ with pkgs;
 
   flex-ndax = callPackage ../applications/radio/flex-ndax { };
 
+  floorp-unwrapped = callPackage ../applications/networking/browsers/floorp { };
+
+  floorp = wrapFirefox floorp-unwrapped { };
+
   fluxbox = callPackage ../applications/window-managers/fluxbox { };
 
   hackedbox = callPackage ../applications/window-managers/hackedbox { };


### PR DESCRIPTION
## Description of changes

Closes #255940.

This adds [Floorp](https://floorp.app/), which is another fork of Firefox.
It describes itself as being "built on Firefox, built in Japan and is a new browser with excellent privacy & flexibility".

Due to it having its own versioning system, a small adjustment for `buildMozillaMach` was needed - hopefully that is fine.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
