### PR TITLE
teleport_11: 11.3.25 -> 11.3.27, teleport_12: 12.4.20 -> 12.4.22, teleport_13: 13.4.1 -> 13.4.3, teleport: 14.0.1 -> 14.0.3

### DIFF
--- a/pkgs/servers/teleport/11/default.nix
+++ b/pkgs/servers/teleport/11/default.nix
@@ -1,7 +1,7 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "11.3.25";
-  hash = "sha256-KIbRn90BUJp8Uc8GMHuIMMSn5tJQbxzE0ntngx1ELaE=";
+  version = "11.3.27";
+  hash = "sha256-A3EeFQsDOaggfb5S+eyRCe/vm054MabfRrcHPxhO0So=";
   vendorHash = "sha256-hjMv/H4dlinlv3ku7i1km2/b+6uCdbznHtVOMIjDlUc=";
   yarnHash = "sha256-hip0WQVZpx2qfVDmEy4nk4UFYEjX1Xhj8HsIIQ8PF1Y=";
   cargoLock = {

--- a/pkgs/servers/teleport/12/Cargo.lock
+++ b/pkgs/servers/teleport/12/Cargo.lock
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring",
  "untrusted 0.7.1",

--- a/pkgs/servers/teleport/12/default.nix
+++ b/pkgs/servers/teleport/12/default.nix
@@ -1,9 +1,9 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "12.4.20";
-  hash = "sha256-Qz+JOS4YPj2865Fkj7eVJMdilHMOGbTD179bQ5wHY7A=";
-  vendorHash = "sha256-cS8ylLujgp9Is+D2JjoK4yGgWRCVRyRw3NPQAAuE2vY=";
-  yarnHash = "sha256-tOdT7X8jM+tl1GZ7lBN2aW8KRiVW/zWK9fZIU7CSHVE=";
+  version = "12.4.22";
+  hash = "sha256-UEiS+GiderYTU34GHsQr4G8XrasV5ewmPcdrec4v5B4=";
+  vendorHash = "sha256-etutgK/5u+e86kx7ha3x+di9np7Tcr7hpGUMKZxJNT4=";
+  yarnHash = "sha256-MBTElkMH5rb33l+AYWH+zguSLQf+ntXpOkHZpjLAx/Q=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/servers/teleport/13/Cargo.lock
+++ b/pkgs/servers/teleport/13/Cargo.lock
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring",
  "untrusted 0.7.1",

--- a/pkgs/servers/teleport/13/default.nix
+++ b/pkgs/servers/teleport/13/default.nix
@@ -1,9 +1,9 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "13.4.1";
-  hash = "sha256-wgSaek4eq5Jx9SZFenvdRSU1wEtfJHzTz9GdczzUU2w=";
-  vendorHash = "sha256-DesT18nV/SxOsKCC+Nt0hgtH7CRtRL0B5FQhE1J148I=";
-  yarnHash = "sha256-iyMcP9L6dwBhN8JL9eSVEzsXI2EOjfyxjF9Dm4Gs04s=";
+  version = "13.4.3";
+  hash = "sha256-x8G94jKycK3nYwqDA5RPc63GHIk9y4pHfSwSBqGBINk=";
+  vendorHash = "sha256-Pb3eO9zqLgTD7otM7yGRWicQjvpIXg7xKV8Oc4yh8PA=";
+  yarnHash = "sha256-GnoiLqzqGV0UZm5zePCDBUUX63NTIIo1dcxtiWQDPqc=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/servers/teleport/14/Cargo.lock
+++ b/pkgs/servers/teleport/14/Cargo.lock
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring",
  "untrusted 0.7.1",

--- a/pkgs/servers/teleport/14/default.nix
+++ b/pkgs/servers/teleport/14/default.nix
@@ -1,9 +1,9 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "14.0.1";
-  hash = "sha256-esQwk2PFnk3/REzLr3ExtzEcUs2q4Tn/2KpfFWAx5uU=";
-  vendorHash = "sha256-lzwrkW0dHxCHBSJjzNhXgq3Av8Zj8xEn3kfTRtT/q04=";
-  yarnHash = "sha256-Y2dVxRyKPLD2xjwr0QqrKHf/4gnMCErmDzievu5zTGg=";
+  version = "14.0.3";
+  hash = "sha256-X+vekYmuTE7n22SH/z2GWO3wnBsIef1GEjR7WOJpjc8=";
+  vendorHash = "sha256-+R6f2HrlN/RLec83YutccDFJW6gq6HXbxoJVtxMgdp8=";
+  yarnHash = "sha256-udM4DNaTGiMkqfkllJjmT+Nk6PNbGUzT34ixQOhmScw=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {


### PR DESCRIPTION
## Description of changes
By the time #258943 was merged there was already a new vulnerability.

https://github.com/gravitational/teleport/pull/33248

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
