### PR TITLE
xsct: init at 2.0

### DIFF
--- a/pkgs/by-name/xs/xsct/package.nix
+++ b/pkgs/by-name/xs/xsct/package.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, libX11
+, libXrandr
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xsct";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "faf0";
+    repo = "sct";
+    rev = finalAttrs.version;
+    hash = "sha256-XhrkaK85I/U2ChO5mZYah/TaXz03yahfMEbfgzXqytU=";
+  };
+
+  buildInputs = [
+    libX11
+    libXrandr
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "Set color temperature of screen";
+    homepage = "https://github.com/faf0/sct";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = with platforms; linux ++ freebsd ++ openbsd;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[xsct](https://github.com/faf0/sct) is a modified version of the `sct` utility. `ayatana-indicator-display` will depend on it for color adjustment functionality on non-Lomiri, X11 desktops.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
