### PR TITLE
vesktop: init at 0.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18328,6 +18328,15 @@
     githubId = 245573;
     name = "Dmitry Kalinkin";
   };
+  vgskye = {
+    name = "Skye Green";
+    email = "me@skye.vg";
+    github = "vgskye";
+    githubId = 116078858;
+    keys = [{
+      fingerprint = "CDEA 7E04 69E3 0885 A754  4B05 0104 BC05 F41B 77B8";
+    }];
+  };
   victormeriqui = {
     name = "Victor Meriqui";
     email = "victor.meriqui@ororatech.com";

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -1,0 +1,138 @@
+{ lib
+, stdenv
+, stdenvNoCC
+, fetchFromGitHub
+, substituteAll
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, vencord
+, electron
+, pipewire
+, libicns
+, jq
+, moreutils
+, nodePackages
+}:
+stdenv.mkDerivation rec {
+  pname = "vesktop";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "Vencord";
+    repo = "Vesktop";
+    rev = "v${version}";
+    sha256 = "sha256-Njs3tACxUyRolYUtS/q2lITIQnUBFXVXWZEfQ66HpPM=";
+  };
+
+  pnpm-deps = stdenvNoCC.mkDerivation {
+    pname = "${pname}-pnpm-deps";
+    inherit src version patches ELECTRON_SKIP_BINARY_DOWNLOAD;
+
+    nativeBuildInputs = [
+      jq
+      moreutils
+      nodePackages.pnpm
+    ];
+
+    # https://github.com/NixOS/nixpkgs/blob/763e59ffedb5c25774387bf99bc725df5df82d10/pkgs/applications/misc/pot/default.nix#L56
+    installPhase = ''
+      export HOME=$(mktemp -d)
+
+      pnpm config set store-dir $out
+      pnpm install --frozen-lockfile --ignore-script
+
+      rm -rf $out/v3/tmp
+      for f in $(find $out -name "*.json"); do
+        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
+        jq --sort-keys . $f | sponge $f
+      done
+    '';
+
+    dontFixup = true;
+    outputHashMode = "recursive";
+    outputHash = "sha256-vInaSLGahRUgvwAeUcI+oV84L+tgNRCmfFpE0aUD4X4=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    nodePackages.pnpm
+    nodePackages.nodejs
+    makeWrapper
+  ];
+
+  patches = [
+    (substituteAll { inherit vencord; src = ./use_system_vencord.patch; })
+  ];
+
+  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    export STORE_PATH=$(mktemp -d)
+
+    cp -r ${pnpm-deps}/* "$STORE_PATH"
+    chmod -R +w "$STORE_PATH"
+
+    pnpm config set store-dir "$STORE_PATH"
+    pnpm install --offline --frozen-lockfile --ignore-script
+    patchShebangs node_modules/{*,.*}
+  '';
+
+  postBuild = ''
+    pnpm build
+    # using `pnpm exec` here apparently makes it ignore ELECTRON_SKIP_BINARY_DOWNLOAD
+    ./node_modules/.bin/electron-builder \
+      --dir \
+      -c.electronDist=${electron}/libexec/electron \
+      -c.electronVersion=${electron.version}
+  '';
+
+  # this is consistent with other nixpkgs electron packages and upstream, as far as I am aware
+  # yes, upstream really packages it as "vesktop" but uses "vencorddesktop" file names
+  installPhase =
+    let
+      libPath = lib.makeLibraryPath [ pipewire ];
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/opt/Vesktop/resources
+      cp dist/linux-unpacked/resources/app.asar $out/opt/Vesktop/resources
+
+      pushd build
+      ${libicns}/bin/icns2png -x icon.icns
+      for file in icon_*x32.png; do
+        file_suffix=''${file//icon_}
+        install -Dm0644 $file $out/share/icons/hicolor/''${file_suffix//x32.png}/apps/vencorddesktop.png
+      done
+
+      makeWrapper ${electron}/bin/electron $out/bin/vencorddesktop \
+        --prefix LD_LIBRARY_PATH : ${libPath} \
+        --add-flags $out/opt/Vesktop/resources/app.asar \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vencorddesktop";
+      desktopName = "Vesktop";
+      exec = "vencorddesktop %U";
+      icon = "vencorddesktop";
+      startupWMClass = "VencordDesktop";
+      genericName = "Internet Messenger";
+      keywords = [ "discord" "vencord" "electron" "chat" ];
+    })
+  ];
+
+  meta = with lib; {
+    description = "An alternate client for Discord with Vencord built-in";
+    homepage = "https://github.com/Vencord/Vesktop";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ getchoo Scrumplex vgskye ];
+    platforms = platforms.linux;
+    mainProgram = "vencorddesktop";
+  };
+}

--- a/pkgs/by-name/ve/vesktop/use_system_vencord.patch
+++ b/pkgs/by-name/ve/vesktop/use_system_vencord.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/constants.ts b/src/main/constants.ts
+index d5c5fa6..a1b32f1 100644
+--- a/src/main/constants.ts
++++ b/src/main/constants.ts
+@@ -16,7 +16,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
+ // needs to be inline require because of circular dependency
+ // as otherwise "DATA_DIR" (which is used by ./settings) will be uninitialised
+ export const VENCORD_FILES_DIR =
+-    (require("./settings") as typeof import("./settings")).Settings.store.vencordDir || join(DATA_DIR, "vencordDist");
++    (require("./settings") as typeof import("./settings")).Settings.store.vencordDir || "@vencord@";
+ 
+ export const USER_AGENT = `Vesktop/${app.getVersion()} (https://github.com/Vencord/Vesktop)`;
+ 


### PR DESCRIPTION
## Description of changes

Adds [vesktop](https://github.com/Vencord/Vesktop)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

package was tested with the commits cherry-picked onto unstable due to me not wanting to compile electron from scratch just because it's not cached in hydra yet

closes #259297