### PR TITLE
lomiri.qqc2-suru-style: init at 0.20230206

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -25,6 +25,7 @@ let
     lomiri-action-api = callPackage ./qml/lomiri-action-api { };
     lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
     lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
+    qqc2-suru-style = callPackage ./qml/qqc2-suru-style { };
 
     #### Services
     biometryd = callPackage ./services/biometryd { };

--- a/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
+++ b/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, qmake
+, qtdeclarative
+, qtquickcontrols2
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qqc2-suru-style";
+  version = "0.20230206";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/qqc2-suru-style";
+    rev = finalAttrs.version;
+    hash = "sha256-ZLPuXnhlR1IDhGnprcdWHLnOeS6ZzVkFhQML0iKMjO8=";
+  };
+
+  # QMake can't find Qt modules from buildInputs
+  strictDeps = false;
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtdeclarative
+    qtquickcontrols2
+  ];
+
+  dontWrapQtApps = true;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "Suru Style for QtQuick Controls 2";
+    homepage = "https://gitlab.com/ubports/development/core/qqc2-suru-style";
+    license = with licenses; [ gpl2Plus lgpl3Only cc-by-sa-30 ];
+    maintainers = teams.lomiri.members;
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
+++ b/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Suru Style for QtQuick Controls 2";
     homepage = "https://gitlab.com/ubports/development/core/qqc2-suru-style";
+    changelog = "https://gitlab.com/ubports/development/core/qqc2-suru-style/-/blob/${finalAttrs.version}/ChangeLog";
     license = with licenses; [ gpl2Plus lgpl3Only cc-by-sa-30 ];
     maintainers = teams.lomiri.members;
     platforms = platforms.unix;


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[qqc2-suru-style](https://gitlab.com/ubports/development/core/qqc2-suru-style), a QML style for Qt QuickControls2 using Suru icons. Will be used by some Lomiri applications, for example the gallery app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
