### PR TITLE
WIP: blivet: init at 3.8.1

### DIFF
--- a/pkgs/tools/filesystems/blivet/default.nix
+++ b/pkgs/tools/filesystems/blivet/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, fetchPypi
+, gobject-introspection
+, libblockdev
+, libbytesize
+, parted
+, python3
+}:
+
+let
+  pname = "blivet";
+  version = "3.8.1";
+in
+python3.pkgs.buildPythonApplication {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-cvgE1/lA24lzGj1eFSFR8w6GZaaZLUoMclzWZK9VNKU=";
+  };
+
+  # FIXME: unable to make tests work.
+  # ValueError: Namespace BlockDev not available
+  # Relevant Issue: https://github.com/storaged-project/blivet/issues/894
+  doCheck = false;
+
+  # checkPhase = ''
+  #   runHook preCheck
+  #   make test
+  #   runHook postCheck
+  # '';
+
+  propagatedBuildInputs = [
+    gobject-introspection
+    libblockdev
+    libbytesize
+    parted
+  ] ++ (with python3.pkgs; [
+    six
+    pyaml
+    pyparted
+    pygobject3
+  ]);
+
+  meta = with lib; {
+    description = "A python module for configuration of block devices";
+    homepage = "https://github.com/storaged-project/blivet";
+    license = with lib.licenses; [ lgpl2Plus gpl2Plus ];
+    maintainers = with maintainers; [ jfvillablanca ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3561,6 +3561,8 @@ with pkgs;
 
   blackmagic-desktop-video = callPackage ../tools/video/blackmagic-desktop-video { };
 
+  blivet = callPackage ../tools/filesystems/blivet { };
+
   blockbench-electron = callPackage ../applications/graphics/blockbench-electron { };
 
   blocksat-cli = with python3Packages; toPythonApplication blocksat-cli;


### PR DESCRIPTION
## Description of changes
Partially resolves https://github.com/NixOS/nixpkgs/issues/257955
This builds if tests are disabled.
I am unable to make the upstream tests work

```
ValueError: Namespace BlockDev not available
```

Relevant Issue: https://github.com/storaged-project/blivet/issues/894

Can someone help me with the required package here.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
