### PR TITLE
python311Packages.devpi-common: 3.7.2 -> 4.0.0; unbreak

### DIFF
--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -1,37 +1,35 @@
 { lib, buildPythonPackage, fetchPypi
+, pythonOlder
 , setuptools
+, setuptools-changelog-shortener
 , requests
-, py
 , pytestCheckHook
 , lazy
 }:
 
 buildPythonPackage rec {
   pname = "devpi-common";
-  version = "3.7.2";
+  version = "4.0.0";
   pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kHiYknmteenBgce63EpzhGBEUYcQHrDLreZ1k01eRkQ=";
+    hash = "sha256-N4f43B1Dg1mCnDF3Sj2341vVXNdjlDzF1vn7ORoLWJ8=";
   };
 
-  postPatch = ''
-    substituteInPlace tox.ini \
-      --replace "--flake8" ""
-  '';
   nativeBuildInputs = [
     setuptools
+    setuptools-changelog-shortener
   ];
 
   propagatedBuildInputs = [
     requests
-    py
     lazy
   ];
 
   nativeCheckInputs = [
-    py
     pytestCheckHook
   ];
 
@@ -45,11 +43,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/devpi/devpi/blob/common-${version}/common/CHANGELOG";
     license = licenses.mit;
     maintainers = with maintainers; [ lewo makefu ];
-    # It fails to build because it depends on packaging <22 while we
-    # use packaging >22.
-    # See the following issues for details:
-    # - https://github.com/NixOS/nixpkgs/issues/231346
-    # - https://github.com/devpi/devpi/issues/939
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -1,4 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
+, setuptools
 , requests
 , py
 , pytestCheckHook
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "devpi-common";
   version = "3.7.2";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -18,6 +20,9 @@ buildPythonPackage rec {
     substituteInPlace tox.ini \
       --replace "--flake8" ""
   '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     requests
@@ -30,9 +35,14 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pythonImportsCheck = [
+    "devpi_common"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/devpi/devpi";
     description = "Utilities jointly used by devpi-server and devpi-client";
+    changelog = "https://github.com/devpi/devpi/blob/common-${version}/common/CHANGELOG";
     license = licenses.mit;
     maintainers = with maintainers; [ lewo makefu ];
     # It fails to build because it depends on packaging <22 while we

--- a/pkgs/development/python-modules/setuptools-changelog-shortener/default.nix
+++ b/pkgs/development/python-modules/setuptools-changelog-shortener/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, tomli
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "setuptools-changelog-shortener";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fschulze";
+    repo = "setuptools-changelog-shortener";
+    rev = "refs/tags/${version}";
+    hash = "sha256-K8oVcX40K5j2CwQnulK55HykkEXAmOiUg4mZPg5T+YI=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    tomli
+    wheel
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "setuptools_changelog_shortener" ];
+
+  meta = with lib; {
+    description = "Setuptools-changelog-shortener: add only newest changelog entries to long_description";
+    homepage = "https://github.com/fschulze/setuptools-changelog-shortener";
+    changelog = "https://github.com/fschulze/setuptools-changelog-shortener/blob/${src.rev}/README.rst#changelog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -8,12 +8,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "devpi-client";
-  version = "6.0.3";
+  version = "7.0.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-csdQUxnopH+kYtoqdvyXKNW3fGkQNSREJYxjes9Dgi8=";
+    hash = "sha256-AI/GNubb7+nwz/vM6v/JoUtWup6rBJieKXtFQzrdPkE=";
   };
 
   postPatch = ''
@@ -21,8 +21,10 @@ python3.pkgs.buildPythonApplication rec {
       --replace "--flake8" ""
   '';
 
-  nativeBuildInputs = [
-    python3.pkgs.setuptools
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    setuptools-changelog-shortener
+    wheel
   ];
 
   buildInputs = [
@@ -30,17 +32,13 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    argon2-cffi-bindings
     build
     check-manifest
     devpi-common
     iniconfig
-    pep517
     pkginfo
     pluggy
     platformdirs
-    py
-    setuptools
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -9,8 +9,7 @@
 python3.pkgs.buildPythonApplication rec {
   pname = "devpi-client";
   version = "6.0.3";
-
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -21,6 +20,10 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace tox.ini \
       --replace "--flake8" ""
   '';
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+  ];
 
   buildInputs = [
     glibcLocales
@@ -66,6 +69,10 @@ python3.pkgs.buildPythonApplication rec {
   LC_ALL = "en_US.UTF-8";
 
   __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [
+    "devpi"
+  ];
 
   meta = with lib; {
     description = "Client for devpi, a pypi index server and packaging meta tool";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -92,6 +92,9 @@ buildPythonApplication rec {
   disabledTests = [
     "root_passwd_hash_option"
     "TestMirrorIndexThings"
+    "test_auth_mirror_url_no_hash"
+    "test_auth_mirror_url_with_hash"
+    "test_auth_mirror_url_hidden_in_logs"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,4 +1,5 @@
-{ lib, fetchFromGitHub, buildPythonApplication, isPy27
+{ lib, fetchFromGitHub, buildPythonApplication
+, pythonOlder
 , aiohttp
 , appdirs
 , beautifulsoup4
@@ -24,16 +25,16 @@
 
 buildPythonApplication rec {
   pname = "devpi-server";
-  version = "6.7.0";
+  version = "6.9.2";
   pyproject = true;
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
     rev = "server-${version}";
-    hash = "sha256-tevQ/Ocusz2PythGnedP6r4xARgetVosAc8uTD49H3M=";
+    hash = "sha256-HnxWLxOK+6B8O/7lpNjuSUQ0Z7NOmV2n01WFyjow6oU=";
   };
 
   sourceRoot = "${src.name}/server";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -25,7 +25,7 @@
 buildPythonApplication rec {
   pname = "devpi-server";
   version = "6.7.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = isPy27;
 
@@ -42,6 +42,10 @@ buildPythonApplication rec {
     substituteInPlace tox.ini \
       --replace "--flake8" ""
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     aiohttp
@@ -91,9 +95,14 @@ buildPythonApplication rec {
 
   __darwinAllowLocalNetworking = true;
 
+  pythonImportsCheck = [
+    "devpi_server"
+  ];
+
   meta = with lib;{
     homepage = "http://doc.devpi.net";
     description = "Github-style pypi index server and packaging meta tool";
+    changelog = "https://github.com/devpi/devpi/blob/${src.rev}/server/CHANGELOG";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12645,6 +12645,8 @@ self: super: with self; {
 
   setupmeta = callPackage ../development/python-modules/setupmeta { };
 
+  setuptools-changelog-shortener = callPackage ../development/python-modules/setuptools-changelog-shortener { };
+
   setuptools-declarative-requirements = callPackage ../development/python-modules/setuptools-declarative-requirements { };
 
   setuptools-generate = callPackage ../development/python-modules/setuptools-generate { };


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/devpi/devpi/blob/common-4.0.0/common/CHANGELOG

- python311Packages.setuptools-changelog-shortener: init at 0.2.0 as a dependency
https://github.com/fschulze/setuptools-changelog-shortener

- devpi-server: 6.7.0 -> 6.9.2
Diff: https://github.com/devpi/devpi/compare/server-6.7.0...server-6.9.2
Changelog: https://github.com/devpi/devpi/blob/server-6.9.2/server/CHANGELOG

- devpi-client: 6.0.3 -> 7.0.0
Changelog: https://github.com/devpi/devpi/blob/client-7.0.0/client/CHANGELOG

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
