### PR TITLE
csh: init at 20230828

### DIFF
--- a/pkgs/by-name/cs/csh/package.nix
+++ b/pkgs/by-name/cs/csh/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  libbsd,
+}: let
+  inherit (stdenvNoCC.hostPlatform) system;
+  selectSystem = attrs: attrs.${system} or (throw "Unsupported system: ${system}");
+in
+  stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "csh";
+    version = "20230828";
+
+    src = fetchurl {
+      url = selectSystem {
+        "aarch64-linux" = "http://deb.debian.org/debian/pool/main/c/csh/csh_${finalAttrs.version}-1_arm64.deb";
+        "x86_64-linux" = "http://deb.debian.org/debian/pool/main/c/csh/csh_${finalAttrs.version}-1_amd64.deb";
+      };
+      hash = selectSystem {
+        "aarch64-linux" = "sha256-Dax671mBzu+vNOSy6qXkMz3vpBA/fDrgEDZEZ35WkD0=";
+        "x86_64-linux" = "sha256-x5nxdSzjKZoIMyj0ObxKpvmvaqszsMoYRfHShcc3znM=";
+      };
+    };
+
+    unpackPhase = ''
+      runHook preUnpack
+      ar x $src
+      tar xf data.tar.xz
+      rm control.tar.xz data.tar.xz debian-binary
+      runHook postUnpack
+    '';
+
+    nativeBuildInputs = [
+      libbsd
+      autoPatchelfHook
+    ];
+
+    installPhase = ''
+      mkdir -p "$out"/bin/
+      cp bin/bsd-csh $out/bin/csh
+    '';
+
+    meta = with lib; {
+      description = "Shell with C-like syntax";
+      longDescription = ''
+        The C shell was originally written at UCB to overcome limitations in the
+        Bourne shell. Its flexibility and comfort (at that time) quickly made it
+        the shell of choice until more advanced shells like ksh, bash, zsh or tcsh
+        appeared. Most of the latter incorporate features original to csh.
+
+        This package is based on current OpenBSD sources (as mirrored through
+        debian).
+      '';
+      license = licenses.bsd3;
+      maintainers = [maintainers.cafkafk];
+      mainProgram = "csh";
+      platforms = ["aarch64-linux" "x86_64-linux"];
+    };
+
+    passthru = {
+      shellPath = "/bin/csh";
+    };
+  })


### PR DESCRIPTION
## Description of changes
Building csh from source (openbsd version), even with the presence of `bmake`
and `libbsd` is surprisingly hard. This just packages the binaries from debian.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
