### PR TITLE
nexttrace: 1.2.1.1 -> 1.2.2.2

### DIFF
--- a/pkgs/tools/networking/nexttrace/default.nix
+++ b/pkgs/tools/networking/nexttrace/default.nix
@@ -2,23 +2,27 @@
 
 buildGoModule rec {
   pname = "nexttrace";
-  version = "1.2.1.1";
+  version = "1.2.2.2";
 
   src = fetchFromGitHub {
-    owner = "sjlleo";
-    repo = pname;
+    owner = "nxtrace";
+    repo = "NTrace-core";
     rev = "v${version}";
-    sha256 = "sha256-B3NHY4wYCa3lR3XPqhjcrgf9iA4Bz/8bKrwxdNSa1Bk=";
+    sha256 = "sha256-a9l6nsrbgwmk6cq/rPBwPwZ8yhH35VxKmn9x5PgcqGI=";
   };
-  vendorHash = "sha256-8etZelvdUmHNWC0FnSX9oO3reuhB7xIzd/KxPTt6Szc=";
+  vendorHash = "sha256-YAmGvmHkR1G2MLlDja5aPJqX2F3etogebasqD72YJ3M=";
 
   doCheck = false; # Tests require a network connection.
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/xgadget-lab/nexttrace/config.Version=v${version}"
+    "-X github.com/nxtrace/NTrace-core/config.Version=v${version}"
   ];
+
+  postInstall = ''
+    mv $out/bin/NTrace-core $out/bin/nexttrace
+  '';
 
   meta = with lib; {
     description = "An open source visual route tracking CLI tool";


### PR DESCRIPTION
## Description of changes

Nexttrace has recently moved theire repos (see https://github.com/nxtrace/NTrace-core/commit/a6848f8f235538abc8b575fbec8600af6277e561). And the default binary name is now NTrace-core, corresponding to the changed repo name. I move it to `bin/nexttrace` for consistency with original binary name, and its releases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
