### PR TITLE
lomiri.biometryd: init at 0.3.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -14,6 +14,9 @@ let
     gmenuharness = callPackage ./development/gmenuharness { };
     libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
+
+    #### Services
+    biometryd = callPackage ./services/biometryd { };
   };
 in
   lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -1,0 +1,108 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, boost
+, cmake
+, cmake-extras
+, dbus
+, dbus-cpp
+, gtest
+, libapparmor
+, libelf
+, pkg-config
+, process-cpp
+, properties-cpp
+, qtbase
+, qtdeclarative
+, sqlite
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "biometryd";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/biometryd";
+    rev = finalAttrs.version;
+    hash = "sha256-b095rsQnd63Ziqe+rn3ROo4LGXZxZ3Sa6h3apzCuyCs=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace '/etc' "\''${CMAKE_INSTALL_SYSCONFDIR}" \
+      --replace '/lib' "\''${CMAKE_INSTALL_LIBDIR}"
+
+    substituteInPlace data/biometryd.{conf,service} \
+      --replace '/usr/bin' "$out/bin"
+
+    substituteInPlace src/biometry/qml/Biometryd/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qtdeclarative # qmlplugindump
+  ];
+
+  buildInputs = [
+    boost
+    cmake-extras
+    dbus
+    dbus-cpp
+    libapparmor
+    libelf
+    process-cpp
+    properties-cpp
+    qtbase
+    qtdeclarative
+    sqlite
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DENABLE_WERROR=OFF"
+    "-DWITH_HYBRIS=OFF"
+  ];
+
+  preBuild = ''
+    # Generating plugins.qmltypes (also used in checkPhase?)
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  meta = with lib; {
+    description = "Mediates/multiplexes access to biometric devices";
+    longDescription = ''
+      biometryd mediates and multiplexes access to biometric devices present
+      on the system, enabling applications and system components to leverage
+      them for identification and verification of users.
+    '';
+    homepage = "https://gitlab.com/ubports/development/core/biometryd";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    mainProgram = "biometryd";
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "biometryd"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , gitUpdater
 , testers
 , boost
@@ -35,13 +36,41 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  postPatch = ''
-    substituteInPlace data/CMakeLists.txt \
-      --replace '/etc' "\''${CMAKE_INSTALL_SYSCONFDIR}" \
-      --replace '/lib' "\''${CMAKE_INSTALL_LIBDIR}"
+  patches = [
+    # https://gitlab.com/ubports/development/core/biometryd/-/merge_requests/31
+    (fetchpatch {
+      url = "https://gitlab.com/OPNA2608/biometryd/-/commit/d01d979e4f98c6473761d1ace308aa182017804e.patch";
+      hash = "sha256-JxL3BLuh33ptfneU1y2qNGFKpeMlZlTMwCK97Rk3aTA=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/OPNA2608/biometryd/-/commit/3cec6a3d42ea6aba8892da2c771b317f44daf9e2.patch";
+      hash = "sha256-Ij/aio38WmZ+NsUSbM195Gwb83goWIcCnJvGwAOJi50=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/OPNA2608/biometryd/-/commit/e89bd9444bc1cfe84a9aa93faa23057c80f39564.patch";
+      hash = "sha256-1vEG349X9+SvY/f3no/l5cMVGpdzC8h/8XOZwL/70Dc=";
+    })
 
-    substituteInPlace data/biometryd.{conf,service} \
-      --replace '/usr/bin' "$out/bin"
+    # https://gitlab.com/ubports/development/core/biometryd/-/merge_requests/32
+    (fetchpatch {
+      url = "https://gitlab.com/OPNA2608/biometryd/-/commit/9e52fad0139c5a45f69e6a6256b2b5ff54f77740.patch";
+      hash = "sha256-DZSdzKq6EYgAllKSDgkGk2g57zHN+gI5fOoj7U5AcKY=";
+    })
+  ];
+
+  postPatch = ''
+    # Remove with !31 patches, fetchpatch can't apply renames
+    pushd data
+    for type in conf service; do
+      mv biometryd.$type biometryd.$type.in
+      substituteInPlace biometryd.$type.in \
+        --replace '/usr/bin' "\''${CMAKE_INSTALL_FULL_BINDIR}"
+    done
+    popd
+
+    # Uses pkg_get_variable, cannot substitute prefix with that
+    substituteInPlace CMakeLists.txt \
+      --replace 'pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)' 'set(SYSTEMD_SYSTEM_UNIT_DIR "${placeholder "out"}/lib/systemd/system")'
 
     substituteInPlace src/biometry/qml/Biometryd/CMakeLists.txt \
       --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Biometryd](https://gitlab.com/ubports/development/core/biometryd) multiplexes and mediates access to biometric identification & verification hardware for the Lomiri stack. I lack the hardware to test this, and I think it might be designed more for mobile devices (via Hybris) than the desktop, but some applications depend on in: Lomiri Shell, system settings app & file manager app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
