### PR TITLE
WIP: Update gnunet, multiuser nixos module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -356,6 +356,7 @@ in
       rstudio-server = 324;
       localtimed = 325;
       automatic-timezoned = 326;
+      # gnunetdns = 327; # unused
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -666,6 +667,7 @@ in
       rstudio-server = 324;
       localtimed = 325;
       automatic-timezoned = 326;
+      gnunetdns = 327;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/networking/gnunet.nix
+++ b/nixos/modules/services/networking/gnunet.nix
@@ -1,170 +1,109 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
+{config, lib, pkgs, ...}:
 let
-
   cfg = config.services.gnunet;
+  format = pkgs.formats.ini { };
 
-  stateDir = "/var/lib/gnunet";
-
-  configFile = with cfg;
-    ''
-      [PATHS]
-      GNUNET_HOME = ${stateDir}
-      GNUNET_RUNTIME_DIR = /run/gnunet
-      GNUNET_USER_RUNTIME_DIR = /run/gnunet
-      GNUNET_DATA_HOME = ${stateDir}/data
-
-      [ats]
-      WAN_QUOTA_IN = ${toString load.maxNetDownBandwidth} b
-      WAN_QUOTA_OUT = ${toString load.maxNetUpBandwidth} b
-
-      [datastore]
-      QUOTA = ${toString fileSharing.quota} MB
-
-      [transport-udp]
-      PORT = ${toString udp.port}
-      ADVERTISED_PORT = ${toString udp.port}
-
-      [transport-tcp]
-      PORT = ${toString tcp.port}
-      ADVERTISED_PORT = ${toString tcp.port}
-
-      ${extraOptions}
-    '';
-
+  configFile = format.generate "gnunet-config.conf" cfg.settings;
 in
-
 {
-
-  ###### interface
-
   options = {
-
     services.gnunet = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Whether to run the GNUnet daemon.  GNUnet is GNU's anonymous
-          peer-to-peer communication and file sharing framework.
-        '';
-      };
-
-      fileSharing = {
-        quota = mkOption {
-          type = types.int;
-          default = 1024;
-          description = lib.mdDoc ''
-            Maximum file system usage (in MiB) for file sharing.
-          '';
+      enable = lib.mkEnableOption "GNUnet daemon";
+      package = lib.mkPackageOption pkgs "gnunet" { };
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = format.type;
+          options = {
+            transport-udp.PORT = lib.mkOption {
+              default = 2086;
+              type = lib.types.port;
+              description = "The UDP port for use by GNUnet.";
+            };
+          };
         };
-      };
-
-      udp = {
-        port = mkOption {
-          type = types.port;
-          default = 2086;  # assigned by IANA
-          description = lib.mdDoc ''
-            The UDP port for use by GNUnet.
-          '';
-        };
-      };
-
-      tcp = {
-        port = mkOption {
-          type = types.port;
-          default = 2086;  # assigned by IANA
-          description = lib.mdDoc ''
-            The TCP port for use by GNUnet.
-          '';
-        };
-      };
-
-      load = {
-        maxNetDownBandwidth = mkOption {
-          type = types.int;
-          default = 50000;
-          description = lib.mdDoc ''
-            Maximum bandwidth usage (in bits per second) for GNUnet
-            when downloading data.
-          '';
-        };
-
-        maxNetUpBandwidth = mkOption {
-          type = types.int;
-          default = 50000;
-          description = lib.mdDoc ''
-            Maximum bandwidth usage (in bits per second) for GNUnet
-            when downloading data.
-          '';
-        };
-
-        hardNetUpBandwidth = mkOption {
-          type = types.int;
-          default = 0;
-          description = lib.mdDoc ''
-            Hard bandwidth limit (in bits per second) when uploading
-            data.
-          '';
-        };
-      };
-
-      package = mkOption {
-        type = types.package;
-        default = pkgs.gnunet;
-        defaultText = literalExpression "pkgs.gnunet";
-        description = lib.mdDoc "Overridable attribute of the gnunet package to use.";
-        example = literalExpression "pkgs.gnunet_git";
-      };
-
-      extraOptions = mkOption {
-        type = types.lines;
-        default = "";
-        description = lib.mdDoc ''
-          Additional options that will be copied verbatim in `gnunet.conf`.
-          See {manpage}`gnunet.conf(5)` for details.
-        '';
       };
     };
-
   };
 
-
-  ###### implementation
-
-  config = mkIf config.services.gnunet.enable {
-
+  config = lib.mkIf cfg.enable {
     users.users.gnunet = {
       group = "gnunet";
       description = "GNUnet User";
       uid = config.ids.uids.gnunet;
     };
-
     users.groups.gnunet.gid = config.ids.gids.gnunet;
+    users.groups.gnunetdns.gid = config.ids.gids.gnunetdns;
 
-    # The user tools that talk to `gnunetd' should come from the same source,
-    # so install them globally.
-    environment.systemPackages = [ cfg.package ];
-
-    environment.etc."gnunet.conf".text = configFile;
-
-    systemd.services.gnunet = {
-      description = "GNUnet";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      restartTriggers = [ config.environment.etc."gnunet.conf".source ];
-      path = [ cfg.package pkgs.miniupnpc ];
-      serviceConfig.ExecStart = "${cfg.package}/lib/gnunet/libexec/gnunet-service-arm -c /etc/gnunet.conf";
-      serviceConfig.User = "gnunet";
-      serviceConfig.UMask = "0007";
-      serviceConfig.WorkingDirectory = stateDir;
-      serviceConfig.RuntimeDirectory = "gnunet";
-      serviceConfig.StateDirectory = "gnunet";
+    # TODO: Avoid putting these in $PATH
+    security.wrappers = let
+      mkGnunetSuid = source: {
+        setuid = true;
+        owner = "root";
+        group = "gnunet";
+        permissions = "o+rx,o-w,g+rx,g-w,o-rwx";
+        inherit source;
+      };
+      helpers = b: "${cfg.package}/lib/gnunet/libexec/${b}";
+    in {
+      gnunet-helper-vpn = mkGnunetSuid (helpers "gnunet-helper-vpn");
+      # These don't exist
+      #gnunet-helper-transport-wlan = mkGnunetSuid (helpers "gnunet-helper-transport-wlan");
+      #gnunet-helper-transport-bluetooth = mkGnunetSuid (helpers "gnunet-helper-transport-bluetooth");
+      gnunet-helper-exit = mkGnunetSuid (helpers "gnunet-helper-exit");
+      gnunet-helper-nat-server = mkGnunetSuid (helpers "gnunet-helper-nat-server");
+      gnunet-helper-nat-client = mkGnunetSuid (helpers "gnunet-helper-nat-client");
+      # > The binary should then be owned by root and be in group "gnunetdns"
+      # > and be installed SUID and only be group-executable (2750).
+      # But logically it should be 4750
+      gnunet-helper-dns = {
+        setuid = true;
+        owner = "root";
+        group = "gnunetdns";
+        permissions = "o+rx,o-w,g+rx,g-w,o-rwx";
+        source = (helpers "gnunet-helper-dns");
+      };
+      gnunet-service-dns = {
+        setgid = true;
+        owner = "root";
+        group = "gnunetdns";
+        permissions = "o+rx,o-w,g-rwx,o-rwx";
+        source = (helpers "gnunet-service-dns");
+      };
     };
 
-  };
+    services.gnunet.settings = {
+      arm = {
+        START_SYSTEM_SERVICES = lib.mkDefault "YES";
+        START_USER_SERVICES = lib.mkDefault "NO";
+      };
+      dns = {
+        BINARY = lib.mkDefault "/run/wrappers/bin/gnunet-service-dns";
+      };
+      PATHS = {
+        SUID_BINARY_PATH = lib.mkDefault "/run/wrappers/bin";
+        GNUNET_HOME = lib.mkDefault "/var/lib/gnunet";
+        GNUNET_RUNTIME_DIR = lib.mkDefault "/run/gnunet";
+        GNUNET_USER_RUNTIME_DIR = lib.mkDefault "/run/gnunet";
+        GNUNET_DATA_HOME = lib.mkDefault "/var/lib/gnunet/data";
+      };
+    };
 
+    systemd.services.gnunet = {
+      description = "GNUnet system deamon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ cfg.package pkgs.miniupnpc ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/lib/gnunet/libexec/gnunet-service-arm -c ${configFile}";
+        User = "gnunet";
+        Group = "gnunet";
+        StateDirectory = "gnunet";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "/var/lib/gnunet";
+        RuntimeDirectory = "gnunet";
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
 }

--- a/nixos/modules/services/networking/gnunet.nix
+++ b/nixos/modules/services/networking/gnunet.nix
@@ -21,6 +21,7 @@ in
             };
           };
         };
+        description = "Freeform settings for the system gnunet daemon";
       };
     };
   };

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnunet";
-  version = "0.17.6";
+  version = "0.19.4";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/${pname}-${version}.tar.gz";
-    sha256 = "sha256-JJNY7zsQzpmBB4H+2uxSam6rlDwSDku6CWrt+Rwa/EA=";
+    sha256 = "sha256-AKY99AjVmH9bqaUEQfKncYK9n7MvHjAq5WOslOesAJs=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/networking/p2p/gnunet/gtk.nix
+++ b/pkgs/applications/networking/p2p/gnunet/gtk.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnunet-gtk";
-  version = "0.15.0";
+  version = "0.19.0";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/${pname}-${version}.tar.gz";
-    sha256 = "sha256-FLLlqpQ7Bf+oNRUvx7IniVxFusy/tPYxEP2T6VGF7h8=";
+    sha256 = "sha256-MwAWs1rHXYlRUcAWX8LnCLTwEOSI68aA0s7uZGgYR3w=";
   };
 
   nativeBuildInputs= [


### PR DESCRIPTION
Changelog: https://git.gnunet.org/gnunet.git/tree/ChangeLog?h=v0.19.4## Description of changes

I'm opening this PR as a draft so it will be easier to find if useful for others.

GNUnet multiuser does not support the fs subsystem, which makes it not very reasonable to use as default.

This isn't looking for review or feedback. and should not be merged

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
