### PR TITLE
viber: 16.1.0.37 -> 21.0.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10037,6 +10037,12 @@
     githubId = 1769386;
     name = "Liam Diprose";
   };
+  liarokapisv = {
+    email = "liarokapis.v@gmail.com";
+    github = "liarokapisv";
+    githubId = 19633626;
+    name = "Alexandros Liarokapis";
+  };
   liberatys = {
     email = "liberatys@hey.com";
     name = "Nick Anthony Flueckiger";

--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -1,111 +1,28 @@
-{fetchurl, lib, stdenv, dpkg, makeWrapper,
- alsa-lib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1,
- harfbuzz, libcap, libGL, libGLU, libpulseaudio, libxkbcommon, libxml2, libxslt,
- nspr, nss, openssl_1_1, systemd, wayland, xorg, zlib, ...
-}:
+{ callPackage, buildFHSEnv }:
+let
+  unwrapped = callPackage ./unwrapped.nix { };
+in
+buildFHSEnv
+{
+  inherit (unwrapped) name meta;
 
-stdenv.mkDerivation {
-  pname = "viber";
-  version = "16.1.0.37";
+  targetPkgs = pkgs: with pkgs;
+    [
+      unwrapped
+      # needed because of hard-coded lookup to /usr/share/X11/xkb
+      xorg.xkeyboardconfig
+      # needed because of hard-coded lookup to /usr/share/fonts
+      open-fonts
+      # needed for xdg-mime - improves startup time
+      xdg-utils
+    ];
 
-  src = fetchurl {
-    # Official link: https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
-    url = "https://web.archive.org/web/20211119123858/https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "sha256-hOz+EQc2OOlLTPa2kOefPJMUyWvSvrgqgPgBKjWE3p8=";
-  };
-
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ dpkg ];
-
-  dontUnpack = true;
-
-  libPath = lib.makeLibraryPath [
-      alsa-lib
-      cups
-      curl
-      dbus
-      expat
-      fontconfig
-      freetype
-      glib
-      gst_all_1.gst-plugins-base
-      gst_all_1.gstreamer
-      harfbuzz
-      libcap
-      libGLU libGL
-      libpulseaudio
-      libxkbcommon
-      libxml2
-      libxslt
-      nspr
-      nss
-      openssl_1_1
-      stdenv.cc.cc
-      systemd
-      wayland
-      zlib
-
-      xorg.libICE
-      xorg.libSM
-      xorg.libX11
-      xorg.libxcb
-      xorg.libXcomposite
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXi
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXScrnSaver
-      xorg.libXtst
-      xorg.xcbutilimage
-      xorg.xcbutilkeysyms
-      xorg.xcbutilrenderutil
-      xorg.xcbutilwm
-  ]
-  ;
-
-  installPhase = ''
-    dpkg-deb -x $src $out
-    mkdir -p $out/bin
-
-    # Soothe nix-build "suspicions"
-    chmod -R g-w $out
-
-    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-      patchelf --set-rpath $libPath:$out/opt/viber/lib $file || true
-    done
-
-    # qt.conf is not working, so override everything using environment variables
-    wrapProgram $out/opt/viber/Viber \
-      --set QT_QPA_PLATFORM "xcb" \
-      --set QT_PLUGIN_PATH "$out/opt/viber/plugins" \
-      --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
-      --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale" \
-      --set QML2_IMPORT_PATH "$out/opt/viber/qml"
-    ln -s $out/opt/viber/Viber $out/bin/viber
-
-    mv $out/usr/share $out/share
-    rm -rf $out/usr
-
-    # Fix the desktop link
-    substituteInPlace $out/share/applications/viber.desktop \
-      --replace /opt/viber/Viber $out/opt/viber/Viber \
-      --replace /usr/share/ $out/share/
+  runScript = "/bin/Viber";
+  extraInstallCommands = ''
+    mv $out/bin/${unwrapped.name} $out/bin/Viber
+    ln -s ${unwrapped}/share $out/share
   '';
-
-  dontStrip = true;
-  dontPatchELF = true;
-
-  meta = {
-    homepage = "https://www.viber.com";
-    description = "An instant messaging and Voice over IP (VoIP) app";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ jagajaga ];
+  passthru = {
+    inherit unwrapped;
   };
-
 }

--- a/pkgs/applications/networking/instant-messengers/viber/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/unwrapped.nix
@@ -1,0 +1,152 @@
+{ lib
+, fetchurl
+, makeBinaryWrapper
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, nss
+, gst_all_1
+, stdenvNoCC
+, xorg
+, lcms
+, libwebp
+, snappy
+, gdk-pixbuf
+, libmng
+, gtk3
+, pango
+, libtiff
+, tslib
+, mtdev
+, libxslt
+, libpulseaudio
+, mesa
+, xcb-util-cursor
+, libxkbcommon
+, libglvnd
+, brotli
+, cups
+, libevent
+, fontconfig
+, freetype
+, libkrb5
+, harfbuzz
+, nspr
+, zstd
+, udev
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "viber";
+  version = "21.0.0.1";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20231030150355/https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
+    hash = "sha256-47E6emeIYyG0jid7Oqrn2CEKtb9nQhOckFtEMBevZGA=";
+  };
+
+  # Needed due to failing libudev dlopen.
+  appendRunpaths = [
+    "${udev}/lib"
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    brotli.lib
+    cups.lib
+    libevent
+    fontconfig.lib
+    freetype
+    gtk3
+    gdk-pixbuf
+    libkrb5
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    gtk3
+    harfbuzz
+    xorg.libICE
+    lcms
+    libmng
+    mtdev
+    nspr
+    nss
+    pango
+    xorg.libSM
+    snappy
+    libtiff
+    libwebp
+    xorg.xcbutilwm
+    xorg.xcbutilkeysyms
+    xorg.libxkbfile
+    xorg.libXrandr
+    libxslt
+    xorg.libXScrnSaver
+    xorg.libXtst
+    zstd
+    libxkbcommon
+    libglvnd
+    libpulseaudio
+    mesa
+    xcb-util-cursor
+    tslib
+  ];
+
+  installPhase =
+    let
+      gstreamerPluginPath = lib.makeSearchPath "lib/gstreamer-1.0/" [
+        gst_all_1.gstreamer.out
+        gst_all_1.gst-plugins-base
+        gst_all_1.gst-plugins-good
+        gst_all_1.gst-plugins-ugly
+        gst_all_1.gst-plugins-bad
+      ];
+    in
+    ''
+      dpkg-deb -x $src $out
+      mkdir -p $out/bin
+
+      # Soothe nix-build "suspicions"
+      chmod -R g-w $out
+
+      # GST_PLUGIN_SYSTEM_PATH is specified because Qt6's QGStreamerMediaPlayer calls
+      # gst_element_factory_make which in turn uses the env variable to perform the lookup.
+      # Qt6 uses the returned object without checking for NULL which will lead to a SEGFAULT.
+
+      wrapProgram $out/opt/viber/Viber \
+      --set QT_PLUGIN_PATH "$out/opt/viber/plugins" \
+      --set QML2_IMPORT_PATH "$out/opt/viber/qml" \
+      --prefix XDG_DATA_DIRS : "$out/share" \
+      --set GST_PLUGIN_SYSTEM_PATH "${gstreamerPluginPath}"
+
+      ln -s $out/opt/viber/Viber $out/bin/Viber
+
+      mv $out/usr/share $out/share
+      rm -rf $out/usr
+
+      # Fix the desktop link
+      substituteInPlace $out/share/applications/viber.desktop \
+        --replace /opt/viber/Viber Viber \
+        --replace /usr/share/ $out/share/
+    '';
+
+  preFixup = ''
+    # Ugly hack, libtiff.so.5 is not in nixpkgs. Does not seem to break anything.
+    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/viber/plugins/imageformats/libqtiff.so
+  '';
+
+  meta = {
+    homepage = "https://www.viber.com";
+    description = "An instant messaging and Voice over IP (VoIP) app";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ jagajaga liarokapisv ];
+  };
+}

--- a/pkgs/by-name/ts/tslib/package.nix
+++ b/pkgs/by-name/ts/tslib/package.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, stdenv, cmake }:
+
+stdenv.mkDerivation rec {
+
+  pname = "tslib";
+  version = "1.22";
+
+  src = fetchFromGitHub {
+    owner = "libts";
+    repo = "tslib";
+    rev = version;
+    hash = "sha256-fiEC8WakW1ApNSTqaGVQXmbiVd3rqSF2dpunUfw296Q=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    homepage = "http://www.tslib.org";
+    description = "C library for filtering touchscreen events";
+    license = lib.licenses.lgpl21;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ liarokapisv ];
+  };
+}

--- a/pkgs/by-name/ts/tslib/package.nix
+++ b/pkgs/by-name/ts/tslib/package.nix
@@ -1,7 +1,6 @@
 { lib, fetchFromGitHub, stdenv, cmake }:
 
 stdenv.mkDerivation rec {
-
   pname = "tslib";
   version = "1.22";
 
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.tslib.org";
     description = "C library for filtering touchscreen events";
     license = lib.licenses.lgpl21;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ liarokapisv ];
   };
 }


### PR DESCRIPTION
## Description of changes

[Viber](https://www.viber.com/en/) is a cross-platform VoIP instant messenger application.
The current version in nixpkgs is from a few years ago and also has OpenSSL-1.1 as a dependency which
is nearing end of life and is unsupported in the current NixOS version.

[tslib](http://www.tslib.org/) is a touch device event library that is used by some Qt6 libraries (that are required to package Viber) so
I also took the liberty to package it in the process.

fixes #193394

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
