### PR TITLE
dbus-cpp: init at 5.0.3

### DIFF
--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -1,0 +1,122 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, boost
+, cmake
+, dbus
+, doxygen
+, graphviz
+, gtest
+, libxml2
+, lomiri
+, pkg-config
+, process-cpp
+, properties-cpp
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dbus-cpp";
+  version = "5.0.3";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lib-cpp/dbus-cpp";
+    rev = finalAttrs.version;
+    hash = "sha256-t8SzPRUuKeEchT8vAsITf8MwbgHA+mR5C9CnkdVyX7s=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+    "examples"
+  ];
+
+  patches = [
+    # Handle already-stolen dbus call better
+    # Remove when version > 5.0.3
+    (fetchpatch {
+      name = "0001-dbus-cpp-src-Dont-steal-a-pending-dbus-call-more-then-once.patch";
+      url = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/commit/9f3d1ff2b1c6c732285949c3dbb35e40cf55ea92.patch";
+      hash = "sha256-xzOCIJVsK2J+X9RsV930R9uw6h4UxqwSaNOgv8v4qQU=";
+    })
+
+    # Fix GCC13 compilation
+    # Remove when version > 5.0.3
+    (fetchpatch {
+      name = "0002-dbus-cpp-Add-missing-headers-for-GCC13.patch";
+      url = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/commit/c761b1eec084962dbe64d35d7f7b86dcbe57a3f7.patch";
+      hash = "sha256-/tKe3iHWxP9jWtpdgwwRynj8565u9LxCt4WXJDXzgX4=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace doc/CMakeLists.txt \
+      --replace 'DESTINATION share/''${CMAKE_PROJECT_NAME}/doc' 'DESTINATION ''${CMAKE_INSTALL_DOCDIR}'
+
+    # Warning on aarch64-linux breaks build due to -Werror
+    substituteInPlace CMakeLists.txt \
+      --replace '-Werror' ""
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    lomiri.cmake-extras
+    dbus
+    libxml2
+    process-cpp
+    properties-cpp
+  ];
+
+  nativeCheckInputs = [
+    dbus
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DDBUS_CPP_ENABLE_DOC_GENERATION=ON"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # DBus mess, hoping this fixes occational flakiness
+  enableParallelChecking = false;
+
+  preFixup = ''
+    moveToOutput libexec/examples $examples
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "A dbus-binding leveraging C++-11";
+    homepage = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    mainProgram = "dbus-cppc";
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "dbus-cpp"
+    ];
+  };
+})

--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -94,9 +94,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-DDBUS_CPP_ENABLE_DOC_GENERATION=ON"
   ];
 
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  # Too flaky on ARM CI & for some amd64 users
+  doCheck = false;
 
-  # DBus mess, hoping this fixes occational flakiness
+  # DBus, parallelism messes with communication
   enableParallelChecking = false;
 
   preFixup = ''

--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -60,6 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Warning on aarch64-linux breaks build due to -Werror
     substituteInPlace CMakeLists.txt \
       --replace '-Werror' ""
+
+    # pkg-config output patching hook expects prefix variable here
+    substituteInPlace data/dbus-cpp.pc.in \
+      --replace 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
   '' + lib.optionalString (!finalAttrs.doCheck) ''
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
   '';


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[dbus-cpp](https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp), a C++11 dbus-binding. Repo says it's header only, *squints at monitor* but it builds a library to link against. Oh well. Needed by Lomiri's location service, biometry daemon, mediascanner2 service & trust store.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
