### PR TITLE
nixos/nix-gc: add `perUser` option

### DIFF
--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -71,6 +71,17 @@ in
         '';
       };
 
+      perUser = mkOption {
+        default = false;
+        type = types.bool;
+        description = lib.mdDoc ''
+          Run the garbage collector for each user.
+          This is only useful when using `--delete-old` or `--delete-older-than`.
+
+          This option can not be used with empty `options`.
+        '';
+      };
+
     };
 
   };
@@ -84,6 +95,11 @@ in
         assertion = cfg.automatic -> config.nix.enable;
         message = ''nix.gc.automatic requires nix.enable'';
       }
+
+      {
+        assertion = cfg.perUser -> cfg.options != "";
+        message = ''nix.gc.perUser can not be used with empty nix.gc.options'';
+      }
     ];
 
     systemd.services.nix-gc = lib.mkIf config.nix.enable {
@@ -93,6 +109,19 @@ in
     };
 
     systemd.timers.nix-gc = lib.mkIf cfg.automatic {
+      timerConfig = {
+        RandomizedDelaySec = cfg.randomizedDelaySec;
+        Persistent = cfg.persistent;
+      };
+    };
+
+    systemd.user.services.nix-gc = lib.mkIf (config.nix.enable && cfg.perUser) {
+      description = "Nix Garbage Collector";
+      script = "exec ${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
+      startAt = optional cfg.automatic cfg.dates;
+    };
+
+    systemd.user.timers.nix-gc = lib.mkIf (cfg.automatic && cfg.perUser) {
       timerConfig = {
         RandomizedDelaySec = cfg.randomizedDelaySec;
         Persistent = cfg.persistent;


### PR DESCRIPTION
## Description of changes

Since nix 2.14 the handling of `nix-collect-garbage` changed as a result of
the XDG-handling.

This added option is to mitigate for this change.

This is **untested**, as I do not use `nix-collect-garbage` anymore, though after a discussion in the unofficial Discord, I decided to quickly create a PR covering this. Therefore I leave this as draft until someone confirms "WFM".

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
