### PR TITLE
pulumiPackages.pulumi-azure-native: 1.92 -> 2.11

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/pulumi-azure-native.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-azure-native.nix
@@ -4,15 +4,30 @@
 mkPulumiPackage rec {
   owner = "pulumi";
   repo = "pulumi-azure-native";
-  version = "1.92.0";
+  version = "2.11.0";
   rev = "v${version}";
-  hash = "sha256-eSHD7ckiHJJoqJFeSlwxl063QRRTtiWdpu1m9OVRhoA=";
-  vendorHash = "sha256-DI92fCe8HPwjERkBVlOebZpvCreq9850OeERDkiayz8=";
+  hash = "sha256-qz/dCQR4BV+noJj7WPGuzDNMaR7I/D01F7FfvxU8z28=";
+  vendorHash = "sha256-SICms1JJk8Q10XWC69bw/RXsIPL43l1s+Aqy+cLOwRI=";
   cmdGen = "pulumi-gen-azure-native";
   cmdRes = "pulumi-resource-azure-native";
   extraLdflags = [
-    "-X github.com/pulumi/${repo}/provider/pkg/version.Version=v${version}"
+    "-X github.com/pulumi/${repo}/v2/provider/pkg/version.Version=${version}"
   ];
+  postConfigure = ''
+    pushd ..
+
+    chmod +w . provider/cmd/${cmdRes} sdk/
+    chmod -R +w reports/ versions/
+    mkdir bin
+    ${cmdGen} schema ${version}
+
+    cp bin/schema-full.json provider/cmd/${cmdRes}
+    cp bin/metadata-compact.json provider/cmd/${cmdRes}
+
+    popd
+
+    VERSION=v${version} go generate cmd/${cmdRes}/main.go
+  '';
   fetchSubmodules = true;
   __darwinAllowLocalNetworking = true;
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

When updating a pulumi project, I hit:

```
warning: resource plugin azure-native is expected to have version >=2.11.0, but has 1.92.0; the wrong version may be on your path, or this may be a bug in the plugin
```
Thus I tried to update the package, but it fails with:
```
nix build .#pulumiPackages.pulumi-azure-native
note: keeping build directory '/tmp/nix-build-pulumi-azure-native-2.11.0.drv-0'
error: builder for '/nix/store/n6ddndmkavl3jq1l0s5cicx4l2mfnjf7-pulumi-azure-native-2.11.0.drv' failed with exit code 2;
       last 13 log lines:
       > unpacking sources
       > unpacking source archive /nix/store/mhmdi50z2gy3qghzzlmjbphs9v29m9m5-source-pulumi-azure-native-v2.11.0
       > source root is source-pulumi-azure-native-v2.11.0/provider
       > patching sources
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > /build/source-pulumi-azure-native-v2.11.0 /build/source-pulumi-azure-native-v2.11.0/provider
       > panic: strconv.ParseInt: parsing "": invalid syntax
       >
       > goroutine 1 [running]:
       > main.main()
       > 	github.com/pulumi/pulumi-azure-native/v2/provider/cmd/pulumi-gen-azure-native/main.go:81 +0xfec
       > /nix/store/3pfjacvdg9f491lfqc9qb2d0nknx73fb-stdenv-linux/setup: line 144: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/n6ddndmkavl3jq1l0s5cicx4l2mfnjf7-pulumi-azure-native-2.11.0.drv'.
```
I am not comfortable with nix+go, I find it harder to work with than other
ecosystems (can't overrideAttrs for instance), not sure how to get a proper nix
shell plus I dont know go so I would appreciate if any of the maintainer @veehaitch @trundle
could take over / heavily guide me.

cheers


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
