### PR TITLE
lib: CA fixes

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -993,12 +993,17 @@ rec {
        => false
   */
   isStorePath = x:
-    if isStringLike x then
-      let str = toString x; in
-      substring 0 1 str == "/"
-      && dirOf str == storeDir
+    # Derivations can be assumed to be store paths
+    # When CA is used `toString bash` will give a path like "/1gbwc5nl0k01hg0n8ggqrgyz52babwivwyn01isd7cghw7bhd0kv"
+    if lib.isDerivation x then
+      true
     else
-      false;
+      if isStringLike x then
+        let str = toString x; in
+        substring 0 1 str == "/"
+        && dirOf str == storeDir
+      else
+        false;
 
   /* Parse a string as an int. Does not support parsing of integers with preceding zero due to
   ambiguity between zero-padded and octal numbers. See toIntBase10.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -993,17 +993,12 @@ rec {
        => false
   */
   isStorePath = x:
-    # Derivations can be assumed to be store paths
-    # When CA is used `toString bash` will give a path like "/1gbwc5nl0k01hg0n8ggqrgyz52babwivwyn01isd7cghw7bhd0kv"
-    if lib.isDerivation x then
-      true
+    if isStringLike x then
+      let str = toString x; in
+      substring 0 1 str == "/"
+      && (dirOf str == storeDir || builtins.match "^/[A-Za-z0-9]{52}" str != null)
     else
-      if isStringLike x then
-        let str = toString x; in
-        substring 0 1 str == "/"
-        && dirOf str == storeDir
-      else
-        false;
+      false;
 
   /* Parse a string as an int. Does not support parsing of integers with preceding zero due to
   ambiguity between zero-padded and octal numbers. See toIntBase10.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -498,7 +498,7 @@ rec {
       name = "pathInStore";
       description = "path in the Nix store";
       descriptionClass = "noun";
-      check = x: isStringLike x && builtins.match "${builtins.storeDir}/[^.].*" (toString x) != null;
+      check = x: (isStringLike x && builtins.match "${builtins.storeDir}/[^.].*" (toString x) != null) || lib.isDerivation x;
       merge = mergeEqualOption;
     };
 


### PR DESCRIPTION
```nix
nix-repl> pkgs = import ./. { config = { contentAddressedByDefault = true; }; }

nix-repl> toString pkgs.busybox
"/083nm0nmzng04dzx05w8zbc4ha70674wc1slfbk09ng69a28fgg2"
```

`iso.nix`

```
{ config, pkgs, ... }:
{
  imports = [
    <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix>
  ];
  # This breaks the build:
  nixpkgs.config.contentAddressedByDefault = true;
}
```

```
nix repl -I nixos-config=iso.nix --file ./nixos/.
nix-repl> config.system.extraDependencies
  error: A definition for option `system.extraDependencies."[definition 1-entry 1]"' is not of type `path in the Nix store'. Definition values:
       - In `/nix/store/m90lvfa50gc7s1ysa9zzx2drdm10pmyc-source/nixos/modules/profiles/installation-device.nix': <derivation stdenv-linux>
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
