### PR TITLE
python311Packages.zope-lifecycleevent: 4.4 -> 5.0; rename from zope_lifecycleevent

### DIFF
--- a/pkgs/development/python-modules/zope-lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope-lifecycleevent/default.nix
@@ -2,13 +2,15 @@
 , buildPythonPackage
 , fetchPypi
 , isPy3k
+, setuptools
 , zope_event
-, zope-component
+, zope_interface
 }:
 
 buildPythonPackage rec {
   pname = "zope-lifecycleevent";
   version = "4.4";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "zope.lifecycleevent";
@@ -16,7 +18,11 @@ buildPythonPackage rec {
     hash = "sha256-9ahU6J/5fe6ke/vqN4u77yeJ0uDMkKHB2lfZChzmfLU=";
   };
 
-  propagatedBuildInputs = [ zope_event zope-component ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [ zope_event zope_interface ];
 
   # namespace colides with local directory
   doCheck = false;
@@ -30,8 +36,8 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/zopefoundation/zope.lifecycleevent";
     description = "Object life-cycle events";
-    license = licenses.zpl20;
+    changelog = "https://github.com/zopefoundation/zope.lifecycleevent/blob/${version}/CHANGES.rst";
+    license = licenses.zpl21;
     maintainers = with maintainers; [ goibhniu ];
   };
-
 }

--- a/pkgs/development/python-modules/zope-lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope-lifecycleevent/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy3k
+, pythonOlder
 , setuptools
 , zope_event
 , zope_interface
@@ -9,13 +9,15 @@
 
 buildPythonPackage rec {
   pname = "zope-lifecycleevent";
-  version = "4.4";
+  version = "5.0";
   pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "zope.lifecycleevent";
     inherit version;
-    hash = "sha256-9ahU6J/5fe6ke/vqN4u77yeJ0uDMkKHB2lfZChzmfLU=";
+    hash = "sha256-6tP7SW52FPm1adFtrUt4BSsKwhh1utjWbKNQNS2bb50=";
   };
 
   nativeBuildInputs = [
@@ -27,8 +29,7 @@ buildPythonPackage rec {
   # namespace colides with local directory
   doCheck = false;
 
-  # zope uses pep 420 namespaces for python3, doesn't work with nix + python2
-  pythonImportsCheck = lib.optionals isPy3k [
+  pythonImportsCheck = [
     "zope.lifecycleevent"
     "zope.interface"
   ];

--- a/pkgs/development/python-modules/zope-lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope-lifecycleevent/default.nix
@@ -7,11 +7,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zope.lifecycleevent";
+  pname = "zope-lifecycleevent";
   version = "4.4";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "zope.lifecycleevent";
+    inherit version;
     hash = "sha256-9ahU6J/5fe6ke/vqN4u77yeJ0uDMkKHB2lfZChzmfLU=";
   };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -421,5 +421,6 @@ mapAliases ({
   zope_component = zope-component; # added 2023-07-28
   zope_deprecation = zope-deprecation; # added 2023-10-07
   zope_i18nmessageid = zope-i18nmessageid; # added 2023-07-29
+  zope_lifecycleevent = zope-lifecycleevent; # added 2023-10-11
   zope_proxy = zope-proxy; # added 2023-10-07
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15918,7 +15918,7 @@ self: super: with self; {
 
   zope_interface = callPackage ../development/python-modules/zope_interface { };
 
-  zope_lifecycleevent = callPackage ../development/python-modules/zope_lifecycleevent { };
+  zope-lifecycleevent = callPackage ../development/python-modules/zope-lifecycleevent { };
 
   zope_location = callPackage ../development/python-modules/zope_location { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/zopefoundation/zope.lifecycleevent/blob/5.0/CHANGES.rst

part of #245383 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
