### PR TITLE
vesktop: vendor esbuild

### DIFF
--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -13,6 +13,8 @@
 , jq
 , moreutils
 , nodePackages
+, esbuild
+, buildGoModule
 }:
 stdenv.mkDerivation rec {
   pname = "vesktop";
@@ -67,17 +69,64 @@ stdenv.mkDerivation rec {
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
-  preBuild = ''
-    export HOME=$(mktemp -d)
-    export STORE_PATH=$(mktemp -d)
+  preBuild =
+    let
+      arch = if stdenv.isx86_64 then "x64" else
+      if stdenv.isi686 then "ia32" else
+      if stdenv.isAarch64 then "arm64" else
+      abort "vesktop: could not determine arch";
+      makePackageJson = version: builtins.toFile "package.json" (builtins.toJSON {
+        inherit version;
+        name = "@esbuild/linux-${arch}";
+      });
+      esbuildVesktop = lib.getExe (esbuild.override {
+        buildGoModule = args: buildGoModule (args // rec {
+          version = "0.18.17";
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${version}";
+            hash = "sha256-OnAOomKVUIBTEgHywDSSx+ggqUl/vn/R0JdjOb3lUho=";
+          };
+          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+        });
+      });
+      esbuildTsx = lib.getExe (esbuild.override {
+        buildGoModule = args: buildGoModule (args // rec {
+          version = "0.17.19";
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${version}";
+            hash = "sha256-PLC7OJLSOiDq4OjvrdfCawZPfbfuZix4Waopzrj8qsU=";
+          };
+          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+        });
+      });
+    in
+    ''
+      export HOME=$(mktemp -d)
+      export STORE_PATH=$(mktemp -d)
 
-    cp -r ${pnpm-deps}/* "$STORE_PATH"
-    chmod -R +w "$STORE_PATH"
+      cp -r ${pnpm-deps}/* "$STORE_PATH"
+      chmod -R +w "$STORE_PATH"
 
-    pnpm config set store-dir "$STORE_PATH"
-    pnpm install --offline --frozen-lockfile --ignore-script
-    patchShebangs node_modules/{*,.*}
-  '';
+      pnpm config set store-dir "$STORE_PATH"
+      pnpm install --offline --frozen-lockfile --ignore-script
+
+      # there are two copies of esbuild with different versions in the dependency tree.
+      # `ESBUILD_BINARY_PATH` will affect both of them, so it doesn't work.
+      # so I'm constructing fake esbuild native packages in their expected places.
+      mkdir -p node_modules/@esbuild-kit/core-utils/node_modules/esbuild/node_modules/@esbuild/linux-${arch}/bin
+      cp ${makePackageJson "0.17.19"} node_modules/@esbuild-kit/core-utils/node_modules/esbuild/node_modules/@esbuild/linux-${arch}/package.json
+      cp ${esbuildTsx} node_modules/@esbuild-kit/core-utils/node_modules/esbuild/node_modules/@esbuild/linux-${arch}/bin/esbuild
+
+      mkdir -p node_modules/esbuild/node_modules/@esbuild/linux-${arch}/bin
+      cp ${makePackageJson "0.18.17"} node_modules/esbuild/node_modules/@esbuild/linux-${arch}/package.json
+      cp ${esbuildVesktop} node_modules/esbuild/node_modules/@esbuild/linux-${arch}/bin/esbuild
+
+      patchShebangs node_modules/{*,.*}
+    '';
 
   postBuild = ''
     pnpm build


### PR DESCRIPTION
## Description of changes
vendor esbuild for vesktop
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
