### PR TITLE
linuxPackages.nvidia_x11_beta: 535.43.02 -> 545.23.06

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -54,12 +54,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "535.43.02";
-    sha256_64bit = "sha256-4KTdk4kGDmBGyHntMIzWRivUpEpzmra+p7RBsTL8mYM=";
-    sha256_aarch64 = "sha256-0blD8R+xpOVlitWefIbtw1d3KAnmWHBy7hkxGZHBrE4=";
-    openSha256 = "sha256-W1fwbbEEM7Z/S3J0djxGTtVTewbSALqX1G1OSpdajCM=";
-    settingsSha256 = "sha256-j0sSEbtF2fapv4GSthVTkmJga+ycmrGc1OnGpV6jEkc=";
-    persistencedSha256 = "sha256-M0ovNaJo8SZwLW4CQz9accNK79Z5JtTJ9kKwOzicRZ4=";
+    version = "545.23.06";
+    sha256_64bit = "sha256-QTnTKAGfcvKvKHik0BgAemV3PrRqRlM3B9jjZeupCC8=";
+    sha256_aarch64 = "sha256-qkVP6AiXNoRTqgqPvs/AfErEq8BTQw25rtJ6GS06JTM=";
+    openSha256 = "sha256-m7D5LZdhFCZYAIbhrgZ0pN2z19LsU3I3Q7qsKX7Z6mM=";
+    settingsSha256 = "sha256-+X6gDeU8Qlvprb05aB2quM55y0zEcBXtb65e3Rq9gKg=";
+    persistencedSha256 = "sha256-RQJAIwPqOUI5FB3uf0/Y4K/iwFfoLpU1/+BOK/KF5VA=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
## Description of changes


- Added experimental HDMI 10 bits per component support; enable by loading nvidia-modeset with `hdmi_deepcolor=1`.
- Added support for the CTM, DEGAMMA_LUT, and GAMMA_LUT DRM-KMS CRTC properties. These are used by features such as the "Night Light" feature in GNOME and the "Night Color" feature in KDE, when they are used as Wayland compositors.
- Added beta-quality support for GeForce and Workstation GPUs to open kernelmodules. Please see the "Open Linux Kernel Modules" chapter in the README for details.
- Added initial experimental support for runtime D3 (RTD3) power management on Desktop GPUs. Please see the 'PCI-Express Runtime D3 (RTD3) Power Management' chapter in the README for more details.
- Added support for the EGL_ANDROID_native_fence_sync EGL extension and the VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT and VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT Vulkan external handle types when the nvidia-drm kernel module is loaded with the modeset=1 parameter.
- Added experimental support for framebuffer consoles provided by nvidia-drm. On kernels that implement drm_fbdev_generic_setup and drm_aperture_remove_conflicting_pci_framebuffers, nvidia-drm will install a framebuffer console when loaded with both `modeset=1` and `fbdev=1` kernel module parameters. This will replace the Linux boot console driven by a system framebuffer driver such as efifb or vesafb.
- Note that when an nvidia-drm framebuffer console is enabled, unloading nvidia-drm will cause the screen to turn off.
- Updated nvidia-installer to allow installing the driver while an existing NVIDIA driver is already loaded.
- Added support for virtual reality displays, such as the SteamVR platform, on Wayland compositors that support DRM leasing. Support requires xwayland version 22.1.0 and wayland-protocols version 1.22, or later. Tested on sway, minimum version 1.7 with wlroots version 0.15, and also on Kwin, minimum version 5.24.
- Note: Before xwayland 23.2, there is a known issue with HDMI displays where the headset will fail to start a second time after closing SteamVR. This can be worked around by unplugging and replugging in the headset.
- Fixed a bug that prevented VRR (Variable Refresh Rate) from working with Wayland.
- Added support to the NVIDIA VDPAU driver for running in Xwayland. Please refer to the "Xwayland support in VDPAU" section of the README for further details.
- Added libnvidia-gpucomp.so to the driver package. This is a helper library used for GPU shader compilation.
- Removed libnvidia-vulkan-producer.so from the driver package. This helper library is no longer needed by the Wayland WSI.
- Fixed a bug that intermittently caused the display to freeze when resuming from suspend on some Ada GPUs.
- Fixed a bug that could cause monitors to flicker when the performance state changes on Turing GPUs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
