### PR TITLE
mbrola: convert data to a fixed-output derivation

### DIFF
--- a/pkgs/applications/audio/mbrola/default.nix
+++ b/pkgs/applications/audio/mbrola/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, stdenvNoCC, lib, symlinkJoin, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, runCommandLocal }:
 
 let
   pname = "mbrola";
@@ -12,26 +12,14 @@ let
     homepage = "https://github.com/numediart/MBROLA";
   };
 
-  voices = stdenvNoCC.mkDerivation {
-    pname = "${pname}-voices";
-    inherit version;
+  # Very big (0.65 G) so kept as a fixed-output derivation to limit "duplicates".
+  voices = fetchFromGitHub {
+    owner = "numediart";
+    repo = "MBROLA-voices";
+    rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";  # using latest commit
+    sha256 = "1w0y2xjp9rndwdjagp2wxh656mdm3d6w9cs411g27rjyfy1205a0";
 
-    src = fetchFromGitHub {
-      owner = "numediart";
-      repo = "MBROLA-voices";
-      rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";  # using latest commit
-      sha256 = "1w0y2xjp9rndwdjagp2wxh656mdm3d6w9cs411g27rjyfy1205a0";
-    };
-
-    dontBuild = true;
-    installPhase = ''
-      runHook preInstall
-      install -d $out/share/mbrola/voices
-      cp -R $src/data/* $out/share/mbrola/voices/
-      runHook postInstall
-    '';
-    dontFixup = true;
-
+    name = "${pname}-voices-${version}";
     meta = meta // {
       description = "Speech synthesizer based on the concatenation of diphones (voice files)";
       homepage = "https://github.com/numediart/MBROLA-voices";
@@ -65,8 +53,14 @@ let
   };
 
 in
-symlinkJoin {
-  inherit pname version meta;
-  name = "${pname}-${version}";
-  paths = [ bin voices ];
-}
+  runCommandLocal
+    "${pname}-${version}"
+    {
+      inherit pname version meta;
+    }
+    ''
+      mkdir -p "$out/share/mbrola"
+      ln -s '${voices}/data' "$out/share/mbrola/voices"
+      ln -s '${bin}/bin' "$out/"
+    ''
+


### PR DESCRIPTION
It's quite annoying that we had to redownload this 0.65G on every rebuild.  Also disk space gets saved, unless you used some deduplication (e.g. nix.settings.auto-optimise-store). And cache.nixos.org space, too.

## Things done
The resulting tree of the exposed/aggregate `mbrola` attribute looks the same to me, though symlinks happen at a bit different names.

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
