### PR TITLE
Revert "[staging-next] kubo: use buildGo120Module due to breakage after default go version bump"

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9862,9 +9862,7 @@ with pkgs;
 
   kubergrunt = callPackage ../applications/networking/cluster/kubergrunt { };
 
-  kubo = callPackage ../applications/networking/kubo {
-    buildGoModule = buildGo120Module;
-  };
+  kubo = callPackage ../applications/networking/kubo { };
 
   kubo-migrator-all-fs-repo-migrations = callPackage ../applications/networking/kubo-migrator/all-migrations.nix { };
   kubo-migrator-unwrapped = callPackage ../applications/networking/kubo-migrator/unwrapped.nix { };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#257901

As per comment https://github.com/NixOS/nixpkgs/pull/257901#issuecomment-1751995132 by maintainer @Luflosi.

Targetting https://github.com/NixOS/nixpkgs/pull/257792/