### PR TITLE
CUDA EULA references

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -878,6 +878,7 @@ in mkLicense lset) ({
   };
 
   nvidiaCuda = {
+    shortName = "CUDA EULA";
     fullName = "CUDA Toolkit End User License Agreement (EULA)";
     url = "https://docs.nvidia.com/cuda/eula/index.html#cuda-toolkit-supplement-license-agreement";
     free = false;

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -878,7 +878,7 @@ in mkLicense lset) ({
   };
 
   nvidiaCuda = {
-    fullName = "CUDA Toolkit Supplement to Software License Agreement for NVIDIA Software Development Kits";
+    fullName = "CUDA Toolkit End User License Agreement (EULA)";
     url = "https://docs.nvidia.com/cuda/eula/index.html#cuda-toolkit-supplement-license-agreement";
     free = false;
   };

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -883,6 +883,14 @@ in mkLicense lset) ({
     free = false;
   };
 
+  nvidiaCudaRedist = {
+    shortName = "CUDA EULA";
+    fullName = "CUDA Toolkit End User License Agreement (EULA)";
+    url = "https://docs.nvidia.com/cuda/eula/index.html#cuda-toolkit-supplement-license-agreement";
+    free = false;
+    redistributable = true;
+  };
+
   obsidian = {
     fullName = "Obsidian End User Agreement";
     url = "https://obsidian.md/eula";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -883,12 +883,6 @@ in mkLicense lset) ({
     free = false;
   };
 
-  nvidiaCudnn = {
-    fullName = "cuDNN Supplement to Software License Agreement for NVIDIA Software Development Kits";
-    url = "https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html#supplement";
-    free = false;
-  };
-
   obsidian = {
     fullName = "Obsidian End User Agreement";
     url = "https://obsidian.md/eula";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -877,6 +877,18 @@ in mkLicense lset) ({
     fullName = "Non-Profit Open Software License 3.0";
   };
 
+  nvidiaCuda = {
+    fullName = "CUDA Toolkit Supplement to Software License Agreement for NVIDIA Software Development Kits";
+    url = "https://docs.nvidia.com/cuda/eula/index.html#cuda-toolkit-supplement-license-agreement";
+    free = false;
+  };
+
+  nvidiaCudnn = {
+    fullName = "cuDNN Supplement to Software License Agreement for NVIDIA Software Development Kits";
+    url = "https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html#supplement";
+    free = false;
+  };
+
   obsidian = {
     fullName = "Obsidian End User Agreement";
     url = "https://obsidian.md/eula";

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -361,7 +361,7 @@ backendStdenv.mkDerivation rec {
     description = "A compiler for NVIDIA GPUs, math libraries, and tools";
     homepage = "https://developer.nvidia.com/cuda-toolkit";
     platforms = [ "x86_64-linux" ];
-    license = licenses.unfree;
+    license = licenses.nvidiaCuda;
     maintainers = teams.cuda.members;
   };
 }

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -39,7 +39,7 @@ let
   inherit (lib.meta) getExe;
   inherit (lib.strings) optionalString;
 in
-backendStdenv.mkDerivation {
+backendStdenv.mkDerivation (finalAttrs: {
   # NOTE: Even though there's no actual buildPhase going on here, the derivations of the
   # redistributables are sensitive to the compiler flags provided to stdenv. The patchelf package
   # is sensitive to the compiler flags provided to stdenv, and we depend on it. As such, we are
@@ -164,7 +164,8 @@ backendStdenv.mkDerivation {
   outputSpecified = true;
 
   meta = {
-    inherit description platforms;
+    inherit platforms;
+    description = "${description}. By downloading and using the packages you accept the terms and conditions of the ${finalAttrs.meta.license.shortName}";
     license = lib.licenses.nvidiaCudaRedist // {
       url = "https://developer.download.nvidia.com/compute/cuda/redist/${releaseAttrs.license_path or "${pname}/LICENSE.txt"}";
     };
@@ -174,4 +175,4 @@ backendStdenv.mkDerivation {
     # causes Nix to prefer that output over the others if outputSpecified isn't set).
     outputsToInstall = [ "out" ];
   };
-}
+})

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -165,7 +165,9 @@ backendStdenv.mkDerivation {
 
   meta = {
     inherit description platforms;
-    license = lib.licenses.unfree;
+    license = lib.licenses.nvidiaCudaRedist // {
+      url = "https://developer.download.nvidia.com/compute/cuda/redist/${releaseAttrs.license_path or "${pname}/LICENSE.txt"}";
+    };
     maintainers = lib.teams.cuda.members;
     # Force the use of the default, fat output by default (even though `dev` exists, which
     # causes Nix to prefer that output over the others if outputSpecified isn't set).

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -168,6 +168,7 @@ backendStdenv.mkDerivation {
     license = lib.licenses.nvidiaCudaRedist // {
       url = "https://developer.download.nvidia.com/compute/cuda/redist/${releaseAttrs.license_path or "${pname}/LICENSE.txt"}";
     };
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     maintainers = lib.teams.cuda.members;
     # Force the use of the default, fat output by default (even though `dev` exists, which
     # causes Nix to prefer that output over the others if outputSpecified isn't set).

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -154,7 +154,7 @@ in
       homepage = "https://developer.nvidia.com/cudnn";
       sourceProvenance = with sourceTypes; [binaryNativeCode];
       license = {
-        fullName = "cuDNN Supplement to Software License Agreement for NVIDIA Software Development Kits";
+        fullName = "NVIDIA cuDNN Software License Agreement (EULA)";
         url = "https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html#supplement";
         free = false;
       } // lib.optionalAttrs (!useCudatoolkitRunfile) {

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -154,6 +154,7 @@ in
       homepage = "https://developer.nvidia.com/cudnn";
       sourceProvenance = with sourceTypes; [binaryNativeCode];
       license = {
+        shortName = "cuDNN EULA";
         fullName = "NVIDIA cuDNN Software License Agreement (EULA)";
         url = "https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html#supplement";
         free = false;

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -153,8 +153,13 @@ in
       description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
       homepage = "https://developer.nvidia.com/cudnn";
       sourceProvenance = with sourceTypes; [binaryNativeCode];
-      # TODO: consider marking unfreRedistributable when not using runfile
-      license = licenses.unfree;
+      license = {
+        fullName = "cuDNN Supplement to Software License Agreement for NVIDIA Software Development Kits";
+        url = "https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html#supplement";
+        free = false;
+      } // lib.optionalAttrs (!useCudatoolkitRunfile) {
+        redistributable = true;
+      };
       platforms = ["x86_64-linux"];
       maintainers = with maintainers; [mdaiter samuela];
       # Force the use of the default, fat output by default (even though `dev` exists, which


### PR DESCRIPTION
## Description of changes

Continuing the work in https://github.com/NixOS/nixpkgs/pull/76233.
The motivation is that we want to positively eliminate even the potential of having any legal issues with NVidia, and that we know there's a precedent of Anaconda distributing patchelf-ed cuda binaries on the grounds of an exclusive permission from NVidia, and that part of the anaconda-nvidia deal seems to have been concerned with the EULA notices as seen at https://anaconda.org/conda-forge/cudatoolkit. This just ensures that we follow the example and display similar notices on https://search.nixos.org

## Example

```bash
❯ nix eval .#cudaPackages.cuda_nvcc.meta.description
"CUDA NVCC. By downloading and using the packages you accept the terms and conditions of the CUDA EULA"
❯ nix eval .#cudaPackages.cuda_nvcc.meta.license
{ deprecated = false; free = false; fullName = "CUDA Toolkit End User License Agreement (EULA)"; redistributable = true; shortName = "CUDA EULA"; url = "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/LICENSE.txt"; }
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


@NixOS/cuda-maintainers 