### PR TITLE
k0sctl: 0.15.5 -> 0.16.0

### DIFF
--- a/pkgs/applications/networking/cluster/k0sctl/default.nix
+++ b/pkgs/applications/networking/cluster/k0sctl/default.nix
@@ -1,31 +1,34 @@
 { lib
-, buildGoModule
+, buildGo121Module
 , fetchFromGitHub
 , installShellFiles
 }:
 
-buildGoModule rec {
+buildGo121Module rec {
   pname = "k0sctl";
-  version = "0.15.5";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "k0sproject";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ntjrk2OEIkAmNpf9Ag6HkSIOSA3NtO9hSJOBgvne4b0=";
+    hash = "sha256-DUDvsF4NCFimpW9isqEhodieiJXwjhwhfXR2t/ho3kE=";
   };
 
-  vendorHash = "sha256-JlaXQqDO/b1xe9NA2JtuB1DZZlphWu3Mo/Mf4lhmKNo=";
+  vendorHash = "sha256-eJTVUSAcgE1AaOCEEc202sC0yIfMj30UoK/ObowJ9Zk=";
 
   ldflags = [
     "-s"
     "-w"
     "-X github.com/k0sproject/k0sctl/version.Environment=production"
-    "-X github.com/carlmjohnson/versioninfo.Version=${version}"
-    "-X github.com/carlmjohnson/versioninfo.Revision=${version}"
+    "-X github.com/carlmjohnson/versioninfo.Version=v${version}" # Doesn't work currently: https://github.com/carlmjohnson/versioninfo/discussions/12
+    "-X github.com/carlmjohnson/versioninfo.Revision=v${version}"
   ];
 
   nativeBuildInputs = [ installShellFiles ];
+
+  # https://github.com/k0sproject/k0sctl/issues/569
+  checkFlags = [ "-skip=^Test(Unmarshal|VersionDefaulting)/version_not_given$" ];
 
   postInstall = ''
     for shell in bash zsh fish; do
@@ -38,6 +41,7 @@ buildGoModule rec {
     description = "A bootstrapping and management tool for k0s clusters.";
     homepage = "https://k0sproject.io/";
     license = licenses.asl20;
+    mainProgram = pname;
     maintainers = with maintainers; [ nickcao qjoly ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/k0sproject/k0sctl/releases/tag/v0.16.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A k0sctl
/nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0

$ find /nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0 -type f
/nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0/bin/k0sctl
/nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0/share/bash-completion/completions/k0sctl.bash
/nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0/share/zsh/site-functions/_k0sctl
/nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0/share/fish/vendor_completions.d/k0sctl.fish

$ /nix/store/fkpl4ccy599jkfi14aq8f1ps3ag1fns4-k0sctl-0.16.0/bin/k0sctl version
version: (devel)
commit: v0.16.0
```