### PR TITLE
openpgl: Fix aarch64 compilation build failure

### DIFF
--- a/pkgs/by-name/op/openpgl/package.nix
+++ b/pkgs/by-name/op/openpgl/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DTBB_ROOT=${tbb.out}"
   ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-flax-vector-conversions";
+
   meta = {
     description = "Intel Open Path Guiding Library";
     homepage = "https://github.com/OpenPathGuidingLibrary/openpgl";


### PR DESCRIPTION
## Description of changes
Encountered error while cross compiling Blender to aarch64
```
building
build flags: -j80
[1/9] Building CXX object openpgl/CMakeFiles/openpgl.dir/__/third-party/embreeSrc/common/simd/sse.cpp.o
FAILED: openpgl/CMakeFiles/openpgl.dir/__/third-party/embreeSrc/common/simd/sse.cpp.o 
/nix/store/h6p0c4m39pbxb1i84jfgshwzzq3wcyhi-gcc-wrapper-12.3.0/bin/g++ -DBUILD_SHARED -DOPENPGL_DEVICE_TYPE_CPU_4 -DOPENPGL_DEVICE_TYPE_CPU_8 -DOPENPGL_VERSION_MAJOR=0 -DOPENPGL_VERSION_MINOR=5 -DOPENPGL_VERSION_PATCH=0 -DOPENPGL_VERSION_STRING=\"0.5.0\" -D__TBB_NO_IMPLICIT_LINKAGE=1 -Dopenpgl_EXPORTS -I/build/source/openpgl/include -I/build/source/build/openpgl/include -I/build/source/openpgl/../third-party -I/build/source/openpgl -I/build/source/build/openpgl/include/openpgl -O3 -DNDEBUG -std=c++11 -fPIC -O3 -Wall -MD -MT openpgl/CMakeFiles/openpgl.dir/__/third-party/embreeSrc/common/simd/sse.cpp.o -MF openpgl/CMakeFiles/openpgl.dir/__/third-party/embreeSrc/common/simd/sse.cpp.o.d -o openpgl/CMakeFiles/openpgl.dir/__/third-party/embreeSrc/common/simd/sse.cpp.o -c /build/source/third-party/embreeSrc/common/simd/sse.cpp
In file included from /build/source/third-party/embreeSrc/common/simd/../sys/../simd/arm/emulation.h:12,
                 from /build/source/third-party/embreeSrc/common/simd/../sys/intrinsics.h:13,
                 from /build/source/third-party/embreeSrc/common/simd/sse.h:7,
                 from /build/source/third-party/embreeSrc/common/simd/sse.cpp:4:
```

I referenced [a build file from gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/openpgl/openpgl-0.5.0.ebuild) and added a build flag `-flax-vector-conversions` 

Library built with and without cross compilation on `x86_64-linux`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
