### PR TITLE
octorpki: init at 1.5.10

### DIFF
--- a/pkgs/by-name/oc/octorpki/package.nix
+++ b/pkgs/by-name/oc/octorpki/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, fetchpatch
+}:
+
+buildGoModule rec {
+  pname = "octorpki";
+  version = "1.5.10";
+
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = "cfrpki";
+    rev = "v${version}";
+    hash = "sha256-eqIAauwFh1Zbv3Jkk8plz1OR3ZW8fs0ugNwwTnSHSFM=";
+  };
+
+  patches = [
+    # https://github.com/cloudflare/cfrpki/pull/150
+    (fetchpatch {
+      url = "https://github.com/cloudflare/cfrpki/commit/fd0c4e95b880c463430c91ce1f86205b9309399b.patch";
+      hash = "sha256-cJ0mWkjtGvgTIH5eEum8h2Gy2PqR+nPto+mj5m/I/d4=";
+    })
+  ];
+
+  ldflags = [
+    "-X main.version=v${version}"
+    "-X main.talpath=${placeholder "out"}/share/tals"
+  ];
+
+  subPackages = [
+    "cmd/octorpki"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp -R cmd/octorpki/tals $out/share/tals
+  '';
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    homepage = "https://github.com/cloudflare/cfrpki#octorpki";
+    changelog = "https://github.com/cloudflare/cfrpki/releases/tag/v${version}";
+    description = "A software used to download RPKI (RFC 6480) certificates and validate them";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = teams.wdz.members;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds octorpki as package to nixpkgs. This is an RPKI validator used by routers to validate learned BGP routes. We (@WOBCOM) use this package in production for well over a year now and just forgot to upstream this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
