### PR TITLE
thorium-browser: init at 117.0.5938.157

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7612,6 +7612,13 @@
     githubId = 137306;
     name = "Michele Catalano";
   };
+  isabelroses = {
+    email = "isabel@isabelroses.com";
+    matrix = "@isabel@isabelroses.com";
+    github = "isabelroses";
+    githubId = 71222764;
+    name = "Isabel Roses";
+  };
   isaozler = {
     email = "isaozler@gmail.com";
     github = "isaozler";

--- a/pkgs/by-name/th/thorium-browser/package.nix
+++ b/pkgs/by-name/th/thorium-browser/package.nix
@@ -1,0 +1,162 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  wrapGAppsHook,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  cairo,
+  cups,
+  curl,
+  dbus,
+  expat,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  glib,
+  glibc,
+  gtk3,
+  gtk4,
+  libcanberra,
+  liberation_ttf,
+  libexif,
+  libglvnd,
+  libkrb5,
+  libnotify,
+  libpulseaudio,
+  libu2f-host,
+  libva,
+  libxkbcommon,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  pciutils,
+  pipewire,
+  qt6,
+  speechd,
+  udev,
+  _7zz,
+  vaapiVdpau,
+  vulkan-loader,
+  wayland,
+  wget,
+  xdg-utils,
+  xfce,
+  xorg,
+}:
+stdenv.mkDerivation rec {
+  pname = "thorium-browser";
+  version = "117.0.5938.157";
+
+  src = fetchurl {
+    url = "https://github.com/Alex313031/thorium/releases/download/M${version}/thorium-browser_${version}_amd64.deb";
+    hash = "sha256-muNBYP6832PmP0et9ESaRpd/BIwYZmwdkHhsMNBLQE4=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    wrapGAppsHook
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    ffmpeg
+    fontconfig
+    freetype
+    glib
+    glibc
+    gtk3
+    gtk4
+    libcanberra
+    liberation_ttf
+    libexif
+    libglvnd
+    libkrb5
+    libnotify
+    libpulseaudio
+    libu2f-host
+    libva
+    libxkbcommon
+    mesa
+    nspr
+    nss
+    qt6.qtbase
+    pango
+    pciutils
+    pipewire
+    speechd
+    udev
+    _7zz
+    vaapiVdpau
+    vulkan-loader
+    wayland
+    wget
+    xdg-utils
+    xfce.exo
+    xorg.libxcb
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXxf86vm
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libQt5Widgets.so.5"
+    "libQt5Gui.so.5"
+    "libQt5Core.so.5"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -vr usr/* $out
+    cp -vr etc $out
+    cp -vr opt $out
+    ln -sf $out/opt/chromium.org/thorium/thorium-browser $out/bin/thorium-browser
+    substituteInPlace $out/share/applications/thorium-shell.desktop \
+      --replace /usr/bin $out/bin \
+      --replace /opt $out/opt
+    substituteInPlace $out/share/applications/thorium-browser.desktop \
+      --replace /usr/bin $out/bin \
+      --replace StartupWMClass=thorium StartupWMClass=thorium-browser \
+      --replace Icon=thorium-browser Icon=$out/opt/chromium.org/thorium/product_logo_256.png
+    addAutoPatchelfSearchPath $out/chromium.org/thorium
+    addAutoPatchelfSearchPath $out/chromium.org/thorium/lib
+    substituteInPlace $out/opt/chromium.org/thorium/thorium-browser \
+      --replace 'export LD_LIBRARY_PATH' "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${lib.makeLibraryPath buildInputs}:$out/chromium.org/thorium:$out/chromium.org/thorium/lib"
+    makeWrapper "$out/opt/chromium.org/thorium/thorium-browser" "$out/bin/thorium-browser" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Compiler-optimized Chromium fork";
+    homepage = "https://thorium.rocks";
+    sourceProvenance = with sourceTypes; [binaryNativeCode];
+    maintainers = with maintainers; [isabelroses];
+    license = licenses.bsd3;
+    platforms = ["x86_64-linux"];
+    mainProgram = "thorium-browser";
+  };
+}


### PR DESCRIPTION
## Description of changes

- Added [thorium browser](https://github.com/Alex313031/thorium) at version 117.0.5938.157

closes https://github.com/NixOS/nixpkgs/issues/184823

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

