### PR TITLE
nushellPlugins.regex: init at unstable-2023-10-08

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -4,4 +4,5 @@ lib.makeScope newScope (self: with self; {
   gstat = callPackage ./gstat.nix { inherit Security; };
   formats = callPackage ./formats.nix { inherit IOKit Foundation; };
   query = callPackage ./query.nix { inherit IOKit CoreFoundation; };
+  regex = callPackage ./regex.nix { };
 })

--- a/pkgs/shells/nushell/plugins/regex.nix
+++ b/pkgs/shells/nushell/plugins/regex.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, lib
+, rustPlatform
+, fetchFromGitHub
+, nix-update-script
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "nushell_plugin_regex";
+  version = "unstable-2023-10-08";
+
+  src = fetchFromGitHub {
+    owner = "fdncred";
+    repo = "nu_plugin_regex";
+    rev = "e1aa88e703f1f632ede685dd733472d34dd0c8e7";
+    hash = "sha256-GJgnsaeNDJoJjw8RPw6wpEq1mIult18Eh4frl8Plgxc=";
+  };
+
+  cargoHash = "sha256-AACpzSavY6MlYnl1lDYxVlfsEvEpNK0u8SzsoSZbqFc=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "A Nushell plugin to parse regular expressions";
+    homepage = "https://github.com/fdncred/nu_plugin_regex";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aidalgol ];
+    platforms = with platforms; all;
+  };
+}


### PR DESCRIPTION
## Description of changes
Add Nushell plugin [nu_plugin_regex](https://github.com/fdncred/nu_plugin_regex).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
