### PR TITLE
nixos/flamenco, flamenco: init at 3.5

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -332,7 +332,7 @@ in
       cassandra = 300;
       qemu-libvirtd = 301;
       # kvm = 302; # unused
-      # render = 303; # unused
+      render = 303;
       # zeronet = 304; # removed 2019-01-03
       lirc = 305;
       lidarr = 306;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -706,6 +706,7 @@
   ./services/misc/etesync-dav.nix
   ./services/misc/evdevremapkeys.nix
   ./services/misc/felix.nix
+  ./services/misc/flamenco.nix
   ./services/misc/forgejo.nix
   ./services/misc/freeswitch.nix
   ./services/misc/fstrim.nix

--- a/nixos/modules/services/misc/flamenco.nix
+++ b/nixos/modules/services/misc/flamenco.nix
@@ -1,0 +1,252 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.flamenco;
+  yaml = pkgs.formats.yaml {};
+  roleIs = role: lib.any (x: x == role) cfg.role;
+  defaultConfig = {
+    manager = {
+      _meta = {version = 3;};
+      manager_name = "Flamenco";
+      autodiscoverable = true;
+      shaman = {
+        enabled = true;
+        garbageCollect = {
+          period = "24h0m0s";
+          maxAge = "7440m0s";
+          extraCheckoutPaths = [];
+        };
+      };
+      task_timeout = "10m0s";
+      worker_timeout = "1m0s";
+      blocklist_threshold = 3;
+      task_fail_after_softfail_count = 3;
+      variables = {
+        "blender" = {
+          values = [
+            {
+              platform = "linux";
+              value = "blender";
+            }
+            {
+              platform = "windows";
+              value = "blender";
+            }
+            {
+              platform = "darwin";
+              value = "blender";
+            }
+          ];
+        };
+
+        "blenderArgs" = {
+          values = [
+            {
+              platform = "all";
+              value = "-b -y";
+            }
+          ];
+        };
+      };
+    };
+
+    worker = {
+      task_types = ["blender" "ffmpeg" "file-managerment" "misc"];
+      restart_exit_code = 47;
+    };
+  };
+
+  configFile = {
+    manager = yaml.generate "flamenco-manager.yaml" (defaultConfig.manager // cfg.managerConfig // {
+      # Flamenco manager config accepts this as relative path ONLY
+      local_manager_storage_path = "../../../../${cfg.managerConfig.local_manager_storage_path}";
+      listen = cfg.listen.ip + ":" + (toString cfg.listen.port);
+    });
+    worker = yaml.generate "flamenco-worker.yaml" (defaultConfig.worker // cfg.workerConfig);
+  };
+
+  mkService = role: {
+    wantedBy = ["multi-user.target"];
+    after = ["network-online.target"];
+    wants = ["network-online.target"];
+    description = "flamenco ${role}";
+    environment =
+      if (role == "worker")
+      then {
+        FLAMENCO_HOME = cfg.home;
+        FLAMENCO_WORKER_NAME =
+          if (!builtins.isNull cfg.workerConfig.worker_name)
+          then cfg.workerConfig.worker_name
+          else null;
+      }
+      else {};
+
+    serviceConfig = {
+      ExecStart = "${cfg.package}/bin/flamenco-${role}";
+
+      User = cfg.user;
+      Group = cfg.group;
+      StateDirectory = "flamenco";
+      StateDirectoryMode = "0755";
+      WorkingDirectory = "${pkgs.linkFarm "flamenco-${role}-wd" [
+        {
+          name = "flamenco-${role}.yaml";
+          path = "${configFile.${role}}";
+        }
+      ]}";
+
+      RestartForceExitStatus =
+        if (role == "worker")
+        then cfg.workerConfig.restart_exit_code
+        else null;
+      Restart = "on-failure";
+    };
+  };
+in {
+  meta.maintainers = with lib.maintainers; [ hubble ];
+
+  options.services.flamenco = with lib.types; {
+    enable = lib.mkEnableOption "Flamenco, a render farm management software for Blender";
+    package = lib.mkPackageOption pkgs "flamenco" {};
+    openFirewall = lib.mkEnableOption "service ports in the firewall";
+
+    role = lib.mkOption {
+      description = "Flamenco role that this machine should take.";
+      default = ["worker"];
+      type = listOf (enum ["manager" "worker"]);
+    };
+
+    user = lib.mkOption {
+      description = "User under which flamenco runs under.";
+      default = "render";
+      type = str;
+    };
+
+    group = lib.mkOption {
+      description = "Group under which flamenco runs under.";
+      default = "render";
+      type = str;
+    };
+
+    home = lib.mkOption {
+      description = "Directory for worker-specific files.";
+      default = "${cfg.stateDir}/worker";
+      defaultText = "$\{config.services.flamenco.stateDir\}/worker";
+      type = path;
+    };
+
+    listen = lib.mkOption {
+      description = "IP and port flamenco binds to.";
+      type = submodule {
+        options = {
+          ip = lib.mkOption {
+            default = "";
+            description = "The IP flamenco listens to.";
+            type = str;
+          };
+          port = lib.mkOption {
+            default = 8080;
+            description = "The port flamenco listens to";
+            type = int;
+          };
+        };
+      };
+    };
+
+    managerConfig = lib.mkOption {
+      description = "Manager configuration";
+      default = defaultConfig.manager;
+      type = submodule {
+        freeformType = attrsOf anything;
+        options = {
+          autodiscoverable = lib.mkOption {
+            description = "Use UPnP/SSDP to advertise manager.";
+            default = true;
+            type = bool;
+          };
+          manager_name = lib.mkOption {
+            description = "The name of the Manager.";
+            default = "Flamenco Manager";
+            type = str;
+          };
+          database = lib.mkOption {
+            description = "Path of the database";
+            default = "${cfg.stateDir}/flamenco-manager.sqlite";
+            defaultText = "$\{config.services.flamenco.stateDir\}/flamenco-manager.sqlite";
+            type = path;
+          };
+          shared_storage_path = lib.mkOption {
+            description = "Path of shared storage, used to store project files and output";
+            default = "/srv/flamenco";
+            type = path;
+          };
+          local_manager_storage_path = lib.mkOption {
+            description = "Path for Flamenco manager state files";
+            default = "${cfg.stateDir}/flamenco-manager-storage";
+            defaultText = "$\{config.services.flamenco.stateDir\}/flamenco-manager-storage";
+            type = path;
+          };
+        };
+      };
+    };
+
+    workerConfig = lib.mkOption {
+      description = "Worker configuration";
+      default = defaultConfig.worker;
+      type = submodule {
+        freeformType = attrsOf anything;
+        options = {
+          worker_name = lib.mkOption {
+            description = "The name of the Worker. If not specified, the worker will use the hostname.";
+            default = null;
+            type = nullOr str;
+          };
+          manager_url = lib.mkOption {
+            description = "The URL of the Manager to connect to. If the setting is blank (or removed altogether) the Worker will try to auto-detect the Manager on the network.";
+            default = null;
+            type = nullOr str;
+          };
+          restart_exit_code = lib.mkOption {
+            description = "Having this set to a non-zero value will mark this Worker as ‘restartable’.";
+            default = 47;
+            type = int;
+          };
+        };
+      };
+    };
+
+    stateDir = lib.mkOption {
+      description = "Specifies the directory in which flamenco state files and credentials reside.";
+      default = "/var/lib/flamenco";
+      type = path;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+    networking.firewall = lib.optionalAttrs (cfg.openFirewall && roleIs "manager") {
+      allowedTCPPorts = [(cfg.listen.port)];
+      allowedUDPPorts = lib.optionals (cfg.managerConfig.autodiscoverable) [1900];
+    };
+
+    systemd = {
+      services = {
+        flamenco-manager = lib.optionalAttrs (roleIs "manager") (mkService "manager");
+        flamenco-worker = lib.optionalAttrs (roleIs "worker") (mkService "worker");
+      };
+    };
+
+    users = {
+      users = lib.optionalAttrs (cfg.user == "render" && cfg.group == "render") {
+        "${cfg.user}" = {
+          uid = config.ids.uids.render;
+          group = cfg.group;
+          isSystemUser = true;
+        };
+      };
+    };
+  };
+}

--- a/pkgs/by-name/fl/flamenco/package.nix
+++ b/pkgs/by-name/fl/flamenco/package.nix
@@ -1,0 +1,95 @@
+{ lib
+, buildGoModule
+, fetchFromGitea
+, fetchYarnDeps
+, fixup-yarn-lock
+, makeWrapper
+, blender
+, ffmpeg
+, go
+, oapi-codegen
+, mockgen
+, nodejs
+, yarn
+, prefetch-yarn-deps
+}:
+let
+ version = "3.5";
+in buildGoModule rec {
+  pname = "flamenco";
+  inherit version;
+
+  src = fetchFromGitea {
+    domain = "projects.blender.org";
+    owner = "studio";
+    repo = "flamenco";
+    rev = "v${version}";
+    hash = "sha256-iAMQv4GzxS5PPQPrLCjBj7qd2HpAg91/BtMRoGTuJ5U=";
+  };
+
+  webappOfflineCache = fetchYarnDeps {
+    yarnLock = "${src}/web/app/yarn.lock";
+    hash = "sha256-QcfyiL2/ALkxZpJyiwyD7xNlkOCPu4THCyywwZ40H8s=";
+  };
+
+  vendorHash = "sha256-DJooc+rGQ61lxjqP5+5eyQe7x69R3ADOwHDMu6NbICQ=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    go
+    oapi-codegen
+    mockgen
+    nodejs
+    yarn
+    prefetch-yarn-deps
+    fixup-yarn-lock
+  ];
+
+  buildInputs = [
+    blender
+    ffmpeg
+  ];
+
+  postConfigure = ''
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror ${webappOfflineCache}
+    fixup-yarn-lock web/app/yarn.lock
+    cd web/app && yarn --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive install && cd ../..
+    patchShebangs web
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -s webapp-static
+    make -s flamenco-manager-without-webapp GOOS=linux GOARCH=amd64
+    make -s flamenco-worker GOOS=linux GOARCH=amd64
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/bin"
+    cp flamenco-manager flamenco-worker $out/bin
+  '';
+
+  postFixup = ''
+    for f in $out/bin/*
+    do
+      wrapProgram $f \
+        --set PATH ${lib.makeBinPath [
+      blender
+      ffmpeg
+    ]}
+    done
+  '';
+
+  meta = {
+    description = "Production render farm manager for Blender";
+    homepage = "https://flamenco.blender.org/";
+    license = lib.licenses.gpl3Only;
+    # TODO Wanted: maintainer for darwin
+    platforms = ["x86_64-linux"];
+    maintainers = with lib.maintainers; [hubble];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Flamenco is a render farm management software for Blender, used in production at Blender studio.

The applications are meant to be run as portable applications, but I wanted to setup systemd services and users, and so I made a module with it.

Note for testers: By default, executable will use the directory that its running in as work directory.  

homepage: https://flamenco.blender.org/
development docs: https://flamenco.blender.org/development/getting-started/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
