### PR TITLE
espeak-ng: disable mbrola by default because it is very big

### DIFF
--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -9,7 +9,7 @@
 , ronn
 , substituteAll
 , buildPackages
-, mbrolaSupport ? true
+, mbrolaSupport ? false # adds almost 700MB to closure size but has better voice quality
 , mbrola
 , pcaudiolibSupport ? true
 , pcaudiolib


### PR DESCRIPTION
## Description of changes
Motivated since firefox now enabeld speechd by default which increased firefox' closure size drastically. 

With mbrola:

``` 
 ➜ nix build .#espeak-ng
 ➜ nix path-info -hS ./result
/nix/store/klj2hglk9vz35jrqvygcjns8j9zq4mwk-espeak-ng-1.51.1     772.0M
 ➜ nix build .#firefox
 ➜ nix path-info -hS ./result
/nix/store/j5l32v4kmjp7s35ygrzwaik4nh591064-firefox-118.0.1        1.7G
```

without mbrola:
```
 ➜ nix build .#espeak-ng
 ➜ nix path-info -hS ./result
/nix/store/lqm1l361bh2ym8dkkhx5x049nnygb9pk-espeak-ng-1.51.1     127.1M
 ➜ nix build .#firefox
 ➜ nix path-info -hS ./result
/nix/store/z0sch4i5k5xdmy575vmf7czd2149ar7k-firefox-118.0.1        1.1G
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
