### PR TITLE
quicksand: init at 2.0-unstable-2021-01-15

### DIFF
--- a/pkgs/by-name/qu/quicksand/package.nix
+++ b/pkgs/by-name/qu/quicksand/package.nix
@@ -1,0 +1,40 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation {
+  pname = "quicksand";
+  version = "2.0-unstable-2021-01-15";
+
+  src = fetchFromGitHub {
+    owner = "andrew-paglinawan";
+    repo = "QuicksandFamily";
+    rev = "be4b9d638e1c79fa42d4a0ab0aa7fe29466419c7";
+    hash = "sha256-zkxm2u35Ll2qyCoUeuA0eumVjNSel+y1kkWoHxeNI/g=";
+    sparseCheckout = ["fonts"];
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/quicksand
+
+    install -Dm444 fonts/*.ttf -t $out/share/fonts/quicksand/
+    install -Dm444 fonts/statics/*.ttf -t $out/share/fonts/quicksand/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/andrew-paglinawan/QuicksandFamily";
+    description = "A sans serif font designed using geometric shapes";
+    longDescription = ''
+      Quicksand is a sans serif typeface designed by Andrew Paglinawan
+      in 2008 using geometric shapes as it's core foundation. It is
+      designed for display purposes but legible enough to use in small
+      sizes as well. Quicksand Family is available in three styles
+      which are Light, Regular and Bold including true italics for each weight.
+    '';
+    license = with lib.licenses; [ ofl ];
+    maintainers = with lib.maintainers; [ hubble ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Wanted to add this font, as it is part of my Fursona's refsheet graphical design.

First time making a font package, but I don't know how to test it. Please let me know if I need to change the directories.

The Google fonts version is known to break on inkscape and blender, so I used the Github version from the author.

~~Since I have multiple PRs waiting without `hubble` added as maintainer, I'll make it a separate PR.~~ added!

Homepage: https://github.com/andrew-paglinawan/QuicksandFamily
Google fonts preview: https://fonts.google.com/specimen/Quicksand

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
