### PR TITLE
dmd: Fix druntime imports

### DIFF
--- a/pkgs/development/compilers/dmd/generic.nix
+++ b/pkgs/development/compilers/dmd/generic.nix
@@ -155,6 +155,7 @@ stdenv.mkDerivation rec {
     fi
 
     ${dmd_bin}/rdmd dmd/compiler/src/build.d -j$buildJobs HOST_DMD=${dmd_bin}/dmd $buildFlags
+    make -C dmd/druntime -f posix.mak DMD=${pathToDmd} $buildFlags -j$buildJobs
     echo ${tzdata}/share/zoneinfo/ > TZDatabaseDirFile
     echo ${lib.getLib curl}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} > LibcurlPathFile
     make -C phobos -f posix.mak $buildFlags -j$buildJobs DMD=${pathToDmd} DFLAGS="-version=TZDatabaseDir -version=LibcurlPath -J$PWD"
@@ -195,7 +196,7 @@ stdenv.mkDerivation rec {
     installManPage dmd/docs/man/man*/*
 
     mkdir -p $out/include/dmd
-    cp -r {druntime/import/*,phobos/{std,etc}} $out/include/dmd/
+    cp -r {dmd/druntime/import/*,phobos/{std,etc}} $out/include/dmd/
 
     mkdir $out/lib
     cp phobos/generated/${osname}/release/${bits}/libphobos2.* $out/lib/


### PR DESCRIPTION
## Description of changes

Dmd currently does not provide druntime imports.
Currently it provides in include/dmd: `etc  std`

After this change it also contains druntime imports: `__builtins.di  core  etc  importc.h  object.d  std`

## Things done

1. Build druntime for import to be generated.
2. Update path from `druntime/import` to `dmd/druntime/import`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
