### PR TITLE
anilibria-winmaclinux: build with libvlc

### DIFF
--- a/pkgs/applications/video/anilibria-winmaclinux/0003-build-with-vlc.patch
+++ b/pkgs/applications/video/anilibria-winmaclinux/0003-build-with-vlc.patch
@@ -1,0 +1,28 @@
+diff --git a/AniLibria.pro b/AniLibria.pro
+index 407dbde..ae69502 100644
+--- a/AniLibria.pro
++++ b/AniLibria.pro
+@@ -21,17 +21,17 @@ windows {
+     DEFINES += NO_NEED_STANDART_PLAYER
+ }
+ 
+-#unix {
+-#    LIBS += -lvlc
++unix {
++    LIBS += -lvlc
+ 
+ #    INCLUDEPATH += /usr/include/
+ #    DEPENDPATH += /usr/include/
+ 
+-#    INCLUDEPATH += /usr/include/vlc/plugins
+-#    DEPENDPATH += /usr/include/vlc/plugins
++    INCLUDEPATH += @VLC_PATH@/vlc/plugins
++    DEPENDPATH += @VLC_PATH@/vlc/plugins
+ 
+-#    CONFIG += buildwithvlc
+-#}
++    CONFIG += buildwithvlc
++}
+ 
+ buildwithvlc {
+     DEFINES += USE_VLC_PLAYER

--- a/pkgs/applications/video/anilibria-winmaclinux/default.nix
+++ b/pkgs/applications/video/anilibria-winmaclinux/default.nix
@@ -10,6 +10,7 @@
 , wrapQtAppsHook
 , makeDesktopItem
 , copyDesktopItems
+, libvlc
 }:
 
 mkDerivation rec {
@@ -30,11 +31,13 @@ mkDerivation rec {
   patches = [
     ./0001-fix-installation-paths.patch
     ./0002-disable-version-check.patch
+    ./0003-build-with-vlc.patch
   ];
 
   preConfigure = ''
     substituteInPlace AniLibria.pro \
-      --replace "\$\$PREFIX" '${placeholder "out"}'
+      --replace "\$\$PREFIX" '${placeholder "out"}' \
+      --replace '@VLC_PATH@' '${libvlc}/include'
   '';
 
   qtWrapperArgs = [
@@ -58,6 +61,7 @@ mkDerivation rec {
     qtquickcontrols2
     qtwebsockets
     qtmultimedia
+    libvlc
   ] ++ (with gst_all_1; [
     gst-plugins-bad
     gst-plugins-good


### PR DESCRIPTION
## Description of changes

Building with libvlc gives the ability to use [TorrentStream](https://github.com/trueromanus/TorrentStream)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
