### PR TITLE
Jetbrains RustRover: unstable 232.9921.62 -> 233.8264.22

### DIFF
--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -108,10 +108,10 @@
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2023.2 EAP",
-      "sha256": "1f67e1a82f5cbb7c84382c7f251ae06b1e2699fa7d2fa4129e23ec2e43251687",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-232.9921.62.tar.gz",
-      "build_number": "232.9921.62"
+      "version": "2023.3 EAP",
+      "sha256": "3dd8e99b066164efc11e86e3289e444c5238dfce8e9142fe2d3a8c340eeeb175",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.8264.22.tar.gz",
+      "build_number": "233.8264.22"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
@@ -231,10 +231,10 @@
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2023.2 EAP",
-      "sha256": "dfde444bff011783cb4a5aa2aafae8ea989874c19535b01da8214df5eb3174fb",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-232.9921.62.dmg",
-      "build_number": "232.9921.62"
+      "version": "2023.3 EAP",
+      "sha256": "889ed748efbd44b76da03186efac063baf36c2208d919550dd97cf2dae8f40e3",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.8264.22.dmg",
+      "build_number": "233.8264.22"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
@@ -354,10 +354,10 @@
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2023.2 EAP",
-      "sha256": "35d44a4f72c027283843aaa6409de701d14274cdc5a614c3fdc53121383f9389",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-232.9921.62-aarch64.dmg",
-      "build_number": "232.9921.62"
+      "version": "2023.3 EAP",
+      "sha256": "9c4f26089697f6cb394e971dac8ef4fe974b5ecffd63311fcf0be66d4b4aec59",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.8264.22-aarch64.dmg",
+      "build_number": "233.8264.22"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",


### PR DESCRIPTION
## Description of changes


Update Jetbrains RustRover build from 232.9921.62 to 233.8264.22.
changelog: https://www.jetbrains.com/rust/nextversion/

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
