### PR TITLE
NixOS Integration Tests on macOS: Remove some obstacles (ulimit, requiredSystemFeatures)

### DIFF
--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -14,6 +14,7 @@ let
     ./legacy.nix
     ./meta.nix
     ./name.nix
+    ./macos-host.nix
     ./network.nix
     ./nodes.nix
     ./pkgs.nix

--- a/nixos/lib/testing/macos-host.nix
+++ b/nixos/lib/testing/macos-host.nix
@@ -1,0 +1,19 @@
+{ config, lib, hostPkgs, ... }:
+
+{
+  config = lib.mkIf hostPkgs.stdenv.hostPlatform.isDarwin {
+    defaults = {
+      virtualisation.host.pkgs = hostPkgs;
+
+      # On non-darwin, mounting the whole nix store from the host is the default because
+      # this generally makes rebuilds of the VMs faster and the VMs smaller, while reducing
+      # disk I/O.
+      # However, on macOS it currently leads to many crashing guest processes.
+      virtualisation.useNixStoreImage = true;
+      # Without this, the store image uses "raw" instead of "qcow2" and
+      # that throws some errors on macOS on startup of the VM
+      # TODO: remove when `raw` errors are fixed.
+      virtualisation.writableStore = true;
+    };
+  };
+}

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -33,7 +33,9 @@ in
       derivation = hostPkgs.stdenv.mkDerivation {
         name = "vm-test-run-${config.name}";
 
-        requiredSystemFeatures = [ "kvm" "nixos-test" ];
+        requiredSystemFeatures = [ "nixos-test" ]
+          ++ lib.optionals hostPkgs.stdenv.hostPlatform.isLinux [ "kvm" ]
+          ++ lib.optionals hostPkgs.stdenv.hostPlatform.isDarwin [ "apple-virt" ];
 
         buildCommand = ''
           mkdir -p $out

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -208,6 +208,10 @@ let
         idx=$((idx + 1))
       '')}
 
+      ${lib.optionalString (hostPkgs.stdenv.hostPlatform.isDarwin && !config.virtualisation.useNixStoreImage) ''
+        ulimit -n 12288
+      ''}
+
       # Start QEMU.
       exec ${qemu-common.qemuBinary qemu} \
           -name ${config.system.name} \

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -97,9 +97,15 @@
   # See doc/builders/testers.chapter.md or
   # https://nixos.org/manual/nixpkgs/unstable/#tester-runNixOSTest
   runNixOSTest =
-    let nixos = import ../../../nixos/lib {
-      inherit lib;
-    };
+    let
+      toGuest = builtins.replaceStrings [ "darwin" ] [ "linux" ];
+      guestPkgs =
+        if (!pkgs.stdenv.hostPlatform.isDarwin)
+          then pkgs
+          else import pkgs.path { system = toGuest pkgs.system; };
+      nixos = import ../../../nixos/lib {
+        inherit lib;
+      };
     in testModule:
         nixos.runTest {
           _file = "pkgs.runNixOSTest implementation";
@@ -107,7 +113,7 @@
             (lib.setDefaultModuleLocation "the argument that was passed to pkgs.runNixOSTest" testModule)
           ];
           hostPkgs = pkgs;
-          node.pkgs = pkgs;
+          node.pkgs = guestPkgs;
         };
 
   # See doc/builders/testers.chapter.md or


### PR DESCRIPTION
## Description of changes

I got a step towards running NixOS integration tests on macOS without modifications in the test, other than the ones on nixpkgs in this PR.

```nix
let
  pkgs = import ./. {};

  testConfig = { lib, hostPkgs, ... }: {
    name = "An awesome test.";

    nodes = {
      machine1 = { pkgs, ... }: { };
      machine2 = { pkgs, ... }: { };
    };

    testScript = ''
      machine1.wait_for_unit("network-online.target")
      machine2.wait_for_unit("network-online.target")

      machine1.succeed("ping -c 1 machine2")
      machine2.succeed("ping -c 1 machine1")
    '';
  };
in

pkgs.testers.runNixOSTest testConfig
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
