### PR TITLE
flatpak: Fix fix-test-paths.patch

### DIFF
--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -180,14 +180,16 @@ index d9fc8251..d8ddb96e 100755
 @@ -1,10 +1,10 @@
  #!/bin/sh
  
- if command -v gtk-update-icon-cache >/dev/null && test -d "$1/exports/share/icons/hicolor"; then
+-if command -v gtk-update-icon-cache >/dev/null && test -d "$1/exports/share/icons/hicolor"; then
 -    cp /usr/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
-+    cp @hicolorIconTheme@/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
++if test -d "$1/exports/share/icons/hicolor"; then
++    @coreutils@/bin/cp -f @hicolorIconTheme@/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
      for dir in "$1"/exports/share/icons/*; do
          if test -f "$dir/index.theme"; then
 -            if ! gtk-update-icon-cache --quiet "$dir"; then
+-                echo "Failed to run gtk-update-icon-cache for $dir"
 +            if ! @gtk3@/bin/gtk-update-icon-cache --quiet "$dir"; then
-                 echo "Failed to run gtk-update-icon-cache for $dir"
++                @coreutils@/bin/echo "Failed to run gtk-update-icon-cache for $dir"
                  exit 1
              fi
 diff --git a/triggers/mime-database.trigger b/triggers/mime-database.trigger


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add substitutions to `fix-test-paths.patch`, fixing execution of `gtk-icon-cache.trigger`. This fixes missing icons after newly installing flatpak applications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Added substitution for `coreutils` in `fix-test-paths.patch`.

Remove check for `gtk-update-icon-cache`, as the path is hardcoded

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
