### PR TITLE
python311Packages.modelcif: init at 0.9; python311Packages.ihm: init at 0.41

### DIFF
--- a/pkgs/development/python-modules/ihm/default.nix
+++ b/pkgs/development/python-modules/ihm/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, swig
+, wheel
+, msgpack
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ihm";
+  version = "0.41";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ihmwg";
+    repo = "python-ihm";
+    rev = "refs/tags/${version}";
+    hash = "sha256-weeOizVWFcOxD45QsvEaoknTofZjglCvidyvXpyRKwc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    swig
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    msgpack
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # requires network access
+    "test_validator_example"
+  ];
+
+  pythonImportsCheck = [ "ihm" ];
+
+  meta = with lib; {
+    description = "Python package for handling IHM mmCIF and BinaryCIF files";
+    homepage = "https://github.com/ihmwg/python-ihm";
+    changelog = "https://github.com/ihmwg/python-ihm/blob/${src.rev}/ChangeLog.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/modelcif/default.nix
+++ b/pkgs/development/python-modules/modelcif/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, ihm
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "modelcif";
+  version = "0.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ihmwg";
+    repo = "python-modelcif";
+    rev = "refs/tags/${version}";
+    hash = "sha256-u+e2QtG6gO1e31OzPfAuzfCkwZymEZMxa2p0haYplAk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    ihm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # require network access
+    "test_validate_mmcif_example"
+    "test_validate_modbase_example"
+  ];
+
+  pythonImportsCheck = [ "modelcif" ];
+
+  meta = with lib; {
+    description = "Python package for handling ModelCIF mmCIF and BinaryCIF files";
+    homepage = "https://github.com/ihmwg/python-modelcif";
+    changelog = "https://github.com/ihmwg/python-modelcif/blob/${src.rev}/ChangeLog.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5210,6 +5210,8 @@ self: super: with self; {
     inherit (pkgs) igraph;
   };
 
+  ihm = callPackage ../development/python-modules/ihm { };
+
   iisignature = callPackage ../development/python-modules/iisignature { };
 
   ijson = callPackage ../development/python-modules/ijson { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6892,6 +6892,8 @@ self: super: with self; {
 
   model-bakery = callPackage ../development/python-modules/model-bakery { };
 
+  modelcif = callPackage ../development/python-modules/modelcif { };
+
   modeled = callPackage ../development/python-modules/modeled { };
 
   moderngl = callPackage ../development/python-modules/moderngl { };


### PR DESCRIPTION
## Description of changes

- add python311Packages.modelcif
Python package for handling ModelCIF mmCIF and BinaryCIF files
https://github.com/ihmwg/python-modelcif

- add python311Packages.ihm as a dependency
Python package for handling IHM mmCIF and BinaryCIF files
https://github.com/ihmwg/python-ihm

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
