### PR TITLE
sfwbar: 1.0_beta11 -> 1.0_beta13

### DIFF
--- a/pkgs/applications/misc/sfwbar/default.nix
+++ b/pkgs/applications/misc/sfwbar/default.nix
@@ -10,17 +10,19 @@
 , libpulseaudio
 , libmpdclient
 , libxkbcommon
+, alsa-lib
+, makeWrapper
 ,
 }:
 stdenv.mkDerivation rec {
   pname = "sfwbar";
-  version = "1.0_beta11";
+  version = "1.0_beta13";
 
   src = fetchFromGitHub {
     owner = "LBCrion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "PmpiO5gvurpaFpoq8bQdZ53FYSVDnyjN8MxDpelMnAU=";
+    hash = "sha256-7oiuTEqdXDReKdakJX6+HRaSi1XovM+MkHFkaFZtq64=";
   };
 
   buildInputs = [
@@ -30,13 +32,20 @@ stdenv.mkDerivation rec {
     libpulseaudio
     libmpdclient
     libxkbcommon
+    alsa-lib
   ];
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    makeWrapper
   ];
+
+  postFixup = ''
+    wrapProgram $out/bin/sfwbar \
+      --suffix XDG_DATA_DIRS : $out/share
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/LBCrion/sfwbar";


### PR DESCRIPTION
## Description of changes

- SFWBar now respects `$XDG_DATA_DIRS` and `$XDG_CONFIG_DIRS` which makes it significantly more usable on NixOS.
- New modules:
    - ALSA
    - Bluez
- New expressions and actions
- Now supports mirroring across multiple monitors
- Bugfixes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).