### PR TITLE
onnxruntime: add CUDA support

### DIFF
--- a/pkgs/development/libraries/microsoft-gsl/default.nix
+++ b/pkgs/development/libraries/microsoft-gsl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , gtest
 , pkg-config
@@ -22,6 +23,15 @@ stdenv.mkDerivation rec {
 
   # error: unsafe buffer access
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unsafe-buffer-usage";
+
+  patches = [
+    # nvcc doesn't recognize the "gsl" attribute namespace (microsoft/onnxruntime#13573)
+    # only affects nvcc
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/microsoft/onnxruntime/4bfa69def85476b33ccfaf68cf070f3fb65d39f7/cmake/patches/gsl/1064.patch";
+      hash = "sha256-0jESA+VENWQms9HGE0jRiZZuWLJehBlbArxSaQbYOrM=";
+    })
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/onnxruntime/nvcc-gsl.patch
+++ b/pkgs/development/libraries/onnxruntime/nvcc-gsl.patch
@@ -1,0 +1,32 @@
+diff --git a/cmake/external/onnxruntime_external_deps.cmake b/cmake/external/onnxruntime_external_deps.cmake
+index 9effd1a2db..faff5e8de7 100644
+--- a/cmake/external/onnxruntime_external_deps.cmake
++++ b/cmake/external/onnxruntime_external_deps.cmake
+@@ -280,21 +280,12 @@ if (NOT WIN32)
+   endif()
+ endif()
+ 
+-if(onnxruntime_USE_CUDA)
+-  FetchContent_Declare(
+-    GSL
+-    URL ${DEP_URL_microsoft_gsl}
+-    URL_HASH SHA1=${DEP_SHA1_microsoft_gsl}
+-    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/gsl/1064.patch
+-  )
+-else()
+-  FetchContent_Declare(
+-    GSL
+-    URL ${DEP_URL_microsoft_gsl}
+-    URL_HASH SHA1=${DEP_SHA1_microsoft_gsl}
+-    FIND_PACKAGE_ARGS 4.0 NAMES Microsoft.GSL
+-  )
+-endif()
++FetchContent_Declare(
++  GSL
++  URL ${DEP_URL_microsoft_gsl}
++  URL_HASH SHA1=${DEP_SHA1_microsoft_gsl}
++  FIND_PACKAGE_ARGS 4.0 NAMES Microsoft.GSL
++)
+ 
+ FetchContent_Declare(
+     safeint


### PR DESCRIPTION
## Description of changes

Adds CUDA support to onnxruntime. Possibly closes #228093.

I've successfully used this same expression out-of-tree back in August to run it with CUDA; the PR code has only been built and tested with CPU fallback as I lack access to a machine with a suitable Nvidia card at the moment. Hopefully I'll be able to test it next week. People interested in #228093 are welcome to test and report issues as well :)

Marking it as a draft for now, as the commited version effectively replaces the current onnxruntime with CUDA-enabled version - to show the necessary changes.

Pinging @NixOS/cuda-maintainers as well as the listed maintainers (@jonringer @puffnfresh @ck3d @cbourjau) as to how to approach these issues:

### 1. Package structure

What is the best way to integrate this into nixpkgs? I've seen packages with a "generic" base that is not exposed and then several exposed attributes using different configuration. Another approach would be to override the base expression, or possibly only add the `cudaSupport` attribute (defaulting to false) and leave it up to the user to override it locally.

### 2. checkPhase

When built with CUDA, the included tests seem to try test the CUDA functionality, which obviously fails on systems without an Nvidia card (no idea if they pass there). I suppose this is undesirable, as it prevents the package from being built on most systems. 

Simply disabling `doCheck` does not work, as CMake fails on `gtest` dependency. The included `checkPhase` is a dirty hack for now.

The simple solution would be to conditionally override `checkPhase` for CUDA builds. A better alternative would be to somehow disable the problematic tests (changing the `checkPhase`, patching the source to disable them, etc.) but I've not investigated how feasible this would be.

### 3. CUDA-specific changes

First, the usage of  `cudaPackages.backendStdenv.mkDerivation` - is this the correct way to do things?

Onnxruntime itself patches gsl during CUDA builds to suppress some nvcc warnings, as they treat all warnings as errors. This obviously doesn't fly in our Nix build, so I've patched the patching out and applied the patch to our gsl dep. I presume this is harmless and can be done unconditionally, but there is an argument to be made for following the upstream process and doing it only for CUDA builds.

Similarly for`cutlass`, looking at the code now I think it'd be best to move it to the `cudaSupport` part of CMake.

Finally, I'm not sure what's the approach to `CUDA_ARCHITECTURES` in nixpkgs, the included value is what I've needed for the card I used it with. I remember seeing somewhere that it's part of some nixpkgs CUDA configuration, but I haven't found it documented well anywhere, and from all the open CUDA-Team issues here I get the feeling that this part of the infrastructure is in a state of flux right now.

### 4. ROCm Support

My understanding is that the `onnxruntime-gpu` in Pypi supports both CUDA and ROCm. Do we want to follow that, or have `onnxruntime-cuda` and `onnxruntime-rocm` packages? This PR only deals with CUDA, which seems to be the much more popular variant.

### 5. Update to 1.16.0

When making this PR, I noticed #258392 is open. These two are in conflict :) But I'm hopeful that rebasing this on top of 1.16.0 should not be too painful, and the addition `FETCHCONTENT_SOURCE_DIR_GOOGLETEST` could potentially fix the `gtest` issue mentioned in 2.

Thanks to everyone in advance, hope to get this into 23.11!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
