### PR TITLE
lomiri.lomiri-action-api: init at 1.1.2

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -20,6 +20,7 @@ let
     u1db-qt = callPackage ./development/u1db-qt { };
 
     #### QML / QML-related
+    lomiri-action-api = callPackage ./qml/lomiri-action-api { };
     lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
 
     #### Services

--- a/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, cmake
+, dbus
+, dbus-test-runner
+, pkg-config
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-action-api";
+  version = "1.1.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-action-api";
+    rev = finalAttrs.version;
+    hash = "sha256-FOHjZ5F4IkjSn/SpZEz25CbTR/gaK4D7BRxDVSDuAl8=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Drop deprecated qt5_use_modules usage
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-action-api/-/merge_requests/4 merged & in release
+    (fetchpatch {
+      url = "https://gitlab.com/OPNA2608/lomiri-action-api/-/commit/ff1d7f7eb127f6a00a99e8b278c963899d0303f0.patch";
+      hash = "sha256-nLUoRl260hMbtEPjOQJI/3w54xgFxjcxerAqNN5FU/0=";
+    })
+  ];
+
+  postPatch = ''
+    # Queries QMake for broken Qt variable: '/build/qtbase-<commit>/$(out)/$(qtQmlPrefix)'
+    substituteInPlace qml/Lomiri/Action/CMakeLists.txt \
+      --replace "\''${QT_IMPORTS_DIR}/Lomiri" '${qtbase.qtQmlPrefix}/Lomiri'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_TESTING=${lib.boolToString finalAttrs.finalPackage.doCheck}"
+    "-Duse_libhud2=OFF" # Use vendored libhud2, TODO package libhud2 separately?
+    "-DGENERATE_DOCUMENTATION=OFF" # QML docs need qdoc, https://github.com/NixOS/nixpkgs/pull/245379
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Allow applications to export actions in various forms to the Lomiri Shell";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-action-api";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "lomiri-action-qt-1"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[lomiri-action-api](https://gitlab.com/ubports/development/core/lomiri-action-api) lets applications export actions to the Lomiri Shell. Used by some Lomiri applications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
