### PR TITLE
erofs-utils: fix filesystem corruption issues

### DIFF
--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ util-linux lz4 zlib ]
     ++ lib.optionals fuseSupport [ fuse ];
 
-  configureFlags = lib.optionals fuseSupport [ "--enable-fuse" ];
+  configureFlags = [
+    "MAX_BLOCK_SIZE=4096"
+  ] ++ lib.optional fuseSupport "--enable-fuse";
 
   meta = with lib; {
     description = "Userspace utilities for linux-erofs file system";

--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, fuse, util-linux, lz4, zlib
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, pkg-config, fuse, util-linux, lz4, zlib
 , fuseSupport ? stdenv.isLinux
 }:
 
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
       "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${version}.tar.gz";
     hash = "sha256-tutSm7Qj6y3XecnanCYyhVSItLkeI1U6Mc4j8Rycziw=";
   };
+
+  patches = [
+    # Fixes #261394. Can be dropped with the next erofs version.
+    (fetchpatch {
+      url = "https://github.com/erofs/erofs-utils/commit/8cbc205185a18b9510f4c1fbd54957354f696321.patch";
+      hash = "sha256-CQ5hxav5+HGnBVJW66St9FaVgkuqhkv89rjC/4cmXLs=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ util-linux lz4 zlib ]


### PR DESCRIPTION
## Description of changes

When packaging a Nix store, erofs hits a bug in version 1.7:

```
 [36640.475349] erofs: (device loop0): erofs_read_inode: bogus i_mode (0) @ nid 0
 cannot access '.../-tzdata-2023c/share/zoneinfo/Brazil/Acre': Structure needs cleaning
```

Backport the fix from erofs master.

Fixes #261394.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
