### PR TITLE
xwaylandvideobridge: init at 0.2

### DIFF
--- a/pkgs/tools/wayland/xwaylandvideobridge/default.nix
+++ b/pkgs/tools/wayland/xwaylandvideobridge/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, pkg-config
+, qtbase
+, qtquickcontrols2
+, qtx11extras
+, kdelibs4support
+, kpipewire
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xwaylandvideobridge";
+  version = "0.2";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "system";
+    repo = "xwaylandvideobridge";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-79Z4BH7C85ZF+1Zivs3bTey7IdUnaDKhvZxzL6sDqUs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtquickcontrols2
+    qtx11extras
+    kdelibs4support
+    kpipewire
+  ];
+
+  meta = {
+    description = "Utility to allow streaming Wayland windows to X applications";
+    homepage = "https://invent.kde.org/system/xwaylandvideobridge";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ stepbrobd ];
+    platforms = lib.platforms.linux;
+    mainProgram = "xwaylandvideobridge";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27497,6 +27497,8 @@ with pkgs;
 
   xwayland = callPackage ../servers/x11/xorg/xwayland.nix { };
 
+  xwaylandvideobridge = libsForQt5.callPackage ../tools/wayland/xwaylandvideobridge { };
+
   yaws = callPackage ../servers/http/yaws { };
 
   youtrack = callPackage ../servers/jetbrains/youtrack.nix { };


### PR DESCRIPTION
## Description of changes

added xwaylandvideobridge (https://github.com/NixOS/nixpkgs/issues/222741)

thanks @dacioromero!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
