### PR TITLE
zip: fix buffer overflow on Unicode path names

### DIFF
--- a/pkgs/tools/archivers/zip/buffer-overflow-on-utf8-rh-bug-2165653.patch
+++ b/pkgs/tools/archivers/zip/buffer-overflow-on-utf8-rh-bug-2165653.patch
@@ -1,0 +1,12 @@
+diff -urp zip30/fileio.c zip30/fileio.c
+--- zip30/fileio.c	2008-05-29 03:13:24.000000000 +0300
++++ zip30/fileio.c	2023-05-02 12:19:50.488314853 +0300
+@@ -3502,7 +3502,7 @@ zwchar *local_to_wide_string(local_strin
+   if ((wc_string = (wchar_t *)malloc((wsize + 1) * sizeof(wchar_t))) == NULL) {
+     ZIPERR(ZE_MEM, "local_to_wide_string");
+   }
+-  wsize = mbstowcs(wc_string, local_string, strlen(local_string) + 1);
++  wsize = mbstowcs(wc_string, local_string, wsize + 1);
+   wc_string[wsize] = (wchar_t) 0;
+ 
+   /* in case wchar_t is not zwchar */

--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
     ./fix-memset-detection.patch
     # Implicit declaration of `closedir` and `opendir` cause dirent detection to fail with clang 16.
     ./fix-implicit-declarations.patch
+    # Buffer overflow on Unicode characters in path names
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2165653
+    ./buffer-overflow-on-utf8-rh-bug-2165653.patch
   ] ++ lib.optionals (enableNLS && !stdenv.isCygwin) [ ./natspec-gentoo.patch.bz2 ];
 
   buildInputs = lib.optional enableNLS libnatspec


### PR DESCRIPTION
## Description of changes

When creating ZIP files with non-ASCII names (such as some European accent chars), something was detecting a buffer overflow and bailing out. It turns out that [this has been already fixed earlier this year in Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=2165653), so let's reuse their patch as-is.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

