### PR TITLE
build-support/php: `phpDrv` in `nativeBuildInputs`

### DIFF
--- a/pkgs/build-support/php/build-composer-project.nix
+++ b/pkgs/build-support/php/build-composer-project.nix
@@ -17,6 +17,7 @@ let
       nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [
         composer
         composer-local-repo-plugin
+        phpDrv
         phpDrv.composerHooks.composerInstallHook
       ];
 

--- a/pkgs/build-support/php/build-composer-repository.nix
+++ b/pkgs/build-support/php/build-composer-repository.nix
@@ -41,6 +41,7 @@ let
       nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [
         composer
         composer-local-repo-plugin
+        phpDrv
         phpDrv.composerHooks.composerRepositoryHook
       ];
 

--- a/pkgs/build-support/php/hooks/default.nix
+++ b/pkgs/build-support/php/hooks/default.nix
@@ -3,7 +3,6 @@
 , jq
 , moreutils
 , makeBinaryWrapper
-, php
 , cacert
 , buildPackages
 }:
@@ -12,14 +11,14 @@
   composerRepositoryHook = makeSetupHook
     {
       name = "composer-repository-hook.sh";
-      propagatedBuildInputs = [ jq moreutils php cacert ];
+      propagatedBuildInputs = [ jq moreutils cacert ];
       substitutions = { };
     } ./composer-repository-hook.sh;
 
   composerInstallHook = makeSetupHook
     {
       name = "composer-install-hook.sh";
-      propagatedBuildInputs = [ jq makeBinaryWrapper moreutils php cacert ];
+      propagatedBuildInputs = [ jq makeBinaryWrapper moreutils cacert ];
       substitutions = {
         # Specify the stdenv's `diff` by abspath to ensure that the user's build
         # inputs do not cause us to find the wrong `diff`.


### PR DESCRIPTION
Fixes NixOS/nixpkgs#261500

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md)) (does not apply)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
