### PR TITLE
uhdm: 1.74 -> 1.76, surelog: 1.73 -> 1.76

### DIFF
--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -11,17 +11,18 @@
 , uhdm
 , antlr4
 , capnproto
+, nlohmann_json
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "surelog";
-  version = "1.73";
+  version = "1.76";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-z47Eqs3fP53pbEb3s66CqMiO4UpEwox+fKakxtRBakQ=";
+    hash = "sha256-Vg9NZrgzFRVIsEbZQe8DItDhFOVG1XZoQWBrLzVNwLU=";
     fetchSubmodules = false;  # we use all dependencies from nix
   };
 
@@ -43,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     uhdm
     capnproto
     antlr4.runtime.cpp
+    nlohmann_json
   ];
 
   cmakeFlags = [
@@ -50,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSURELOG_USE_HOST_UHDM=On"
     "-DSURELOG_USE_HOST_GTEST=On"
     "-DSURELOG_USE_HOST_ANTLR=On"
+    "-DSURELOG_USE_HOST_JSON=On"
     "-DANTLR_JAR_LOCATION=${antlr4.jarLocation}"
   ];
 

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -9,13 +9,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "UHDM";
-  version = "1.74";
+  # When updating this package, also consider updating science/logic/surelog
+  version = "1.76";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-DiwLo/3RcXY+wG2+7aDx4p6UuQm/eNX/kG35TJzIbe0=";
+    hash = "sha256-Q/u5lvILYDT5iScES3CTPIm/B5apoOHXOQmCsZ73NlU=";
     fetchSubmodules = false;  # we use all dependencies from nix
   };
 


### PR DESCRIPTION
## Description of changes

Version update of both UHDM and Surelog. Surelog and UHDM are developed alongside, so Surelog should typically be the same version as UHDM fore compatibility.

One pull request, but two separate commits to update 
  * UHDM 1.74 -> 1.76
  * Surelog 1.73 -> 1.76

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
