### PR TITLE
updfparser: unstable 2023-01-10 -> 2023-08-08

### DIFF
--- a/pkgs/development/libraries/updfparser/default.nix
+++ b/pkgs/development/libraries/updfparser/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "updfparser";
-  version = "unstable-2023-01-10";
-  rev = "a421098092ba600fb1686a7df8fc58cd67429f59";
+  version = "unstable-2023-08-08";
+  rev = "c5ce75b9eea8ebb2746b13eeb0f335813c615115";
 
   src = fetchzip {
     url = "https://indefero.soutade.fr/p/updfparser/source/download/${rev}/";
-    sha256 = "sha256-Kt1QDj7E0GaT615kJW2MQKF9BeU5U7/95TQKODpxgNI=";
+    hash = "sha256-RT7mvu43Izp0rHhKq4wR4kt0TDfzHvB2NGMR+fxO5UM=";
     extension = "zip";
   };
 


### PR DESCRIPTION
Without the change build fails against gcc-13 as:

    $ nix build --impure --expr 'with import ./. {}; updfparser.override { stdenv = gcc13Stdenv; }'
    error: builder for '/nix/store/8p5hwa50rild5yaijxg9iavr3lyvi3w2-updfparser.drv' failed with exit code 2;
       last 10 log lines:
       > building
       > build flags: SHELL=/nix/store/xdqlrixlspkks50m9b0mpvag65m3pf2w-bash-5.2-p15/bin/bash BUILD_STATIC=1 BUILD_SHARED=1
       > mkdir obj
       > g++ -Wall -fPIC -I./include -O2 -c src/uPDFParser.cpp -o obj/uPDFParser.o
       > In file included from ./include/uPDFParser.h:34,
       >                  from src/uPDFParser.cpp:26:
       > ./include/uPDFObject.h:49:52: error: 'uint64_t' has not been declared
       >    49 |         Object(int objectId, int generationNumber, uint64_t offset, bool isNew=false,
       >       |                                                    ^~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
