### PR TITLE
writeShellApplication: exclude shell checks

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -311,6 +311,8 @@ rec {
     Similar to writeShellScriptBin and writeScriptBin.
     Writes an executable Shell script to /nix/store/<store path>/bin/<name> and
     checks its syntax with shellcheck and the shell's -n option.
+    Individual checks can be foregone by putting them in the excludeShellChecks
+    list, e.g. [ "SC2016" ].
     Automatically includes sane set of shellopts (errexit, nounset, pipefail)
     and handles creation of PATH based on runtimeInputs
 
@@ -338,6 +340,7 @@ rec {
     , runtimeInputs ? [ ]
     , meta ? { }
     , checkPhase ? null
+    , excludeShellChecks ? [  ]
     }:
     writeTextFile {
       inherit name meta;
@@ -363,10 +366,11 @@ rec {
         # but we still want to use writeShellApplication on those platforms
         let
           shellcheckSupported = lib.meta.availableOn stdenv.buildPlatform shellcheck.compiler;
+          excludeOption = lib.optionalString (excludeShellChecks != [  ]) "--exclude '${lib.concatStringsSep "," excludeShellChecks}'";
           shellcheckCommand = lib.optionalString shellcheckSupported ''
             # use shellcheck which does not include docs
             # pandoc takes long to build and documentation isn't needed for just running the cli
-            ${lib.getExe (haskell.lib.compose.justStaticExecutables shellcheck.unwrapped)} "$target"
+            ${lib.getExe (haskell.lib.compose.justStaticExecutables shellcheck.unwrapped)} ${excludeOption} "$target"
           '';
         in
         if checkPhase == null then ''

--- a/pkgs/build-support/trivial-builders/test/default.nix
+++ b/pkgs/build-support/trivial-builders/test/default.nix
@@ -25,6 +25,7 @@ recurseIntoAttrs {
     then callPackage ./references.nix {}
     else null;
   writeCBin = callPackage ./writeCBin.nix {};
+  writeShellApplication = callPackage ./writeShellApplication.nix {};
   writeScriptBin = callPackage ./writeScriptBin.nix {};
   writeShellScript = callPackage ./write-shell-script.nix {};
   writeShellScriptBin = callPackage ./writeShellScriptBin.nix {};

--- a/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
+++ b/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
@@ -1,0 +1,29 @@
+/*
+  Run with:
+
+      cd nixpkgs
+      nix-build -A tests.trivial-builders.writeShellApplication
+*/
+
+{ lib, writeShellApplication, runCommand }:
+let
+  pkg = writeShellApplication {
+    name = "test-script";
+    excludeShellChecks = [ "SC2016" ];
+    text = ''
+      echo -e '#!/usr/bin/env bash\n' \
+       'echo "$SHELL"' > /tmp/something.sh  # this line would normally
+                                            # ...cause shellcheck error
+    '';
+  };
+in
+  assert pkg.meta.mainProgram == "test-script";
+  runCommand "test-writeShellApplication" { } ''
+
+    echo Testing if writeShellApplication builds without shellcheck error...
+
+    target=${lib.getExe pkg}
+
+    touch $out
+  ''
+


### PR DESCRIPTION
## Description of changes

Add an `excludeShellChecks` parameter to the `writeShellApplication` trivial builder.

Unfortunately, the way `writeShellApplication` prepends to the script text, file-level `# shellcheck disable=...` comments are not recognized by shellcheck, because they'd need to come right after the hashbang. This PR provides a nix-native way to disable certain shell checks.

Another approach would be to add these ignores right after the script's shebang, as comment.
This would document in the resulting file that something was not checked.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).