### PR TITLE
python311Packages.openant: 2017-02-11 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/openant/default.nix
+++ b/pkgs/development/python-modules/openant/default.nix
@@ -1,14 +1,20 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , setuptools
 , pyusb
+, influxdb-client
+, pyserial
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "openant-unstable";
   version = "1.2.1";
   pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Tigge";
@@ -28,11 +34,27 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyusb ];
 
+  passthru.optional-dependencies = {
+    serial = [
+      pyserial
+    ];
+    influx = [
+      influxdb-client
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "openant"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/Tigge/openant";
     description = "ANT and ANT-FS Python Library";
     license = licenses.mit;
-    platforms = platforms.unix;
   };
 
 }

--- a/pkgs/development/python-modules/openant/default.nix
+++ b/pkgs/development/python-modules/openant/default.nix
@@ -1,29 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pyusb
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "openant-unstable";
-  version = "2017-02-11";
+  version = "1.2.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Tigge";
     repo = "openant";
-    rev = "ed89281e37f65d768641e87356cef38877952397";
-    sha256 = "1g81l9arqdy09ijswn3sp4d6i3z18d44lzyb78bwnvdb14q22k19";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Ook9dwcyWvpaGylVDjBxQ2bnXRUBPYQHo6Wub+ISpwE=";
   };
 
-  # Removes some setup.py hacks intended to install udev rules.
-  # We do the job ourselves in postInstall below.
-  postPatch = ''
-    sed -i -e '/cmdclass=.*/d' setup.py
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   postInstall = ''
     install -dm755 "$out/etc/udev/rules.d"
-    install -m644 resources/ant-usb-sticks.rules "$out/etc/udev/rules.d/99-ant-usb-sticks.rules"
+    install -m644 resources/42-ant-usb-sticks.rules "$out/etc/udev/rules.d/99-ant-usb-sticks.rules"
   '';
 
   propagatedBuildInputs = [ pyusb ];


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/Tigge/openant/compare/ed89281e37f65d768641e87356cef38877952397...v1.2.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
