### PR TITLE
incus: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7442,6 +7442,12 @@
     githubId = 993484;
     name = "Greg Hale";
   };
+  imbearchild = {
+    name = "Nianqing Yao";
+    email = "imbearchild@outlook.com";
+    github = "Nianqing Yao";
+    githubId = 29907700;
+  };
   imgabe = {
     email = "gabrielpmonte@hotmail.com";
     github = "ImGabe";

--- a/pkgs/by-name/co/cowsql/package.nix
+++ b/pkgs/by-name/co/cowsql/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  file,
+  libuv,
+  raft-canonical,
+  sqlite,
+}:
+stdenv.mkDerivation rec {
+  pname = "cowsql";
+  version = "unstable-2023-09-21";
+
+  src = fetchFromGitHub {
+    owner = "cowsql";
+    repo = "cowsql";
+    rev = "a1d49d0d3e40b32ba655fffe14b7669c2aa1bcec";
+    hash = "sha256-+za3pIcV4BhoImKvJlKatCK372wL4OyPbApQvGxGGGk=";
+  };
+
+  nativeBuildInputs = [autoreconfHook file pkg-config];
+  buildInputs = [
+    libuv
+    raft-canonical.dev
+    sqlite
+  ];
+
+  enableParallelBuilding = true;
+
+  # tests fail
+  doCheck = false;
+
+  outputs = ["dev" "out"];
+
+  meta = with lib; {
+    description = ''
+      Expose a SQLite database over the network and replicate it across a
+      cluster of peers
+    '';
+    homepage = "https://github.com/cowsql/cowsql";
+    license = licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ imbearchild ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  hwdata,
+  pkg-config,
+  lxc,
+  buildGoModule,
+  fetchurl,
+  acl,
+  libcap,
+  cowsql,
+  raft-canonical,
+  sqlite,
+  udev,
+  installShellFiles,
+  nixosTests,
+  gitUpdater,
+  callPackage,
+}:
+buildGoModule rec {
+  pname = "incus";
+  version = "0.1";
+
+  src = fetchurl {
+    url = "https://github.com/lxc/incus/releases/download/incus-${version}/incus-${version}.tar.gz";
+    hash = "sha256-dxtvQ442n3Keqqbf2TjxTcyN4J28naI8fIDG0U8CZTs=";
+  };
+
+  vendorHash = null;
+
+  postPatch = ''
+    substituteInPlace internal/usbid/load.go \
+      --replace "/usr/share/misc/usb.ids" "${hwdata}/share/hwdata/usb.ids"
+  '';
+
+  excludedPackages = ["test" "incus/internal/server/db/generate" "incus-agent" "incus-migrate" "cmd/lxd-to-incus"];
+
+  nativeBuildInputs = [installShellFiles pkg-config];
+  buildInputs = [
+    lxc
+    acl
+    libcap
+    cowsql.dev
+    raft-canonical.dev
+    sqlite
+    udev.dev
+  ];
+
+  ldflags = ["-s" "-w"];
+  tags = ["libsqlite3"];
+
+  # required for go-dqlite. See: https://github.com/canonical/lxd/pull/8939
+  preBuild = ''
+    export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+  '';
+
+  # build static binaries: https://github.com/canonical/lxd/blob/6fd175c45e65cd475d198db69d6528e489733e19/Makefile#L43-L51
+  postBuild = ''
+    make incus-agent incus-migrate
+  '';
+
+  preCheck = let
+    skippedTests = [
+      "TestValidateConfig"
+      "TestConvertNetworkConfig"
+      "TestConvertStorageConfig"
+      "TestSnapshotCommon"
+      "TestContainerTestSuite"
+    ];
+  # Disable tests requiring local operations
+  in ''
+    buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
+  '';
+
+  postInstall = ''
+    installShellCompletion --bash --name incus ./scripts/bash/incus
+  '';
+
+  meta = with lib; {
+    description = "A modern, secure and powerful system container and virtual machine manager.";
+    homepage = "https://linuxcontainers.org/incus/introduction/";
+    changelog = "https://github.com/lxc/incus/releases/tag/incus-${version}";
+    license = licenses.asl20;
+    maintainers = with lib.maintainers; [ imbearchild ];
+    mainProgram = "incus";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -42119,4 +42119,6 @@ with pkgs;
   ssl-proxy = callPackage ../tools/networking/ssl-proxy { };
 
   code-maat = callPackage ../development/tools/code-maat {};
+
+  cowsql = callPackage ../by-name/co/cowsql/package.nix { };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -42121,4 +42121,6 @@ with pkgs;
   code-maat = callPackage ../development/tools/code-maat {};
 
   cowsql = callPackage ../by-name/co/cowsql/package.nix { };
+
+  incus = callPackage ../by-name/in/incus/package.nix { };
 }


### PR DESCRIPTION
## Description of changes

This PR contains `incus` and `cowsql`.

[Incus](https://linuxcontainers.org/incus/introduction/) is a modern, secure and powerful system container and virtual machine manager, it’s a fork of LXD created by Aleksa Sarai, and now part of the Linux Containers project. This initial [release](https://discuss.linuxcontainers.org/t/incus-0-1-has-been-released/18036) is roughly equivalent to LXD 5.18 but with a number of breaking changes on top of the obvious rename.

[cowsql](https://github.com/cowsql/cowsql) is a C library that implements an embeddable and replicated SQL database engine with high availability and automatic failover, it's a fork of Canonical's [dqlite](https://github.com/canonical/dqlite) project, which was originally written by cowsql's author [himself](https://github.com/canonical/dqlite/commits?author=freeekanayaka) while working at Canonical. cowsql is used by incus as a replacement of dqlite.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
