### PR TITLE
`loginctl` user lingering configuration revisited

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25142,6 +25142,12 @@
     githubId = 2027925;
     name = "Thomas Gebert";
   };
+  tomeon = {
+    email = "tomeon@dogea.red";
+    github = "tomeon";
+    githubId = 1287639;
+    name = "Matt Schreiber";
+  };
   tomfitzhenry = {
     email = "tom@tom-fitzhenry.me.uk";
     github = "tomfitzhenry";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -27,3 +27,5 @@
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - `services.clamsmtp` is unmaintained and was removed from Nixpkgs.
+
+- `users.users.<name>` now supports the nullable boolean option `linger` for controlling user lingering (see `man 1 loginctl` for a description of the `enable-linger` and `disable-linger` operations and their effects).

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -13,6 +13,8 @@ my $uidMap = -e $uidMapFile ? decode_json(read_file($uidMapFile)) : {};
 my $gidMapFile = "/var/lib/nixos/gid-map";
 my $gidMap = -e $gidMapFile ? decode_json(read_file($gidMapFile)) : {};
 
+my $systemd = "@systemd@";
+
 my $is_dry = ($ENV{'NIXOS_ACTION'} // "") eq "dry-activate";
 GetOptions("dry-activate" => \$is_dry);
 make_path("/var/lib/nixos", { mode => 0755 }) unless $is_dry;
@@ -89,6 +91,18 @@ sub allocUid {
         return $prevUid;
     }
     return allocId(\%uidsUsed, \%uidsPrevUsed, $min, $max, $delta, sub { my ($uid) = @_; getpwuid($uid) });
+}
+
+sub disableLinger {
+    return unless scalar @_;
+    dry_print("disabling", "would disable", "lingering for user(s) '$_'") foreach @_;
+    system("${systemd}/bin/loginctl", "disable-linger", @_) unless $is_dry;
+}
+
+sub enableLinger {
+    return unless scalar @_;
+    dry_print("enabling", "would enable", "lingering for user(s) '$_'") foreach @_;
+    system("${systemd}/bin/loginctl", "enable-linger", @_) unless $is_dry;
 }
 
 # Read the declared users/groups
@@ -219,6 +233,13 @@ foreach my $u (@{$spec->{users}}) {
             dry_print("warning: not applying", "warning: would not apply", "UID change of user ‘$name’ ($existing->{uid} -> $u->{uid}) in /etc/passwd");
             $u->{uid} = $existing->{uid};
         }
+
+        # When `mutableUsers` is in effect, only apply the specified lingering
+        # setting when creating the user account.
+        if ($spec->{mutableUsers}) {
+            dry_print("warning: not applying", "warning: would not apply", "lingering setting of mutable user '$name'");
+            delete $u->{linger};
+        }
     } else {
         $u->{uid} = allocUid($name, $u->{isSystemUser}) if !defined $u->{uid};
 
@@ -267,16 +288,25 @@ foreach my $u (@{$spec->{users}}) {
 # Update the persistent list of declarative users.
 updateFile($declUsersFile, join(" ", sort(keys %usersOut)));
 
-# Merge in the existing /etc/passwd.
+# Merge in the existing /etc/passwd and gather the names of users whose
+# lingering should be disabled.
+my @disableLingerRemoved;
 foreach my $name (keys %usersCur) {
     my $u = $usersCur{$name};
     next if defined $usersOut{$name};
     if (!$spec->{mutableUsers} || defined $declUsers{$name}) {
         dry_print("removing user", "would remove user", "‘$name’");
+        push @disableLingerRemoved, $name;
     } else {
         $usersOut{$name} = $u;
     }
 }
+
+# Remove these lingering settings before updating the user DB, as otherwise
+# `loginctl disable-linger my-deleted-user` is liable to complain "Failed to
+# look up user my-deleted-user: No such process" and fail to remove
+# /var/lib/systemd/linger/my-deleted-user.
+disableLinger(@disableLingerRemoved);
 
 # Rewrite /etc/passwd. FIXME: acquire lock.
 @lines = map { join(":", $_->{name}, $_->{fakePassword}, $_->{uid}, $_->{gid}, $_->{description}, $_->{home}, $_->{shell}) . "\n" }
@@ -347,6 +377,8 @@ sub allocSubUid {
 
 my @subGids;
 my @subUids;
+my @disableLinger;
+my @enableLinger;
 foreach my $u (values %usersOut) {
     my $name = $u->{name};
 
@@ -375,8 +407,12 @@ foreach my $u (values %usersOut) {
         push @subUids, $value;
         push @subGids, $value;
     }
+
+    push @{$u->{linger} ? \@enableLinger : \@disableLinger}, $name if exists $u->{linger};
 }
 
 updateFile("/etc/subuid", join("\n", @subUids) . "\n");
 updateFile("/etc/subgid", join("\n", @subGids) . "\n");
 updateFile($subUidMapFile, to_json($subUidMap) . "\n");
+disableLinger(@disableLinger);
+enableLinger(@enableLinger);

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -3,6 +3,7 @@ use warnings;
 use File::Path qw(make_path);
 use File::Slurp;
 use Getopt::Long;
+use IPC::Open3 qw(open3);
 use JSON;
 use Time::Piece;
 
@@ -93,16 +94,59 @@ sub allocUid {
     return allocId(\%uidsUsed, \%uidsPrevUsed, $min, $max, $delta, sub { my ($uid) = @_; getpwuid($uid) });
 }
 
+sub loginctl {
+    system("${systemd}/bin/loginctl", "--no-legend", "--no-pager", @_);
+}
+
+sub loginctlSilent {
+    my $pid = open3(my $stdin, my $stdout, undef, "${systemd}/bin/loginctl", "--no-legend", "--no-pager", @_);
+    waitpid($pid, 0);
+    return $?;
+};
+
+# `loginctl show-session`, when called without any session names, "[shows]
+# properties [of] the manager itself" (`man 1 loginctl`), where "the manager"
+# is the systemd login manager.  If this command completes successfully, we can
+# be confident that the login manager is up and running.
+if (loginctlSilent("show-session") == 0) {
+    *doDisableLinger = sub { loginctl("disable-linger", @_); };
+    *doEnableLinger = sub { loginctl("enable-linger", @_); };
+} else {
+    require Errno; # For magic `%!' in `doDisableLinger`
+
+    my $lingering_dir = "/var/lib/systemd/linger";
+
+    *doDisableLinger = sub {
+        foreach my $name (@_) {
+            my $file = "${lingering_dir}/${name}";
+            unlink $file or do {
+                # Don't bother warning about files that are already absent.
+                warn "failed to unlink '$file': $!" unless $!{ENOENT};
+            };
+        }
+    };
+
+    *doEnableLinger = sub {
+        make_path($lingering_dir);
+
+        foreach my $name (@_) {
+            my $file = "${lingering_dir}/${name}";
+            open my $fh, ">>", $file or warn "failed to touch '$file': $!";
+            close $fh;
+        }
+    };
+}
+
 sub disableLinger {
     return unless scalar @_;
     dry_print("disabling", "would disable", "lingering for user(s) '$_'") foreach @_;
-    system("${systemd}/bin/loginctl", "disable-linger", @_) unless $is_dry;
+    doDisableLinger(@_) unless $is_dry;
 }
 
 sub enableLinger {
     return unless scalar @_;
     dry_print("enabling", "would enable", "lingering for user(s) '$_'") foreach @_;
-    system("${systemd}/bin/loginctl", "enable-linger", @_) unless $is_dry;
+    doEnableLinger(@_) unless $is_dry;
 }
 
 # Read the declared users/groups

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -237,7 +237,7 @@ foreach my $u (@{$spec->{users}}) {
         # When `mutableUsers` is in effect, only apply the specified lingering
         # setting when creating the user account.
         if ($spec->{mutableUsers}) {
-            dry_print("warning: not applying", "warning: would not apply", "lingering setting of mutable user '$name'");
+            dry_print("warning: not applying", "warning: would not apply", "lingering setting of mutable user '$name'") if defined $u->{linger};
             delete $u->{linger};
         }
     } else {
@@ -408,7 +408,7 @@ foreach my $u (values %usersOut) {
         push @subGids, $value;
     }
 
-    push @{$u->{linger} ? \@enableLinger : \@disableLinger}, $name if exists $u->{linger};
+    push @{$u->{linger} ? \@enableLinger : \@disableLinger}, $name if defined $u->{linger};
 }
 
 updateFile("/etc/subuid", join("\n", @subUids) . "\n");

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -137,6 +137,12 @@ if (loginctlSilent("show-session") == 0) {
     };
 }
 
+sub disableLingerRemoved {
+    return unless scalar @_;
+    dry_print("disabling", "would disable", "lingering for removed user(s) '$_'") foreach @_;
+    doDisableLinger(@_) unless $is_dry;
+}
+
 sub disableLinger {
     return unless scalar @_;
     dry_print("disabling", "would disable", "lingering for user(s) '$_'") foreach @_;
@@ -350,7 +356,7 @@ foreach my $name (keys %usersCur) {
 # `loginctl disable-linger my-deleted-user` is liable to complain "Failed to
 # look up user my-deleted-user: No such process" and fail to remove
 # /var/lib/systemd/linger/my-deleted-user.
-disableLinger(@disableLingerRemoved);
+disableLingerRemoved(@disableLingerRemoved);
 
 # Rewrite /etc/passwd. FIXME: acquire lock.
 @lines = map { join(":", $_->{name}, $_->{fakePassword}, $_->{uid}, $_->{gid}, $_->{description}, $_->{home}, $_->{shell}) . "\n" }

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -455,7 +455,7 @@ let
         };
 
         linger = mkOption {
-          type = types.bool;
+          type = types.nullOr types.bool;
           default = false;
           description = ''
             Whether to enable lingering for this user. If true, systemd user
@@ -465,6 +465,9 @@ let
 
             If false, user units will not be started until the user logs in, and
             may be stopped on logout depending on the settings in `logind.conf`.
+
+            If null, no change will be made to the user's current lingering
+            configuration.
           '';
         };
       };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1423,6 +1423,7 @@ in
   user-expiry = runTest ./user-expiry.nix;
   user-home-mode = handleTest ./user-home-mode.nix { };
   ustreamer = handleTest ./ustreamer.nix { };
+  user-lingering = handleTest ./user-lingering.nix { };
   uwsgi = handleTest ./uwsgi.nix { };
   v2ray = handleTest ./v2ray.nix { };
   varnish60 = runTest {

--- a/nixos/tests/docker-rootless.nix
+++ b/nixos/tests/docker-rootless.nix
@@ -14,6 +14,7 @@
 
         users.users.alice = {
           uid = 1000;
+          linger = true;
           isNormalUser = true;
         };
       };
@@ -23,20 +24,22 @@
     { nodes, ... }:
     let
       user = nodes.machine.config.users.users.alice;
+      runtimeUID = "$(id -u ${user.name})";
+      runtimeDir = "/run/user/${runtimeUID}";
       sudo = lib.concatStringsSep " " [
-        "XDG_RUNTIME_DIR=/run/user/${toString user.uid}"
-        "DOCKER_HOST=unix:///run/user/${toString user.uid}/docker.sock"
+        "XDG_RUNTIME_DIR=${runtimeDir}"
+        "DOCKER_HOST=unix:///${runtimeDir}/docker.sock"
         "sudo"
         "--preserve-env=XDG_RUNTIME_DIR,DOCKER_HOST"
         "-u"
-        "alice"
+        user.name
       ];
     in
     ''
       machine.wait_for_unit("multi-user.target")
 
-      machine.succeed("loginctl enable-linger alice")
-      machine.wait_until_succeeds("${sudo} systemctl --user is-active docker.service")
+      machine.wait_for_unit("user@${runtimeUID}")
+      machine.wait_for_unit("docker.service", "${user.name}")
 
       machine.succeed("tar cv --files-from /dev/null | ${sudo} docker import - scratchimg")
       machine.succeed(

--- a/nixos/tests/livebook-service.nix
+++ b/nixos/tests/livebook-service.nix
@@ -20,6 +20,8 @@ import ./make-test-python.nix (
               LIVEBOOK_PASSWORD = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
             '';
           };
+
+          users.users.alice.linger = true;
         };
     };
 
@@ -27,19 +29,20 @@ import ./make-test-python.nix (
       { nodes, ... }:
       let
         user = nodes.machine.users.users.alice;
+        runtimeUID = "$(id -u ${user.name})";
         sudo = lib.concatStringsSep " " [
-          "XDG_RUNTIME_DIR=/run/user/${toString user.uid}"
+          "XDG_RUNTIME_DIR=/run/user/${runtimeUID}"
           "sudo"
           "--preserve-env=XDG_RUNTIME_DIR"
           "-u"
-          "alice"
+          user.name
         ];
       in
       ''
         machine.wait_for_unit("multi-user.target")
 
-        machine.succeed("loginctl enable-linger alice")
-        machine.wait_until_succeeds("${sudo} systemctl --user is-active livebook.service")
+        machine.wait_for_unit("user@${runtimeUID}")
+        machine.wait_for_unit("livebook.service", "${user.name}")
         machine.wait_for_open_port(20123, timeout=10)
 
         machine.succeed("curl -L localhost:20123 | grep 'Type password'")

--- a/nixos/tests/maestral.nix
+++ b/nixos/tests/maestral.nix
@@ -27,10 +27,11 @@ import ./make-test-python.nix (
               wantedBy = [ "default.target" ];
               serviceConfig.ExecStart = "${pkgs.maestral}/bin/maestral start --foreground";
             };
+            users.users.alice.linger = true;
           };
 
         gui =
-          { ... }:
+          { config, ... }:
           common {
             services.xserver = {
               enable = true;
@@ -43,7 +44,7 @@ import ./make-test-python.nix (
               defaultSession = "plasma";
               autoLogin = {
                 enable = true;
-                user = "alice";
+                user = config.users.users.alice.name;
               };
             };
 
@@ -67,9 +68,7 @@ import ./make-test-python.nix (
         start_all()
 
         with subtest("CLI"):
-          # we need SOME way to give the user an active login session
-          cli.execute("loginctl enable-linger ${user.name}")
-          cli.systemctl("start user@${toString user.uid}")
+          cli.wait_for_unit("user@${toString user.uid}")
           cli.wait_for_unit("maestral.service", "${user.name}")
 
         with subtest("GUI"):

--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -39,6 +39,7 @@ import ../make-test-python.nix (
 
           users.users.alice = {
             isNormalUser = true;
+            linger = true;
           };
         };
       dns =
@@ -70,147 +71,150 @@ import ../make-test-python.nix (
         };
     };
 
-    testScript = ''
-      import shlex
+    testScript =
+      { nodes, ... }:
+      let
+        user = nodes.machine.users.users.alice;
+      in
+      ''
+        import shlex
 
 
-      def su_cmd(cmd, user = "alice"):
-          cmd = shlex.quote(cmd)
-          return f"su {user} -l -c {cmd}"
+        def su_cmd(cmd, user = "${user.name}"):
+            cmd = shlex.quote(cmd)
+            return f"su {user} -l -c {cmd}"
 
 
-      rootful.wait_for_unit("sockets.target")
-      rootless.wait_for_unit("sockets.target")
-      dns.wait_for_unit("sockets.target")
-      docker.wait_for_unit("sockets.target")
-      start_all()
+        rootful.wait_for_unit("sockets.target")
+        rootless.wait_for_unit("sockets.target")
+        dns.wait_for_unit("sockets.target")
+        docker.wait_for_unit("sockets.target")
+        start_all()
 
-      with subtest("Run container as root with runc"):
-          rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful.succeed(
-              "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-          rootful.succeed("podman ps | grep sleeping")
-          rootful.succeed("podman stop sleeping")
-          rootful.succeed("podman rm sleeping")
+        with subtest("Run container as root with runc"):
+            rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+            rootful.succeed(
+                "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+            )
+            rootful.succeed("podman ps | grep sleeping")
+            rootful.succeed("podman stop sleeping")
+            rootful.succeed("podman rm sleeping")
 
-      with subtest("Run container as root with crun"):
-          rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful.succeed(
-              "podman run --runtime=crun -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-          rootful.succeed("podman ps | grep sleeping")
-          rootful.succeed("podman stop sleeping")
-          rootful.succeed("podman rm sleeping")
+        with subtest("Run container as root with crun"):
+            rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+            rootful.succeed(
+                "podman run --runtime=crun -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+            )
+            rootful.succeed("podman ps | grep sleeping")
+            rootful.succeed("podman stop sleeping")
+            rootful.succeed("podman rm sleeping")
 
-      with subtest("Run container as root with the default backend"):
-          rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful.succeed(
-              "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-          rootful.succeed("podman ps | grep sleeping")
-          rootful.succeed("podman stop sleeping")
-          rootful.succeed("podman rm sleeping")
+        with subtest("Run container as root with the default backend"):
+            rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+            rootful.succeed(
+                "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+            )
+            rootful.succeed("podman ps | grep sleeping")
+            rootful.succeed("podman stop sleeping")
+            rootful.succeed("podman rm sleeping")
 
-      # start systemd session for rootless
-      rootless.succeed("loginctl enable-linger alice")
-      rootless.succeed(su_cmd("whoami"))
-      rootless.sleep(1)
+        # wait for systemd user session for rootless
+        rootless.wait_for_unit("user@$(id -u ${user.name})")
 
-      with subtest("Run container rootless with runc"):
-          rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
-          rootless.succeed(
-              su_cmd(
-                  "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-              )
-          )
-          rootless.succeed(su_cmd("podman ps | grep sleeping"))
-          rootless.succeed(su_cmd("podman stop sleeping"))
-          rootless.succeed(su_cmd("podman rm sleeping"))
+        with subtest("Run container rootless with runc"):
+            rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
+            rootless.succeed(
+                su_cmd(
+                    "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+                )
+            )
+            rootless.succeed(su_cmd("podman ps | grep sleeping"))
+            rootless.succeed(su_cmd("podman stop sleeping"))
+            rootless.succeed(su_cmd("podman rm sleeping"))
 
-      with subtest("Run container rootless with crun"):
-          rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
-          rootless.succeed(
-              su_cmd(
-                  "podman run --runtime=crun -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-              )
-          )
-          rootless.succeed(su_cmd("podman ps | grep sleeping"))
-          rootless.succeed(su_cmd("podman stop sleeping"))
-          rootless.succeed(su_cmd("podman rm sleeping"))
+        with subtest("Run container rootless with crun"):
+            rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
+            rootless.succeed(
+                su_cmd(
+                    "podman run --runtime=crun -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+                )
+            )
+            rootless.succeed(su_cmd("podman ps | grep sleeping"))
+            rootless.succeed(su_cmd("podman stop sleeping"))
+            rootless.succeed(su_cmd("podman rm sleeping"))
 
-      with subtest("Run container rootless with the default backend"):
-          rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
-          rootless.succeed(
-              su_cmd(
-                  "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-              )
-          )
-          rootless.succeed(su_cmd("podman ps | grep sleeping"))
-          rootless.succeed(su_cmd("podman stop sleeping"))
-          rootless.succeed(su_cmd("podman rm sleeping"))
+        with subtest("Run container rootless with the default backend"):
+            rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
+            rootless.succeed(
+                su_cmd(
+                    "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+                )
+            )
+            rootless.succeed(su_cmd("podman ps | grep sleeping"))
+            rootless.succeed(su_cmd("podman stop sleeping"))
+            rootless.succeed(su_cmd("podman rm sleeping"))
 
-      with subtest("rootlessport"):
-          rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
-          rootless.succeed(
-              su_cmd(
-                  "podman run -d -p 9000:8888 --name=rootlessport -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -w ${pkgs.writeTextDir "index.html" "<h1>Testing</h1>"} scratchimg ${pkgs.python3}/bin/python -m http.server 8888"
-              )
-          )
-          rootless.succeed(su_cmd("podman ps | grep rootlessport"))
-          rootless.wait_until_succeeds(su_cmd("${pkgs.curl}/bin/curl localhost:9000 | grep Testing"))
-          rootless.succeed(su_cmd("podman stop rootlessport"))
-          rootless.succeed(su_cmd("podman rm rootlessport"))
+        with subtest("rootlessport"):
+            rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
+            rootless.succeed(
+                su_cmd(
+                    "podman run -d -p 9000:8888 --name=rootlessport -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -w ${pkgs.writeTextDir "index.html" "<h1>Testing</h1>"} scratchimg ${pkgs.python3}/bin/python -m http.server 8888"
+                )
+            )
+            rootless.succeed(su_cmd("podman ps | grep rootlessport"))
+            rootless.wait_until_succeeds(su_cmd("${pkgs.curl}/bin/curl localhost:9000 | grep Testing"))
+            rootless.succeed(su_cmd("podman stop rootlessport"))
+            rootless.succeed(su_cmd("podman rm rootlessport"))
 
-      with subtest("Run container with init"):
-          rootful.succeed(
-              "tar cv -C ${pkgs.pkgsStatic.busybox} . | podman import - busybox"
-          )
-          pid = rootful.succeed("podman run --rm busybox readlink /proc/self").strip()
-          assert pid == "1"
-          pid = rootful.succeed("podman run --rm --init busybox readlink /proc/self").strip()
-          assert pid == "2"
+        with subtest("Run container with init"):
+            rootful.succeed(
+                "tar cv -C ${pkgs.pkgsStatic.busybox} . | podman import - busybox"
+            )
+            pid = rootful.succeed("podman run --rm busybox readlink /proc/self").strip()
+            assert pid == "1"
+            pid = rootful.succeed("podman run --rm --init busybox readlink /proc/self").strip()
+            assert pid == "2"
 
-      with subtest("aardvark-dns"):
-          dns.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          dns.succeed(
-              "podman run -d --name=webserver -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -w ${pkgs.writeTextDir "index.html" "<h1>Testing</h1>"} scratchimg ${pkgs.python3}/bin/python -m http.server 8000"
-          )
-          dns.succeed("podman ps | grep webserver")
-          dns.wait_until_succeeds(
-              "podman run --rm --name=client -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg ${pkgs.curl}/bin/curl http://webserver:8000 | grep Testing"
-          )
-          dns.succeed("podman stop webserver")
-          dns.succeed("podman rm webserver")
+        with subtest("aardvark-dns"):
+            dns.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+            dns.succeed(
+                "podman run -d --name=webserver -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -w ${pkgs.writeTextDir "index.html" "<h1>Testing</h1>"} scratchimg ${pkgs.python3}/bin/python -m http.server 8000"
+            )
+            dns.succeed("podman ps | grep webserver")
+            dns.wait_until_succeeds(
+                "podman run --rm --name=client -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg ${pkgs.curl}/bin/curl http://webserver:8000 | grep Testing"
+            )
+            dns.succeed("podman stop webserver")
+            dns.succeed("podman rm webserver")
 
-      with subtest("A podman member can use the docker cli"):
-          docker.succeed(su_cmd("docker version"))
+        with subtest("A podman member can use the docker cli"):
+            docker.succeed(su_cmd("docker version"))
 
-      with subtest("Run container via docker cli"):
-          docker.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          docker.succeed(
-            "docker run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin localhost/scratchimg /bin/sleep 10"
-          )
-          docker.succeed("docker ps | grep sleeping")
-          docker.succeed("podman ps | grep sleeping")
-          docker.succeed("docker stop sleeping")
-          docker.succeed("docker rm sleeping")
+        with subtest("Run container via docker cli"):
+            docker.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+            docker.succeed(
+              "docker run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin localhost/scratchimg /bin/sleep 10"
+            )
+            docker.succeed("docker ps | grep sleeping")
+            docker.succeed("podman ps | grep sleeping")
+            docker.succeed("docker stop sleeping")
+            docker.succeed("docker rm sleeping")
 
-      with subtest("A podman non-member can not use the docker cli"):
-          docker.fail(su_cmd("docker version", user="mallory"))
+        with subtest("A podman non-member can not use the docker cli"):
+            docker.fail(su_cmd("docker version", user="mallory"))
 
-      with subtest("A rootless quadlet container service is created"):
-          dir = "/home/alice/.config/containers/systemd"
-          rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
-          rootless.succeed(su_cmd(f"mkdir -p {dir}"))
-          rootless.succeed(su_cmd(f"cp -f ${quadletContainerFile} {dir}/quadlet.container"))
-          rootless.systemctl("daemon-reload", "alice")
-          rootless.systemctl("start quadlet", "alice")
-          rootless.wait_until_succeeds(su_cmd("podman ps | grep quadlet"), timeout=20)
-          rootless.systemctl("stop quadlet", "alice")
+        with subtest("A rootless quadlet container service is created"):
+            dir = "~${user.name}/.config/containers/systemd"
+            rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
+            rootless.succeed(su_cmd(f"mkdir -p {dir}"))
+            rootless.succeed(su_cmd(f"cp -f ${quadletContainerFile} {dir}/quadlet.container"))
+            rootless.systemctl("daemon-reload", "${user.name}")
+            rootless.systemctl("start quadlet", "${user.name}")
+            rootless.wait_until_succeeds(su_cmd("podman ps | grep quadlet"), timeout=20)
+            rootless.systemctl("stop quadlet", "${user.name}")
 
-      # TODO: add docker-compose test
+        # TODO: add docker-compose test
 
-    '';
+      '';
   }
 )

--- a/nixos/tests/user-lingering.nix
+++ b/nixos/tests/user-lingering.nix
@@ -1,0 +1,162 @@
+# Test user lingering management (`man 1 loginctl`).
+
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  {
+    name = "user-lingering";
+    meta.maintainers = with lib.maintainers; [ tomeon ];
+
+    nodes.machine =
+      { config, ... }:
+      let
+        common = {
+          users.users = {
+            yes-linger = {
+              isNormalUser = true;
+              linger = true;
+            };
+
+            no-linger = {
+              isNormalUser = true;
+              linger = false;
+            };
+          };
+        };
+      in
+      {
+        # Stop this service in order to isolate the lingering-management logic
+        # in `update-users-groups.pl`.
+        systemd.services.linger-users.enable = false;
+
+        specialisation.mutable.configuration = lib.mkMerge [
+          common
+          { users.mutableUsers = true; }
+        ];
+
+        specialisation.immutable.configuration = lib.mkMerge [
+          common
+          { users.mutableUsers = false; }
+        ];
+
+        specialisation.removed-mutable.configuration = {
+          users.mutableUsers = true;
+        };
+
+        specialisation.removed-immutable.configuration = {
+          users.mutableUsers = false;
+        };
+      };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("default.target")
+
+      def manageLinger(user, mode, host=machine):
+          return host.succeed(f"loginctl {mode} {user}")
+
+      def disableLinger(user, host=machine):
+          return manageLinger(user, "disable-linger", host=host)
+
+      def enableLinger(user, host=machine):
+          return manageLinger(user, "enable-linger", host=host)
+
+      def lingerDirOf(user):
+          return f"/var/lib/systemd/linger/{user}"
+
+      def lingerDirPresent(user, host=machine):
+          return host.succeed(f"test -e {lingerDirOf(user)}")
+
+      def lingerDirAbsent(user, host=machine):
+          return host.fail(f"test -e {lingerDirOf(user)}")
+
+      def prepLingering():
+          disableLinger("yes-linger")
+          enableLinger("no-linger")
+          lingerDirAbsent("yes-linger")
+          lingerDirPresent("no-linger")
+
+      with subtest("Lingering settings for new users are enforced in mutable mode"):
+          lingerDirAbsent("yes-linger")
+          lingerDirAbsent("no-linger")
+          machine.succeed(
+              "/run/booted-system/specialisation/mutable/bin/switch-to-configuration test"
+          )
+          lingerDirPresent("yes-linger")
+          lingerDirAbsent("no-linger")
+
+      with subtest("Lingering settings are enforced in immutable mode"):
+          prepLingering()
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration test"
+          )
+          lingerDirPresent("yes-linger")
+          lingerDirAbsent("no-linger")
+
+      with subtest("Lingering settings for existing users are left untouched in mutable mode"):
+          prepLingering()
+          machine.succeed(
+              "/run/booted-system/specialisation/mutable/bin/switch-to-configuration test"
+          )
+          lingerDirAbsent("yes-linger")
+          lingerDirPresent("no-linger")
+
+      with subtest("dry-activation does not change lingering settings"):
+          prepLingering()
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration dry-activate"
+          )
+          lingerDirAbsent("yes-linger")
+          lingerDirPresent("no-linger")
+
+      with subtest("Removing declarative user accounts in immutable mode disables lingering for those users"):
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration test"
+          )
+          enableLinger("no-linger")
+          lingerDirPresent("no-linger")
+          machine.succeed(
+              "/run/booted-system/specialisation/removed-immutable/bin/switch-to-configuration test"
+          )
+          lingerDirAbsent("yes-linger")
+          lingerDirAbsent("no-linger")
+
+      with subtest("Removing declarative user accounts in mutable mode disables lingering for those users"):
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration test"
+          )
+          enableLinger("no-linger")
+          lingerDirPresent("no-linger")
+          machine.succeed(
+              "/run/booted-system/specialisation/removed-mutable/bin/switch-to-configuration test"
+          )
+          lingerDirAbsent("yes-linger")
+          lingerDirAbsent("no-linger")
+
+      with subtest("Removing non-declarative user accounts in immutable mode disables lingering for those users"):
+          user = "extra-linger"
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration test"
+          )
+          machine.succeed(f"useradd {user}")
+          enableLinger(user)
+          lingerDirPresent(user)
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration test"
+          )
+          lingerDirAbsent(user)
+
+      with subtest("Applying user configuration in mutable mode does not disable lingering for non-declarative users"):
+          user = "extra-linger"
+          machine.succeed(
+              "/run/booted-system/specialisation/immutable/bin/switch-to-configuration test"
+          )
+          machine.succeed(f"useradd {user}")
+          enableLinger(user)
+          lingerDirPresent(user)
+          machine.succeed(
+              "/run/booted-system/specialisation/removed-mutable/bin/switch-to-configuration test"
+          )
+          lingerDirPresent(user)
+    '';
+  }
+)


### PR DESCRIPTION
## Description of changes

Follow-up to #260248 (and related to #3702).  The main goal is to address the concerns expressed in [this review comment](https://github.com/NixOS/nixpkgs/pull/260248#discussion_r1359637530); namely, that user lingering settings should be left alone when `users.mutableUsers` is enabled.

Questions for reviewers:

1. Error handling in `update-users-groups.pl`.  This script warns, but does not abort, if something goes wrong with enabling or disabling lingering (e.g. failure to create or remove files under `/var/lib/systemd/linger`) (at least, this is true when using the fallback implementations of `do{En,Dis}ableLinger`).  Should these warnings be promoted to fatal exceptions?
2. Does it make sense to have fallback implementation of `do{En,Dis}ableLinger`?  IIUC `/run/booted-system/sw/bin/loginctl` is not guaranteed to exist when the relevant activation script runs.
3. Is `/run/booted-system/sw/bin/loginctl` the correct choice of `loginctl` path?  Should `update-users-groups.pl` instead use (for instance) `${pkgs.systemd}/bin/loginctl`?

Note that I incorporated the user lingering management implementation into `update-users-groups.pl` because this makes it easy to detect whether a given user account is newly-created or not, and thereby determine whether it is okay to touch the user's lingering setting when `users.mutableUsers` is enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (kinda sorta non-applicable, though I did test the functionality of the executable [`update-users-groups.pl`])
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
