### PR TITLE
xfsprogs: 6.4.0 -> 6.6.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -148,6 +148,10 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 - `services.archisteamfarm` no longer uses the abbreviation `asf` for its state directory (`/var/lib/asf`), user and group (both `asf`). Instead the long name `archisteamfarm` is used.
   Configurations with `system.stateVersion` 23.11 or earlier, default to the old stateDirectory until the 24.11 release and must either set the option explicitly or move the data to the new directory.
 
+- `xfsprogs` was updated to version 6.6.0, which enables reverse mapping (rmapbt) and large extent counts (nrext64) by default.
+   Support for these features was added in kernel 4.9 and 5.19 and nrext64 was deemed stable in kernel 6.5.
+   Format your filesystems with `mkfs.xfs -i nrext64=0`, if they need to be readable by GRUB2 before 2.12 or kernels older than 5.19.
+
 - `networking.iproute2.enable` now does not set `environment.etc."iproute2/rt_tables".text`.
 
   Setting `environment.etc."iproute2/{CONFIG_FILE_NAME}".text` will override the whole configuration file instead of appending it to the upstream configuration file.

--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -36,9 +36,14 @@ lib.listToAttrs (
     lib.flip lib.concatMap kernelVersionsToTest (version:
       let
         v' = lib.replaceStrings [ "." ] [ "_" ] version;
+        mkXfsFlags = lib.optionalString (lib.versionOlder version "5.10") " -m bigtime=0 -m inobtcount=0 "
+                     + lib.optionalString (lib.versionOlder version "5.19") " -i nrext64=0 ";
       in
       lib.flip lib.mapAttrsToList tests (name: t:
-        lib.nameValuePair "lvm-${name}-linux-${v'}" (lib.optionalAttrs (builtins.elem version (t.kernelFilter kernelVersionsToTest)) (t.test ({ kernelPackages = pkgs."linuxPackages_${v'}"; } // builtins.removeAttrs t [ "test" "kernelFilter" ])))
+        lib.nameValuePair "lvm-${name}-linux-${v'}" (lib.optionalAttrs (builtins.elem version (t.kernelFilter kernelVersionsToTest)) (t.test ({
+          kernelPackages = pkgs."linuxPackages_${v'}";
+          inherit mkXfsFlags;
+        } // builtins.removeAttrs t [ "test" "kernelFilter" ])))
       )
     )
   )

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -1,4 +1,4 @@
-{ kernelPackages ? null, flavour }: let
+{ kernelPackages ? null, flavour, mkXfsFlags ? "" }: let
   preparationCode = {
     raid = ''
       machine.succeed("vgcreate test_vg /dev/vdb /dev/vdc")
@@ -71,7 +71,7 @@ in import ../make-test-python.nix ({ pkgs, lib, ... }: {
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
 
-    environment.systemPackages = with pkgs; [ e2fsprogs ]; # for mkfs.ext4
+    environment.systemPackages = with pkgs; [ xfsprogs ];
     boot = {
       initrd.systemd = {
         enable = true;
@@ -88,7 +88,7 @@ in import ../make-test-python.nix ({ pkgs, lib, ... }: {
     machine.wait_for_unit("multi-user.target")
     # Create a VG for the root
     ${preparationCode}
-    machine.succeed("mkfs.ext4 /dev/test_vg/test_lv")
+    machine.succeed("mkfs.xfs ${mkXfsFlags} /dev/test_vg/test_lv")
     machine.succeed("mkdir -p /mnt && mount /dev/test_vg/test_lv /mnt && echo hello > /mnt/test && umount /mnt")
 
     # Boot from LVM

--- a/nixos/tests/lvm2/thinpool.nix
+++ b/nixos/tests/lvm2/thinpool.nix
@@ -1,4 +1,4 @@
-{ kernelPackages ? null }:
+{ kernelPackages ? null, mkXfsFlags ? "" }:
 import ../make-test-python.nix ({ pkgs, lib, ... }: {
   name = "lvm2-thinpool";
   meta.maintainers = lib.teams.helsinki-systems.members;
@@ -18,7 +18,8 @@ import ../make-test-python.nix ({ pkgs, lib, ... }: {
   };
 
   testScript = let
-    mkXfsFlags = lib.optionalString (lib.versionOlder kernelPackages.kernel.version "5.10") "-m bigtime=0 -m inobtcount=0";
+    mkXfsFlags = lib.optionalString (lib.versionOlder kernelPackages.kernel.version "5.10") " -m bigtime=0 -m inobtcount=0 "
+               + lib.optionalString (lib.versionOlder kernelPackages.kernel.version "5.19") " -i nrext64=0 ";
   in ''
     machine.succeed("vgcreate test_vg /dev/vdb")
     machine.succeed("lvcreate -L 512M -T test_vg/test_thin_pool")

--- a/nixos/tests/lvm2/vdo.nix
+++ b/nixos/tests/lvm2/vdo.nix
@@ -1,4 +1,4 @@
-{ kernelPackages ? null }:
+{ kernelPackages ? null, mkXfsFlags ? "" }:
 import ../make-test-python.nix ({ pkgs, lib, ... }: {
   name = "lvm2-vdo";
   meta.maintainers = lib.teams.helsinki-systems.members;
@@ -17,7 +17,7 @@ import ../make-test-python.nix ({ pkgs, lib, ... }: {
   testScript = ''
     machine.succeed("vgcreate test_vg /dev/vdb")
     machine.succeed("lvcreate --type vdo -n vdo_lv -L 6G -V 12G test_vg/vdo_pool_lv")
-    machine.succeed("mkfs.xfs -K /dev/test_vg/vdo_lv")
+    machine.succeed("mkfs.xfs ${mkXfsFlags} -K /dev/test_vg/vdo_lv")
     machine.succeed("mkdir /mnt; mount /dev/test_vg/vdo_lv /mnt")
     assert "/dev/mapper/test_vg-vdo_lv" == machine.succeed("findmnt -no SOURCE /mnt").strip()
     machine.succeed("umount /mnt")

--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "xfsprogs";
-  version = "6.4.0";
+  version = "6.6.0";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/fs/xfs/xfsprogs/${pname}-${version}.tar.xz";
-    hash = "sha256-wxhoQYv79Jo6nEf8cM3/3p2W9P8AUb0EoIgeZlRkgQQ=";
+    hash = "sha256-UMovRnbfj6tMtMPvPdUS1VUeaETUCmWjHVuOA1k9It8=";
   };
 
   outputs = [ "bin" "dev" "out" "doc" ];


### PR DESCRIPTION
## Description of changes

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).