### PR TITLE
octodns: init at 1.4.0

### DIFF
--- a/pkgs/tools/networking/octodns/default.nix
+++ b/pkgs/tools/networking/octodns/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools
+, wheel
+, pytestCheckHook
+, dnspython
+, fqdn
+, idna
+, natsort
+, python-dateutil
+, pyyaml
+, python
+, runCommand
+}:
+
+buildPythonPackage rec {
+  pname = "octodns";
+  version = "1.4.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "octodns";
+    repo = "octodns";
+    rev = "v${version}";
+    hash = "sha256-l4JGodbUmFxHFeEaxgClEozHcbyYP0F2yj5gDqV88IA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    dnspython
+    fqdn
+    idna
+    natsort
+    python-dateutil
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "octodns" ];
+
+  passthru.withProviders = ps: let
+    pyEnv = python.withPackages ps;
+  in runCommand "octodns-with-providers" { } ''
+    mkdir -p $out/bin
+    ln -st $out/bin ${pyEnv}/bin/octodns-*
+  '';
+
+  meta = with lib; {
+    description = "Tools for managing DNS across multiple providers";
+    homepage = "https://github.com/octodns/octodns";
+    changelog = "https://github.com/octodns/octodns/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ janik ];
+  };
+}

--- a/pkgs/tools/networking/octodns/providers/bind/default.nix
+++ b/pkgs/tools/networking/octodns/providers/bind/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, octodns
+, pytestCheckHook
+, pythonOlder
+, dnspython
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "octodns-bind";
+  version = "0.0.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "octodns";
+    repo = "octodns-bind";
+    rev = "v${version}";
+    hash = "sha256-0ia/xYarrOiLZa8KU0s5wtCGtXIyxSl6OcwNkSJb/rA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    octodns
+    dnspython
+  ];
+
+  env.OCTODNS_RELEASE = 1;
+
+  pythonImportsCheck = [ "octodns_bind" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = " RFC compliant (Bind9) provider for octoDNS";
+    homepage = "https://github.com/octodns/octodns-bind";
+    changelog = "https://github.com/octodns/octodns-bind/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ janik ];
+  };
+}

--- a/pkgs/tools/networking/octodns/providers/hetzner/default.nix
+++ b/pkgs/tools/networking/octodns/providers/hetzner/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, octodns
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-mock
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "octodns-hetzner";
+  # the latest release tag is over a year behind.
+  version = "0.0.2-unstable-2023-09-29";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "octodns";
+    repo = "octodns-hetzner";
+    rev = "620840593a520dac9e365240b3ab361ded309c8e";
+    hash = "sha256-WdYy8tc0+PYsKuyp3uqOzbxwhLSZ+06L3JVaTSATEKM=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    octodns
+    requests
+  ];
+
+  pythonImportsCheck = [ "octodns_hetzner" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  meta = with lib; {
+    description = "Hetzner DNS provider for octoDNS";
+    homepage = "https://github.com/octodns/octodns-hetzner/";
+    changelog = "https://github.com/octodns/octodns-hetzner/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ janik ];
+  };
+}

--- a/pkgs/tools/networking/octodns/providers/powerdns/default.nix
+++ b/pkgs/tools/networking/octodns/providers/powerdns/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, octodns
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-mock
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "octodns-powerdns";
+  version = "0.0.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "octodns";
+    repo = "octodns-powerdns";
+    rev = "v${version}";
+    hash = "sha256-jt0+JnpCgvsoqMcC9mANX7uq2WPTiI2JQjwQi7LGWj0=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    octodns
+    requests
+  ];
+
+  env.OCTODNS_RELEASE = 1;
+
+  pythonImportsCheck = [ "octodns_powerdns" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  meta = with lib; {
+    description = "PowerDNS API provider for octoDNS";
+    homepage = "https://github.com/octodns/octodns-powerdns/";
+    changelog = "https://github.com/octodns/octodns-powerdns/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ janik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -827,6 +827,7 @@ with pkgs;
 
   octodns-providers = recurseIntoAttrs {
     hetzner = python3Packages.callPackage ../tools/networking/octodns/providers/hetzner { };
+    powerdns = python3Packages.callPackage ../tools/networking/octodns/providers/powerdns { };
   };
 
   octosuite = callPackage ../tools/security/octosuite { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -826,6 +826,7 @@ with pkgs;
   octodns = python3Packages.callPackage ../tools/networking/octodns { };
 
   octodns-providers = recurseIntoAttrs {
+    bind = python3Packages.callPackage ../tools/networking/octodns/providers/bind { };
     hetzner = python3Packages.callPackage ../tools/networking/octodns/providers/hetzner { };
     powerdns = python3Packages.callPackage ../tools/networking/octodns/providers/powerdns { };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -823,6 +823,8 @@ with pkgs;
 
   oauth2c = callPackage ../tools/security/oauth2c { };
 
+  octodns = python3Packages.callPackage ../tools/networking/octodns { };
+
   octosuite = callPackage ../tools/security/octosuite { };
 
   octosql = callPackage ../tools/misc/octosql { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -825,6 +825,10 @@ with pkgs;
 
   octodns = python3Packages.callPackage ../tools/networking/octodns { };
 
+  octodns-providers = recurseIntoAttrs {
+    hetzner = python3Packages.callPackage ../tools/networking/octodns/providers/hetzner { };
+  };
+
   octosuite = callPackage ../tools/security/octosuite { };
 
   octosql = callPackage ../tools/misc/octosql { };


### PR DESCRIPTION
## Description of changes

This PR adds [octodns](https://github.com/octodns) and some of it's [providers](https://github.com/octodns/octodns#providers)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
