### PR TITLE
check: fix compilation on cross-compiled musl

### DIFF
--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "02m25y9m46pb6n46s51av62kpd936lkfv3b13kfpckgvmh5lxpm8";
   };
 
+  # fortify breaks the libcompat vsnprintf implementation
+  hardeningDisable = lib.optionals (stdenv.hostPlatform.isMusl && (stdenv.hostPlatform != stdenv.buildPlatform)) [ "fortify" ];
+
   # Test can randomly fail: https://hydra.nixos.org/build/7243912
   doCheck = false;
 


### PR DESCRIPTION
for some reason it detects static musl as having a non-compliant vsnprintf implementation.

It then tries to provide its own implementation, but it conflicts with `FORTIFY_SOURCE`.

`FORTIFY_SOURCE`  error:
```console
       > In file included from /nix/store/0q2slv31qy84nlqqbhv0bfzxbf5ryqhg-fortify-headers-1.1alpine3/include/stdio.h:26,
       >                  from libcompat.h:99,
       >                  from libcompat.c:21:
       > /nix/store/0q2slv31qy84nlqqbhv0bfzxbf5ryqhg-fortify-headers-1.1alpine3/include/stdio.h:80:1: error: 'vsnprintf' undeclared here (not in a function); did you mean 'vsprintf'?
       >    80 | _FORTIFY_FN(vsnprintf) int vsnprintf(char * _FORTIFY_POS0 __s, size_t __n,
       >       | ^~~~~~~~~~~
       > compilation terminated due to -Wfatal-errors.
```

Detection of non-compliant implementation:
```console
check> checking whether vsnprintf is C99 compliant... no
check> checking whether snprintf is C99 compliant... no
```

## Description of changes

I've disabled the autoconf check for compliance for static stdenv, but I'm not sure how to check whether the implementation is actually compliant or not.

Since I've edited the autoconf config, I've also added the necessary dependencies to rebuild the makefiles.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
