### PR TITLE
dell-command-configure: init at 4.8.0-494

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15283,6 +15283,12 @@
       fingerprint = "E4F4 1EAB BF0F C785 06D8  62EF EF68 CF41 D42A 593D";
     }];
   };
+  ryangibb = {
+    email = "ryan@freumh.org";
+    github = "ryangibb";
+    githubId = 22669046;
+    name = "Ryan Gibb";
+  };
   ryanorendorff = {
     github = "ryanorendorff";
     githubId = 12442942;

--- a/pkgs/tools/system/dell-command-configure/default.nix
+++ b/pkgs/tools/system/dell-command-configure/default.nix
@@ -28,7 +28,7 @@ let
         "https://dl.dell.com/FOLDER08911312M/1/command-configure_${version}.ubuntu20_amd64.tar.gz";
       # The CDN blocks the Curl user-agent, so set to blank instead.
       curlOpts = ''-A=""'';
-      sha256 = "sha256-l5oHgDkFBF6llNsHufTmuDzjkhGmXHYXlOJ4hvZfRoE=";
+      hash = "sha256-l5oHgDkFBF6llNsHufTmuDzjkhGmXHYXlOJ4hvZfRoE=";
     };
 
     dontBuild = true;
@@ -47,7 +47,6 @@ let
     '';
   };
 
-
   # Contains a fopen() wrapper for finding the firmware package
   wrapperLibName = "wrapper-lib.so";
   wrapperLib = stdenv.mkDerivation {
@@ -56,15 +55,14 @@ let
 
     src = ./.;
 
-    dontUnpack = true;
-    buildPhase = ''
-      substitute ${./wrapper-lib.c} lib.c \
+    postPatch = ''
+      ls -al
+      substitute wrapper-lib.c lib.c \
         --subst-var-by to "${unpacked}/srvadmin-hapi/opt/dell/srvadmin/etc/omreg.d/omreg-hapi.cfg"
       cc -fPIC -shared lib.c -o ${wrapperLibName}
     '';
     installPhase = ''
-      mkdir -p $out/lib
-      cp ${wrapperLibName} $out/lib/
+      install -D ${wrapperLibName} -t $out/lib
     '';
   };
 
@@ -79,13 +77,12 @@ in stdenv.mkDerivation rec {
   src = unpacked;
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib
-    install -t $out/lib -m644 -v command-configure/opt/dell/dcc/libhapiintf.so
-    install -t $out/lib -m644 -v command-configure/opt/dell/dcc/libsmbios_c.so.2
-    install -t $out/bin -m755 -v command-configure/opt/dell/dcc/cctk
-    install -t $out/bin -m755 -v srvadmin-hapi/opt/dell/srvadmin/sbin/dchcfg
+    install -D -t $out/lib -m644 -v command-configure/opt/dell/dcc/libhapiintf.so
+    install -D -t $out/lib -m644 -v command-configure/opt/dell/dcc/libsmbios_c.so.2
+    install -D -t $out/bin -m755 -v command-configure/opt/dell/dcc/cctk
+    install -D -t $out/bin -m755 -v srvadmin-hapi/opt/dell/srvadmin/sbin/dchcfg
     for lib in $(find srvadmin-hapi/opt/dell/srvadmin/lib64 -type l); do
-        install -t $out/lib -m644 -v $lib
+        install -D -t $out/lib -m644 -v $lib
     done
   '';
 

--- a/pkgs/tools/system/dell-command-configure/default.nix
+++ b/pkgs/tools/system/dell-command-configure/default.nix
@@ -1,0 +1,111 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  patchelfUnstable,
+  openssl,
+}:
+
+# Use techniques described in https://web.archive.org/web/20220904051329/https://tapesoftware.net/replace-symbol/
+
+# Adapted from https://github.com/KenMacD/etc-nixos/blob/d3d28085586358a62b2bb4b427eb21aad05b5b23/dcc/default.nix
+
+# Used https://github.com/NixOS/nixpkgs/pull/84926 as a template
+# then converted to use autoPatchelfHook instead, and link with
+# the dependencies from other pkgs.
+
+let
+  version = "4.8.0-494";
+
+  unpacked = stdenv.mkDerivation rec {
+    inherit version;
+    pname = "dell-command-configure-unpacked";
+
+    src = fetchurl {
+      url =
+        "https://dl.dell.com/FOLDER08911312M/1/command-configure_${version}.ubuntu20_amd64.tar.gz";
+      # The CDN blocks the Curl user-agent, so set to blank instead.
+      curlOpts = ''-A=""'';
+      sha256 = "sha256-l5oHgDkFBF6llNsHufTmuDzjkhGmXHYXlOJ4hvZfRoE=";
+    };
+
+    dontBuild = true;
+
+    nativeBuildInputs = [ dpkg ];
+
+    unpackPhase = ''
+      tar -xzf ${src}
+      dpkg-deb -x command-configure_${version}.ubuntu20_amd64.deb command-configure
+      dpkg-deb -x srvadmin-hapi_9.5.0_amd64.deb srvadmin-hapi
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -r . $out
+    '';
+  };
+
+
+  # Contains a fopen() wrapper for finding the firmware package
+  wrapperLibName = "wrapper-lib.so";
+  wrapperLib = stdenv.mkDerivation {
+    pname = "dell-command-configure-unpacked-wrapper-lib";
+    inherit version;
+
+    src = ./.;
+
+    dontUnpack = true;
+    buildPhase = ''
+      substitute ${./wrapper-lib.c} lib.c \
+        --subst-var-by to "${unpacked}/srvadmin-hapi/opt/dell/srvadmin/etc/omreg.d/omreg-hapi.cfg"
+      cc -fPIC -shared lib.c -o ${wrapperLibName}
+    '';
+    installPhase = ''
+      mkdir -p $out/lib
+      cp ${wrapperLibName} $out/lib/
+    '';
+  };
+
+in stdenv.mkDerivation rec {
+  inherit version;
+  pname = "dell-command-configure";
+
+  buildInputs = [ openssl stdenv.cc.cc.lib ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+  dontConfigure = true;
+
+  src = unpacked;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    install -t $out/lib -m644 -v command-configure/opt/dell/dcc/libhapiintf.so
+    install -t $out/lib -m644 -v command-configure/opt/dell/dcc/libsmbios_c.so.2
+    install -t $out/bin -m755 -v command-configure/opt/dell/dcc/cctk
+    install -t $out/bin -m755 -v srvadmin-hapi/opt/dell/srvadmin/sbin/dchcfg
+    for lib in $(find srvadmin-hapi/opt/dell/srvadmin/lib64 -type l); do
+        install -t $out/lib -m644 -v $lib
+    done
+  '';
+
+  postFixup = ''
+    echo fopen fopen_wrapper > fopen_name_map
+    echo access access_wrapper > access_name_map
+    ${patchelfUnstable}/bin/patchelf \
+      --rename-dynamic-symbols fopen_name_map \
+      --rename-dynamic-symbols access_name_map \
+      --add-needed ${wrapperLibName} \
+      --set-rpath ${lib.makeLibraryPath [ wrapperLib ]} \
+      $out/lib/*
+  '';
+
+  meta = with lib; {
+    description = "Configure BIOS settings on Dell laptops.";
+    homepage =
+      "https://www.dell.com/support/article/us/en/19/sln311302/dell-command-configure";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ryangibb ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/system/dell-command-configure/wrapper-lib.c
+++ b/pkgs/tools/system/dell-command-configure/wrapper-lib.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <string.h>
+
+static const char from[] =  "/usr/lib/ext/dell/omreg.cfg";
+static const char to[] = "@to@";
+
+int access_wrapper(const char *fn, int mode)
+{
+	if (!strcmp(fn, from)) {
+		printf("access_wrapper.c: Replacing path '%s' with '%s'\n", from, to);
+		fn = to;
+	}
+	return access(fn, mode);
+}
+
+FILE* fopen_wrapper(const char* fn, const char* mode)
+{
+	if (!strcmp(fn, from)) {
+		printf("fopen_wrapper.c: Replacing path '%s' with '%s'\n", from, to);
+		fn = to;
+	}
+	return fopen(fn, mode);
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3709,6 +3709,8 @@ with pkgs;
 
   delayarchitect = callPackage ../applications/audio/delayarchitect { };
 
+  dell-command-configure = callPackage ../tools/system/dell-command-configure { };
+
   deltachat-desktop = callPackage ../applications/networking/instant-messengers/deltachat-desktop {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
## Description of changes

Adds dell-command-configure utility.

Similar to https://github.com/NixOS/nixpkgs/pull/84926 but uses https://github.com/NixOS/patchelf/pull/459 to patch the binary to look for the configuration file in the derivation to avoid requiring a module with a one shot systemd service.

Closes https://github.com/RyanGibb/nixos/issues/1.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)