### PR TITLE
Revert "firefox: default to speech synthesis enabled"

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -84,7 +84,7 @@ let
             ++ lib.optional sndioSupport sndio
             ++ lib.optional jackSupport libjack2
             ++ lib.optional smartcardSupport opensc
-            ++ lib.optional (cfg.speechSynthesisSupport or true) speechd
+            ++ lib.optional (cfg.speechSynthesisSupport or false) speechd
             ++ pkcs11Modules
             ++ gtk_modules;
       gtk_modules = [ libcanberra-gtk3 ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#259534

speech-dispatcher is 0.7 GB big mostly due to embrola-voices.


with:
```
 ➜ nix path-info -hS $(which firefox)
/nix/store/36gd5ak5kzj99fla99mbnsw1bwja2820-firefox-bin-118.0.1    2.8G
```

without:
```
 ➜ nix path-info -hS $(which firefox)
/nix/store/n5vdac59hffc8bvsy0yjbg4h61rp3349-firefox-bin-118.0.1    2.1G
``` 

So when speechd support is enabled, 25% of the closure size are taken by an optional feature the majority of people are not going to use, which is IMO way way to big.

A solution to this extreme closure size increase would be to split mbrola-voices into one package per language and make that depended on the configured locale. I do not have time to work on this, so I'd rather like to revert this than that every firefox user downloads a potential unused 0.7 GB.