### PR TITLE
mktemp: fix parallel installing

### DIFF
--- a/pkgs/tools/security/mktemp/default.nix
+++ b/pkgs/tools/security/mktemp/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchurl, groff }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, groff
+}:
 
 stdenv.mkDerivation rec {
   pname = "mktemp";
@@ -6,6 +11,15 @@ stdenv.mkDerivation rec {
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
   NROFF = "${groff}/bin/nroff";
+
+  patches = [
+    # Pull upstream fix for parallel install failures.
+    (fetchpatch {
+      name = "parallel-install.patch";
+      url = "https://www.mktemp.org/repos/mktemp/raw-rev/eb87d96ce8b7";
+      hash = "sha256-cJ/0pFj8tOkByUwhlMwLNSQgTHyAU8svEkjKWWwsNmY=";
+    })
+  ];
 
   # Don't use "install -s"
   postPatch = ''
@@ -16,6 +30,8 @@ stdenv.mkDerivation rec {
     url = "ftp://ftp.mktemp.org/pub/mktemp/mktemp-${version}.tar.gz";
     sha256 = "0x969152znxxjbj7387xb38waslr4yv6bnj5jmhb4rpqxphvk54f";
   };
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Simple tool to make temporary file handling in shells scripts safe and simple";


### PR DESCRIPTION
Without the upstream patch parallel install fails as:

    mktemp> mkdir /nix/store/k5b7wyhwyv9x3z5i6d88y7l1kdrkkfgj-mktemp-1.7/share/man/man1
    mktemp> cp: cannot create regular file '/nix/store/k5b7wyhwyv9x3z5i6d88y7l1kdrkkfgj-mktemp-1.7/share/man/man1/1185.tmp': No such file or directory
    mktemp> make: *** [Makefile:101: install-man] Error 1
    mktemp> make: *** Waiting for unfinished jobs....

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
