### PR TITLE
guile-zstd: init at 0.1.1

### DIFF
--- a/pkgs/by-name/gu/guile-zstd/package.nix
+++ b/pkgs/by-name/gu/guile-zstd/package.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, fetchFromGitea
+, autoreconfHook
+, pkg-config
+, guile
+, texinfo
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guile-zstd";
+  version = "0.1.1";
+
+  src = fetchFromGitea {
+    domain = "notabug.org";
+    owner = "guile-zstd";
+    repo = "guile-zstd";
+    rev = "v${version}";
+    hash = "sha256-IAyDoqb7qHAy666hxs6CCZrFnfwwV8AaR92XlQQ6FLE=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ autoreconfHook guile pkg-config texinfo ];
+  buildInputs = [ guile ];
+  propagatedBuildInputs = [ zstd ];
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = with lib; {
+    description = "A GNU Guile library providing bindings to zstd";
+    homepage = "https://notabug.org/guile-zstd/guile-zstd";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ foo-dogsquared ];
+    platforms = guile.meta.platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [guile-zlib](https://notabug.org/guile-zlib/guile-zlib) as part of packaging Guix.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @cafkafk 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
