### PR TITLE
pcaudiolib, espeak-ng: fix darwin builds

### DIFF
--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -15,6 +15,9 @@
 , pcaudiolib
 , sonicSupport ? true
 , sonic
+, CoreAudio
+, AudioToolbox
+, AudioUnit
 , alsa-plugins
 , makeWrapper
 }:
@@ -42,9 +45,20 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optional mbrolaSupport mbrola
     ++ lib.optional pcaudiolibSupport pcaudiolib
-    ++ lib.optional sonicSupport sonic;
+    ++ lib.optional sonicSupport sonic
+    ++ lib.optionals stdenv.isDarwin [
+    CoreAudio
+    AudioToolbox
+    AudioUnit
+  ];
 
-  preConfigure = "./autogen.sh";
+  # touch ChangeLog to avoid below error on darwin:
+  # Makefile.am: error: required file './ChangeLog.md' not found
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    touch ChangeLog
+  '' + ''
+    ./autogen.sh
+  '';
 
   configureFlags = [
     "--with-mbrola=${if mbrolaSupport then "yes" else "no"}"

--- a/pkgs/development/libraries/pcaudiolib/default.nix
+++ b/pkgs/development/libraries/pcaudiolib/default.nix
@@ -38,7 +38,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.isLinux alsa-lib
   ++ lib.optional pulseaudioSupport libpulseaudio;
 
-  preConfigure = ''
+  # touch ChangeLog to avoid below error on darwin:
+  # Makefile.am: error: required file './ChangeLog.md' not found
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    touch ChangeLog
+  '' + ''
     ./autogen.sh
   '';
 
@@ -48,6 +52,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ aske ];
     platforms = platforms.unix;
-    badPlatforms = platforms.darwin;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31369,7 +31369,9 @@ with pkgs;
 
   espeak-classic = callPackage ../applications/audio/espeak { };
 
-  espeak-ng = callPackage ../applications/audio/espeak-ng { };
+  espeak-ng = callPackage ../applications/audio/espeak-ng {
+    inherit (darwin.apple_sdk.frameworks) AudioToolbox AudioUnit CoreAudio;
+  };
   espeak = res.espeak-ng;
 
   espeakedit = callPackage ../applications/audio/espeak/edit.nix { };


### PR DESCRIPTION
- I'm not certain touching ChangeLog is the "right" fix for that issue, but I do see some other packages doing the same.  Some of these do it globally, but I've gone back and limited this change to Darwin here since it seemed to be working on Linux without this.
- nixpkgs-review for x86_64-linux wanted to do 179 builds including hefties like chromium that took way more disk space than I have available; I just ran a small slice:

    Result of `nixpkgs-review pr 261272` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
    <details>
      <summary>12 packages built:</summary>
      <ul>
        <li>espeak-ng</li>
        <li>espeakup</li>
        <li>goldendict-ng</li>
        <li>normcap</li>
        <li>normcap.dist (normcap.dist.dist)</li>
        <li>pcaudiolib</li>
        <li>phonemizer</li>
        <li>phonemizer.dist (phonemizer.dist.dist)</li>
        <li>rhvoice</li>
        <li>syncplay</li>
        <li>tts</li>
        <li>tts.dist (tts.dist.dist)</li>
      </ul>
    </details>

- Result of `nixpkgs-review pr 261272` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
    <details>
      <summary>15 packages marked as broken and skipped:</summary>
      <ul>
        <li>arcanPackages.arcan</li>
        <li>arcanPackages.xarcan</li>
        <li>calibre</li>
        <li>dasher</li>
        <li>goxlr-utility</li>
        <li>phonemizer</li>
        <li>phonemizer.dist</li>
        <li>piper-train</li>
        <li>piper-train.dist</li>
        <li>python310Packages.phonemizer</li>
        <li>python310Packages.phonemizer.dist</li>
        <li>python311Packages.phonemizer</li>
        <li>python311Packages.phonemizer.dist</li>
        <li>rhvoice</li>
        <li>unbook</li>
      </ul>
    </details>
    <details>
      <summary>15 packages built:</summary>
      <ul>
        <li>espeak (arcanPackages.espeak ,espeak-ng)</li>
        <li>chickenPackages_5.chickenEggs.espeak</li>
        <li>gruut (python310Packages.gruut)</li>
        <li>gruut-ipa (python310Packages.gruut-ipa)</li>
        <li>gruut-ipa.dist (python310Packages.gruut-ipa.dist)</li>
        <li>gruut.dist (python310Packages.gruut.dist)</li>
        <li>pcaudiolib</li>
        <li>python310Packages.piper-phonemize</li>
        <li>python310Packages.piper-phonemize.dist</li>
        <li>python311Packages.gruut</li>
        <li>python311Packages.gruut-ipa</li>
        <li>python311Packages.gruut-ipa.dist</li>
        <li>python311Packages.gruut.dist</li>
        <li>python311Packages.piper-phonemize</li>
        <li>python311Packages.piper-phonemize.dist</li>
      </ul>
    </details>
  

## Things Done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
