### PR TITLE
toxiproxy: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/development/tools/toxiproxy/default.nix
+++ b/pkgs/development/tools/toxiproxy/default.nix
@@ -1,17 +1,22 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, testers
+, toxiproxy
+}:
 
 buildGoModule rec {
   pname = "toxiproxy";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "Shopify";
     repo = "toxiproxy";
     rev = "v${version}";
-    sha256 = "sha256-SL3YHsNeFw8K8lPrzJXAoTkHxS+1sTREfzjawBxdnf0=";
+    sha256 = "sha256-wa39RsopmENXNEI5kiNIYSLGi/qGwIEfNVKWhAgVOuE=";
   };
 
-  vendorHash = "sha256-CmENxPAdjz0BAyvhLKIaJjSbK/mvRzHGCQOfGIiA3yI=";
+  vendorHash = "sha256-m6jZOVlJI3GGqCsCkMAIB2jg1Nk8oAELyzL3y4b2nqA=";
 
   excludedPackages = [ "test/e2e" ];
 
@@ -20,14 +25,28 @@ buildGoModule rec {
   # Fixes tests on Darwin
   __darwinAllowLocalNetworking = true;
 
-  checkFlags = [ "-short" ];
+  checkFlags = [ "-short" "-skip=TestVersionEndpointReturnsVersion" ];
 
   postInstall = ''
     mv $out/bin/cli $out/bin/toxiproxy-cli
     mv $out/bin/server $out/bin/toxiproxy-server
   '';
 
+  passthru.tests = {
+    cliVersion = testers.testVersion {
+      inherit version;
+      package = toxiproxy;
+      command = "${toxiproxy}/bin/toxiproxy-cli -version";
+    };
+    serverVersion = testers.testVersion {
+      inherit version;
+      package = toxiproxy;
+      command = "${toxiproxy}/bin/toxiproxy-server -version";
+    };
+  };
+
   meta = {
+    changelog = "https://github.com/Shopify/toxiproxy/releases/tag/v${version}";
     description = "Proxy for for simulating network conditions";
     homepage = "https://github.com/Shopify/toxiproxy";
     maintainers = with lib.maintainers; [ avnik ];


### PR DESCRIPTION
## Description of changes

This PR updates toxiproxy to its latest release: https://github.com/Shopify/toxiproxy/releases/tag/v2.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
