### PR TITLE
python3Packages.desktop-entry-lib: init at 3.1

### DIFF
--- a/pkgs/development/python-modules/desktop-entry-lib/default.nix
+++ b/pkgs/development/python-modules/desktop-entry-lib/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, pytestCheckHook
+, fetchFromGitea
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "desktop-entry-lib";
+  version = "3.1";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  # We could use fetchPypi, but then the tests won't run
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "JakobDev";
+    repo = pname;
+    rev = version;
+    hash = "sha256-+c+FuLv88wc4yVw3iyFFtfbocnWzTCIe2DS0SWoj+VI=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "desktop_entry_lib" ];
+
+  meta = with lib; {
+    description = "Allows reading and writing .desktop files according to the Desktop Entry Specification";
+    homepage = "https://codeberg.org/JakobDev/desktop-entry-lib";
+    changelog = "https://codeberg.org/JakobDev/desktop-entry-lib/releases/tag/${version}";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ Madouura ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2717,6 +2717,8 @@ self: super: with self; {
 
   derpconf = callPackage ../development/python-modules/derpconf { };
 
+  desktop-entry-lib = callPackage ../development/python-modules/desktop-entry-lib { };
+
   desktop-notifier = callPackage ../development/python-modules/desktop-notifier { };
 
   detect-secrets = callPackage ../development/python-modules/detect-secrets { };


### PR DESCRIPTION
## Description of changes
For ricing purposes
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
