### PR TITLE
{libsForQt5.qzxing,qt6Packages.qzxing}: init at 3.3.0

### DIFF
--- a/pkgs/development/libraries/qzxing/default.nix
+++ b/pkgs/development/libraries/qzxing/default.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, nix-update-script
+, testers
+, qmake
+, qtmultimedia
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qzxing";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ftylitak";
+    repo = "qzxing";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ASgsF5ocNWAiIy2jm6ygpDkggBcEpno6iVNWYkuWcVI=";
+  };
+
+  # QMake can't find qtmultimedia in buildInputs
+  strictDeps = false;
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtmultimedia
+  ];
+
+  dontWrapQtApps = true;
+
+  preConfigure = ''
+    cd src
+  '';
+
+  qmakeFlags = [
+    "CONFIG+=qzxing_qml"
+    "CONFIG+=qzxing_multimedia"
+    "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "Qt/QML wrapper library for the ZXing library";
+    homepage = "https://github.com/ftylitak/qzxing";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.unix;
+    pkgConfigModules = [
+      "QZXing"
+    ];
+  };
+})

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -229,6 +229,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   qxlsx = callPackage ../development/libraries/qxlsx { };
 
+  qzxing = callPackage ../development/libraries/qzxing { };
+
   soqt = callPackage ../development/libraries/soqt { };
 
   telepathy = callPackage ../development/libraries/telepathy/qt { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -40,6 +40,8 @@ in
 
   qxlsx = callPackage ../development/libraries/qxlsx { };
 
+  qzxing = callPackage ../development/libraries/qzxing { };
+
   poppler = callPackage ../development/libraries/poppler {
     lcms = pkgs.lcms2;
     qt6Support = true;


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[qzxing](https://github.com/ftylitak/qzxing), a Qt/QML wrapper for the C++ port of the ZXing library. Will be used by Lomiri's camera application for barcode scanning capabilities.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
