### PR TITLE
lomiri.u1db-qt: init at 0.1.7

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -17,6 +17,7 @@ let
     gmenuharness = callPackage ./development/gmenuharness { };
     libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
+    u1db-qt = callPackage ./development/u1db-qt { };
 
     #### Services
     biometryd = callPackage ./services/biometryd { };

--- a/pkgs/desktops/lomiri/development/u1db-qt/default.nix
+++ b/pkgs/desktops/lomiri/development/u1db-qt/default.nix
@@ -1,0 +1,102 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, cmake
+, dbus-test-runner
+, pkg-config
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "u1db-qt";
+  version = "0.1.7";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/u1db-qt";
+    rev = finalAttrs.version;
+    hash = "sha256-qlWkxpiVEUbpsKhzR0s7SKaEFCLM2RH+v9XmJ3qLoGY=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "examples"
+  ];
+
+  postPatch = ''
+    patchShebangs tests/strict-qmltestrunner.sh
+
+    # QMake query response is broken
+    substituteInPlace modules/U1db/CMakeLists.txt \
+      --replace "\''${QT_IMPORTS_DIR}" "$out/$qtQmlPrefix"
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    # Other locations add dependencies to custom check target from tests
+    substituteInPlace CMakeLists.txt \
+      --replace 'add_subdirectory(tests)' 'add_custom_target(check COMMAND "echo check dummy")'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qtdeclarative # qmlplugindump
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus-test-runner
+  ];
+
+  cmakeFlags = [
+    # Needs qdoc
+    "-DBUILD_DOCS=OFF"
+  ];
+
+  dontWrapQtApps = true;
+
+  preBuild = ''
+    # Executes qmlplugindump
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export QT_QPA_PLATFORM=minimal
+  '';
+
+  postInstall = ''
+    # Example seems unmaintained & depends on old things
+    # (unity-icon-theme, QtWebKit, Ubuntu namespace compat in LUITK)
+    # With an uneducated attempt at porting it to QtWebView, only displays blank window. Just throw it away.
+    rm -r $out/share/applications
+
+    moveToOutput share/u1db-qt/qtcreator $dev
+    moveToOutput share/u1db-qt/examples $examples
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Qt5 binding and QtQuick2 plugin for U1DB";
+    homepage = "https://gitlab.com/ubports/development/core/u1db-qt";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "libu1db-qt5"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[u1db-qt](https://gitlab.com/ubports/development/core/u1db-qt), a Qt5 binding & QML module for the [U1DB API](https://launchpad.net/u1db/). Will be used by the Lomiri clock app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
