### PR TITLE
Expose some additional nixosModules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,9 @@
       legacyPackages = forAllSystems (system: import ./. { inherit system; });
 
       nixosModules = {
+        assertions = ./nixos/modules/misc/assertions.nix;
+        lib = ./nixos/modules/misc/lib.nix;
+        meta = ./nixos/modules/misc/meta.nix;
         notDetected = ./nixos/modules/installer/scan/not-detected.nix;
 
         /*


### PR DESCRIPTION
These are “general” modules that provide options without config and are already relied on by other projects (such as home-manager). Exposing them this way makes them an explicit part of the nixpkgs flake interface and can allow other projects to use, e.g.,

    nixpkgs.nixosModules.assertions

rather than something like

    (pkgs.path + "/nixos/modules/misc/assertions.nix")

which is bad not only because it treats the directory structure of nixpkgs as an interface, but also because it shouldn’t be necessary to have `pkgs` at the point modules are loaded (as opposed to when they are applied).