### PR TITLE
python311: fix cross to/from musl

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -302,9 +302,12 @@ in with passthru; stdenv.mkDerivation {
     ./3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
     # Use sysconfigdata to find headers. Fixes cross-compilation of extension modules.
     ./3.7/fix-finding-headers-when-cross-compiling.patch
-  ] ++ optionals stdenv.hostPlatform.isLoongArch64 [
+  ] ++ optionals (pythonOlder "3.12") [
     # https://github.com/python/cpython/issues/90656
     ./loongarch-support.patch
+  ] ++ optionals (pythonAtLeast "3.11" && pythonOlder "3.13") [
+    # backport fix for https://github.com/python/cpython/issues/95855
+    ./platform-triplet-detection.patch
   ] ++ optionals (stdenv.hostPlatform.isMinGW) (let
     # https://src.fedoraproject.org/rpms/mingw-python3
     mingw-patch = fetchgit {

--- a/pkgs/development/interpreters/python/cpython/platform-triplet-detection.patch
+++ b/pkgs/development/interpreters/python/cpython/platform-triplet-detection.patch
@@ -1,0 +1,295 @@
+diff --git a/configure.ac b/configure.ac
+index ba768aea93..621ac166bd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -936,125 +936,192 @@ cat > conftest.c <<EOF
+ #if defined(__ANDROID__)
+     # Android is not a multiarch system.
+ #elif defined(__linux__)
++# include <features.h>
++# if defined(__UCLIBC__)
++#  error uclibc not supported
++# elif defined(__dietlibc__)
++#  error dietlibc not supported
++# elif defined(__GLIBC__)
++#  define LIBC gnu
++#  define LIBC_X32 gnux32
++#  if defined(__ARM_PCS_VFP)
++#   define LIBC_ARM gnueabihf
++#  else
++#   define LIBC_ARM gnueabi
++#  endif
++#  if defined(__loongarch__)
++#   if defined(__loongarch_soft_float)
++#    define LIBC_LA gnusf
++#   elif defined(__loongarch_single_float)
++#    define LIBC_LA gnuf32
++#   elif defined(__loongarch_double_float)
++#    define LIBC_LA gnu
++#   else
++#    error unknown loongarch floating-point base abi
++#   endif
++#  endif
++#  if defined(_MIPS_SIM)
++#   if defined(__mips_hard_float)
++#    if _MIPS_SIM == _ABIO32
++#     define LIBC_MIPS gnu
++#    elif _MIPS_SIM == _ABIN32
++#     define LIBC_MIPS gnuabin32
++#    elif _MIPS_SIM == _ABI64
++#     define LIBC_MIPS gnuabi64
++#    else
++#     error unknown mips sim value
++#    endif
++#   else
++#    if _MIPS_SIM == _ABIO32
++#     define LIBC_MIPS gnusf
++#    elif _MIPS_SIM == _ABIN32
++#     define LIBC_MIPS gnuabin32sf
++#    elif _MIPS_SIM == _ABI64
++#     define LIBC_MIPS gnuabi64sf
++#    else
++#     error unknown mips sim value
++#    endif
++#   endif
++#  endif
++#  if defined(__SPE__)
++#   define LIBC_PPC gnuspe
++#  else
++#   define LIBC_PPC gnu
++#  endif
++# else
++#  include <stdarg.h>
++#  ifdef __DEFINED_va_list
++#   define LIBC musl
++#   define LIBC_X32 muslx32
++#   if defined(__ARM_PCS_VFP)
++#    define LIBC_ARM musleabihf
++#   else
++#    define LIBC_ARM musleabi
++#   endif
++#   if defined(__loongarch__)
++#    if defined(__loongarch_soft_float)
++#     define LIBC_LA muslsf
++#    elif defined(__loongarch_single_float)
++#     define LIBC_LA muslf32
++#    elif defined(__loongarch_double_float)
++#     define LIBC_LA musl
++#    else
++#     error unknown loongarch floating-point base abi
++#    endif
++#   endif
++#   if defined(_MIPS_SIM)
++#    if defined(__mips_hard_float)
++#     if _MIPS_SIM == _ABIO32
++#      define LIBC_MIPS musl
++#     elif _MIPS_SIM == _ABIN32
++#      define LIBC_MIPS musln32
++#     elif _MIPS_SIM == _ABI64
++#      define LIBC_MIPS musl
++#     else
++#      error unknown mips sim value
++#     endif
++#    else
++#     if _MIPS_SIM == _ABIO32
++#      define LIBC_MIPS muslsf
++#     elif _MIPS_SIM == _ABIN32
++#      define LIBC_MIPS musln32sf
++#     elif _MIPS_SIM == _ABI64
++#      define LIBC_MIPS muslsf
++#     else
++#      error unknown mips sim value
++#     endif
++#    endif
++#   endif
++#   if defined(_SOFT_FLOAT) || defined(__NO_FPRS__)
++#    define LIBC_PPC muslsf
++#   else
++#    define LIBC_PPC musl
++#   endif
++#  else
++#   error unknown libc
++#  endif
++# endif
+ # if defined(__x86_64__) && defined(__LP64__)
+-        x86_64-linux-gnu
++        x86_64-linux-LIBC
+ # elif defined(__x86_64__) && defined(__ILP32__)
+-        x86_64-linux-gnux32
++        x86_64-linux-LIBC_X32
+ # elif defined(__i386__)
+-        i386-linux-gnu
++        i386-linux-LIBC
+ # elif defined(__aarch64__) && defined(__AARCH64EL__)
+ #  if defined(__ILP32__)
+-        aarch64_ilp32-linux-gnu
++        aarch64_ilp32-linux-LIBC
+ #  else
+-        aarch64-linux-gnu
++        aarch64-linux-LIBC
+ #  endif
+ # elif defined(__aarch64__) && defined(__AARCH64EB__)
+ #  if defined(__ILP32__)
+-        aarch64_be_ilp32-linux-gnu
++        aarch64_be_ilp32-linux-LIBC
+ #  else
+-        aarch64_be-linux-gnu
++        aarch64_be-linux-LIBC
+ #  endif
+ # elif defined(__alpha__)
+-        alpha-linux-gnu
+-# elif defined(__ARM_EABI__) && defined(__ARM_PCS_VFP)
++        alpha-linux-LIBC
++# elif defined(__ARM_EABI__)
+ #  if defined(__ARMEL__)
+-        arm-linux-gnueabihf
++        arm-linux-LIBC_ARM
+ #  else
+-        armeb-linux-gnueabihf
+-#  endif
+-# elif defined(__ARM_EABI__) && !defined(__ARM_PCS_VFP)
+-#  if defined(__ARMEL__)
+-        arm-linux-gnueabi
+-#  else
+-        armeb-linux-gnueabi
++        armeb-linux-LIBC_ARM
+ #  endif
+ # elif defined(__hppa__)
+-        hppa-linux-gnu
++        hppa-linux-LIBC
+ # elif defined(__ia64__)
+-        ia64-linux-gnu
+-# elif defined(__loongarch__)
+-#  if defined(__loongarch_lp64)
+-#   if defined(__loongarch_soft_float)
+-        loongarch64-linux-gnusf
+-#   elif defined(__loongarch_single_float)
+-        loongarch64-linux-gnuf32
+-#   elif defined(__loongarch_double_float)
+-        loongarch64-linux-gnu
++        ia64-linux-LIBC
++# elif defined(__loongarch__) && defined(__loongarch_lp64)
++        loongarch64-linux-LIBC_LA
++# elif defined(__m68k__) && !defined(__mcoldfire__)
++        m68k-linux-LIBC
++# elif defined(__mips__)
++#  if defined(__mips_isa_rev) && (__mips_isa_rev >=6)
++#   if defined(_MIPSEL) && defined(__mips64)
++        mipsisa64r6el-linux-LIBC_MIPS
++#   elif defined(_MIPSEL)
++        mipsisa32r6el-linux-LIBC_MIPS
++#   elif defined(__mips64)
++        mipsisa64r6-linux-LIBC_MIPS
+ #   else
+-#    error unknown platform triplet
++        mipsisa32r6-linux-LIBC_MIPS
+ #   endif
+ #  else
+-#   error unknown platform triplet
+-#  endif
+-# elif defined(__m68k__) && !defined(__mcoldfire__)
+-        m68k-linux-gnu
+-# elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6) && defined(_MIPSEL)
+-#  if _MIPS_SIM == _ABIO32
+-        mipsisa32r6el-linux-gnu
+-#  elif _MIPS_SIM == _ABIN32
+-        mipsisa64r6el-linux-gnuabin32
+-#  elif _MIPS_SIM == _ABI64
+-        mipsisa64r6el-linux-gnuabi64
+-#  else
+-#   error unknown platform triplet
+-#  endif
+-# elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6)
+-#  if _MIPS_SIM == _ABIO32
+-        mipsisa32r6-linux-gnu
+-#  elif _MIPS_SIM == _ABIN32
+-        mipsisa64r6-linux-gnuabin32
+-#  elif _MIPS_SIM == _ABI64
+-        mipsisa64r6-linux-gnuabi64
+-#  else
+-#   error unknown platform triplet
+-#  endif
+-# elif defined(__mips_hard_float) && defined(_MIPSEL)
+-#  if _MIPS_SIM == _ABIO32
+-        mipsel-linux-gnu
+-#  elif _MIPS_SIM == _ABIN32
+-        mips64el-linux-gnuabin32
+-#  elif _MIPS_SIM == _ABI64
+-        mips64el-linux-gnuabi64
+-#  else
+-#   error unknown platform triplet
+-#  endif
+-# elif defined(__mips_hard_float)
+-#  if _MIPS_SIM == _ABIO32
+-        mips-linux-gnu
+-#  elif _MIPS_SIM == _ABIN32
+-        mips64-linux-gnuabin32
+-#  elif _MIPS_SIM == _ABI64
+-        mips64-linux-gnuabi64
+-#  else
+-#   error unknown platform triplet
++#   if defined(_MIPSEL) && defined(__mips64)
++        mips64el-linux-LIBC_MIPS
++#   elif defined(_MIPSEL)
++        mipsel-linux-LIBC_MIPS
++#   elif defined(__mips64)
++        mips64-linux-LIBC_MIPS
++#   else
++        mips-linux-LIBC_MIPS
++#   endif
+ #  endif
+ # elif defined(__or1k__)
+-        or1k-linux-gnu
+-# elif defined(__powerpc__) && defined(__SPE__)
+-        powerpc-linux-gnuspe
++        or1k-linux-LIBC
+ # elif defined(__powerpc64__)
+ #  if defined(__LITTLE_ENDIAN__)
+-        powerpc64le-linux-gnu
++        powerpc64le-linux-LIBC
+ #  else
+-        powerpc64-linux-gnu
++        powerpc64-linux-LIBC
+ #  endif
+ # elif defined(__powerpc__)
+-        powerpc-linux-gnu
++        powerpc-linux-LIBC_PPC
+ # elif defined(__s390x__)
+-        s390x-linux-gnu
++        s390x-linux-LIBC
+ # elif defined(__s390__)
+-        s390-linux-gnu
++        s390-linux-LIBC
+ # elif defined(__sh__) && defined(__LITTLE_ENDIAN__)
+-        sh4-linux-gnu
++        sh4-linux-LIBC
+ # elif defined(__sparc__) && defined(__arch64__)
+-        sparc64-linux-gnu
++        sparc64-linux-LIBC
+ # elif defined(__sparc__)
+-        sparc-linux-gnu
++        sparc-linux-LIBC
+ # elif defined(__riscv)
+ #  if __riscv_xlen == 32
+-        riscv32-linux-gnu
++        riscv32-linux-LIBC
+ #  elif __riscv_xlen == 64
+-        riscv64-linux-gnu
++        riscv64-linux-LIBC
+ #  else
+ #   error unknown platform triplet
+ #  endif
+@@ -1102,12 +1169,7 @@ cat > conftest.c <<EOF
+ EOF
+ 
+ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
+-  PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	'`
+-  case "$build_os" in
+-  linux-musl*)
+-    PLATFORM_TRIPLET=`echo "$PLATFORM_TRIPLET" | sed 's/linux-gnu/linux-musl/'`
+-    ;;
+-  esac
++  PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | grep -v typedef | tr -d ' 	'`
+   AC_MSG_RESULT([$PLATFORM_TRIPLET])
+ else
+   AC_MSG_RESULT([none])


### PR DESCRIPTION
## Description of changes

Related: #259752 

My summary of this mess:

**Python <3.11:**
under Linux the abi string is always -gnu*

**Python 3.11-3.12**
musl is treated as its own abi in the python build system, but when cross-compiling the build host's libc is used for the target abi string. Cross compiling from glibc to musl gives a -gnu* target abi string and vice versa.

**Python >=3.13**
musl is treated as its own abi, and when cross-compiling the target libc is used for the target abi string

My solution is to backport [the fix](https://github.com/python/cpython/commit/c163d7f0b67a568e9b64eeb9c1cbbaa127818596) for python 3.11-3.12, since the intermediate state is almost impossible to model in the nix expression
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
