### PR TITLE
lomiri.hfd-service: init at 0.2.1

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -20,6 +20,7 @@ let
 
     #### Services
     biometryd = callPackage ./services/biometryd { };
+    hfd-service = callPackage ./services/hfd-service { };
   };
 in
   lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/services/hfd-service/default.nix
+++ b/pkgs/desktops/lomiri/services/hfd-service/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitLab
 , gitUpdater
+, accountsservice
 , cmake
 , cmake-extras
 , deviceinfo
@@ -15,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hfd-service";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/hfd-service";
     rev = finalAttrs.version;
-    hash = "sha256-F1MLYcCYe2GAPNO3UuONM4/j9AnV+V2YgePBn2QY5zM=";
+    hash = "sha256-KcHwLTSdo86YCteUsPndoxmLf23SOEhROc5cJQ8GS1Q=";
   };
 
   postPatch = ''
@@ -31,6 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Queries pkg-config via pkg_get_variable, can't override prefix
     substituteInPlace init/CMakeLists.txt \
       --replace "\''${SYSTEMD_SYSTEM_DIR}" "$out/lib/systemd/system"
+    substituteInPlace CMakeLists.txt \
+      --replace 'pkg_get_variable(AS_INTERFACES_DIR accountsservice interfacesdir)' 'set(AS_INTERFACES_DIR "''${CMAKE_INSTALL_DATADIR}/accountsservice/interfaces")' \
+      --replace 'DESTINATION ''${DBUS_INTERFACES_DIR}' 'DESTINATION ${placeholder "out"}/''${DBUS_INTERFACES_DIR}'
+    substituteInPlace src/CMakeLists.txt \
+      --replace "\''${DBUS_INTERFACES_DIR}/org.freedesktop.Accounts.xml" '${accountsservice}/share/dbus-1/interfaces/org.freedesktop.Accounts.xml'
   '';
 
   strictDeps = true;
@@ -41,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    accountsservice
     cmake-extras
     deviceinfo
     libgbinder

--- a/pkgs/desktops/lomiri/services/hfd-service/default.nix
+++ b/pkgs/desktops/lomiri/services/hfd-service/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, cmake
+, cmake-extras
+, deviceinfo
+, libgbinder
+, libglibutil
+, pkg-config
+, qtbase
+, qtdeclarative
+, qtfeedback
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hfd-service";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/hfd-service";
+    rev = finalAttrs.version;
+    hash = "sha256-F1MLYcCYe2GAPNO3UuONM4/j9AnV+V2YgePBn2QY5zM=";
+  };
+
+  postPatch = ''
+    substituteInPlace qt/feedback-plugin/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/plugins" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}"
+
+    # Queries pkg-config via pkg_get_variable, can't override prefix
+    substituteInPlace init/CMakeLists.txt \
+      --replace "\''${SYSTEMD_SYSTEM_DIR}" "$out/lib/systemd/system"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    deviceinfo
+    libgbinder
+    libglibutil
+    qtbase
+    qtdeclarative
+    qtfeedback
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_LIBHYBRIS=OFF"
+  ];
+
+  dontWrapQtApps = true;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "DBus-activated service that manages human feedback devices such as LEDs and vibrators on mobile devices";
+    homepage = "https://gitlab.com/ubports/development/core/hfd-service";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[hfd-service](https://gitlab.com/ubports/development/core/hfd-service) manages human feedback devices for the Lomiri stack. Pretty sure this is primarily designed for mobile devices via Hybris, but doesn't hurt to package it in dummy mode. Lomiri Shell will attempt to start this up on launch, and tries to import its QML module.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
Test binaries do nothing of note due to dummy mode, but they don't *fail* either.
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
