### PR TITLE
turso-cli: 0.85.3 -> 0.86.3

### DIFF
--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -21,12 +21,9 @@ buildGo121Module rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # Build with production code
-  tags = ["prod"];
-  # Include version for `turso --version` reporting
-  preBuild = ''
-    echo "v${version}" > internal/cmd/version.txt
-  '';
+  ldflags = [
+    "-X github.com/tursodatabase/turso-cli/internal/cmd.version=v${version}"
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -4,19 +4,20 @@
   buildGo121Module,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
 }:
 buildGo121Module rec {
   pname = "turso-cli";
-  version = "0.85.3";
+  version = "0.86.3";
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
     repo = "turso-cli";
     rev = "v${version}";
-    hash = "sha256-dJpHrqPyikkUnE4Un1fGOEJL49U5IiInYeSWmI04r18=";
+    hash = "sha256-hTqjNQSScQzCUBs4pYgxRnRvUSoQXXeZIceSZAR1Oa0=";
   };
 
-  vendorHash = "sha256-Hv4CacBrRX2YT3AkbNzyWrA9Ex6YMDPrPvezukwMkTE=";
+  vendorHash = "sha256-EqND/W+NNatoBUMXWrsjNPfxAtX0oUASUxN6Rmhp7SQ=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -37,6 +38,8 @@ buildGo121Module rec {
       --fish <($out/bin/turso completion fish) \
       --zsh <($out/bin/turso completion zsh)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "This is the command line interface (CLI) to Turso.";


### PR DESCRIPTION
## Description of changes

Changes: https://github.com/tursodatabase/turso-cli/compare/v0.85.3...v0.86.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

