### PR TITLE
etcher: 1.18.12 -> 1.19.3

### DIFF
--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "etcher";
-  version = "1.19.0";
+  version = "1.19.3";
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher_${version}_amd64.deb";
-    hash = "sha256-twxBZfzDlvJ8Vmn4bbxWBc3gB03Do7Cvw3ownl0rxtY=";
+    hash = "sha256-JXGaDa8MdDKtdNvnLGmVihNvGrhux2OtgBS94qqrLb8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchurl
 , bash
-, util-linux
 , autoPatchelfHook
 , dpkg
 , makeWrapper
@@ -12,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "etcher";
-  version = "1.18.12";
+  version = "1.18.13";
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher_${version}_amd64.deb";
-    hash = "sha256-Ucs187xTpbRJ7P32hCl8cHPxO3HCs44ZneAas043FXk=";
+    hash = "sha256-1lfm8RdmDJixx4i0ru8Isd9sHrpU6t6lZFKP9tPN5ig=";
   };
 
   # sudo-prompt has hardcoded binary paths on Linux and we patch them here
@@ -24,8 +23,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace opt/balenaEtcher/resources/app/generated/gui.js \
       --replace '/usr/bin/pkexec' '/usr/bin/pkexec", "/run/wrappers/bin/pkexec' \
-      --replace '/bin/bash' '${bash}/bin/bash' \
-      --replace '"lsblk"' '"${util-linux}/bin/lsblk"'
+      --replace '/bin/bash' '${bash}/bin/bash'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8051,7 +8051,7 @@ with pkgs;
   esshader = callPackage ../tools/graphics/esshader { };
 
   etcher = callPackage ../tools/misc/etcher {
-    electron = electron_19;
+    electron = electron_25;
   };
 
   ethercalc = callPackage ../servers/web-apps/ethercalc { };


### PR DESCRIPTION
## Description of changes

https://github.com/balena-io/etcher/releases/tag/v1.19.3

1.18.13 doesn't work on my machine, nor on other distros: balena-io/etcher#4138
1.19.0+ either: balena-io/etcher#4150

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
