### PR TITLE
composefs: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -27,13 +27,13 @@
 assert installExperimentalTools -> (!stdenv.hostPlatform.isMusl);
 stdenv.mkDerivation (finalAttrs: {
   pname = "composefs";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "composefs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-OjayMhLc3otqQjHsbLN8nm9D9yGOifBcrSLixjnJmvE=";
+    hash = "sha256-8YbDKw4jYEU6l3Nmqu3gsT9VX0lwYF/39hhcwzgTynY=";
   };
 
   strictDeps = true;
@@ -75,9 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
     # MUSL: https://github.com/containers/composefs/issues/204
     substituteInPlace tests/Makefile \
       --replace " check-checksums" ""
-  '' + lib.optionalString (stdenv.hostPlatform.isMusl || enableValgrindCheck) ''
-    # seccomp sandbox breaks these tests
-    # MUSL: https://github.com/containers/composefs/issues/206
+  '' + lib.optionalString enableValgrindCheck ''
+    # valgrind is incompatible with seccomp
     substituteInPlace tests/test-checksums.sh \
       --replace "composefs-from-json" "composefs-from-json --no-sandbox"
   '';


### PR DESCRIPTION
## Description of changes

Changes since 1.0.0:
- mkcomposefs now supports --from-file which reads image descriptions in the format of composefs-info dump output.
- composefs-info dump output now shows content and hardlink target
- mount.composefs now uses the new mount api on recent kernels, which fixes a regression in escaping commas in upperdir/lowerdir/workdir options.
- lcfs_node_set_payload() now accepts NULL to unset
- Some performance improvements
- Fixed errors in error reporting
- Added more manpages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
