### PR TITLE
libsForQt5.accounts-qml-module: init at 0.7-unstable-2022-10-28

### DIFF
--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "accounts-qml-module";
-  version = "0.7-unstable-2022-10-12";
+  version = "0.7-unstable-2022-10-28";
 
   src = fetchFromGitLab {
     owner = "accounts-sso";
     repo = "accounts-qml-module";
-    rev = "4119d52cb969b57fcab63f6bdf543e73c9c17092";
-    hash = "sha256-oixpmNJfmaPqQeAlPuKh+yj2PkXza0EHqF34Do3y4Fk=";
+    rev = "05e79ebbbf3784a87f72b7be571070125c10dfe3";
+    hash = "sha256-ZpnkZauowLPBnO3DDDtG/x07XoQGVNqEF8AQB5TZK84=";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, accounts-qt
+, dbus-test-runner
+, pkg-config
+, qmake
+, qtbase
+, qtdeclarative
+, signond
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "accounts-qml-module";
+  version = "0.7-unstable-2022-10-12";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "accounts-qml-module";
+    rev = "4119d52cb969b57fcab63f6bdf543e73c9c17092";
+    hash = "sha256-oixpmNJfmaPqQeAlPuKh+yj2PkXza0EHqF34Do3y4Fk=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/src.pro \
+      --replace '$$[QT_INSTALL_BINS]/qmlplugindump' 'qmlplugindump' \
+      --replace '$$[QT_INSTALL_QML]' '${placeholder "out"}/${qtbase.qtQmlPrefix}'
+
+    # Don't install test binary
+    sed -i tests/tst_plugin.pro \
+      -e '/TARGET = tst_plugin/a INSTALLS -= target'
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    sed -i accounts-qml-module.pro -e '/tests/d'
+  '';
+
+  # QMake can't find Qt modules in buildInputs
+  strictDeps = false;
+
+  nativeBuildInputs = [
+    pkg-config
+    qmake
+    qtdeclarative # qmlplugindump
+  ];
+
+  buildInputs = [
+    accounts-qt
+    qtbase
+    qtdeclarative
+    signond
+  ];
+
+  nativeCheckInputs = [
+    dbus-test-runner
+    xvfb-run
+  ];
+
+  dontWrapQtApps = true;
+
+  qmakeFlags = [
+    # Needs qdoc, https://github.com/NixOS/nixpkgs/pull/245379
+    "CONFIG+=no_docs"
+  ];
+
+  postConfigure = ''
+    make qmake_all
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    # Needs xcb platform plugin
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  preInstall = ''
+    # Same plugin needed here, re-export in case checks are disabled
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  meta = with lib; {
+    description = "QML bindings for libaccounts-qt + libsignon-qt";
+    homepage = "https://gitlab.com/accounts-sso/accounts-qml-module";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -80,6 +80,8 @@ in (noExtraAttrs (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdP
 
   ### LIBRARIES
 
+  accounts-qml-module = callPackage ../development/libraries/accounts-qml-module { };
+
   accounts-qt = callPackage ../development/libraries/accounts-qt { };
 
   alkimia = callPackage ../development/libraries/alkimia { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[accounts-qml-module](https://gitlab.com/accounts-sso/accounts-qml-module), a QML module to interact with `libaccounts-qt`, for online accounts management via QML. Will be needed by Lomiri applications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
