### PR TITLE
tusc-sh: init at 1.0.2

### DIFF
--- a/pkgs/by-name/tu/tusc-sh/package.nix
+++ b/pkgs/by-name/tu/tusc-sh/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, writeShellApplication
+, curl
+, coreutils
+, jq
+}:
+
+let
+  tusc = stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tusc-sh";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "adhocore";
+    repo = "tusc.sh";
+    rev = finalAttrs.version;
+    hash = "sha256-RFgQMYit12pmWnEAE1cyl34SFW87xEbS7gq5Nyel/ss=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 tusc.sh -t $out/bin
+
+    runHook postInstall
+  '';
+
+});
+in
+writeShellApplication {
+  name = "tusc";
+  runtimeInputs = [ tusc curl coreutils jq ];
+  text = ''
+    tusc.sh "$@"
+  '';
+  meta = with lib; {
+    description = "Tus 1.0.0 client protocol implementation for bash";
+    homepage = "https://github.com/adhocore/tusc.sh";
+    changelog = "https://github.com/adhocore/tusc.sh/blob/${tusc.version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ happysalada ];
+    mainProgram = "tusc";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

simple binary to run the tus protocol for file uploads.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
