### PR TITLE
open62541: 1.3.7 -> 1.3.8

### DIFF
--- a/pkgs/development/libraries/open62541/default.nix
+++ b/pkgs/development/libraries/open62541/default.nix
@@ -5,8 +5,10 @@
 , cmake
 , pkg-config
 , check
+, libxcrypt
 , subunit
 , python3Packages
+, nix-update-script
 
 , withDoc ? false
 , graphviz-nox
@@ -31,13 +33,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open62541";
-  version = "1.3.7";
+  version = "1.3.8";
 
   src = fetchFromGitHub {
     owner = "open62541";
     repo = "open62541";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XmoLmBGTMA6cejLiNU8hAVnHd35eh6lTIu9csmiR+4U=";
+    hash = "sha256-koifSynnJX9IuwX8HUT1TzHoKgJfweNGAVlqUx7nEc4=";
     fetchSubmodules = true;
   };
 
@@ -82,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [
     check
+    libxcrypt
     subunit
   ];
 
@@ -126,6 +129,8 @@ stdenv.mkDerivation (finalAttrs: {
     rm -r bin/libopen62541*
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   passthru.tests = let
     open62541Full = encBackend: open62541.override {
       withDoc = true;
@@ -151,6 +156,7 @@ stdenv.mkDerivation (finalAttrs: {
       OPC UA-based communication into existing applications.
     '';
     homepage = "https://www.open62541.org";
+    changelog = "https://github.com/open62541/open62541/releases/tag/v${finalAttrs.version}";
     license = licenses.mpl20;
     maintainers = with maintainers; [ panicgh ];
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes

https://github.com/open62541/open62541/releases/tag/v1.3.8


## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>open62541</li>
  </ul>
</details>