### PR TITLE
segger-ozone: 3.28e -> 3.30b and refactoring

### DIFF
--- a/pkgs/development/tools/misc/segger-ozone/default.nix
+++ b/pkgs/development/tools/misc/segger-ozone/default.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "segger-ozone";
-  version = "3.28e";
+  version = "3.30b";
 
   src = fetchurl {
     url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${(lib.replaceStrings ["."] [""] version)}_x86_64.tgz";
-    sha256 = "BfmKBAKyTA0V31zkwFLrbT0Xob221KfHa6v0VxKFsSI=";
+    sha256 = "sha256-W8Fo0q58pAn1aB92CjYARcN3vMLEguvsyozsS7VRArQ=";
   };
 
   rpath = lib.makeLibraryPath [

--- a/pkgs/development/tools/misc/segger-ozone/default.nix
+++ b/pkgs/development/tools/misc/segger-ozone/default.nix
@@ -1,14 +1,13 @@
-{ stdenv
+{ lib
+, stdenv
 , fetchurl
+, autoPatchelfHook
 , fontconfig
 , freetype
-, lib
 , libICE
 , libSM
-, udev
 , libX11
 , libXcursor
-, libXext
 , libXfixes
 , libXrandr
 , libXrender
@@ -18,40 +17,43 @@ stdenv.mkDerivation rec {
   pname = "segger-ozone";
   version = "3.30b";
 
-  src = fetchurl {
-    url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${(lib.replaceStrings ["."] [""] version)}_x86_64.tgz";
-    sha256 = "sha256-W8Fo0q58pAn1aB92CjYARcN3vMLEguvsyozsS7VRArQ=";
-  };
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${builtins.replaceStrings ["."] [""] version}_x86_64.tgz";
+      hash = "sha256-W8Fo0q58pAn1aB92CjYARcN3vMLEguvsyozsS7VRArQ=";
+    };
+    i686-linux = fetchurl {
+      url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${builtins.replaceStrings ["."] [""] version}_i386.tgz";
+      hash = "sha256-Xq/69lwF2Ll5VdkYMDNRtc0YUUvWc+XR0FHJXxOLNQ4=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
-  rpath = lib.makeLibraryPath [
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
     fontconfig
     freetype
     libICE
     libSM
-    udev
     libX11
     libXcursor
-    libXext
     libXfixes
     libXrandr
     libXrender
-  ]
-  + ":${stdenv.cc.cc.lib}/lib64";
+    stdenv.cc.cc.lib
+  ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     mv Lib lib
     mv * $out
     ln -s $out/Ozone $out/bin
-  '';
 
-  postFixup = ''
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/Ozone" \
-      --set-rpath ${rpath}:$out/lib "$out/Ozone"
-
-    for file in $(find $out/lib -maxdepth 1 -type f -and -name \*.so\*); do
-      patchelf --set-rpath ${rpath}:$out/lib $file
-    done
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -80,6 +82,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = [ maintainers.bmilanov ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

I've taken the segger-ozone bump from #252266 without change, rebased it, and refactored it to use `autoPatchelfHook` and added support for the i686-linux version.

I don't have real HW to test, but both the 32-bit and 64-bit GUIs start just fine and look ok.

Closes #252266 (I hope this is ok).

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review pr 260762` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>segger-ozone</li>
  </ul>
</details>