### PR TITLE
arcan: 0.6.2.1 -> 0.7-pre

### DIFF
--- a/pkgs/desktops/arcan/arcan/default.nix
+++ b/pkgs/desktops/arcan/arcan/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "letoram";
     repo = "arcan";
     rev = "e8a484e7f6cca019174573885876997d56fb7927";
-    hash = "sha256-k/+mbJZc2lSaOejIQBytjpA9kOPIOaCuFGGoY+8PaFs=";
+    hash = "sha256-NahZwQzPSlwuirpiGBv5RnZjXPp+xDlheBLnnwjn7c8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/arcan/arcan/default.nix
+++ b/pkgs/desktops/arcan/arcan/default.nix
@@ -58,13 +58,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "arcan" + lib.optionalString useStaticOpenAL "-static-openal";
-  version = "0.6.2.1";
+  version = "0.7-pre";
 
   src = fetchFromGitHub {
     owner = "letoram";
     repo = "arcan";
-    rev = finalAttrs.version;
-    hash = "sha256-7H3fVSsW5VANLqwhykY+Q53fPjz65utaGksh/OpZnJM=";
+    rev = "f6a8eb6b0b6276a0ec3e162072681f236194ba33";
+    hash = "sha256-k/+mbJZc4lSaOejIQBytjpA9kOPIOaCuFGGoY+8PaFs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/arcan/arcan/default.nix
+++ b/pkgs/desktops/arcan/arcan/default.nix
@@ -47,7 +47,7 @@
 , useBuiltinLua ? true
 , useStaticFreetype ? false
 , useStaticLibuvc ? false
-, useStaticOpenAL ? true
+, useStaticOpenAL ? false
 , useStaticSqlite ? false
 }:
 
@@ -62,8 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "letoram";
     repo = "arcan";
-    rev = "f6a8eb6b0b6276a0ec3e162072681f236194ba33";
-    hash = "sha256-k/+mbJZc4lSaOejIQBytjpA9kOPIOaCuFGGoY+8PaFs=";
+    rev = "e8a484e7f6cca019174573885876997d56fb7927";
+    hash = "sha256-k/+mbJZc2lSaOejIQBytjpA9kOPIOaCuFGGoY+8PaFs=";
   };
 
   nativeBuildInputs = [
@@ -116,10 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Nixpkgs-specific: redirect vendoring
-    ./000-openal.patch
-    ./001-luajit.patch
-    ./002-libuvc.patch
   ];
 
   # Emulate external/git/clone.sh

--- a/pkgs/desktops/arcan/arcan/default.nix
+++ b/pkgs/desktops/arcan/arcan/default.nix
@@ -4,7 +4,6 @@
 , fetchgit
 , SDL2
 , cmake
-, espeak
 , ffmpeg
 , file
 , freetype
@@ -77,7 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
-    espeak
     ffmpeg
     file
     freetype


### PR DESCRIPTION
NixOS is pegged to a version that is now one year old. I have verified the proposed pre-release works on Linux x86_64 and aarch64 with durden, pipeworld and several custom arcan appls.

This version is used by upstream devs as a daily driver and provides the following improvements over 0.6.2.1

Lua

- inbound events now have a 'frame' tag for pairing with verbose-frame notification util:random_interval(low,high) added for CSPRNG non-biased interval RNG util:random_bytes(len) added for CSPRNG byte string target_input long messages are now marked as multipart convey tui/tpack state in resize events
- target_anchorhint added for informing clients about positioning and hierarchy video_displaymode expose eotf / coordinates for primaries and contents light levels open_nonblock can now adopt an existing iostream into a target vid input_remap_translation overloaded form for serializing backing keymap clockreq no longer forwarded for frameserver event handler image_metadata added for annotating a vid used when streaming/sharing/scanout HDR contents functions creating files now apply a separate WRITEMASK (split from USERMASK)
- 

Core

- respect border attribute in text rasteriser
- added frame_id to external events that pairs with shmif-SIGVID signals optional tracy build for profiling (-DENABLE_TRACY) frameserver clock(stepframe) event handling extended (see shmif)
- 

Tui

- nbio asynch type confusion fix (function becomes pcall:userdata) nbio close without explicit flush
- dock subtype exposed for bar/tray like integration add 'swallow' request for new windows
- cursor(caret) style and color override controls
- readline: add completion style control (border)
- readline: allow attached popup to replace in-band completion readline: history traversal early-stop fixed
- fixes for screencopy on proxy window
- refactored deprecated tsm-screen away out of tui (1/2)

Net

- allow h264 passthrough, sidestepping local encode
- re-add afsrv_net, have it support directory, source and sink access modes. split a12:// into a12:// and a12s:// ARCAN_CONNPATH with the former permitting connecting to unknowns add interactive accept/reject/trust for arcan-net use reserve 'outbound' domain for interactively added outbound keys enforce domain separation for allowed pubkeys
- directory mode now splits out into sandboxed worker processes directory mode can now specify permissions per tag-group directory mode dynamic push appl from client with permission directory mode notification of appl updates and sources coming / leaving directory mode registration of dynamic sinks
- directory mode sourcing dynamic sinks (sink-inbound only)

Terminal

- SGR reset fix, add CNL / CPL
- Add interp=st for suckless terminal based state machine

Platform

- paths: prioritise _APPL_TEMP over _APPL in load order audio: engine audio split out into platform bit
- audio: stub platform added
- egl-dri: evict streams
- egl-dri: default to atomic over legacy
- egl-dri: retain device tracking for unmapped display egl-dri: add hdr infoframe metadata to platform

Shmif

- add audio only- segment type
- wire up ext venc resize for compressed video passthrough extend hdr vsub with more metadata
- dropped unused rhints and rename hdr16f (version bump) CLOCKREQ extended with options for latching to specific msc/vblank events
- 

Decode

- defer REGISTER until proto argument has been parsed, let text register as TUI libuvc path now uses FFMPEG for h264 and mjpeg
- Package / Build
- console: added binding for shutdown
- builtin/mouse: bugfixes to two-sample mode
- 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
