### PR TITLE
passwdqc: init at 2.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16106,6 +16106,12 @@
     githubId = 2770647;
     name = "Simon Vandel Sillesen";
   };
+  simsor = {
+    name = "Simon Garrelou";
+    email = "simon@sixfoisneuf.fr";
+    github = "simsor";
+    githubId = 300958;
+  };
   sioodmy = {
     name = "Antoni Sokołowski";
     github = "sioodmy";

--- a/pkgs/by-name/pa/passwdqc/package.nix
+++ b/pkgs/by-name/pa/passwdqc/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchzip
+, libxcrypt
+, linux-pam
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "passwdqc";
+  version = "2.0.3";
+
+  src = fetchzip {
+    url = "https://www.openwall.com/passwdqc/passwdqc-${version}.tar.gz";
+    hash = "sha256-EgPeccqS+DDDMBVMc4bd70EMnXFuyglftxuqoaYHwNY=";
+  };
+
+  buildInputs = [
+    linux-pam
+    libxcrypt
+  ];
+
+  makeFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "DEVEL_LIBDIR=${placeholder "out"}/lib"
+    "SHARED_LIBDIR=${placeholder "out"}/lib"
+    "SECUREDIR=${placeholder "out"}/lib/secure"
+    "INCLUDEDIR=${placeholder "out"}/include"
+    "MANDIR=${placeholder "out"}/share/man"
+    "LOCALEDIR=${placeholder "out"}/share/locale"
+    "CONFDIR=${placeholder "out"}/etc"
+  ];
+
+  meta = with lib; {
+    description = "Password/passphrase strength checking and enforcement";
+    homepage = "https://www.openwall.com/passwdqc/";
+    platforms = platforms.linux;
+    license = licenses.bsd0;
+    maintainers = [ maintainers.simsor ];
+  };
+}


### PR DESCRIPTION
## Description of changes

passwdqc is a collection of tools to test password strength, generate strong passwords, and enforce them using PAM. It is hosted on OpenWall: https://www.openwall.com/passwdqc/

The package itself does not have any tests to run. Once built, I was able to successfully use `pwqgen` to generate a password.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
