### PR TITLE
ocamlPackages.repr: 0.6.0 → 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/repr/default.nix
+++ b/pkgs/development/ocaml-modules/repr/default.nix
@@ -2,18 +2,16 @@
 
 buildDunePackage rec {
   pname = "repr";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "mirage";
     repo = "repr";
     rev = version;
-    hash = "sha256-jF8KmaG07CT26O/1ANc6s1yHFJqhXDtd0jgTA04tIgw=";
+    hash = "sha256-SM55m5NIaQ2UKAtznNFSt3LN4QA7As0DyTxVeQjOTjI=";
   };
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
-  strictDeps = true;
 
   propagatedBuildInputs = [
     base64

--- a/pkgs/development/ocaml-modules/repr/ppx.nix
+++ b/pkgs/development/ocaml-modules/repr/ppx.nix
@@ -3,8 +3,7 @@
 buildDunePackage {
   pname = "ppx_repr";
 
-  inherit (repr) src version strictDeps;
-  duneVersion = "3";
+  inherit (repr) src version;
 
   propagatedBuildInputs = [
     ppx_deriving
@@ -12,7 +11,7 @@ buildDunePackage {
     repr
   ];
 
-  doCheck = false; # tests fail with ppxlib >= 0.23.0
+  doCheck = true;
   checkInputs = [
     alcotest
     hex


### PR DESCRIPTION
## Description of changes

https://github.com/mirage/repr/blob/0.7.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
