### PR TITLE
lilv: 0.24.12 -> 0.24.20

### DIFF
--- a/pkgs/development/libraries/audio/lilv/default.nix
+++ b/pkgs/development/libraries/audio/lilv/default.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchurl, lv2, pkg-config, python3, serd, sord, sratom, wafHook
+{ lib
+, stdenv
+, fetchurl
+, lv2
+, meson
+, ninja
+, pkg-config
+, python3
+, libsndfile
+, serd
+, sord
+, sratom
+, gitUpdater
 
 # test derivations
 , pipewire
@@ -6,24 +18,29 @@
 
 stdenv.mkDerivation rec {
   pname = "lilv";
-  version = "0.24.12";
+  version = "0.24.20";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
-    url = "https://download.drobilla.net/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-JqN3kIkMnB+DggO0f1sjIDNP6SwCpNJuu+Jmnb12kGE=";
+    url = "https://download.drobilla.net/${pname}-${version}.tar.xz";
+    hash = "sha256-T7CCubiyhuqSu7cb3mt1Ykzsq23wzGOe51oqCWIS7rw=";
   };
 
-  patches = [ ./lilv-pkgconfig.patch ];
-
-  nativeBuildInputs = [ pkg-config python3 wafHook ];
-  buildInputs = [ serd sord sratom ];
+  nativeBuildInputs = [ meson ninja pkg-config python3 ];
+  buildInputs = [ libsndfile serd sord sratom ];
   propagatedBuildInputs = [ lv2 ];
-  dontAddWafCrossFlags = true;
 
-  passthru.tests = {
-    inherit pipewire;
+  mesonFlags = [ "-Ddocs=disabled" ];
+
+  passthru = {
+    tests = {
+      inherit pipewire;
+    };
+    updateScript = gitUpdater {
+      url = "https://gitlab.com/lv2/lilv.git";
+      rev-prefix = "v";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/audio/lilv/lilv-pkgconfig.patch
+++ b/pkgs/development/libraries/audio/lilv/lilv-pkgconfig.patch
@@ -1,6 +1,0 @@
---- a/lilv.pc.in
-+++ b/lilv.pc.in
-@@ -9 +9,2 @@ Description: Simple C library for hosting LV2 plugins
--Requires: @LILV_PKG_DEPS@
-+Requires: lv2
-+Requires.private: @LILV_PKG_DEPS@


### PR DESCRIPTION
Switched to meson build system.
Added trivial updater script.

Changes:
- https://gitlab.com/lv2/lilv/-/releases/v0.24.20
- https://gitlab.com/lv2/lilv/-/releases/v0.24.18
- https://gitlab.com/lv2/lilv/-/releases/v0.24.16
- https://gitlab.com/lv2/lilv/-/releases/v0.24.14
- https://gitlab.com/lv2/lilv/-/releases/v0.24.12

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
