### PR TITLE
pico-sdk: Make full SDK available

### DIFF
--- a/pkgs/development/libraries/pico-sdk/default.nix
+++ b/pkgs/development/libraries/pico-sdk/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, cmake
+, minimal ? false, }:
 
 stdenv.mkDerivation rec {
   pname = "pico-sdk";
@@ -8,7 +9,11 @@ stdenv.mkDerivation rec {
     owner = "raspberrypi";
     repo = pname;
     rev = version;
-    sha256 = "sha256-JNcxd86XNNiPkvipVFR3X255boMmq+YcuJXUP4JwInU=";
+    fetchSubmodules = !minimal;
+    sha256 = if minimal then
+      "sha256-JNcxd86XNNiPkvipVFR3X255boMmq+YcuJXUP4JwInU="
+    else
+      "sha256-GY5jjJzaENL3ftuU5KpEZAmEZgyFRtLwGVg3W1e/4Ho=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -31,5 +36,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ muscaln ];
     platforms = platforms.unix;
+    # Only minimal on hydra: non-minimal is too big.
+    hydraPlatforms = optionals minimal platforms.unix;
   };
 }

--- a/pkgs/development/tools/picotool/default.nix
+++ b/pkgs/development/tools/picotool/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libusb1, pico-sdk }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libusb1, pico-sdk-minimal }:
 
 stdenv.mkDerivation rec {
   pname = "picotool";
@@ -11,9 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-OcQJeiva6X2rUyh1rJ+w4O2dWxaR7MwMfbHlnWuBVb8=";
   };
 
-  buildInputs = [ libusb1 pico-sdk ];
+  buildInputs = [ libusb1 pico-sdk-minimal ];
   nativeBuildInputs = [ cmake pkg-config ];
-  cmakeFlags = [ "-DPICO_SDK_PATH=${pico-sdk}/lib/pico-sdk" ];
+  cmakeFlags = [ "-DPICO_SDK_PATH=${pico-sdk-minimal}/lib/pico-sdk" ];
 
   meta = with lib; {
     homepage = "https://github.com/raspberrypi/picotool";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24689,6 +24689,7 @@ with pkgs;
     physfs;
 
   pico-sdk = callPackage ../development/libraries/pico-sdk { };
+  pico-sdk-minimal = pico-sdk.override { minimal = true; };
 
   pinocchio = callPackage ../development/libraries/pinocchio { };
 


### PR DESCRIPTION
## Description of changes

Fixes #175297

[The instructions for the use of this SDK](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf) (pages 6 and 7) specify that submodules are required for its full/normal use:

> ```
> $ git clone https://github.com/raspberrypi/pico-sdk.git --branch master
> $ cd pico-sdk
> $ git submodule update --init
> ...
> ```
>  WARNING
> Failure to run the `git submodule update --init` command above will mean that the `tinyusb` module will not be included,
and as a result USB functionality will not be compiled into the SDK. This means that USB serial, other USB functions,
and example code will not work

The [Pico W guide](https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.pdf) (pages 5 and 31) has a similar message:

> ```
> $ git clone https://github.com/raspberrypi/pico-sdk.git --branch master
> $ cd pico-sdk
> $ git submodule update --init
> ...
> ```
>  WARNING
> If you have not initialised the `tinyusb` submodule in your `pico-sdk` checkout, then USB CDC serial, and other USB
functions and example code, will not work as the SDK will contain no USB functionality. Similarly, if you have not
initialised the `cyw43-driver` and `lwip` submodules in your checkout, then network-related functionality will not be
enabled.

With this change, I was able to build [a network-using executable](https://git.scottworley.com/tattlekey) & run it on a Pico W.

Without this change, attempting to build an executable that uses the board's WiFi fails with this error message:
```
...
[ 20%] Building C object CMakeFiles/tattlekey.dir/blink.c.obj
/tmp/source/blink.c:18:10: fatal error: pico/cyw43_arch.h: No such file or directory
 #include "pico/cyw43_arch.h"
          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```

---

The previous `pico-sdk` is now called `pico-sdk-minimal`.

I've excluded the full `pico-sdk` from hydra due to size concerns expressed in https://github.com/NixOS/nixpkgs/issues/175297#issuecomment-1140498424 and https://github.com/NixOS/nixpkgs/issues/175297#issuecomment-1179141091 .

I'm not including a note in the release notes about this change because this doesn't remove any existing functionality -- it only adds functionality.

FYI:

* @muscaln, `pico-sdk` maintainer
* Folks from https://github.com/NixOS/nixpkgs/issues/175297
    * @icodeforyou-dot-net, creator
    * @brodul and @danwdart, fellow travelers
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
