### PR TITLE
haskell.compiler.ghc*Binary: fix globbing

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -212,6 +212,7 @@ stdenv.mkDerivation rec {
       (let buildExeGlob = ''ghc-${version}*/"${binDistUsed.exePathForLibraryCheck}"''; in
         lib.concatStringsSep "\n" [
           (''
+            shopt -u nullglob
             echo "Checking that ghc binary exists in bindist at ${buildExeGlob}"
             if ! test -e ${buildExeGlob}; then
               echo >&2 "GHC binary ${binDistUsed.exePathForLibraryCheck} could not be found in the bindist build directory (at ${buildExeGlob}) for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -210,6 +210,7 @@ stdenv.mkDerivation rec {
       (let buildExeGlob = ''ghc-${version}*/"${binDistUsed.exePathForLibraryCheck}"''; in
         lib.concatStringsSep "\n" [
           (''
+            shopt -u nullglob
             echo "Checking that ghc binary exists in bindist at ${buildExeGlob}"
             if ! test -e ${buildExeGlob}; then
               echo >&2 "GHC binary ${binDistUsed.exePathForLibraryCheck} could not be found in the bindist build directory (at ${buildExeGlob}) for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -196,6 +196,7 @@ stdenv.mkDerivation rec {
       (let buildExeGlob = ''ghc-${version}*/"${binDistUsed.exePathForLibraryCheck}"''; in
         lib.concatStringsSep "\n" [
           (''
+            shopt -u nullglob
             echo "Checking that ghc binary exists in bindist at ${buildExeGlob}"
             if ! test -e ${buildExeGlob}; then
               echo >&2 "GHC binary ${binDistUsed.exePathForLibraryCheck} could not be found in the bindist build directory (at ${buildExeGlob}) for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
@@ -368,7 +369,9 @@ stdenv.mkDerivation rec {
   # Recache package db which needs to happen for Hadrian bindists
   # where we modify the package db before installing
   + ''
-    "$out/bin/ghc-pkg" --package-db="$out/lib/"ghc-*/package.conf.d recache
+    shopt -s nullglob
+    package_db=("$out"/lib/ghc-*/lib/package.conf.d "$out"/lib/ghc-*/package.conf.d)
+    "$out/bin/ghc-pkg" --package-db="$package_db" recache
   '';
 
   # In nixpkgs, musl based builds currently enable `pie` hardening by default


### PR DESCRIPTION
Fix the `--package-db="$out/lib/"ghc-*/package.conf.d` glob (this does not do what you think!).

Disable `nullglob` as it seems incompatible with the way globs are used throughout those files, and caused some errors to be silently ignored.