### PR TITLE
anki-sync-server: init at 2.1.66

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -38,7 +38,7 @@ let
     fetchSubmodules = true;
   };
 
-  cargoDeps = rustPlatform.importCargoLock {
+  cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {
       "fsrs-0.1.0" = "sha256-bnLmJk2aaWBdgdsiasRrDG4NiTDMCDCXotCSoc0ldlk=";
@@ -46,6 +46,7 @@ let
       "percent-encoding-iri-2.2.0" = "sha256-kCBeS1PNExyJd4jWfDfctxq6iTdAq69jtxFQgCCQ8kQ=";
     };
   };
+  cargoDeps = rustPlatform.importCargoLock cargoLock;
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
@@ -265,6 +266,11 @@ python3.pkgs.buildPythonApplication {
       --prefix PATH ':' "${lame}/bin:${mpv-unwrapped}/bin"
     )
   '';
+
+  passthru = {
+    # cargoLock is reused in anki-sync-server
+    inherit cargoLock;
+  };
 
   meta = with lib; {
     description = "Spaced repetition flashcard program";

--- a/pkgs/games/anki/sync-server.nix
+++ b/pkgs/games/anki/sync-server.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, rustPlatform
+, anki
+, darwin
+
+, openssl
+, pkg-config
+, protobuf
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "anki-sync-server";
+  inherit (anki) version src cargoLock;
+
+  # only build sync server
+  cargoBuildFlags = [
+    "--bin"
+    "anki-sync-server"
+  ];
+
+  nativeBuildInputs = [ protobuf pkg-config ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ];
+
+  env.PROTOC = lib.getExe protobuf;
+
+  meta = with lib; {
+    description = "Standalone official anki sync server";
+    homepage = "https://apps.ankiweb.net";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ martinetd ];
+    mainProgram = "anki-sync-server";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37534,6 +37534,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AVKit CoreAudio;
   };
   anki-bin = callPackage ../games/anki/bin.nix { };
+  anki-sync-server = callPackage ../games/anki/sync-server.nix { };
 
   armagetronad = callPackage ../games/armagetronad { };
 


### PR DESCRIPTION
## Description of changes

anki-sync-server will be used in new ankisyncd module (see #257692)

anki itself was slightly modified to add its cargoLock as passthru so we
can use it for anki-sync-server as it's built from the same sources.

Cc @euank @oxij @paveloom (anki maintainers): I also have an update for anki to 23.10beta6 lined up in https://github.com/martinetd/nixpkgs/commits/anki-sync-server-nixos as they broke the protocol, so will want to update the server as soon as possible. I don't think we should upgrade anki to a beta yet but it might be worth testing; I've only checked it builds and sync appears to work calling the python internal functions directly.... (yay, at last some nixosTest for this monster)
It might make sense to not link anki-sync-server's version with anki's? but then we'd need two separate Cargo.lock files and maintaining the hashes manually for both, that's a bit inefficient; it's probably best to keep in sync as much as possible and just update to 23.10 when it gets released.
Cc @telotortium 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
