### PR TITLE
libossp-uuid: Fix build error on pkgsCross.mingw32

### DIFF
--- a/pkgs/development/libraries/libossp-uuid/default.nix
+++ b/pkgs/development/libraries/libossp-uuid/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     "ac_cv_va_copy=yes"
   ] ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
-  patches = [ ./shtool.patch ];
+  patches = [ ./shtool.patch ./mingw-install-error.patch ];
 
   meta = with lib; {
     homepage = "http://www.ossp.org/pkg/lib/uuid/";

--- a/pkgs/development/libraries/libossp-uuid/mingw-install-error.patch
+++ b/pkgs/development/libraries/libossp-uuid/mingw-install-error.patch
@@ -1,0 +1,34 @@
+From b1274301c8276954d1960c8db880fc9c3e659216 Mon Sep 17 00:00:00 2001
+From: Neil Mayhew <neil@mayhew.name>
+Date: Thu, 12 Oct 2023 12:48:35 -0600
+Subject: [PATCH] Fix install error on MinGW
+Content-Type: text/plain; charset=utf-8
+
+---
+ Makefile.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index d28f4be..fa361d5 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -56,6 +56,7 @@ CP          = cp
+ RMDIR       = rmdir
+ SHTOOL      = $(S)/shtool
+ LIBTOOL     = $(C)/libtool
++EXEEXT      = @EXEEXT@
+ TRUE        = true
+ POD2MAN     = pod2man
+ PERL        = @PERL@
+@@ -253,7 +254,7 @@ install:
+ 	-@if [ ".$(WITH_CXX)" = .yes ]; then \
+ 	    $(LIBTOOL) --mode=install $(SHTOOL) install -c -m 644 $(CXX_NAME) $(DESTDIR)$(libdir)/; \
+ 	fi
+-	@$(LIBTOOL) --mode=install $(SHTOOL) install -c -s -m 755 uuid $(DESTDIR)$(bindir)/
++	@$(LIBTOOL) --mode=install $(SHTOOL) install -c -s -m 755 $(PRG_NAME)$(EXEEXT) $(DESTDIR)$(bindir)/
+ 	$(SHTOOL) install -c -m 644 $(S)/uuid.1 $(DESTDIR)$(mandir)/man1/
+ 	-@if [ ".$(WITH_PERL)" = .yes ]; then \
+ 	    (cd $(S)/perl && $(MAKE) $(MFLAGS) install DESTDIR=$(DESTDIR)); \
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

 A `pkgsCross.mingw32` build fails with

```
libtool: install: ./shtool install -c -m 755 -s .libs/uuid /nix/store/r8clhx2d35c4iy3y299ifx1i8lpaphcx-libossp-uuid-x86_64-w64-mingw32-1.6.2/bin/uuid
cp: cannot stat '.libs/uuid': No such file or directory
```

The problem is that the built executable file has a .exe suffix which needs to be accounted for. This PR adds a patch that fixes this in a cross-platform way.

The patch has been submitted upstream via [ossp - Ticket #207](http://cvs.ossp.org/tktview?tn=207) but the patch file isn't downloadable from the ticket.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
