### PR TITLE
tinygo: clean up Clang header path patch 

### DIFF
--- a/pkgs/development/compilers/tinygo/0002-Add-clang-header-path.patch
+++ b/pkgs/development/compilers/tinygo/0002-Add-clang-header-path.patch
@@ -1,46 +1,25 @@
-diff --git a/builder/builtins.go b/builder/builtins.go
-index a1066b67..f4f8ca79 100644
---- a/builder/builtins.go
-+++ b/builder/builtins.go
-@@ -179,7 +179,7 @@ var avrBuiltins = []string{
- var CompilerRT = Library{
- 	name: "compiler-rt",
- 	cflags: func(target, headerPath string) []string {
--		return []string{"-Werror", "-Wall", "-std=c11", "-nostdlibinc"}
-+		return []string{"-Werror", "-Wall", "-std=c11", "-isystem", "@clang_include@"}
- 	},
- 	sourceDir: func() string {
- 		llvmDir := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project/compiler-rt/lib/builtins")
-diff --git a/builder/picolibc.go b/builder/picolibc.go
-index 1b7c748b..8a6b9ddd 100644
---- a/builder/picolibc.go
-+++ b/builder/picolibc.go
-@@ -32,7 +32,7 @@ var Picolibc = Library{
- 			"-D__OBSOLETE_MATH_FLOAT=1", // use old math code that doesn't expect a FPU
- 			"-D__OBSOLETE_MATH_DOUBLE=0",
- 			"-D_WANT_IO_C99_FORMATS",
--			"-nostdlibinc",
-+			"-isystem", "@clang_include@",
- 			"-isystem", newlibDir + "/libc/include",
- 			"-I" + newlibDir + "/libc/tinystdio",
- 			"-I" + newlibDir + "/libm/common",
+diff --git a/builder/library.go b/builder/library.go
+index 6517355b..b8de1894 100644
+--- a/builder/library.go
++++ b/builder/library.go
+@@ -142,7 +142,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
+ 	// Note: -fdebug-prefix-map is necessary to make the output archive
+ 	// reproducible. Otherwise the temporary directory is stored in the archive
+ 	// itself, which varies each run.
+-	args := append(l.cflags(target, headerPath), "-c", "-Oz", "-gdwarf-4", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
++	args := append(l.cflags(target, headerPath), "-c", "-Oz", "-gdwarf-4", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir, "-isystem", "@clang_include@")
+ 	cpu := config.CPU()
+ 	if cpu != "" {
+ 		// X86 has deprecated the -mcpu flag, so we need to use -march instead.
 diff --git a/compileopts/config.go b/compileopts/config.go
-index 9a4bc310..424421ae 100644
+index 39fc4f2a..8711b5a8 100644
 --- a/compileopts/config.go
 +++ b/compileopts/config.go
-@@ -276,6 +276,7 @@ func (c *Config) CFlags() []string {
- 		path, _ := c.LibcPath("picolibc")
- 		cflags = append(cflags,
- 			"--sysroot="+path,
-+			"-isystem", "@clang_include@",
- 			"-isystem", filepath.Join(path, "include"), // necessary for Xtensa
- 			"-isystem", filepath.Join(picolibcDir, "include"),
- 			"-isystem", filepath.Join(picolibcDir, "tinystdio"),
-@@ -285,7 +286,6 @@ func (c *Config) CFlags() []string {
- 		path, _ := c.LibcPath("musl")
- 		arch := MuslArchitecture(c.Triple())
- 		cflags = append(cflags,
--			"-nostdlibinc",
- 			"-isystem", filepath.Join(path, "include"),
- 			"-isystem", filepath.Join(root, "lib", "musl", "arch", arch),
- 			"-isystem", filepath.Join(root, "lib", "musl", "include"),
+@@ -264,6 +264,7 @@ func (c *Config) CFlags() []string {
+ 	for _, flag := range c.Target.CFlags {
+ 		cflags = append(cflags, strings.ReplaceAll(flag, "{root}", goenv.Get("TINYGOROOT")))
+ 	}
++	cflags = append([]string{"-isystem", "@clang_include@"}, cflags...)
+ 	switch c.Target.Libc {
+ 	case "darwin-libSystem":
+ 		root := goenv.Get("TINYGOROOT")


### PR DESCRIPTION
## Description of changes

There is a cleaner way to add the needed Clang headers, which I've implemented with this change.
As a side effect, cross compiling to Darwin becomes possible.

~WIP because this depends on https://github.com/NixOS/nixpkgs/pull/251527. Will need to be rebased once that PR is merged.~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
