### PR TITLE
ttags: init at 0.3.0

### DIFF
--- a/pkgs/development/tools/misc/ttags/default.nix
+++ b/pkgs/development/tools/misc/ttags/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchFromGitHub, rustPlatform, testers, ttags }:
+let version = "0.3.0";
+in rustPlatform.buildRustPackage {
+  pname = "ttags";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "npezza93";
+    repo = "ttags";
+    rev = "${version}";
+    hash = "sha256-yqrCcA/+FyGPpX3hhULiwhMfrDWjq+rzT04M+o9ry5s=";
+  };
+
+  cargoHash = "sha256-jW3xIlo2cN5aoEUp3FxN4pwGFvlg50i5RMNgQopGb88=";
+
+  passthru.tests.version = testers.testVersion {
+    package = ttags;
+    command = "ttags --version";
+    version = version;
+  };
+
+  meta = with lib; {
+    description = "Generate tags using tree-sitter";
+    longDescription = ''
+      ttags generates tags (similar to ctags) for various
+      languages, using tree-sitter.
+
+      Can be run as a language server that updates the tags
+      for a file when it is saved.
+
+      Supported languages:
+      - Haskell
+      - JavaScript
+      - Nix
+      - Ruby
+      - Rust
+      - Swift
+    '';
+    homepage = "https://github.com/npezza93/ttags";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mrcjkb ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20306,6 +20306,8 @@ with pkgs;
 
   trellis = callPackage ../development/embedded/fpga/trellis { };
 
+  ttags = callPackage ../development/tools/misc/ttags { };
+
   ttyd = callPackage ../servers/ttyd { };
 
   turbogit = callPackage ../development/tools/turbogit {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Output of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`:

```console
1 package added:
ttags (init at 0.2.1)
1 package built:
ttags
```
