### PR TITLE
libetebase: init at 0.5.6

### DIFF
--- a/pkgs/by-name/li/libetebase/package.nix
+++ b/pkgs/by-name/li/libetebase/package.nix
@@ -1,0 +1,45 @@
+{ rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, lib
+, stdenv
+, testers
+, libetebase
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "libetebase";
+  version = "0.5.6";
+
+  src = fetchFromGitHub {
+    owner = "etesync";
+    repo = "libetebase";
+    rev = "v${version}";
+    hash = "sha256-cXuOKfyMdk+YzDi0G8i44dyBRf4Ez5+AlCKG43BTSSU=";
+  };
+
+  cargoHash = "sha256-GUNj5GrY04CXnej3WDKZmW4EeJhoCl2blHSDfEkQKtE=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  postInstall = ''
+    install -d $out/lib/pkgconfig
+    sed s#@prefix@#$out#g etebase.pc.in > $out/lib/pkgconfig/etebase.pc
+    install -Dm644 EtebaseConfig.cmake -t $out/lib/cmake/Etebase
+    install -Dm644 target/etebase.h -t $out/include/etebase
+    ln -s $out/lib/libetebase.so $out/lib/libetebase.so.0
+  '';
+
+  passthru.tests.pkgs-config = testers.testMetaPkgConfig libetebase;
+
+  meta = with lib; {
+    description = "A C library for Etebase";
+    homepage = "https://www.etebase.com/";
+    license = licenses.bsd3;
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ laalsaas ];
+    pkgConfigModules = [ "etebase" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
add [Libetebase](https://github.com/etesync/libetebase), see [etebase.com](https://etebase.com)

Closes #244286
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Fixes: #244286 
