### PR TITLE
ibm-sw-tpm2: backport openssl-3.1 support

### DIFF
--- a/pkgs/tools/security/ibm-sw-tpm2/default.nix
+++ b/pkgs/tools/security/ibm-sw-tpm2/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, lib, openssl }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, openssl
+}:
 
 stdenv.mkDerivation rec {
   pname = "ibm-sw-tpm2";
@@ -8,6 +13,18 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/ibmswtpm2/ibmtpm${version}.tar.gz";
     hash = "sha256-PLZC+HGheyPVCwRuX5X0ScIodBX8HnrrS9u4kg28s48=";
   };
+
+  patches = [
+    # Backport openssl-3.1 from development branch.
+    # Can be removed with next release.
+    (fetchpatch {
+      name = "openssl-3.1.patch";
+      url = "https://github.com/kgoldman/ibmswtpm2/commit/15501bf4973d334ca9420fa2fb0f0fe1800871e0.patch";
+      includes = [ "TpmToOsslMath.h" ];
+      stripLen = 1;
+      hash = "sha256-8TwyZVy8pQwq5Fl8cy9xJWtdckwL+QK0+DL5EHDLYUY=";
+    })
+  ];
 
   buildInputs = [ openssl ];
 


### PR DESCRIPTION
Without the change build fails against openssl-3.1 as:

       >                  from Tpm.h:78,
       >                  from CryptEccMain.c:64:
       > TpmToOsslMath.h:79:5: error: #error Untested OpenSSL version
       >    79 | #   error Untested OpenSSL version
       >       |     ^~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
