### PR TITLE
add auto-epp-go

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9703,6 +9703,12 @@
     githubId = 55911173;
     name = "Gwendolyn Quasebarth";
   };
+  lamarios = {
+    matrix = "@lamarios:matrix.org";
+    github = "lamarios";
+    githubId = 1192563;
+    name = "Paul Fauchon";
+  };
   lambda-11235 = {
     email = "taranlynn0@gmail.com";
     github = "lambda-11235";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -506,6 +506,7 @@
   ./services/hardware/argonone.nix
   ./services/hardware/asusd.nix
   ./services/hardware/auto-cpufreq.nix
+  ./services/hardware/auto-epp-go.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix

--- a/nixos/modules/services/hardware/auto-epp-go.nix
+++ b/nixos/modules/services/hardware/auto-epp-go.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+with lib;
+
+let
+
+ cfg = config.services.auto-epp;
+ package = pkgs.auto-epp-go;
+
+in {
+ options = {
+
+    services.auto-epp = {
+      enable = mkEnableOption (lib.mdDoc "auto-epp for amd active pstate");
+      batState= mkOption {
+        type = types.str;
+        default = "power";
+        description = lib.mdDoc "energy_performance_preference when on battery";
+      };
+
+     acState= mkOption {
+        type = types.str;
+        default = "balance_performance";
+        description = lib.mdDoc "energy_performance_preference when plugged in";
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    boot.kernelParams = [
+      "amd_pstate=active"
+    ];
+
+    environment.etc."auto-epp-go.conf".text = ''
+     [Settings]
+     epp_state_for_AC=${cfg.acState}
+     epp_state_for_BAT=${cfg.batState}
+    '';
+
+    systemd.packages = [ package ];
+
+    systemd.services.auto-epp = {
+      enable = true;
+      after = [ "network.target" "network-online.target"  ];
+      description = "auto-epp-go - Automatic EPP Changer for amd-pstate-epp";
+      serviceConfig = {
+        Type = "simple";
+        User = "root";
+        ExecStart = "${package}/bin/auto-epp-go";
+        Restart = "on-failure";
+      };
+
+      wantedBy  = [ "multi-user.target" ];
+    };
+
+  };
+}

--- a/pkgs/tools/system/auto-epp-go/default.nix
+++ b/pkgs/tools/system/auto-epp-go/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "auto-epp-go";
+  version = "0.1.1-1";
+
+  goPackagePath = "github.com/tfkhdyt/auto-epp-go";
+
+  ldflags = [ "-s" "-w" ];
+
+  src = fetchFromGitHub {
+    owner = "tfkhdyt";
+    repo = "auto-epp-go";
+    rev = "v${version}";
+    sha256 = "sha256-AeBdXO5I9etmqSiAak0T9LDrwtAT8fHM/5gHRplrhbM=";
+  };
+
+  meta = with lib; {
+    mainProgram = "${pname}";
+    homepage = "https://github.com/tfkhdyt/auto-epp-go";
+    description =
+      "Auto-epp for amd processors when amd_pstate=active";
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.lamarios ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41202,6 +41202,8 @@ with pkgs;
 
   auto-cpufreq = callPackage ../tools/system/auto-cpufreq {  };
 
+  auto-epp-go = callPackage ../tools/system/auto-epp-go {  };
+
   thermald = callPackage ../tools/system/thermald { };
 
   therion = callPackage ../applications/misc/therion { };


### PR DESCRIPTION
## Description of changes

Adds new package auto-epp-go which helps change governor and scaling for recent amd cpus when amd_pstate=active
Adds new module to run systmd service for auto-epp-go

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
