### PR TITLE
ferdium: add aarch64-linux

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ferdium/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdium/default.nix
@@ -1,12 +1,21 @@
-{ lib, mkFranzDerivation, fetchurl, xorg, nix-update-script }:
+{ lib, mkFranzDerivation, fetchurl, xorg, nix-update-script, stdenv }:
 
-mkFranzDerivation rec {
+let
+  arch = {
+    x86_64-linux = "amd64";
+    aarch64-linux = "arm64";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  hash = {
+    amd64-linux_hash = "sha256-Oai5z6/CE/R2rH9LBVhY7eaKpF8eIIYI+3vjJPbq+rw=";
+    arm64-linux_hash = "sha256-bRJTktwnyZgCow8oRZNhTK8FgOhIcjrbESVlYfeaa8E=";
+  }."${arch}-linux_hash";
+in mkFranzDerivation rec {
   pname = "ferdium";
   name = "Ferdium";
   version = "6.4.1";
   src = fetchurl {
-    url = "https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-amd64.deb";
-    hash = "sha256-Oai5z6/CE/R2rH9LBVhY7eaKpF8eIIYI+3vjJPbq+rw=";
+    url = "https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-${arch}.deb";
+    inherit hash;
   };
 
   extraBuildInputs = [ xorg.libxshmfence ];
@@ -22,7 +31,7 @@ mkFranzDerivation rec {
     homepage = "https://ferdium.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [ magnouvean ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     hydraPlatforms = [ ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/ferdium/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdium/default.nix
@@ -21,9 +21,7 @@ in mkFranzDerivation rec {
   extraBuildInputs = [ xorg.libxshmfence ];
 
   passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [ "--override-filename" ./default.nix ];
-    };
+    updateScript = ./update.sh;
   };
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/ferdium/update.sh
+++ b/pkgs/applications/networking/instant-messengers/ferdium/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
+
+set -e
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    arch=$2
+
+    hashKey="${arch}-linux_hash"
+
+    url="https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-linux-$version-$arch.deb"
+    hash=$(nix-prefetch-url --type sha256 $url)
+    sriHash="$(nix hash to-sri --type sha256 $hash)"
+
+    sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd $dirname && nix eval --raw -f ../../../../.. ferdium.version)
+
+latestTag=$(curl https://api.github.com/repos/ferdium/ferdium-app/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr $latestTag : 'v\(.*\)')"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Ferdium is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion $latestVersion
+
+updateHash $latestVersion amd64
+updateHash $latestVersion arm64


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds support for `aarch64-linux` for Ferdium. Based on the code used for [lidarr](https://github.com/NixOS/nixpkgs/blob/69926af81f20e4d4f71d16f18a1802776fc734e3/pkgs/servers/lidarr/default.nix#L7).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
