### PR TITLE
yosys-synlig: init at 2023.10.12

### DIFF
--- a/pkgs/development/compilers/yosys/plugins/synlig-makefile-for-nix.patch
+++ b/pkgs/development/compilers/yosys/plugins/synlig-makefile-for-nix.patch
@@ -1,0 +1,66 @@
+diff --git a/Makefile b/Makefile
+index 4c96ae7..9e1a2e3 100755
+--- a/Makefile
++++ b/Makefile
+@@ -3,7 +3,7 @@
+ # Setup make itself.
+ 
+ .ONESHELL:
+-override SHELL := /bin/bash
++SHELL := bash
+ override .SHELLFLAGS := -e -u -o pipefail -O nullglob -O extglob -O globstar -c
+ 
+ # Unset all default build- and recipe-related variables.
+@@ -315,7 +315,6 @@ endif
+ GetTargetStructName = target[${1}]
+ 
+ makefiles_to_include := \
+-	third_party/Build.*.mk \
+ 	frontends/*/Build.mk \
+ 	tests/*/Build.mk \
+ 	lib/*/Build.mk
+diff --git a/frontends/systemverilog/Build.mk b/frontends/systemverilog/Build.mk
+index acd9cb6..c039994 100644
+--- a/frontends/systemverilog/Build.mk
++++ b/frontends/systemverilog/Build.mk
+@@ -1,6 +1,7 @@
+ t       := systemverilog-plugin
+ ts      := $(call GetTargetStructName,${t})
+ out_dir := $(call GetTargetBuildDir,${t})
++mod_dir := third_party/yosys_mod
+ 
+ cxx_is_clang := $(findstring clang,$(notdir ${CXX}))
+ 
+@@ -13,9 +14,9 @@ ${ts}.sources := \
+ 	${${ts}.src_dir}uhdm_ast_frontend.cc \
+ 	${${ts}.src_dir}uhdm_common_frontend.cc \
+ 	${${ts}.src_dir}uhdm_surelog_ast_frontend.cc \
+-	${$(call GetTargetStructName,yosys).mod_dir}const2ast.cc \
+-	${$(call GetTargetStructName,yosys).mod_dir}edif.cc \
+-	${$(call GetTargetStructName,yosys).mod_dir}simplify.cc
++	$(mod_dir)/const2ast.cc \
++	$(mod_dir)/edif.cc \
++	$(mod_dir)/simplify.cc
+ 
+ define ${ts}.env =
+ export PKG_CONFIG_PATH=$(call ShQuote,${$(call GetTargetStructName,surelog).output_vars.PKG_CONFIG_PATH}$(if ${PKG_CONFIG_PATH},:${PKG_CONFIG_PATH}))
+@@ -35,8 +36,8 @@ endif
+ endif
+ 
+ ${ts}.cxxflags = \
+-	-I${$(call GetTargetStructName,yosys).src_dir} \
+-	-I${$(call GetTargetStructName,yosys).mod_dir} \
++	-I$(shell yosys-config --cxxflags) \
++	-I$(mod_dir) \
+ 	-D_YOSYS_ \
+ 	-DYOSYS_ENABLE_PLUGINS \
+ 	$(shell ${${ts}.env}; pkg-config --cflags Surelog) \
+@@ -55,7 +56,7 @@ ${ts}.ldflags = \
+ 	$(shell ${${ts}.env}; pkg-config --libs-only-L Surelog) \
+ 	${build_type_ldflags} \
+ 	${LDFLAGS} \
+-	-Wl,--export-dynamic
++	$(shell yosys-config --ldflags --ldlibs)
+ 
+ ${ts}.ldlibs = \
+ 	$(shell ${${ts}.env}; pkg-config --libs-only-l --libs-only-other Surelog) \

--- a/pkgs/development/compilers/yosys/plugins/synlig.nix
+++ b/pkgs/development/compilers/yosys/plugins/synlig.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, antlr4
+, capnproto
+, readline
+, surelog
+, uhdm
+, yosys
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yosys-synlig";
+  version = "2023.10.12";  # Currently no tagged versions upstream
+  plugin = "synlig";
+
+  src = fetchFromGitHub {
+    owner  = "chipsalliance";
+    repo   = "synlig";
+    rev    = "c5bd73595151212c61709d69a382917e96877a14";
+    sha256 = "sha256-WJhf5gdZTCs3EeNocP9aZAh6EZquHgYOG/xiTo8l0ao=";
+    fetchSubmodules = false;  # we use all dependencies from nix
+  };
+
+  patches = [
+    ./synlig-makefile-for-nix.patch  # Remove assumption submodules available.
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    antlr4.runtime.cpp
+    capnproto
+    readline
+    surelog
+    uhdm
+    yosys
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make -j $NIX_BUILD_CORES build@systemverilog-plugin
+    runHook postBuild
+  '';
+
+  # Very simple litmus test that the plugin can be loaded successfully.
+  doCheck = true;
+  checkPhase = ''
+     runHook preCheck
+     yosys -p "plugin -i build/release/systemverilog-plugin/systemverilog.so;\
+               help read_systemverilog" | grep "Read SystemVerilog files using"
+     runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/yosys/plugins
+    cp ./build/release/systemverilog-plugin/systemverilog.so \
+           $out/share/yosys/plugins/systemverilog.so
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "SystemVerilog support plugin for Yosys";
+    homepage    = "https://github.com/chipsalliance/synlig";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ hzeller ];
+    platforms   = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17471,6 +17471,7 @@ with pkgs;
   yosys = callPackage ../development/compilers/yosys { };
   yosys-bluespec = callPackage ../development/compilers/yosys/plugins/bluespec.nix { };
   yosys-ghdl = callPackage ../development/compilers/yosys/plugins/ghdl.nix { };
+  yosys-synlig = callPackage ../development/compilers/yosys/plugins/synlig.nix { };
   yosys-symbiflow = callPackage ../development/compilers/yosys/plugins/symbiflow.nix { };
 
   z88dk = callPackage ../development/compilers/z88dk { };


### PR DESCRIPTION
## Description of changes

This is the systemverilog plug-in that had been moved to a separate repository upstream (yosys-f4pga-plugins to synlig).
The upstream code has some assumptions that it pulls its dependencies from submodules in third_party/. I adapted it here  so that we can base everything on dependencies provided by nix - for that I had to add a small patch for the affected makefiles (I'll try to upstream something so that we won't need this in the future).

The project is called `synlig`, the module however has the shared library name `systemverilog.so`. So while `pname = "yosys-synlig"`  clear, I am not sure how to name the `plugin = `: should it by `"synlig"` (done now) or `"systemverilog"` (based on the name of the shared object and the name used in the Yosys `plugin -i` command) ?

Simple manual test with `yosys-synlig` available in nix-pkgs:
```
yosys -p "plugin -i systemverilog; help read_systemverilog;"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
