### PR TITLE
rio: update version and hashes

### DIFF
--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -43,16 +43,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "rio";
-  version = "0.0.19";
+  version = "0.0.22";
 
   src = fetchFromGitHub {
     owner = "raphamorim";
     repo = "rio";
     rev = "v${version}";
-    hash = "sha256-N7eHIyp2imkMUVwiOCameOROoaDJ7g+zNKdIB2aGZy0=";
+    hash = "sha256-q6UNtN1kt/Bmpy2EDvWyVaZccjqlGw9nGWDvVz82HO4=";
   };
 
-  cargoHash = "sha256-XD+/DaaJEJ9jHZITTUma/wfsbduPUTc/SralPOx46Yo=";
+  cargoHash = "sha256-UhDKOxLF1yVr64vTvwb/m+xoIgWEtO8aSX6A3fqW/2c=";
 
   nativeBuildInputs = [
     autoPatchelfHook


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/raphamorim/rio/releases/tag/v0.0.22

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

# Other Information
Hi! It's the first time, that I'm contributing to `nixpkgs`. So, currently I just bumped the version and updated the package-hashes. However, I'm getting the following error message, if I'm trying to run its tests with `nix-build --attr pkgs.rio.passthru.tests`:

<details>

```
error: package `copa v0.0.22 (/build/source/copa)` cannot be built because it requires rustc 1.72.1 or newer, while the currently active rustc version is 1.72.0

error: builder for '/nix/store/rvgpqzkpblpi340rwnw9sc5f023bwmsw-rio-0.0.22.drv' failed with exit code 101;
       last 10 log lines:
       > Executing cargoSetupPostPatchHook
       > Validating consistency between /build/source/Cargo.lock and /build/rio-0.0.22-vendor.tar.gz/Cargo.lock
       > Finished cargoSetupPostPatchHook
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > building
       > Executing cargoBuildHook
       > ++ env CC_x86_64-unknown-linux-gnu=/nix/store/18bs92p6yf6w2wwxhbplgx02y6anq092-gcc-wrapper-12.3.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/18bs92p6yf6w2wwxhbplgx02y6anq092-gcc-wrapper-12.3.0/bin/c++ CC_x86_64-unknown-linux-gnu=/nix/store/18bs92p6yf6w2wwxhbplgx02y6anq092-gcc-wrapper-12.3.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/18bs92p6yf6w2wwxhbplgx02y6anq092-gcc-wrapper-12.3.0/bin/c++ cargo build -j 16 --target x86_64-unknown-linux-gnu --frozen --release --no-default-features --features=x11,wayland
       > error: package `copa v0.0.22 (/build/source/copa)` cannot be built because it requires rustc 1.72.1 or newer, while the currently active rustc version is 1.72.0
       >
       For full logs, run 'nix log /nix/store/rvgpqzkpblpi340rwnw9sc5f023bwmsw-rio-0.0.22.drv'.
error: 1 dependencies of derivation '/nix/store/5mmzj3bfazbhy1x02m5bmm7wylmjcw5v-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ic27ahkkk1mziabp7csn017ap5zaydvn-nixos-system-machine-23.11pre-git.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jn9gj8xd5944fsws2lwdrcmg809ckg6b-nixos-vm.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8ck01l334jahf5fpz265r80kr1d2fmb6-nixos-test-driver-terminal-emulator-rio.drv' failed to build
error: 1 dependencies of derivation '/nix/store/65ahyi3r3gy2492204bsf0ck6za1faxh-vm-test-run-terminal-emulator-rio.drv' failed to build
```

</details>

May I ask how I can fix this issue?