### PR TITLE
codeium: init at 1.2.104

### DIFF
--- a/pkgs/by-name/co/codeium/package.nix
+++ b/pkgs/by-name/co/codeium/package.nix
@@ -1,0 +1,69 @@
+{ stdenv, lib, fetchurl, gzip, autoPatchelfHook }:
+let
+
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  plat = {
+    x86_64-linux = "linux_x64";
+    aarch64-linux = "linux_arm";
+    x86_64-darwin = "macos_x64";
+    aarch64-darwin = "macos_arm";
+
+  }.${system} or throwSystem;
+
+  hash = {
+    x86_64-linux = "sha256-9EGoJ5DoGgVfbhCDeTvn1D7misJEj9jPwuiOK7z95Ts=";
+    aarch64-linux = "sha256-lO0YOSiO8AUrkbV+3Uyvg6p3bdAcTze3La2g5IcK1f0=";
+    x86_64-darwin = "sha256-WjvC3pt8Gd4q+BzrOhyGeYwZIbv2m5O3pSXe1N7Najw=";
+    aarch64-darwin = "sha256-IRm5m/Jaf4pmAzx+MXwmHLejo6Gv2OL56R1IEr/NlZU=";
+  }.${system} or throwSystem;
+
+  bin = "$out/bin/codeium_language_server";
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "codeium";
+  version = "1.2.104";
+  src = fetchurl {
+    name = "${finalAttrs.pname}-${finalAttrs.version}.gz";
+    url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${finalAttrs.version}/language_server_${plat}.gz";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ gzip ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    gzip -dc $src > ${bin}
+    chmod +x ${bin}
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = rec {
+    description = "Codeium language server";
+    longDescription = ''
+      Codeium proprietary language server, patched for Nix(OS) compatibility.
+      bin/language_server_x must be symlinked into the plugin directory, replacing the existing binary.
+      For example:
+      ```shell
+      ln -s "$(which codeium_language_server)" /home/a/.local/share/JetBrains/Rider2023.1/codeium/662505c9b23342478d971f66a530cd102ae35df7/language_server_linux_x64
+      ```
+    '';
+    homepage = "https://codeium.com/";
+    downloadPage = homepage;
+    changelog = homepage;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ anpin ];
+    mainProgram = "codeium";
+    platforms = [ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/co/codeium/update.sh
+++ b/pkgs/by-name/co/codeium/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk nix-prefetch jq
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/package.nix"
+if [ ! -f "$NIX_DRV" ]; then
+  echo "ERROR: cannot find package.nix in $ROOT"
+  exit 1
+fi
+
+fetch_arch() {
+  VER="$1"; ARCH="$2"
+  URL="https://github.com/Exafunction/codeium/releases/download/language-server-v${VER}/language_server_${ARCH}.gz"
+  nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$URL")"
+}
+
+replace_hash() {
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+}
+
+CODEIUM_VER=$(curl -s "https://api.github.com/repos/Exafunction/codeium/releases/latest" | jq -r .tag_name | grep -oP '\d+\.\d+\.\d+' )
+
+CODEIUM_LINUX_X64_HASH=$(fetch_arch "$CODEIUM_VER" "linux_x64")
+CODEIUM_LINUX_AARCH64_HASH=$(fetch_arch "$CODEIUM_VER" "linux_arm")
+CODEIUM_DARWIN_X64_HASH=$(fetch_arch "$CODEIUM_VER" "macos_x64")
+CODEIUM_DARWIN_AARCH64_HASH=$(fetch_arch "$CODEIUM_VER" "macos_arm")
+
+sed -i "s/version = \".*\"/version = \"$CODEIUM_VER\"/" "$NIX_DRV"
+
+replace_hash "x86_64-linux" "$CODEIUM_LINUX_X64_HASH"
+replace_hash "aarch64-linux" "$CODEIUM_LINUX_AARCH64_HASH"
+replace_hash "x86_64-darwin" "$CODEIUM_DARWIN_X64_HASH"
+replace_hash "aarch64-darwin" "$CODEIUM_DARWIN_AARCH64_HASH"


### PR DESCRIPTION
## Description of changes

Codeium language server 

Overhaul of https://github.com/NixOS/nixpkgs/pull/234808 with update script and without jetbrains plugin

## Things done

- Built on platform(s)
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).