### PR TITLE
yosys-symbiflow: 1.20230808 -> 1.20230906

### DIFF
--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -7,20 +7,16 @@
 , yosys
 , zlib
 , yosys-symbiflow
-, uhdm
-, capnproto
-, surelog
-, antlr4
 , pkg-config
 }: let
 
-  version = "1.20230808";
+  version = "1.20230906";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo  = "yosys-f4pga-plugins";
     rev   = "v${version}";
-    hash  = "sha256-wksAHLgLjVZE4Vk2QVcJN1mnQ9mxWCZHk55oO99cVJ0=";
+    hash  = "sha256-XIn5wFw8i2njDN0Arua5BdZ0u1q6a/aJAs48YICehsc=";
   };
 
   # Supported symbiflow plugins.
@@ -37,7 +33,6 @@
     # "ql-qlf"
     "sdc"
     "xdc"
-    "systemverilog"
   ];
 
   static_gtest = gtest.overrideAttrs (old: {
@@ -56,10 +51,6 @@ in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
     yosys
     readline
     zlib
-    uhdm
-    surelog
-    capnproto
-    antlr4.runtime.cpp
   ];
 
   # xdc has an incorrect path to a test which has yet to be patched


### PR DESCRIPTION
## Description of changes

The systemverilog plugin moved to a different project (synlig; I am preparing a [yosys-synlig plugin](https://github.com/hzeller/nixpkgs/commit/086ea3c4721e8bbde32bdaf07a72f8a6ee07044f) once #261128 is in).
Difference in upstream since the last version is mostly just that the systemverilog is removed there (also, it does not compile anymore with latest yosys).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
