### PR TITLE
nxpmicro-mfgtools: pull upstream fix for gcc-13

### DIFF
--- a/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
+++ b/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , pkg-config
 , bzip2
@@ -20,6 +21,16 @@ stdenv.mkDerivation rec {
     rev = "uuu_${version}";
     sha256 = "sha256-XVvGsHltlA3h9hd3C88G3s2wIZ1EVM6DmvdiwD82vTw=";
   };
+
+  patches = [
+    # Backport upstream fix for gcc-13 support:
+    #   https://github.com/nxp-imx/mfgtools/pull/360
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/nxp-imx/mfgtools/commit/24fd043225903247f71ac10666d820277c0b10b1.patch";
+      hash = "sha256-P7n6+Tiz10GIQ7QOd/qQ3BI7Wo5/66b0EwjFSpOUSJg=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkg-config installShellFiles ];
 


### PR DESCRIPTION
Without the change build against gcc-13 fails as:

    $ nix build --impure --expr 'with import ./. {}; nxpmicro-mfgtools.override { stdenv = gcc13Stdenv; }'
    error: builder for '/nix/store/rx3ckzd1z975b3jnx24q53h8mc1a6y4v-nxpmicro-mfgtools-1.5.21.drv' failed with exit code 2;
           last 10 log lines:
           >       | ^~~~~~~~
           > /build/source/libuuu/libcomm.h:146:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
           > /build/source/libuuu/libcomm.h:147:1: error: 'uint64_t' does not name a type
           >   147 | uint64_t str_to_uint64(const string &str, bool * conversion_suceeded = nullptr);
           >       | ^~~~~~~~
           > /build/source/libuuu/libcomm.h:147:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
