### PR TITLE
dublin-traceroute: init at 2023.04.12

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -167,6 +167,7 @@
   ./programs/direnv.nix
   ./programs/dmrconfig.nix
   ./programs/droidcam.nix
+  ./programs/dublin-traceroute.nix
   ./programs/ecryptfs.nix
   ./programs/environment.nix
   ./programs/evince.nix

--- a/nixos/modules/programs/dublin-traceroute.nix
+++ b/nixos/modules/programs/dublin-traceroute.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.dublin-traceroute;
+
+in {
+  meta.maintainers = pkgs.dublin-traceroute.meta.maintainers;
+
+  options = {
+    programs.dublin-traceroute = {
+      enable = mkEnableOption (mdDoc ''
+      dublin-traceroute, add it to the global environment and configure a setcap wrapper for it.
+      '');
+
+      package = mkPackageOption pkgs "dublin-traceroute" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    security.wrappers.dublin-traceroute = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_net_raw+p";
+      source = getExe cfg.package;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -253,6 +253,7 @@ in {
   domination = handleTest ./domination.nix {};
   dovecot = handleTest ./dovecot.nix {};
   drbd = handleTest ./drbd.nix {};
+  dublin-traceroute = handleTest ./dublin-traceroute.nix {};
   earlyoom = handleTestOn ["x86_64-linux"] ./earlyoom.nix {};
   early-mount-options = handleTest ./early-mount-options.nix {};
   ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-config or {};

--- a/nixos/tests/dublin-traceroute.nix
+++ b/nixos/tests/dublin-traceroute.nix
@@ -1,0 +1,63 @@
+# This is a simple distributed test involving a topology with two
+# separate virtual networks - the "inside" and the "outside" - with a
+# client on the inside network, a server on the outside network, and a
+# router connected to both that performs Network Address Translation
+# for the client.
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+  let
+    routerBase =
+      lib.mkMerge [
+        { virtualisation.vlans = [ 2 1 ];
+          networking.nftables.enable = true;
+          networking.nat.internalIPs = [ "192.168.1.0/24" ];
+          networking.nat.externalInterface = "eth1";
+        }
+      ];
+  in
+  {
+    name = "dublin-traceroute";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ baloo ];
+    };
+
+    nodes.client = { nodes, ... }: {
+      imports = [ ./common/user-account.nix ];
+      virtualisation.vlans = [ 1 ];
+
+      networking.defaultGateway =
+        (builtins.head nodes.router.networking.interfaces.eth2.ipv4.addresses).address;
+      networking.nftables.enable = true;
+
+      programs.dublin-traceroute.enable = true;
+    };
+
+    nodes.router = { ... }: {
+      virtualisation.vlans = [ 2 1 ];
+      networking.nftables.enable = true;
+      networking.nat.internalIPs = [ "192.168.1.0/24" ];
+      networking.nat.externalInterface = "eth1";
+      networking.nat.enable = true;
+    };
+
+    nodes.server = { ... }: {
+      virtualisation.vlans = [ 2 ];
+      networking.firewall.enable = false;
+      services.httpd.enable = true;
+      services.httpd.adminAddr = "foo@example.org";
+      services.vsftpd.enable = true;
+      services.vsftpd.anonymousUser = true;
+    };
+
+    testScript = ''
+      client.start()
+      router.start()
+      server.start()
+
+      server.wait_for_unit("network.target")
+      router.wait_for_unit("network.target")
+      client.wait_for_unit("network.target")
+
+      # Make sure we can trace from an unprivileged user
+      client.succeed("sudo -u alice dublin-traceroute server")
+    '';
+  })

--- a/pkgs/by-name/du/dublin-traceroute/package.nix
+++ b/pkgs/by-name/du/dublin-traceroute/package.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, jsoncpp, libtins, libpcap, openssl, unstableGitUpdater, nixosTests }:
+
+stdenv.mkDerivation {
+  pname = "dublin-traceroute";
+  version = "0.4.2-unstable-2023-04-12";
+
+  src = fetchFromGitHub {
+    owner = "insomniacslk";
+    repo = "dublin-traceroute";
+    rev = "2fb78ea05596dfdf8f7764b497eb8d3a812cb695";
+    hash = "sha256-E1HYMd0wDTfAZ0TamQFazh8CPhMa2lNIbF4aEBf5qhk=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ jsoncpp libtins libpcap openssl ];
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  passthru = {
+    # 0.4.2 was tagged in 2017
+    updateScript = unstableGitUpdater { };
+
+    tests = {
+      inherit (nixosTests) dublin-traceroute;
+    };
+  };
+
+  meta = with lib; {
+    description = "NAT-aware multipath traceroute tool";
+    homepage = "https://dublin-traceroute.net/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ baloo ];
+    platforms = platforms.unix;
+    mainProgram = "dublin-traceroute";
+  };
+}


### PR DESCRIPTION
## Description of changes

dublin-traceroute is a tool to help debug ECMP networks.

Although dublin-traceroute had a couple of releases, the latest one is a bit outdated now so I'm getting an unstable and pining it to a git commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
