### PR TITLE
python311Packages.zope-contenttype: 4.6 -> 5.1; rename from zope_contenttype

### DIFF
--- a/pkgs/development/python-modules/zope-contenttype/default.nix
+++ b/pkgs/development/python-modules/zope-contenttype/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , setuptools
 , zope_testrunner
 , pytestCheckHook
@@ -8,13 +9,15 @@
 
 buildPythonPackage rec {
   pname = "zope-contenttype";
-  version = "4.6";
+  version = "5.1";
   pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "zope.contenttype";
     inherit version;
-    hash = "sha256-NnVoeLxSWzY2TQ1b2ZovCw/TuaUND+m73Eqxs4rCOAA=";
+    hash = "sha256-AAHvG2XKZQUZBW3OUwxY0LOWlXzPBQIyPIoVSdtk0xc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/zope-contenttype/default.nix
+++ b/pkgs/development/python-modules/zope-contenttype/default.nix
@@ -1,12 +1,15 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , zope_testrunner
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-contenttype";
   version = "4.6";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "zope.contenttype";
@@ -14,12 +17,24 @@ buildPythonPackage rec {
     hash = "sha256-NnVoeLxSWzY2TQ1b2ZovCw/TuaUND+m73Eqxs4rCOAA=";
   };
 
-  nativeCheckInputs = [ zope_testrunner ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    zope_testrunner
+  ];
+
+  pythonImportsCheck = [
+    "zope.contenttype"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/zopefoundation/zope.contenttype";
     description = "A utility module for content-type (MIME type) handling";
-    license = licenses.zpl20;
+    changelog = "https://github.com/zopefoundation/zope.contenttype/blob/${version}/CHANGES.rst";
+    license = licenses.zpl21;
     maintainers = with maintainers; [ goibhniu ];
   };
 }

--- a/pkgs/development/python-modules/zope-contenttype/default.nix
+++ b/pkgs/development/python-modules/zope-contenttype/default.nix
@@ -5,11 +5,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zope.contenttype";
+  pname = "zope-contenttype";
   version = "4.6";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "zope.contenttype";
+    inherit version;
     hash = "sha256-NnVoeLxSWzY2TQ1b2ZovCw/TuaUND+m73Eqxs4rCOAA=";
   };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -419,6 +419,7 @@ mapAliases ({
   zc_buildout_nix = throw "zc_buildout_nix was pinned to a version no longer compatible with other modules";
   zope_broken = throw "zope_broken has been removed because it is obsolete and not needed in zodb>=3.10"; # added 2023-07-26
   zope_component = zope-component; # added 2023-07-28
+  zope_contenttype = zope-contenttype; # added 2023-10-11
   zope_deprecation = zope-deprecation; # added 2023-10-07
   zope_i18nmessageid = zope-i18nmessageid; # added 2023-07-29
   zope_proxy = zope-proxy; # added 2023-10-07

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15896,7 +15896,7 @@ self: super: with self; {
 
   zope_configuration = callPackage ../development/python-modules/zope_configuration { };
 
-  zope_contenttype = callPackage ../development/python-modules/zope_contenttype { };
+  zope-contenttype = callPackage ../development/python-modules/zope-contenttype { };
 
   zope_copy = callPackage ../development/python-modules/zope_copy { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/zopefoundation/zope.contenttype/blob/5.1/CHANGES.rst

part of #245383 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
