### PR TITLE
Revert "nixos/syncthing: match stale ids by subtracting in jq"

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -100,13 +100,13 @@ let
       the Nix configured list of IDs
       */
       + lib.optionalString s.override ''
-        stale_${conf_type}_ids="$(curl -X GET ${s.baseAddress} | ${jq} \
-          --argjson new_ids ${lib.escapeShellArg (builtins.toJSON s.new_conf_IDs)} \
-          --raw-output \
-          '[.[].${s.GET_IdAttrName}] - $new_ids | .[]'
-        )"
-        for id in ''${stale_${conf_type}_ids}; do
-          curl -X DELETE ${s.baseAddress}/$id
+        old_conf_${conf_type}_ids="$(curl -X GET ${s.baseAddress} | ${jq} --raw-output '.[].${s.GET_IdAttrName}')"
+        for id in ''${old_conf_${conf_type}_ids}; do
+          if echo ${lib.concatStringsSep " " s.new_conf_IDs} | grep -q $id; then
+            continue
+          else
+            curl -X DELETE ${s.baseAddress}/$id
+          fi
         done
       ''
     ))

--- a/nixos/tests/syncthing-init.nix
+++ b/nixos/tests/syncthing-init.nix
@@ -1,6 +1,7 @@
 import ./make-test-python.nix ({ lib, pkgs, ... }: let
 
   testId = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
+  testName = "testDevice foo'bar";
 
 in {
   name = "syncthing-init";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#259259 We need to write tests for that issue... Closes #260262 . Reopens https://github.com/NixOS/nixpkgs/issues/259256 .