### PR TITLE
tor-browser: use system install & simplify wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -1,9 +1,12 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
 , makeDesktopItem
 , copyDesktopItems
+, makeWrapper
 , writeText
 , autoPatchelfHook
+, wrapGAppsHook
 , callPackage
 
 , atk
@@ -34,6 +37,9 @@
 , libdrm
 , libGL
 
+, mediaSupport ? true
+, ffmpeg
+
 , audioSupport ? mediaSupport
 
 , pipewireSupport ? audioSupport
@@ -46,18 +52,6 @@
 
 , libvaSupport ? mediaSupport
 , libva
-
-# Media support (implies audio support)
-, mediaSupport ? true
-, ffmpeg
-
-# Wrapper runtime
-, coreutils
-, glibcLocales
-, gnome
-, runtimeShell
-, shared-mime-info
-, gsettings-desktop-schemas
 
 # Hardening
 , graphene-hardened-malloc
@@ -150,7 +144,7 @@ stdenv.mkDerivation rec {
 
   src = sources.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
-  nativeBuildInputs = [ autoPatchelfHook copyDesktopItems ];
+  nativeBuildInputs = [ autoPatchelfHook copyDesktopItems makeWrapper wrapGAppsHook ];
   buildInputs = [
     gtk3
     alsa-lib
@@ -192,6 +186,9 @@ stdenv.mkDerivation rec {
     # firefox is a wrapper that checks for a more recent libstdc++ & appends it to the ld path
     mv firefox.real firefox
 
+    # store state at `~/.tor browser` instead of relative to executable
+    touch "$TBB_IN_STORE/system-install"
+
     # The final libPath.  Note, we could split this into firefoxLibPath
     # and torLibPath for accuracy, but this is more convenient ...
     libPath=${libPath}:$TBB_IN_STORE:$TBB_IN_STORE/TorBrowser/Tor
@@ -215,7 +212,6 @@ stdenv.mkDerivation rec {
     sed -i TorBrowser/Data/Tor/torrc-defaults \
         -e "s|\(ClientTransportPlugin snowflake\) exec|\1 exec $interp|"
 
-
     # Prepare for autoconfig.
     #
     # See https://developer.mozilla.org/en-US/Firefox/Enterprise_deployment
@@ -229,24 +225,17 @@ stdenv.mkDerivation rec {
     cat >mozilla.cfg <<EOF
     // First line must be a comment
 
-    // Always update via Nixpkgs
-    lockPref("app.update.auto", false);
-    lockPref("app.update.enabled", false);
-    lockPref("extensions.update.autoUpdateDefault", false);
-    lockPref("extensions.update.enabled", false);
-    lockPref("extensions.torbutton.versioncheck_enabled", false);
+    // Reset pref that captures store paths.
+    clearPref("extensions.xpiState");
+
+    // Stop obnoxious first-run redirection.
+    lockPref("noscript.firstRunRedirection", false);
 
     // User should never change these.  Locking prevents these
     // values from being written to prefs.js, avoiding Store
     // path capture.
     lockPref("extensions.torlauncher.torrc-defaults_path", "$TBB_IN_STORE/TorBrowser/Data/Tor/torrc-defaults");
     lockPref("extensions.torlauncher.tor_path", "$TBB_IN_STORE/TorBrowser/Tor/tor");
-
-    // Reset pref that captures store paths.
-    clearPref("extensions.xpiState");
-
-    // Stop obnoxious first-run redirection.
-    lockPref("noscript.firstRunRedirection", false);
 
     // Insist on using IPC for communicating with Tor
     //
@@ -270,18 +259,12 @@ stdenv.mkDerivation rec {
     ''}
     EOF
 
-    # Hard-code path to TBB fonts; see also FONTCONFIG_FILE in
-    # the wrapper below.
+    # FONTCONFIG_FILE is required to make fontconfig read the TBB
+    # fonts.conf; upstream uses FONTCONFIG_PATH, but FC_DEBUG=1024
+    # indicates the system fonts.conf being used instead.
     FONTCONFIG_FILE=$TBB_IN_STORE/fontconfig/fonts.conf
     sed -i "$FONTCONFIG_FILE" \
-        -e "s,<dir>fonts</dir>,<dir>$TBB_IN_STORE/fonts</dir>,"
-
-    # Preload extensions by moving into the runtime instead of storing under the
-    # user's profile directory.
-    # See https://support.mozilla.org/en-US/kb/deploying-firefox-with-extensions
-    mkdir -p "$TBB_IN_STORE/distribution/extensions"
-    mv "$TBB_IN_STORE/TorBrowser/Data/Browser/profile.default/extensions/"* \
-      "$TBB_IN_STORE/distribution/extensions"
+      -e "s,<dir>fonts</dir>,<dir>$TBB_IN_STORE/fonts</dir>,"
 
     # Hard-code paths to geoip data files.  TBB resolves the geoip files
     # relative to torrc-defaults_path but if we do not hard-code them
@@ -292,145 +275,14 @@ stdenv.mkDerivation rec {
     GeoIPv6File $TBB_IN_STORE/TorBrowser/Data/Tor/geoip6
     EOF
 
-    WRAPPER_LD_PRELOAD=${lib.optionalString (useHardenedMalloc == true)
-      "${graphene-hardened-malloc}/lib/libhardened_malloc.so"}
-
-    WRAPPER_XDG_DATA_DIRS=${lib.concatMapStringsSep ":" (x: "${x}/share") [
-      gnome.adwaita-icon-theme
-      shared-mime-info
-    ]}
-    WRAPPER_XDG_DATA_DIRS+=":"${lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
-      glib
-      gsettings-desktop-schemas
-      gtk3
-    ]};
-
-    # Generate wrapper
     mkdir -p $out/bin
-    cat > "$out/bin/tor-browser" << EOF
-    #! ${runtimeShell}
-    set -o errexit -o nounset
 
-    PATH=${lib.makeBinPath [ coreutils ]}
-    export LC_ALL=C
-    export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
-
-    # Enter local state directory.
-    REAL_HOME=\''${HOME%/}
-    TBB_HOME=\''${TBB_HOME:-''${XDG_DATA_HOME:-\$REAL_HOME/.local/share}/tor-browser}
-    HOME=\$TBB_HOME
-
-    mkdir -p "\$HOME"
-    cd "\$HOME"
-
-    # Initialize empty TBB local state directory hierarchy.  We
-    # intentionally mirror the layout that TBB would see if executed from
-    # the unpacked bundle dir.
-    mkdir -p "\$HOME/TorBrowser" "\$HOME/TorBrowser/Data"
-
-    # Initialize the Tor data directory.
-    mkdir -p "\$HOME/TorBrowser/Data/Tor"
-
-    # TBB will fail if ownership is too permissive
-    chmod 0700 "\$HOME/TorBrowser/Data/Tor"
-
-    # Initialize the browser profile state.
-    # All files under user's profile dir are generated by TBB.
-    mkdir -p "\$HOME/TorBrowser/Data/Browser/profile.default"
-
-    # Clear some files if the last known store path is different from the new one
-    : "\''${KNOWN_STORE_PATH:=\$HOME/known-store-path}"
-    if ! [ "\$KNOWN_STORE_PATH" -ef $out ]; then
-      echo "Cleanup files with outdated store references"
-      ln -Tsf $out "\$KNOWN_STORE_PATH"
-
-      # Clear out some files that tend to capture store references but are
-      # easily generated by firefox at startup.
-      rm -f "\$HOME/TorBrowser/Data/Browser/profile.default"/{addonStartup.json.lz4,compatibility.ini,extensions.ini,extensions.json}
-      rm -f "\$HOME/TorBrowser/Data/Browser/profile.default"/startupCache/*
-    fi
-
-    # XDG
-    : "\''${XDG_RUNTIME_DIR:=/run/user/\$(id -u)}"
-    : "\''${XDG_CONFIG_HOME:=\$REAL_HOME/.config}"
-
-    ${lib.optionalString pulseaudioSupport ''
-      # Figure out some envvars for pulseaudio
-      : "\''${PULSE_SERVER:=\$XDG_RUNTIME_DIR/pulse/native}"
-      : "\''${PULSE_COOKIE:=\$XDG_CONFIG_HOME/pulse/cookie}"
-    ''}
-
-    # Font cache files capture store paths; clear them out on the off
-    # chance that TBB would continue using old font files.
-    rm -rf "\$HOME/.cache/fontconfig"
-
-    # Manually specify data paths (by default TB attempts to create these in the store)
-    {
-      echo "user_pref(\"extensions.torlauncher.toronionauthdir_path\", \"\$HOME/TorBrowser/Data/Tor/onion-auth\");"
-      echo "user_pref(\"extensions.torlauncher.torrc_path\", \"\$HOME/TorBrowser/Data/Tor/torrc\");"
-      echo "user_pref(\"extensions.torlauncher.tordatadir_path\", \"\$HOME/TorBrowser/Data/Tor\");"
-    } >> "\$HOME/TorBrowser/Data/Browser/profile.default/prefs.js"
-
-    # Lift-off
-    #
-    # XAUTHORITY and DISPLAY are required for TBB to work at all.
-    #
-    # DBUS_SESSION_BUS_ADDRESS is inherited to avoid auto-launch; to
-    # prevent that, set it to an empty/invalid value prior to running
-    # tor-browser.
-    #
-    # PULSE_SERVER is necessary for audio playback.
-    #
-    # Setting FONTCONFIG_FILE is required to make fontconfig read the TBB
-    # fonts.conf; upstream uses FONTCONFIG_PATH, but FC_DEBUG=1024
-    # indicates the system fonts.conf being used instead.
-    #
-    # XDG_DATA_DIRS is set to prevent searching system dirs (looking for .desktop & icons)
-    exec env -i \
-      LD_PRELOAD=$WRAPPER_LD_PRELOAD \
-      \
-      TZ=":" \
-      TZDIR="\''${TZDIR:-}" \
-      LOCALE_ARCHIVE="\$LOCALE_ARCHIVE" \
-      \
-      TMPDIR="\''${TMPDIR:-/tmp}" \
-      HOME="\$HOME" \
-      XAUTHORITY="\''${XAUTHORITY:-\$HOME/.Xauthority}" \
-      DISPLAY="\''${DISPLAY:-}" \
-      DBUS_SESSION_BUS_ADDRESS="\''${DBUS_SESSION_BUS_ADDRESS:-unix:path=\$XDG_RUNTIME_DIR/bus}" \\
-      \
-      XDG_DATA_HOME="\$HOME/.local/share" \
-      XDG_DATA_DIRS="$WRAPPER_XDG_DATA_DIRS" \
-      \
-      PULSE_SERVER="\''${PULSE_SERVER:-}" \
-      PULSE_COOKIE="\''${PULSE_COOKIE:-}" \
-      \
-      MOZ_ENABLE_WAYLAND="\''${MOZ_ENABLE_WAYLAND:-}" \
-      WAYLAND_DISPLAY="\''${WAYLAND_DISPLAY:-}" \
-      XDG_RUNTIME_DIR="\''${XDG_RUNTIME_DIR:-}" \
-      XCURSOR_PATH="\''${XCURSOR_PATH:-}" \
-      \
-      APULSE_PLAYBACK_DEVICE="\''${APULSE_PLAYBACK_DEVICE:-plug:dmix}" \
-      \
-      TOR_SKIP_LAUNCH="\''${TOR_SKIP_LAUNCH:-}" \
-      TOR_CONTROL_HOST="\''${TOR_CONTROL_HOST:-}" \
-      TOR_CONTROL_PORT="\''${TOR_CONTROL_PORT:-}" \
-      TOR_CONTROL_COOKIE_AUTH_FILE="\''${TOR_CONTROL_COOKIE_AUTH_FILE:-}" \
-      TOR_CONTROL_PASSWD="\''${TOR_CONTROL_PASSWD:-}" \
-      TOR_SOCKS_HOST="\''${TOR_SOCKS_HOST:-}" \
-      TOR_SOCKS_PORT="\''${TOR_SOCKS_PORT:-}" \
-      \
-      FONTCONFIG_FILE="$FONTCONFIG_FILE" \
-      \
-      LD_LIBRARY_PATH="$libPath" \
-      \
-      "$TBB_IN_STORE/firefox" \
-        --class "Tor Browser" \
-        -no-remote \
-        -profile "\$HOME/TorBrowser/Data/Browser/profile.default" \
-        "\''${@}"
-    EOF
-    chmod +x $out/bin/tor-browser
+    makeWrapper "$TBB_IN_STORE/firefox" "$out/bin/tor-browser" \
+      --prefix LD_PRELOAD : "${lib.optionalString (useHardenedMalloc == true)
+        "${graphene-hardened-malloc}/lib/libhardened_malloc.so"}" \
+      --prefix LD_LIBRARY_PATH : "$libPath" \
+      --set FONTCONFIG_FILE "$FONTCONFIG_FILE" \
+      --set-default MOZ_ENABLE_WAYLAND 1
 
     # Easier access to docs
     mkdir -p $out/share/doc
@@ -447,8 +299,7 @@ stdenv.mkDerivation rec {
     LD_LIBRARY_PATH=$libPath $TBB_IN_STORE/TorBrowser/Tor/tor --version >/dev/null
 
     echo "Checking tor-browser wrapper ..."
-      TBB_HOME=$(mktemp -d) \
-      $out/bin/tor-browser --version >/dev/null
+    $out/bin/tor-browser --version >/dev/null
 
     runHook postBuild
   '';

--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchurl
 , makeDesktopItem
+, copyDesktopItems
 , writeText
 , autoPatchelfHook
 , callPackage
@@ -149,7 +150,7 @@ stdenv.mkDerivation rec {
 
   src = sources.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [ autoPatchelfHook copyDesktopItems ];
   buildInputs = [
     gtk3
     alsa-lib
@@ -160,15 +161,15 @@ stdenv.mkDerivation rec {
   preferLocalBuild = true;
   allowSubstitutes = false;
 
-  desktopItem = makeDesktopItem {
+  desktopItems = [(makeDesktopItem {
     name = "torbrowser";
-    exec = "tor-browser";
-    icon = "torbrowser";
+    exec = "tor-browser %U";
+    icon = "tor-browser";
     desktopName = "Tor Browser";
     genericName = "Web Browser";
     comment = meta.description;
     categories = [ "Network" "WebBrowser" "Security" ];
-  };
+  })];
 
   buildPhase = ''
     runHook preBuild
@@ -435,12 +436,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/doc
     ln -s $TBB_IN_STORE/TorBrowser/Docs $out/share/doc/tor-browser
 
-    # Install .desktop item
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications"/"* $out/share/applications
-    sed -i $out/share/applications/torbrowser.desktop \
-        -e "s,Exec=.*,Exec=$out/bin/tor-browser," \
-        -e "s,Icon=.*,Icon=tor-browser,"
+    # Install icons
     for i in 16 32 48 64 128; do
       mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps/
       ln -s $out/share/tor-browser/browser/chrome/icons/default/default$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/tor-browser.png


### PR DESCRIPTION
## Description of changes
The `tor-browser` package uses a complex wrapper around the binary that provides some isolation.
I want to start a discussion whether this really adds any benefit.

Some downsides of the wrapper:
- it creates and uses a default profile; other profiles cannot be used (see #243605)
- it adds quite a bit of complexity
- the wrapper differs a lot from the simple one in `mullvad-browser`

My suggestion would be to use a system installation (by creating a `system-install` besides the binary) with a simple `makeWrapper` for the `tor-browser` package, which also aligns it even more with the `mullvad-browser` package. If a user really requires more isolation than the default Tor Browser installation, they should probably create their own wrapper. That's just my opinion, though. I'm open to other suggestions.

The Tor Browser directory changes to `~/.tor project/firefox`, which is a breaking change (although most Tor Browser users probably don't mind losing their state).

Fixes #91925, fixes #272670

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).