### PR TITLE
mpvScripts.chapterskip: init at unstable-2022-09-08

### DIFF
--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation {
+  pname = "chapterskip";
+  passthru.scriptName = "chapterskip.lua";
+
+  version = "unstable-2022-09-08";
+  src = fetchFromGitHub {
+    owner = "po5";
+    repo  = "chapterskip";
+    rev   = "b26825316e3329882206ae78dc903ebc4613f039";
+    hash  = "sha256-OTrLQE3rYvPQamEX23D6HttNjx3vafWdTMxTiWpDy90=";
+  };
+
+  dontBuild = true;
+  preferLocalBuild = true;
+  installPhase = "install -Dt $out/share/mpv/scripts chapterskip.lua";
+
+  meta = with lib; {
+    homepage = "https://github.com/po5/chapterskip";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ nicoo ];
+  };
+}

--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, nix-update-script
 , stdenvNoCC }:
 
 stdenvNoCC.mkDerivation {
@@ -17,6 +18,10 @@ stdenvNoCC.mkDerivation {
   dontBuild = true;
   preferLocalBuild = true;
   installPhase = "install -Dt $out/share/mpv/scripts chapterskip.lua";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = with lib; {
     homepage = "https://github.com/po5/chapterskip";

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -9,6 +9,7 @@ lib.recurseIntoAttrs
     autocrop = callPackage ./autocrop.nix { };
     autodeint = callPackage ./autodeint.nix { };
     autoload = callPackage ./autoload.nix { };
+    chapterskip = callPackage ./chapterskip.nix { };
     convert = callPackage ./convert.nix { };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };


### PR DESCRIPTION
## Description of changes

Add new derivation `mpvScripts.chapterskip`.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
