### PR TITLE
Bubblewrap setuid shenanigans

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -293,6 +293,7 @@
   ./security/apparmor.nix
   ./security/audit.nix
   ./security/auditd.nix
+  ./security/bubblewrap.nix
   ./security/ca.nix
   ./security/chromium-suid-sandbox.nix
   ./security/dhparams.nix

--- a/nixos/modules/security/bubblewrap.nix
+++ b/nixos/modules/security/bubblewrap.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.security.bubblewrap;
+in {
+  options.security.bubblewrap = {
+    allowSetuid = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether to set up a setuid wrapper for bubblewrap, a sandboxing solution.
+
+        This is primarily useful for running packages using `buildFHSEnv` without user remapping,
+        which allows other setuid executables to work inside the sandbox.
+      '';
+    };
+
+    package = lib.mkPackageOptionMD pkgs "bubblewrap" {};
+  };
+
+  config = lib.mkIf cfg.allowSetuid {
+    security.wrappers.bwrap = {
+      setuid = true;
+      owner = "root";
+      group = "root";
+      source = "${cfg.package}/bin/bwrap";
+    };
+  };
+}

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -116,6 +116,8 @@ let
 
   indentLines = str: lib.concatLines (map (s: "  " + s) (filter (s: s != "") (lib.splitString "\n" str)));
   bwrapCmd = { initArgs ? "" }: ''
+    export PATH="$PATH:${bubblewrap}/bin"
+
     ignored=(/nix /dev /proc /etc)
     ro_mounts=()
     symlinks=()
@@ -179,8 +181,10 @@ let
       x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
     fi
 
+    # We pick up bwrap from PATH, with the nixpkgs one as a fallback,
+    # in case a setuid version is available ambiently
     cmd=(
-      ${bubblewrap}/bin/bwrap
+      bwrap
       --dev-bind /dev /dev
       --proc /proc
       --chdir "$(pwd)"


### PR DESCRIPTION
## Description of changes

This is mostly a proof-of-concept, semantics are subject to bikeshed, but this allows sudo and such to work in fhsenvs, _if_ the corresponding option is set. I'm mostly interested in this for Jovian, which has Steam running a bunch of stuff via pkexec internally.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
