### PR TITLE
llvmPackages.llvm: propagate deps to nativeCC in cross build

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -270,6 +270,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -288,6 +288,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -276,6 +276,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -238,6 +238,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/15/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/15/llvm/default.nix
@@ -373,6 +373,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postInstall = ''
     mkdir -p $python/share
     mv $out/share/opt-viewer $python/share/opt-viewer

--- a/pkgs/development/compilers/llvm/16/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/16/llvm/default.nix
@@ -361,6 +361,26 @@ in
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postInstall = ''
     mkdir -p $python/share
     mv $out/share/opt-viewer $python/share/opt-viewer

--- a/pkgs/development/compilers/llvm/5/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/5/llvm/default.nix
@@ -209,6 +209,26 @@ stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/6/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/6/llvm/default.nix
@@ -228,6 +228,26 @@ stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/7/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/7/llvm/default.nix
@@ -246,6 +246,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/8/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/8/llvm/default.nix
@@ -244,6 +244,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -259,6 +259,26 @@ in stdenv.mkDerivation (rec {
     )
   ];
 
+  # Make sure dependencies are propagated to the native compiler when cross-compiling LLVM.
+  env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) (
+    let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      deps = lib.concatMap (x: x.all) nativeCC.depsTargetTargetPropagated;
+      devs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "dev"))
+        (map (x: "-isystem ${x}/include"))
+      ];
+      libs = lib.pipe deps [
+        (lib.filter (x: x.outputName == "lib" || x.outputName == "out"))
+        (map (x: "-L${x}/lib"))
+      ];
+    in
+    {
+      "NIX_CFLAGS_COMPILE_${nativeCC.suffixSalt}" = lib.concatStringsSep " " devs;
+      "NIX_LDFLAGS_${nativeCC.suffixSalt}" = lib.concatStringsSep " " libs;
+    }
+  );
+
   postBuild = ''
     rm -fR $out
   '';


### PR DESCRIPTION
## Description of changes

Cross-compiling LLVM fails on Darwin because it cannot link libc++abi. This is because the native compiler’s dependencies are not propagated as expected. This PR propagates them manually for nativeCC when cross-compiling.

Note that x86_64-darwin to aarch64-darwin cross can be tested on master, but aarch64-darwin to x86_64-darwin cross requires #256590.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
