### PR TITLE
nix-health: init at 0.2.3

### DIFF
--- a/pkgs/by-name/ni/nix-health/package.nix
+++ b/pkgs/by-name/ni/nix-health/package.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv
+, rustPlatform
+, fetchCrate
+, libiconv
+, openssl
+, pkg-config
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nix-health";
+  version = "0.2.3";
+
+  src = fetchCrate {
+    inherit version;
+    pname = "nix_health";
+    hash = "sha256-WdzzEFk9VPld6AFTNRsaQbMymw1+mNn/TViGO/Qv0so=";
+  };
+
+  cargoHash = "sha256-xmuosy9T/52D90uXMQAIxtaYDOlCekNCtzpu/3GyQXE=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libiconv openssl ]
+    # Use a newer SDK for CoreFoundation, because the sysinfo crate requires
+    # it, https://github.com/GuillaumeGomez/sysinfo/issues/915
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk_11_0.frameworks;
+      [ IOKit
+        CoreFoundation
+      ]);
+
+  meta = with lib; {
+    description = "Check the health of your Nix setup";
+    homepage = "https://zero-to-flakes.com/health/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ srid ];
+    mainProgram = "nix-health";
+  };
+}


### PR DESCRIPTION
## Description of changes

Packaging a new application called nix-health to check the health of the user's Nix install, allowing some customizations in the project flake.

https://github.com/juspay/nix-browser/tree/main/crates/nix_health#nix-health

I've tested and run this package on aarch64-darwin and x86_64-linux. I am both the author and will be the maintainer for this package.

The Nix expression is fairly similar to that of [another Rust package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/nix/nixci/default.nix) I maintain, except for placing nix-health under`pkgs/by-name`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
