### PR TITLE
pinact: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8930,6 +8930,15 @@
     githubId = 386765;
     matrix = "@k900:0upti.me";
   };
+  kachick = {
+    email = "kachick1@gmail.com";
+    github = "kachick";
+    githubId = 1180335;
+    name = "Kenichi Kamiya";
+    keys = [{
+      fingerprint = "9121 5D87 20CA B405 C63F  24D2 EF6E 574D 040A E2A5";
+    }];
+  };
   kaction = {
     name = "Dmitry Bogatov";
     email = "KAction@disroot.org";

--- a/pkgs/by-name/pi/pinact/package.nix
+++ b/pkgs/by-name/pi/pinact/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, buildGo120Module
+, testers
+, pinact
+}:
+
+let
+  pname = "pinact";
+  version = "0.1.2";
+  src = fetchFromGitHub {
+    owner = "suzuki-shunsuke";
+    repo = "pinact";
+    rev = "v${version}";
+    hash = "sha256-OQo21RHk0c+eARKrA2qB4NAWWanb94DOZm4b9lqDz8o=";
+  };
+in
+buildGo120Module {
+  inherit pname version src;
+
+  vendorHash = "sha256-g7rdIE+w/pn70i8fOmAo/QGjpla3AUWm7a9MOhNmrgE=";
+
+  doCheck = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = pinact;
+    command = "pinact --version";
+    version = src.rev;
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version} -X main.commit=${src.rev}"
+  ];
+
+  meta = with lib; {
+    description = "Pin GitHub Actions versions";
+    homepage = "https://github.com/suzuki-shunsuke/pinact";
+    changelog = "https://github.com/suzuki-shunsuke/pinact/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = [ maintainers.kachick ];
+    mainProgram = "pinact";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Suggestion to add https://github.com/suzuki-shunsuke/pinact as a new package

>pinact edits GitHub Workflow files and pins versions of Actions and Reusable Workflows.

- I deliberately chose `buildGo120Module` over `buildGoModule`.
  Because it respects the project's [go.mod](https://github.com/suzuki-shunsuke/pinact/blob/015644e71ea71def5c5ff8be944874097429a62d/go.mod#L3) definition. Is this desirable way?
  https://github.com/NixOS/nixpkgs/blob/ca012a02bf8327be9e488546faecae5e05d7d749/pkgs/top-level/all-packages.nix#L25860-L25863
- I put this in `pkgs/development/tools` from several tools that I know. Or should I prefer `pkgs/by-name` layering?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
