### PR TITLE
nixos/sysctl: allow merging identical option definitions

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -1,6 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
-
   sysctlOption = lib.mkOptionType {
     name = "sysctl option value";
     check =
@@ -9,15 +12,11 @@ let
         checkType = x: lib.isBool x || lib.isString x || lib.isInt x || x == null;
       in
       checkType val || (val._type or "" == "override" && checkType val.content);
-    merge = loc: defs: lib.mergeOneOption loc (lib.filterOverrides defs);
+    merge = loc: defs: mergeUniqueOption loc (filterOverrides defs);
   };
-
 in
-
 {
-
   options = {
-
     boot.kernel.sysctl = lib.mkOption {
       type =
         let
@@ -56,13 +55,10 @@ in
         parameter may be a string, integer, boolean, or null
         (signifying the option will not appear at all).
       '';
-
     };
-
   };
 
   config = {
-
     environment.etc."sysctl.d/60-nixos.conf".text = lib.concatStrings (
       lib.mapAttrsToList (
         n: v: lib.optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"


### PR DESCRIPTION
## Description of changes

Use `mergeUniqueOption` instead of `mergeOneOption` for sysctl options, to allow multiple non-conflicting definitions to coexist.

Currently something like
```
{
  outputs = {nixpkgs, ...}: {
    nixosConfigurations.foo = nixpkgs.lib.nixosSystem {
      modules = [
        {
          boot.isContainer = true;
          system.stateVersion = "23.05";
          nixpkgs.hostPlatform = "x86_64-linux";
        }
        {boot.kernel.sysctl."net.ipv4.conf.default.forwarding" = 0;}
        {boot.kernel.sysctl."net.ipv4.conf.default.forwarding" = 0;}
      ];
    };
  };
}
```
followed by `nix build .#nixosConfigurations.foo.config.system.build.toplevel` will result in 
```
       error: The option `boot.kernel.sysctl."net.ipv4.conf.default.forwarding"' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `/nix/store/0zyfib4lvfzj8br8rnlz3bv29r9dnp8z-source/flake.nix': 0
       - In `/nix/store/0zyfib4lvfzj8br8rnlz3bv29r9dnp8z-source/flake.nix': 0
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

I think it should not be an error to define sysctl options multiple times, as long as the values are always the same.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
