### PR TITLE
qmk: add wb32 flash tool

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10008,6 +10008,17 @@
     githubId = 3696783;
     name = "Leroy Hopson";
   };
+  liketechnik = {
+    name = "Florian Warzecha";
+
+    email = "liketechnik@disroot.org";
+    github = "liketechnik";
+    githubId = 24209689;
+
+    keys = [{
+      fingerprint = "92D8 A09D 03DD B774 AABD 53B9 E136 2F07 D750 DB5C";
+    }];
+  };
   lillycham = {
     email = "lillycat332@gmail.com";
     github = "lillycat332";

--- a/pkgs/by-name/wb/wb32-dfu-updater/package.nix
+++ b/pkgs/by-name/wb/wb32-dfu-updater/package.nix
@@ -1,5 +1,4 @@
-{ callPackage
-, lib
+{ lib
 , stdenv
 , fetchFromGitHub
 , cmake
@@ -14,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "WestberryTech";
     repo = finalAttrs.pname;
     rev = finalAttrs.version;
-    sha256 = "sha256-DKsDVO00JFhR9hIZksFVJLRwC6PF9LCRpf++QywFO2w=";
+    hash = "sha256-DKsDVO00JFhR9hIZksFVJLRwC6PF9LCRpf++QywFO2w=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/wb/wb32-dfu-updater/package.nix
+++ b/pkgs/by-name/wb/wb32-dfu-updater/package.nix
@@ -1,0 +1,34 @@
+{ callPackage
+, lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libusb1
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wb32-dfu-updater";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "WestberryTech";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    sha256 = "sha256-DKsDVO00JFhR9hIZksFVJLRwC6PF9LCRpf++QywFO2w=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    description = "USB programmer for downloading and uploading firmware to/from USB devices.";
+    longDescription = ''
+      wb32-dfu-updater is a host tool used to download and upload firmware to/from WB32 MCU via USB. (wb32-dfu-updater_cli is the command line version).
+    '';
+    homepage = "https://github.com/WestberryTech/wb32-dfu-updater";
+    license = licenses.asl20;
+    maintainers = [ maintainers.liketechnik ];
+    mainProgram = "wb32-dfu-updater_cli";
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -5,6 +5,7 @@
 , avrdude
 , dfu-programmer
 , dfu-util
+, wb32-dfu-updater
 , gcc-arm-embedded
 , gnumake
 , teensy-loader-cli
@@ -38,6 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     avrdude
     dfu-programmer
     dfu-util
+    wb32-dfu-updater
     teensy-loader-cli
     gcc-arm-embedded
     gnumake


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- add myself to maintainers
- add [wb32-dfu-updater](https://github.com/WestberryTech/wb32-dfu-updater) package
- add wb32-dfu-updater package to qmk (which has recently gotten support for it https://github.com/qmk/qmk_firmware/pull/21217)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
