### PR TITLE
chromium: delete unused paths in source tarball

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, fetchurl, fetchpatch
+, fetchzip, zstd
 , buildPackages
 , pkgsBuildBuild
 , pkgsBuildTarget
@@ -152,9 +153,30 @@ let
     inherit (upstream-info) version;
     inherit packageName buildType buildPath;
 
-    src = fetchurl {
+    src = fetchzip {
+      name = "chromium-${version}.tar.zstd";
       url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
       inherit (upstream-info) sha256;
+
+      nativeBuildInputs = [ zstd ];
+
+      postFetch = ''
+        echo removing unused code from tarball to stay under hydra limit
+        rm -r $out/third_party/{rust-src,llvm}
+
+        echo moving remains out of \$out
+        mv $out source
+
+        echo recompressing final contents into new tarball
+        # try to make a deterministic tarball
+        tar \
+          --use-compress-program "zstd -T$NIX_BUILD_CORES" \
+          --sort name \
+          --mtime 1970-01-01 \
+          --owner=root --group=root \
+          --numeric-owner --mode=go=rX,u+rw,a-s \
+          -cf $out source
+      '';
     };
 
     nativeBuildInputs = [

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -8,7 +8,7 @@
         version = "2023-08-01";
       };
     };
-    sha256 = "1wf0j189cxpayy6ffmj5j6h5yg3amivryilimjc2ap0jkyj4xrbi";
+    sha256 = "0c3adrrgpnhm8g1546ask9pf17qj1sjgb950mj0rv4snxvddi75j";
     sha256bin64 = "11w1di146mjb9ql30df9yk9x4b9amc6514jzyfbf09mqsrw88dvr";
     version = "117.0.5938.22";
   };
@@ -21,7 +21,7 @@
         version = "2023-08-10";
       };
     };
-    sha256 = "1z01b6w4sgndrlcd26jgimk3rhv3wzpn67nv1fd5ln7dwfwkyq20";
+    sha256 = "16dq27lsywrn2xlgr5g46gdv15p30sihfamli4vkv3zxzfxdjisv";
     sha256bin64 = "11y09hsy7y1vg65xfilq44ffsmn15dqy80fa57psj1kin4a52v2x";
     version = "118.0.5966.0";
   };
@@ -41,7 +41,7 @@
         version = "2023-08-10";
       };
     };
-    sha256 = "0gcrnvm3ar7x0fv38kjvdzgb8lflx1sckcqy89yawgfy6jkh1vj9";
+    sha256 = "1g8rllmnmhmmpjzrmi3cww0nszxicq0kim2wd0l0ip2mzk2p8qlp";
     sha256bin64 = "1bq170l0g9yq17x6xlg6fjar6gv3hdi0zijwmx4s02pmw6727484";
     version = "118.0.5993.70";
   };
@@ -58,7 +58,7 @@
         sha256 = "0k6684cy1ks6yba2bdz17g244f05qy9769cvis4h2jzhgbf5rysh";
       };
     };
-    sha256 = "0gcrnvm3ar7x0fv38kjvdzgb8lflx1sckcqy89yawgfy6jkh1vj9";
+    sha256 = "1g8rllmnmhmmpjzrmi3cww0nszxicq0kim2wd0l0ip2mzk2p8qlp";
     sha256bin64 = "1bq170l0g9yq17x6xlg6fjar6gv3hdi0zijwmx4s02pmw6727484";
     version = "118.0.5993.70";
   };


### PR DESCRIPTION
## Description of changes

Delete unused paths in source tarball to stay below hydra limit.

At the time of writing, the hydra.nixos.org's output limit is 3 GB.
The latest chromium tarball, however, is slightly above that.

To work around this, recompress the original `tar.xz` into a `tar.zstd`
and delete two unreasonably big and unused directories.

Bringing it down to roughtly 2.2 GB.

Unfortunately, this change breaks the `update.py` script.

Resolves the current channel-blocker.

The alternative would be to increase hydra.nixos.org's output limit to something like 3.5 GB.
(But the next chromium release might exceed that as well /shrug)

https://github.com/NixOS/nixpkgs/pull/260783#issuecomment-1763426906 
https://hydra.nixos.org/build/238056551

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @vcunat @K900 @networkException 