### PR TITLE
nixos/prometheus-snmp-exporter: add generator options

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -278,7 +278,7 @@ in
       '';
     } {
       assertion = cfg.snmp.enable -> (
-        (cfg.snmp.configurationPath == null) != (cfg.snmp.configuration == null)
+        ((cfg.snmp.configurationPath == null) != (cfg.snmp.configuration == null)) != ((cfg.snmp.generator.configurationPath == null) != (cfg.snmp.generator.configuration == null))
       );
       message = ''
         Please ensure you have either `services.prometheus.exporters.snmp.configuration'

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -12,7 +12,7 @@ in
       type = types.nullOr types.path;
       default = null;
       description = lib.mdDoc ''
-        Path to a snmp exporter configuration file. Mutually exclusive with 'configuration' option.
+        Path to a snmp exporter configuration file. Mutually exclusive with 'configuration', 'generator.configurationPath' and 'generator.configuration' options.
       '';
       example = literalExpression "./snmp.yml";
     };
@@ -21,7 +21,7 @@ in
       type = types.nullOr types.attrs;
       default = null;
       description = lib.mdDoc ''
-        Snmp exporter configuration as nix attribute set. Mutually exclusive with 'configurationPath' option.
+        Snmp exporter configuration as nix attribute set. Mutually exclusive with 'configurationPath' and 'generator.configuration' options.
       '';
       example = {
         "default" = {
@@ -30,6 +30,68 @@ in
             "community" = "public";
           };
         };
+      };
+    };
+
+    generator = {
+      configurationPath = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = lib.mdDoc ''
+          Path to a snmp exporter configuration generator configuration. Mutually exclusive with 'configurationPath', 'configuration' and 'generator.configuration' options.
+        '';
+        example = literalExpression "./generator.yml";
+      };
+
+      configuration = mkOption {
+        type = types.nullOr types.attrs;
+        default = null;
+        description = lib.mdDoc ''
+          Snmp exporter configuration generator configuration as nix attribute set. Mutually exclusive with 'configurationPath', 'configuration' and 'generator.configurationPath' options.
+        '';
+        example = {
+          "modules" = {
+            "if_mib" = {
+              "walk" = [ "sysUpTime" "interfaces" "ifXTable" ];
+              "lookups" = [
+                {
+                  "source_indexes" = [ "ifIndex" ];
+                  "lookup" = "ifAlias";
+                }
+                {
+                  "source_indexes" = [ "ifIndex" ];
+                  "lookup" = "1.3.6.1.2.1.2.2.1.2";
+                }
+                {
+                  "source_indexes" = [ "ifIndex" ];
+                  "lookup" = "1.3.6.1.2.1.31.1.1.1.1";
+                }
+              ];
+              "overrides" = {
+                "ifAlias" = {
+                  "ignore" = true;
+                };
+                "ifDescr" = {
+                  "ignore" = true;
+                };
+                "ifName" = {
+                  "ignore" = true;
+                };
+                "ifType" = {
+                  "type" = "EnumAsInfo";
+                };
+              };
+            };
+          };
+        };
+      };
+
+      mibDirs = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = lib.mdDoc ''
+          Snmp exporter configuration generator MIBs directories as list of paths.
+        '';
       };
     };
 
@@ -50,9 +112,22 @@ in
     };
   };
   serviceOpts = let
+    generatorConfigFile = if cfg.generator.configurationPath != null
+                          then cfg.generator.configurationPath
+                          else "${pkgs.writeText "snmp-exporter-generator.yml" (builtins.toJSON cfg.generator.configuration)}";
+
+    generatedConfigFile = pkgs.runCommand "snmp.yml" { MIBDIRS = concatStringsSep ":" cfg.generator.mibDirs; } ''
+      ln -s ${generatorConfigFile} ./generator.yml
+      ${pkgs.prometheus-snmp-exporter.outPath}/bin/generator generate && mv snmp.yml $out
+    '';
+
     configFile = if cfg.configurationPath != null
                  then cfg.configurationPath
-                 else "${pkgs.writeText "snmp-exporter-conf.yml" (builtins.toJSON cfg.configuration)}";
+                 else (
+                   if cfg.configuration != null
+                   then "${pkgs.writeText "snmp-exporter-conf.yml" (builtins.toJSON cfg.configuration)}"
+                   else generatedConfigFile
+                 );
     in {
     serviceConfig = {
       ExecStart = ''


### PR DESCRIPTION
## Description of changes

Add following options
  - services.prometheus.exporters.snmp.generator.configuration
  - services.prometheus.exporters.snmp.generator.configurationPath
  - services.promethesu.exporters.snmp.generator.mibDirs

Allows users to use snmp-exporter's config file generator in nix build process. When generator options set run generator at build time to generate snmp-exporter config from generator config file and provided directories containing the corresponding MIB files.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
