### PR TITLE
python311Packages.jinja2-git: unstable-2021-07-20 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/jinja2-git/default.nix
+++ b/pkgs/development/python-modules/jinja2-git/default.nix
@@ -7,17 +7,14 @@
 
 buildPythonPackage rec {
   pname = "jinja2-git";
-  version = "unstable-2021-07-20";
+  version = "1.3.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "wemake-services";
     repo = "jinja2-git";
-    # this is master, we can't patch because of poetry.lock :(
-    # luckily, there appear to have been zero API changes since then, only
-    # dependency upgrades
-    rev = "c6d19b207eb6ac07182dc8fea35251d286c82512";
-    sha256 = "0yw0318w57ksn8azmdyk3zmyzfhw0k281fddnxyf4115bx3aph0g";
+    rev = "refs/tags/${version}";
+    hash = "sha256-XuN2L3/HLcZ/WPWiCtufDOmkxj+q4I6IOgjrGQHfNLk=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/jinja2-git/default.nix
+++ b/pkgs/development/python-modules/jinja2-git/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , jinja2
 , poetry-core
 }:
@@ -8,7 +9,9 @@
 buildPythonPackage rec {
   pname = "jinja2-git";
   version = "1.3.0";
-  format = "pyproject";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "wemake-services";
@@ -18,12 +21,18 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ poetry-core ];
+
   propagatedBuildInputs = [ jinja2 ];
+
+  # the tests need to be run on the git repository
+  doCheck = false;
+
   pythonImportsCheck = [ "jinja2_git" ];
 
   meta = with lib; {
     homepage = "https://github.com/wemake-services/jinja2-git";
     description = "Jinja2 extension to handle git-specific things";
+    changelog = "https://github.com/wemake-services/jinja2-git/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];
   };


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/wemake-services/jinja2-git/compare/c6d19b207eb6ac07182dc8fea35251d286c82512...1.3.0

Changelog: https://github.com/wemake-services/jinja2-git/blob/1.3.0/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
