### PR TITLE
xvfb-run: only set fontconfig if not specified

### DIFF
--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation rec {
     chmod a+x $out/bin/xvfb-run
     patchShebangs $out/bin/xvfb-run
     wrapProgram $out/bin/xvfb-run \
-      --set FONTCONFIG_FILE "${fontsConf}" \
+      --set-default FONTCONFIG_FILE "${fontsConf}" \
       --prefix PATH : ${lib.makeBinPath [ getopt xorgserver xauth which util-linux gawk coreutils ]}
   '';
 


### PR DESCRIPTION
Dear Maintainers,

I want to propose a change to how `xvfb-run` handles font configuration. Please see below for details on the matter.

This is a resubmission of #260680, where I scratched the automation in the wrong way.

## Description of changes
Instead of overriding the environment variable `FONTCONFIG_PATH` in all cases for applications invoked via `xvfb-run`, it is only set if no other value is given already.

From commit message:

Nix injects the environment file FONTCONFIG_PATH to xvfb-run, in order to provide some miminmal font support to applications via fontconfig.

This change only sets this environment variable if it is not given already. This allows the user to inject their own font configuration, i.e. allows them to make extra fonts available to the executed application.

If not set, the minimal font configuration will still be provided.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~ (not module)
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~ (not module)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

(I am not sure if I understood all items on this list, please point me to anything I missed.)

My machine does not have enough space (approx. 350G) to run `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.

## Motivation
This is required for using `drawio-headless` with additional fonts:
The previous version indiscriminately overrides `$FONTCONFIG_PATH`, and thus hides the user-supplied fontconfig.
It is impossible to invoke `drawio-headless` with fonts other than the default font (DejaVu Sans as of the time of writing).

> The workaround is to override the `xvfb-run` derivation for `drawio-headless`.
> ```
> drawio-headless-fonts = pkgs.drawio-headless.override {
>   xvfb-run = pkgs.xvfb-run.override {
>     fontsConf = pkgs.makeFontsConf {
>       fontDirectories = with pkgs; [ inconsolata libertine ];
>     };
>   };
> };
> ```

This version proposed in this PR only requires pointing the environment variable `$FONTCONFIG_PATH` to the correct path and then invoking `drawio-headless`.

## Changes to current setups
I don't know what the original intention of overriding `$FONTCONFIG_PATH` by force was.

If it was to isolate the application invoked by `xvfb-run`,
the `fontconfig` library unfourtunately circumvents that:
**Even** if invoked with `$FONTCONFIG_PATH` set (i.e. via `xvfb-run`),
it will still open the **system fontconfig** at `/etc/fonts` (see first row of `strace` output):
    
```bash
$ nix-shell -p xvfb-run -p fontconfig

[nix-shell:~]$ strace -ff --trace openat -- xvfb-run fc-list |& grep '/etc/fonts'
[pid ...] openat(AT_FDCWD, "/etc/fonts/conf.d", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 3
[pid ...] openat(AT_FDCWD, "/nix/store/...-fontconfig-2.14.0/etc/fonts/conf.d/10-hinting-slight.conf", O_RDONLY|O_CLOEXEC) = 4
[pid ...] openat(AT_FDCWD, "/nix/store/...-fontconfig-2.14.0/etc/fonts/conf.d/10-scale-bitmap-fonts.conf", O_RDONLY|O_CLOEXEC) = 4
[...]
```

Setting a fixed value for `$FONTCONFIG_PATH` **does not isolate applications invoked via `xvfb-run`**.
This fixed value only has an effect if running in an isolated environment,
e.g. the build sandbox.

Not overwriting values for `$FONTCONFIG_PATH` should therefore only have an affect on systems,
where `$FONTCONFIG_PATH` is set to a non-default path.
On such systems, the environment variable will now be read.
(The current nixpkgs version discards this value)
Other systems are not be affected.

Therefore, I dont believe that existing setups will be broken.
