### PR TITLE
key: 2.10.0 -> 2.12.1

### DIFF
--- a/pkgs/applications/science/logic/key/default.nix
+++ b/pkgs/applications/science/logic/key/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchurl
+, fetchFromGitHub
 , jdk
 , gradle
 , git
@@ -15,16 +15,17 @@
 let
   pname = "key";
   version = "2.12.1";
-  src = fetchurl {
-    url = "https://github.com/KeYProject/key/archive/refs/tags/KEY-${version}.tar.gz";
-    sha256 = "sha256-yH64KZITKJuVVh9yVDp4rjS4KQg7ZL0txRZ497MfYq0=";
+  src = fetchFromGitHub {
+    owner = "KeYProject";
+    repo = "key";
+    rev = "KEY-${version}";
+    sha256 = "sha256-DZaoCb7rYAp6kskYc1rJ16sErxlAH0cDPDqBItudMnA=";
   };
-  sourceRoot = "key-KEY-${version}";
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
-    inherit version src sourceRoot;
+    inherit version src;
     nativeBuildInputs = [ gradle perl git ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
@@ -43,7 +44,7 @@ let
     outputHash = "sha256-DiwqRCrgJtNYGrOABAHbmSyZcRzrFMtAmS+d0DaD6f4=";
   };
 in stdenv.mkDerivation rec {
-  inherit pname version src sourceRoot;
+  inherit pname version src;
 
   nativeBuildInputs = [
     jdk


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog:
- [KeY-2.12.1](https://github.com/KeYProject/key/releases/tag/KEY-2.12.1)
- [KeY-2.12.0](https://github.com/KeYProject/key/releases/tag/KeY-2.12.0)

Changes in the derivaiton:
- Added `--console plain` option to gradle invocations which disables the progress bar.
- Changed gradle task from "build" to "assemble" (which effectively disables the tests). I couldn't make the tests works due to the [spotless](https://github.com/diffplug/spotless) plugin failing. Seems like, in the fixed output derivation (deps), `gradle classes testClasses` is not enough to cache plugin dependencies. More info on Java Gradle tasks is [here](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_tasks).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
