### PR TITLE
`tflint-plugins.tflint-ruleset-google`: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8502,6 +8502,12 @@
     githubId = 6321578;
     name = "John Rinehart";
   };
+  john-rodewald = {
+    email = "jnrodewald99@gmail.com";
+    github = "john-rodewald";
+    githubId = 51028009;
+    name = "John Rodewald";
+  };
   john-shaffer = {
     email = "jdsha@proton.me";
     github = "john-shaffer";

--- a/pkgs/development/tools/analysis/tflint-plugins/default.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/default.nix
@@ -1,3 +1,4 @@
 { callPackage, ... }: {
   tflint-ruleset-aws = callPackage ./tflint-ruleset-aws.nix { };
+  tflint-ruleset-google = callPackage ./tflint-ruleset-google.nix { };
 }

--- a/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-google.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-google.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "tflint-ruleset-google";
+  version = "0.24.0";
+
+  src = fetchFromGitHub {
+    owner = "terraform-linters";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-1eF/uzOYP/gi+ooHN8OfCR2nz+/z98theO0Lr/BBhWM=";
+  };
+
+  vendorHash = "sha256-owpNcsxuP+sG27vv9V7ArMK1NLBNbnw11KpdpVyWAD0=";
+
+  # upstream Makefile also does a go test $(go list ./... | grep -v integration)
+  preCheck = ''
+    rm integration/integration_test.go
+  '';
+
+  subPackages = [ "." ];
+
+  postInstall = ''
+    mkdir -p $out/github.com/terraform-linters/${pname}/${version}
+    mv $out/bin/${pname} $out/github.com/terraform-linters/${pname}/${version}/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/terraform-linters/tflint-ruleset-google";
+    description = "TFLint ruleset plugin for Terraform Google Provider";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ john-rodewald ];
+    license = with licenses; [ mpl20 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds `tflint`'s GCP plugin to nixpkgs.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).