### PR TITLE
passmark-performancetest: init at 11.0.1002

### DIFF
--- a/pkgs/by-name/pa/passmark-performancetest/package.nix
+++ b/pkgs/by-name/pa/passmark-performancetest/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchurl
+, curl
+, unzip
+, ncurses5
+, dmidecode
+, coreutils
+, util-linux
+, autoPatchelfHook
+, makeWrapper
+}:
+let
+  sources = {
+    "x86_64-linux" = {
+      url = "https://web.archive.org/web/20231205092714/https://www.passmark.com/downloads/pt_linux_x64.zip";
+      hash = "sha256-q9H+/V4fkSwJJEp+Vs+MPvndi5DInx5MQCzAv965IJg=";
+    };
+    "aarch64-linux" = {
+      url = "https://web.archive.org/web/20231205092807/https://www.passmark.com/downloads/pt_linux_arm64.zip";
+      hash = "sha256-7fmd2fukJ56e0BJFJe3SitGlordyIFbNjIzQv+u6Zuw=";
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  version = "11.0.1002";
+  pname = "passmark-performancetest";
+
+  src = fetchurl (sources.${stdenv.system} or (throw "Unsupported system for PassMark performance test"));
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ unzip autoPatchelfHook makeWrapper ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    curl
+    ncurses5
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 pt_linux_* "$out/bin/performancetest"
+    runHook postInstall
+  '';
+
+  # Prefix since program will call sudo
+  postFixup = ''
+    wrapProgram $out/bin/performancetest \
+        --prefix PATH ":" ${lib.makeBinPath [
+          dmidecode
+          coreutils
+          util-linux
+        ]}
+  '';
+
+  meta = with lib; {
+    description = "A software tool that allows everybody to quickly assess the performance of their computer and compare it to a number of standard 'baseline' computer systems.";
+    homepage = "https://www.passmark.com";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ neverbehave ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "performancetest";
+  };
+}


### PR DESCRIPTION
## Description of changes

passmark-performancetest: init at 11.0.1002

Passmark's PerformanceTest for Linux/Mac is a software tool that allows everybody to quickly assess the performance of their computer and compare it to a number of standard 'baseline' computer systems.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).