### PR TITLE
jetbrains: do not hardcode x64 paths

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -17,12 +17,14 @@
 , expat
 , libxcrypt-legacy
 , fontconfig
+, libxml2
+, xz
 , vmopts ? null
 }:
 
 let
   platforms = lib.platforms.linux ++ [ "x86_64-darwin" "aarch64-darwin" ];
-  ideaPlatforms = [ "x86_64-darwin" "i686-darwin" "i686-linux" "x86_64-linux" "aarch64-darwin" ];
+  ideaPlatforms = [ "x86_64-darwin" "i686-darwin" "i686-linux" "x86_64-linux" "aarch64-darwin" "aarch64-linux" ];
 
   inherit (stdenv.hostPlatform) system;
 
@@ -58,6 +60,9 @@ let
         openssl.out
         expat
         libxcrypt-legacy
+      ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+        libxml2
+        xz
       ];
       dontAutoPatchelf = true;
       postFixup = (attrs.postFixup or "") + lib.optionalString (stdenv.isLinux) ''
@@ -65,12 +70,12 @@ let
           cd $out/clion
 
           # I think the included gdb has a couple of patches, so we patch it instead of replacing
-          ls -d $PWD/bin/gdb/linux/x64/lib/python3.8/lib-dynload/* |
+          ls -d $PWD/bin/gdb/linux/*/lib/python3.8/lib-dynload/* |
           xargs patchelf \
             --replace-needed libssl.so.10 libssl.so \
             --replace-needed libcrypto.so.10 libcrypto.so
 
-          ls -d $PWD/bin/lldb/linux/x64/lib/python3.8/lib-dynload/* |
+          ls -d $PWD/bin/lldb/linux/*/lib/python3.8/lib-dynload/* |
           xargs patchelf \
             --replace-needed libssl.so.10 libssl.so \
             --replace-needed libcrypto.so.10 libcrypto.so
@@ -271,7 +276,7 @@ let
       buildInputs = (attrs.buildInputs or [ ]) ++ lib.optionals (stdenv.isLinux) [
         stdenv.cc.cc
         zlib
-        fontconfig  # plugins/dotTrace/DotFiles/linux-x64/libSkiaSharp.so
+        fontconfig  # plugins/dotTrace/DotFiles/linux-*/libSkiaSharp.so
       ];
       dontAutoPatchelf = true;
       postFixup = (attrs.postFixup or "") + lib.optionalString (stdenv.isLinux) ''
@@ -279,12 +284,12 @@ let
           cd $out/rider
 
           # Remove dotnet copy first so it's not considered by autoPatchElf
-          rm -rf lib/ReSharperHost/linux-x64/dotnet
+          rm -rf lib/ReSharperHost/linux-*/dotnet
           autoPatchelf \
-            lib/ReSharperHost/linux-x64/ \
-            plugins/dotCommon/DotFiles/linux-x64/ \
-            plugins/dotTrace/DotFiles/linux-x64/
-          ln -s ${dotnet-sdk_7} lib/ReSharperHost/linux-x64/dotnet
+            lib/ReSharperHost/linux-*/ \
+            plugins/dotCommon/DotFiles/linux-*/ \
+            plugins/dotTrace/DotFiles/linux-*/
+          ln -s ${dotnet-sdk_7} lib/ReSharperHost/linux-*/dotnet
         )
       '';
     });
@@ -320,6 +325,10 @@ let
         libdbusmenu
         openssl.out
         libxcrypt-legacy
+      ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+        expat
+        libxml2
+        xz
       ];
       dontAutoPatchelf = true;
       postFixup = (attrs.postFixup or "") + lib.optionalString (stdenv.isLinux) ''
@@ -327,12 +336,12 @@ let
           cd $out/rust-rover
 
           # Copied over from clion (gdb seems to have a couple of patches)
-          ls -d $PWD/bin/gdb/linux/x64/lib/python3.8/lib-dynload/* |
+          ls -d $PWD/bin/gdb/linux/*/lib/python3.8/lib-dynload/* |
           xargs patchelf \
             --replace-needed libssl.so.10 libssl.so \
             --replace-needed libcrypto.so.10 libcrypto.so
 
-          ls -d $PWD/bin/lldb/linux/x64/lib/python3.8/lib-dynload/* |
+          ls -d $PWD/bin/lldb/linux/*/lib/python3.8/lib-dynload/* |
           xargs patchelf \
             --replace-needed libssl.so.10 libssl.so \
             --replace-needed libcrypto.so.10 libcrypto.so
@@ -340,8 +349,8 @@ let
           autoPatchelf $PWD/bin
 
           interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
-          patchelf --set-interpreter $interp $PWD/plugins/intellij-rust/bin/linux/x86-64/intellij-rust-native-helper
-          chmod +x $PWD/plugins/intellij-rust/bin/linux/x86-64/intellij-rust-native-helper
+          patchelf --set-interpreter $interp $PWD/plugins/intellij-rust/bin/linux/*/intellij-rust-native-helper
+          chmod +x $PWD/plugins/intellij-rust/bin/linux/*/intellij-rust-native-helper
         )
       '';
     });


### PR DESCRIPTION
## Description of changes

Since the sources are ready, this would make the derivations buildable on aarch64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
