### PR TITLE
bruno: package from source

### DIFF
--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -1,62 +1,119 @@
 { lib
-, stdenv
-, fetchurl
-, autoPatchelfHook
-, dpkg
-, wrapGAppsHook
-, alsa-lib
-, gtk3
-, mesa
-, nspr
-, nss
-, systemd
+
+, fetchFromGitHub
+, buildNpmPackage
 , nix-update-script
+, electron
+, writeShellScriptBin
+, makeWrapper
+, copyDesktopItems
+, makeDesktopItem
+, pkg-config
+, pixman
+, cairo
+, pango
+, npm-lockfile-fix
 }:
 
-stdenv.mkDerivation rec {
+buildNpmPackage rec {
   pname = "bruno";
   version = "1.5.1";
 
-  src = fetchurl {
-    url = "https://github.com/usebruno/bruno/releases/download/v${version}/bruno_${version}_amd64_linux.deb";
-    hash = "sha256-kJfS3yORwvh7rMGgDV5Bn2L7+7ZMa8ZBpRI1P5y+ShQ=";
+  src = fetchFromGitHub {
+    owner = "usebruno";
+    repo = "bruno";
+    rev = "v${version}";
+    hash = "sha256-GgXnsPEUurPHrijf966x5ldp+1lDrgS1iBinU+EkdYU=b";
+
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
+    '';
   };
 
-  nativeBuildInputs = [ autoPatchelfHook dpkg wrapGAppsHook ];
+  npmDepsHash = "sha256-R5dEL4QbwCSE9+HHCXlf/pYLmjCaD15tmdSSLbZgmt0=";
 
-  buildInputs = [
-    alsa-lib
-    gtk3
-    mesa
-    nspr
-    nss
+  nativeBuildInputs = [
+    (writeShellScriptBin "phantomjs" "echo 2.1.1")
+    makeWrapper
+    copyDesktopItems
+    pkg-config
   ];
 
-  runtimeDependencies = [ (lib.getLib systemd) ];
+  buildInputs = [
+    pixman
+    cairo
+    pango
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "bruno";
+      desktopName = "Bruno";
+      exec = "bruno %U";
+      icon = "bruno";
+      comment = "Opensource API Client for Exploring and Testing APIs";
+      categories = [ "Development" ];
+      startupWMClass = "Bruno";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace scripts/build-electron.sh \
+      --replace 'if [ "$1" == "snap" ]; then' 'exit 0; if [ "$1" == "snap" ]; then'
+  '';
+
+  ELECTRON_SKIP_BINARY_DOWNLOAD=1;
+
+  dontNpmBuild = true;
+  postBuild = ''
+    npm run build --workspace=packages/bruno-graphql-docs
+    npm run build --workspace=packages/bruno-app
+    npm run build --workspace=packages/bruno-query
+
+    bash scripts/build-electron.sh
+
+    pushd packages/bruno-electron
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=${electron}/libexec/electron \
+      -c.electronVersion=${electron.version} \
+      -c.npmRebuild=false
+
+    popd
+  '';
+
+  npmPackFlags = [ "--ignore-scripts" ];
 
   installPhase = ''
     runHook preInstall
-    mkdir -p "$out/bin"
-    cp -R opt $out
-    cp -R "usr/share" "$out/share"
-    ln -s "$out/opt/Bruno/bruno" "$out/bin/bruno"
-    chmod -R g-w "$out"
-    runHook postInstall
-  '';
 
-  postFixup = ''
-    substituteInPlace "$out/share/applications/bruno.desktop" \
-      --replace "/opt/Bruno/bruno" "$out/bin/bruno"
+    mkdir -p $out/opt/bruno $out/bin
+
+    cp -r packages/bruno-electron/dist/linux-unpacked/{locales,resources{,.pak}} $out/opt/bruno
+
+    makeWrapper ${lib.getExe electron} $out/bin/bruno \
+      --add-flags $out/opt/bruno/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    for s in 16 32 48 64 128 256 512 1024; do
+      size=${"$"}{s}x$s
+      install -Dm644 $src/packages/bruno-electron/resources/icons/png/$size.png $out/share/icons/hicolor/$size/apps/bruno.png
+    done
+
+    runHook postInstall
   '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    description = "Open-source IDE For exploring and testing APIs";
+    description = "Open-source IDE For exploring and testing APIs.";
     homepage = "https://www.usebruno.com";
+    inherit (electron.meta) platforms;
     license = licenses.mit;
     maintainers = with maintainers; [ water-sucks lucasew kashw2 ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "bruno";
   };
 }

--- a/pkgs/by-name/np/npm-lockfile-fix/package.nix
+++ b/pkgs/by-name/np/npm-lockfile-fix/package.nix
@@ -1,0 +1,33 @@
+{ lib
+, python3
+, fetchFromGitHub
+, nix-update-script
+}:
+
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "npm-lockfile-fix";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jeslie0";
+    repo = "npm-lockfile-fix";
+    rev = "v${version}";
+    hash = "sha256-0EGPCPmCf6bxbso3aHCeJ1XBOpYp3jtMXv8LGdwrsbs=";
+  };
+
+  propagatedBuildInputs = [
+    python3.pkgs.requests
+  ];
+
+  doCheck = false; # no tests
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = with lib; {
+    description = "Add missing integrity and resolved fields to a package-lock.json file";
+    mainProgram = "npm-lockfile-fix";
+    license = lib.licenses.mit;
+    maintainers = [ maintainers.lucasew ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Package bruno from source as now they ship package-lock.json together with the repo.

To fix the package-lock.json issue, that upstream doesn't seem to care, I also integrated the tool mentioned in #261137. Using the patch approach requires manual intervention at each bump and generating the package-lock.json is tricky because the tool that fetches src would actually fetch the patched package-lock.json to fix. It's much simpler to integrate the fix into a derivation and also easier bumps using r-ryantm.

I checked if npm-lockfile-fix creates a reproducible result by running the cold build of `bruno.src` twice and it gave the same hash.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
