### PR TITLE
google-cloud-bigtable-tool: init at 0.12.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -264,6 +264,8 @@
 - Package `noto-fonts-emoji` was renamed to `noto-fonts-color-emoji`;
   see [#221181](https://github.com/NixOS/nixpkgs/issues/221181).
 
+- Package `cloud-sql-proxy` was renamed to `google-cloud-sql-proxy` as it cannot be used with other cloud providers.;
+
 - Package `pash` was removed due to being archived upstream. Use `powershell` as an alternative.
 
 - `security.sudo.extraRules` now includes `root`'s default rule, with ordering

--- a/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
+++ b/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "google-cloud-bigtable-tool";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "cloud-bigtable-cbt-cli";
+    rev = "v.${version}";
+    hash = "sha256-N5nbWMj7kLIdRiwBUWFz4Rat88Wx01i3hceMxAvSjaA=";
+  };
+
+  subPackages = [ "." ];
+
+  vendorHash = "sha256-kwvEfvHs6XF84bB3Ss1307OjId0nh/0Imih1fRFdY0M=";
+
+  preCheck = ''
+    buildFlagsArray+="-short"
+  '';
+
+  meta = with lib; {
+    description = "Google Cloud Bigtable Tool";
+    longDescription = ''
+      `cbt` is the Google Cloud Bigtable Tool. A CLI utility to interact with Google Cloud Bigtable.
+      The cbt CLI is a command-line interface for performing several different operations on Cloud Bigtable.
+      It is written in Go using the Go client library for Cloud Bigtable.
+      An overview of it's usage can be found in the [Google Cloud docs](https://cloud.google.com/bigtable/docs/cbt-overview).
+      For information about Bigtable in general, see the [overview of Bigtable](https://cloud.google.com/bigtable/docs/overview).
+    '';
+    homepage = "https://github.com/googleapis/cloud-bigtable-cbt-cli";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ totoroot ];
+    platforms = platforms.all;
+    mainProgram = "cbt";
+  };
+}

--- a/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
+++ b/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
@@ -32,7 +32,6 @@ buildGoModule rec {
     homepage = "https://github.com/googleapis/cloud-bigtable-cbt-cli";
     license = licenses.asl20;
     maintainers = with maintainers; [ totoroot ];
-    platforms = platforms.all;
     mainProgram = "cbt";
   };
 }

--- a/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
+++ b/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
@@ -14,8 +14,6 @@ buildGoModule rec {
     hash = "sha256-N5nbWMj7kLIdRiwBUWFz4Rat88Wx01i3hceMxAvSjaA=";
   };
 
-  subPackages = [ "." ];
-
   vendorHash = "sha256-kwvEfvHs6XF84bB3Ss1307OjId0nh/0Imih1fRFdY0M=";
 
   preCheck = ''

--- a/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
+++ b/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
       `cbt` is the Google Cloud Bigtable Tool. A CLI utility to interact with Google Cloud Bigtable.
       The cbt CLI is a command-line interface for performing several different operations on Cloud Bigtable.
       It is written in Go using the Go client library for Cloud Bigtable.
-      An overview of it's usage can be found in the [Google Cloud docs](https://cloud.google.com/bigtable/docs/cbt-overview).
+      An overview of its usage can be found in the [Google Cloud docs](https://cloud.google.com/bigtable/docs/cbt-overview).
       For information about Bigtable in general, see the [overview of Bigtable](https://cloud.google.com/bigtable/docs/overview).
     '';
     homepage = "https://github.com/googleapis/cloud-bigtable-cbt-cli";

--- a/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
+++ b/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
@@ -35,7 +35,6 @@ buildGoModule rec {
     homepage = "https://github.com/GoogleCloudPlatform/cloud-sql-proxy";
     license = licenses.asl20;
     maintainers = with maintainers; [ nicknovitski totoroot ];
-    platforms = platforms.all;
     mainProgram = "cloud-sql-proxy";
   };
 }

--- a/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
+++ b/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildGoModule rec {
-  pname = "cloud-sql-proxy";
+  pname = "google-cloud-sql-proxy";
   version = "2.7.0";
 
   src = fetchFromGitHub {
@@ -24,9 +24,18 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Utility for ensuring secure connections to Google Cloud SQL instances";
+    longDescription = ''
+      The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances.
+      It provides IAM authorization, allowing you to control who can connect to your instance through IAM permissions,
+      and TLS 1.3 encryption, without having to manage certificates.
+      See the [Connecting Overview](https://cloud.google.com/sql/docs/mysql/connect-overview) page for more information
+      on connecting to a Cloud SQL instance, or the [About the Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy)
+      page for details on how the Cloud SQL Proxy works.
+    '';
     homepage = "https://github.com/GoogleCloudPlatform/cloud-sql-proxy";
     license = licenses.asl20;
     maintainers = with maintainers; [ nicknovitski totoroot ];
+    platforms = platforms.all;
     mainProgram = "cloud-sql-proxy";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3615,8 +3615,6 @@ with pkgs;
 
   clairvoyance = callPackage ../tools/security/clairvoyance { };
 
-  cloud-sql-proxy = callPackage ../tools/misc/cloud-sql-proxy { };
-
   cloudfox = callPackage ../tools/security/cloudfox { };
 
   cloudhunter = callPackage ../tools/security/cloudhunter { };
@@ -8753,6 +8751,8 @@ with pkgs;
   };
 
   google-cloud-bigtable-tool = callPackage ../tools/misc/google-cloud-bigtable-tool { };
+
+  google-cloud-sql-proxy = callPackage ../tools/misc/google-cloud-sql-proxy { };
 
   google-fonts = callPackage ../data/fonts/google-fonts { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8752,6 +8752,8 @@ with pkgs;
     with-gce = true;
   };
 
+  google-cloud-bigtable-tool = callPackage ../tools/misc/google-cloud-bigtable-tool { };
+
   google-fonts = callPackage ../data/fonts/google-fonts { };
 
   google-clasp = callPackage ../development/tools/google-clasp { };


### PR DESCRIPTION
## Description of changes

- Adds a new package `google-cloud-bigtable-tool` at latest version 0.12.0

  The main program of the package is `cbt`.
  
  `cbt` is the Google Cloud Bigtable Tool. A CLI utility to interact with Google Cloud Bigtable.
  The cbt CLI is a command-line interface for performing several different operations on Cloud Bigtable.
  An overview of it's usage can be found in the [Google Cloud docs](https://cloud.google.com/bigtable/docs/cbt-overview).

- Renames package `cloud-sql-proxy` to `google-cloud-sql-proxy` as it cannot be used with other cloud providers (also to improve consistency)
  I added a note to the release notes of 23.11 as renaming a package might be considered breaking.
- Adds meta attributes to package `google-cloud-sql-proxy`

Ping maintainer @nicknovitski @totoroot 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
