### PR TITLE
termscp: Fix broken Cargo.lock for v0.12.3

### DIFF
--- a/pkgs/tools/networking/termscp/Cargo.lock.patch
+++ b/pkgs/tools/networking/termscp/Cargo.lock.patch
@@ -1,0 +1,13 @@
+diff --git i/Cargo.lock w/Cargo.lock
+index 5cbb602..47046b8 100644
+--- i/Cargo.lock
++++ w/Cargo.lock
+@@ -2949,7 +2949,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "termscp"
+-version = "0.12.2"
++version = "0.12.3"
+ dependencies = [
+  "argh",
+  "bitflags 2.3.3",

--- a/pkgs/tools/networking/termscp/default.nix
+++ b/pkgs/tools/networking/termscp/default.nix
@@ -23,7 +23,11 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-+5s5PskSHZKv1deti5r986qXg8J9APuVXY+Lvq3ki0w=";
   };
 
-  cargoHash = "sha256-0go6ZTqhPUwnnE+VIQrbtKm90AWaYsYT/25QrWLMFbU=";
+  cargoPatches = [
+    ./Cargo.lock.patch
+  ];
+
+  cargoHash = "sha256-2RmYxtjJm70qbiGl8YHXgebtvNsQvBdgkNDm8td9oNk=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

Add Cargo.lock.patch and update the CargoHash to fix the build for v0.12.3

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
