### PR TITLE
erlang: 24.3.4.13 -> 24.3.4.14 25.3.2.6 -> 25.3.2.7 26.1.1 -> 26.1.2

### DIFF
--- a/pkgs/development/interpreters/erlang/24.nix
+++ b/pkgs/development/interpreters/erlang/24.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "24.3.4.13";
-  sha256 = "sha256-2+Fmj6qUJoutLXbexgPRpJbspnzuwSfu4OpyRd+7N3Y=";
+  version = "24.3.4.14";
+  sha256 = "sha256-+OEA7bVomZox/iHhkRQPt91WayyxZQDkDI92B5Ez24Q=";
 }

--- a/pkgs/development/interpreters/erlang/25.nix
+++ b/pkgs/development/interpreters/erlang/25.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "25.3.2.6";
-  sha256 = "iImrVaoS5bajaZZQoZoG3VzWHFmWvId8xQPKLhl9iQo=";
+  version = "25.3.2.7";
+  sha256 = "sha256-JMHfnnvjAIrJ2YhSzk1qVeS7qGx2HDf2J+8+WFD5Bv8=";
 }

--- a/pkgs/development/interpreters/erlang/26.nix
+++ b/pkgs/development/interpreters/erlang/26.nix
@@ -1,7 +1,6 @@
-{ lib, mkDerivation }:
+{ mkDerivation }:
 
 mkDerivation {
-  version = "26.1.1";
-  sha256 = "sha256-Y0sArUFkGxlAAgrgUxn5Rjnd72geG08VO9FBxg/fJAg=";
+  version = "26.1.2";
+  sha256 = "sha256-exLLdg7z/HKJI81w33vcQUDF6NG5n2WKtcYwdPxN+0A=";
 }
-


### PR DESCRIPTION
## Description of changes

This aims to fix the issues on macOS 14 Sonoma, which has been fixed and backported to main versions.

* https://github.com/NixOS/nixpkgs/issues/258100
* https://github.com/NixOS/nixpkgs/issues/257880 (already closed, but issue exist still.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Maintainer pings
cc @ankhers @Br1ght0ne @DianaOlympos @gleber @happysalada @minijackson @yurrriq