### PR TITLE
monotone: fix build for upcoming gcc-14

### DIFF
--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
       revert = true;
       sha256 = "0fzjdv49dx5lzvqhkvk50lkccagwx8h0bfha4a0k6l4qh36f9j7c";
     })
+    ./monotone-1.1-gcc-14.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/version-management/monotone/monotone-1.1-gcc-14.patch
+++ b/pkgs/applications/version-management/monotone/monotone-1.1-gcc-14.patch
@@ -1,0 +1,17 @@
+Unsetting __STRICT_ANSI__ is not a supported configuration for gcc
+nowadays. gcc-14 started failing libstdc++ build as it uses gcc
+extensions without __STRICT_ANSI__: https://gcc.gnu.org/PR111824
+--- a/src/base.hh
++++ b/src/base.hh
+@@ -34,11 +34,6 @@
+ #define WIN32_LEAN_AND_MEAN
+ #endif
+ 
+-// Cygwin somehow enables strict ansi, which we don't want.
+-#ifdef __STRICT_ANSI__
+-#undef __STRICT_ANSI__
+-#endif
+-
+ #include <iosfwd>
+ #include <string>  // it would be nice if there were a <stringfwd>
+ 


### PR DESCRIPTION
Without the change build fails as:

    In file included from /<<NIX>>/gcc-14.0.0/include/c++/14.0.0/limits:42,
                     from <stdin>:1:
    /<<NIX>>/gcc-14.0.0/include/c++/14.0.0/x86_64-unknown-linux-gnu/bits/c++config.h:668:2: warning: #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported" [-Wcpp]
      668 | #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported"
          |  ^~~~~~~
    /<<NIX>>/gcc-14.0.0/include/c++/14.0.0/limits:2100:30: error: exponent has no digits
     2100 |         return __extension__ 0x1.0p-16382Q;
          |                              ^~~~~~
    /<<NIX>>/gcc-14.0.0/include/c++/14.0.0/limits:2114:30: error: exponent has no digits
     2114 |         return __extension__ 0x1.ffffffffffffffffffffffffffffp+16383Q;

gcc upstream confirms unsetting __STRICT_ANSI__ is an unsupported configuration: https://gcc.gnu.org/PR111824

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
