### PR TITLE
net-cpp: init at 3.1.0

### DIFF
--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -1,0 +1,118 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, boost
+, cmake
+, curl
+, doxygen
+, graphviz
+, gtest
+, jsoncpp
+, lomiri
+, pkg-config
+, process-cpp
+, properties-cpp
+, python3
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: with ps; [
+    httpbin
+  ]);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "net-cpp";
+  version = "3.1.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lib-cpp/net-cpp";
+    rev = finalAttrs.version;
+    hash = "sha256-qXKuFLmtPjdqTcBIM07xbRe3DnP7AzieCy7Tbjtl0uc=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  patches = [
+    # Enable disabling of Werror
+    # Remove when version > 3.1.0
+    (fetchpatch {
+      name = "0001-net-cpp-Add-ENABLE_WERROR-option.patch";
+      url = "https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/commit/0945180aa6dd38245688d5ebc11951b272e93dc4.patch";
+      hash = "sha256-91YuEgV+Q9INN4BJXYwWgKUNHHtUYz3CG+ROTy24GIE=";
+    })
+
+    # Be more lenient with how quickly HTTP test server must be up, for slower hardware / archs
+    (fetchpatch {
+      url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/941d9eceaa66a06eabb1eb79554548b47d4a60ab/debian/patches/1007_wait-for-flask.patch";
+      hash = "sha256-nsGkZBuqahsg70PLUxn5EluDjmfZ0/wSnOYimfAI4ag=";
+    })
+  ];
+
+  postPatch = if finalAttrs.doCheck then ''
+    # Use wrapped python. Removing just the /usr/bin doesn't seem to work?
+    substituteInPlace tests/httpbin.h.in \
+      --replace '/usr/bin/python3' '${lib.getExe pythonEnv}'
+  '' else ''
+    sed -i CMakeLists.txt -e '/add_subdirectory(tests)/d'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+  ];
+
+  buildInputs = [
+    boost
+    curl
+  ];
+
+  nativeCheckInputs = [
+    pkg-config
+    pythonEnv
+  ];
+
+  checkInputs = [
+    lomiri.cmake-extras
+    gtest
+    jsoncpp
+    process-cpp
+    properties-cpp
+  ];
+
+  cmakeFlags = [
+    # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/issues/4
+    "-DENABLE_WERROR=OFF"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Tests start HTTP server in separate process with fixed URL, parallelism breaks things
+  enableParallelChecking = false;
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Simple yet beautiful networking API for C++11";
+    homepage = "https://gitlab.com/ubports/development/core/lib-cpp/net-cpp";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "net-cpp"
+    ];
+  };
+})

--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -49,6 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-91YuEgV+Q9INN4BJXYwWgKUNHHtUYz3CG+ROTy24GIE=";
     })
 
+    # Enable opting out of tests
+    # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/merge_requests/14
+    (fetchpatch {
+      name = "0002-net-cpp-Make-tests-optional.patch";
+      url = "https://gitlab.com/OPNA2608/net-cpp/-/commit/cfbcd55446a4224a4c913ead3a370cd56d07a71b.patch";
+      hash = "sha256-kt48txzmWNXyxvx3DWAJl7I90c+o3KlgveNQjPkhfxA=";
+    })
+
     # Be more lenient with how quickly HTTP test server must be up, for slower hardware / archs
     (fetchpatch {
       url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/941d9eceaa66a06eabb1eb79554548b47d4a60ab/debian/patches/1007_wait-for-flask.patch";
@@ -56,12 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = if finalAttrs.doCheck then ''
+  postPatch = lib.optionalString finalAttrs.doCheck ''
     # Use wrapped python. Removing just the /usr/bin doesn't seem to work?
     substituteInPlace tests/httpbin.h.in \
       --replace '/usr/bin/python3' '${lib.getExe pythonEnv}'
-  '' else ''
-    sed -i CMakeLists.txt -e '/add_subdirectory(tests)/d'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[net-cpp](https://gitlab.com/ubports/development/core/lib-cpp/net-cpp), a C++11 networking library. Needed by Lomiri's location service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
