### PR TITLE
qmk_hid: 0.1.5 -> 0.1.11

### DIFF
--- a/pkgs/tools/misc/qmk_hid/default.nix
+++ b/pkgs/tools/misc/qmk_hid/default.nix
@@ -7,22 +7,28 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "qmk_hid";
-  version = "0.1.5";
+  version = "0.1.11";
 
   src = fetchFromGitHub {
     owner = "FrameworkComputer";
     repo = "qmk_hid";
     rev = "v${version}";
-    hash = "sha256-k5D+Ph4DtdTafdNhclK3t4SmHmktuOKRlMMGMmKp48E=";
+    hash = "sha256-k5cZcrjen7nNJM9mKQEwNTVfBPawXwbwNlCyTARdH/g=";
   };
 
-  cargoHash = "sha256-+frWup9sbxCAxl2oiHAn1ccpuGkfa3kjerUByd65oSI=";
+  cargoHash = "sha256-GrerrNDoSFtOEAf0vB9MlkBl+yLnzd/szrpFsAmkB6s=";
 
   nativeBuildInputs = [
     pkg-config
   ];
+
   buildInputs = [
     systemd
+  ];
+
+  checkFlags = [
+    # test doesn't compile
+    "--skip=src/lib.rs"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/FrameworkComputer/qmk_hid/compare/v0.1.5...v0.1.11

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
