### PR TITLE
tmux: add extraConfigBeforePlugins (backport) [23.05]

### DIFF
--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -52,6 +52,8 @@ let
     set  -s escape-time       ${toString cfg.escapeTime}
     set  -g history-limit     ${toString cfg.historyLimit}
 
+    ${cfg.extraConfigBeforePlugins}
+
     ${lib.optionalString (cfg.plugins != []) ''
     # Run plugins
     ${lib.concatMapStringsSep "\n" (x: "run-shell ${x.rtp}") cfg.plugins}
@@ -108,10 +110,18 @@ in {
         description = lib.mdDoc "Time in milliseconds for which tmux waits after an escape is input.";
       };
 
+      extraConfigBeforePlugins = mkOption {
+        default = "";
+        description = lib.mdDoc ''
+          Additional contents of /etc/tmux.conf, to be run before sourcing plugins.
+        '';
+        type = types.lines;
+      };
+
       extraConfig = mkOption {
         default = "";
         description = lib.mdDoc ''
-          Additional contents of /etc/tmux.conf
+          Additional contents of /etc/tmux.conf, to be run after sourcing plugins.
         '';
         type = types.lines;
       };


### PR DESCRIPTION
Backport of addfb000c4f2ae2643886c7c3206b7b06fdad850.

Original PR: https://github.com/NixOS/nixpkgs/pull/222515