### PR TITLE
uwimap: fix build with clang 16

### DIFF
--- a/pkgs/tools/networking/uwimap/clang-fix.patch
+++ b/pkgs/tools/networking/uwimap/clang-fix.patch
@@ -1,0 +1,306 @@
+diff -ur a/src/c-client/netmsg.c b/src/c-client/netmsg.c
+--- a/src/c-client/netmsg.c	2011-07-22 20:20:18.000000000 -0400
++++ b/src/c-client/netmsg.c	2023-10-17 22:23:29.026638315 -0400
+@@ -29,6 +29,7 @@
+ 
+ #include <stdio.h>
+ #include <errno.h>
++#include <time.h>
+ extern int errno;		/* just in case */
+ #include "c-client.h"
+ #include "netmsg.h"
+diff -ur a/src/c-client/nntp.c b/src/c-client/nntp.c
+--- a/src/c-client/nntp.c	2011-07-22 20:20:18.000000000 -0400
++++ b/src/c-client/nntp.c	2023-10-17 22:23:05.195194961 -0400
+@@ -29,6 +29,7 @@
+ 
+ #include <ctype.h>
+ #include <stdio.h>
++#include <time.h>
+ #include "c-client.h"
+ #include "newsrc.h"
+ #include "netmsg.h"
+diff -ur a/src/dmail/dmail.c b/src/dmail/dmail.c
+--- a/src/dmail/dmail.c	2011-07-22 20:19:57.000000000 -0400
++++ b/src/dmail/dmail.c	2023-10-17 22:44:23.049223758 -0400
+@@ -27,6 +27,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <ctype.h>
+ #include <pwd.h>
+ #include <errno.h>
+ extern int errno;		/* just in case */
+diff -ur a/src/mlock/mlock.c b/src/mlock/mlock.c
+--- a/src/mlock/mlock.c	2011-07-22 20:19:57.000000000 -0400
++++ b/src/mlock/mlock.c	2023-10-17 22:44:44.533985203 -0400
+@@ -31,6 +31,9 @@
+ #include <stdio.h>
+ #include <sysexits.h>
+ #include <syslog.h>
++#include <ctype.h>
++#include <time.h>
++#include <unistd.h>
+ #include <grp.h>
+ #include <sys/types.h>
+ #include <sys/file.h>
+diff -ur a/src/osdep/unix/dummy.c b/src/osdep/unix/dummy.c
+--- a/src/osdep/unix/dummy.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/dummy.c	2023-10-17 22:23:17.123963204 -0400
+@@ -30,6 +30,7 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <errno.h>
++#include <time.h>
+ extern int errno;		/* just in case */
+ #include "mail.h"
+ #include "osdep.h"
+diff -ur a/src/osdep/unix/mbx.c b/src/osdep/unix/mbx.c
+--- a/src/osdep/unix/mbx.c	2011-07-22 20:20:11.000000000 -0400
++++ b/src/osdep/unix/mbx.c	2023-10-17 22:25:13.189158845 -0400
+@@ -41,6 +41,7 @@
+ #include "mail.h"
+ #include "osdep.h"
+ #include <pwd.h>
++#include <utime.h>
+ #include <sys/stat.h>
+ #include <sys/time.h>
+ #include "misc.h"
+diff -ur a/src/osdep/unix/mh.c b/src/osdep/unix/mh.c
+--- a/src/osdep/unix/mh.c	2011-07-22 20:20:09.000000000 -0400
++++ b/src/osdep/unix/mh.c	2023-10-17 22:31:50.240740603 -0400
+@@ -30,6 +30,7 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <errno.h>
++#include <utime.h>
+ extern int errno;		/* just in case */
+ #include "mail.h"
+ #include "osdep.h"
+@@ -103,8 +104,8 @@
+ 	      long options);
+ long mh_append (MAILSTREAM *stream,char *mailbox,append_t af,void *data);
+ 
+-int mh_select (struct direct *name);
+-int mh_numsort (const void *d1,const void *d2);
++int mh_select (const struct direct *name);
++int mh_numsort (const struct dirent **d1,const struct dirent **d2);
+ char *mh_file (char *dst,char *name);
+ long mh_canonicalize (char *pattern,char *ref,char *pat);
+ void mh_setdate (char *file,MESSAGECACHE *elt);
+@@ -1194,7 +1195,7 @@
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int mh_select (struct direct *name)
++int mh_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -1209,10 +1210,10 @@
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int mh_numsort (const void *d1,const void *d2)
++int mh_numsort (const struct dirent **d1,const struct dirent **d2)
+ {
+-  return atoi ((*(struct direct **) d1)->d_name) -
+-    atoi ((*(struct direct **) d2)->d_name);
++  return atoi ((*d1)->d_name) -
++    atoi ((*d2)->d_name);
+ }
+ 
+ 
+diff -ur a/src/osdep/unix/mix.c b/src/osdep/unix/mix.c
+--- a/src/osdep/unix/mix.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/mix.c	2023-10-17 22:35:22.368131654 -0400
+@@ -125,7 +125,7 @@
+ long mix_create (MAILSTREAM *stream,char *mailbox);
+ long mix_delete (MAILSTREAM *stream,char *mailbox);
+ long mix_rename (MAILSTREAM *stream,char *old,char *newname);
+-int mix_rselect (struct direct *name);
++int mix_rselect (const struct direct *name);
+ MAILSTREAM *mix_open (MAILSTREAM *stream);
+ void mix_close (MAILSTREAM *stream,long options);
+ void mix_abort (MAILSTREAM *stream);
+@@ -140,8 +140,8 @@
+ long mix_ping (MAILSTREAM *stream);
+ void mix_check (MAILSTREAM *stream);
+ long mix_expunge (MAILSTREAM *stream,char *sequence,long options);
+-int mix_select (struct direct *name);
+-int mix_msgfsort (const void *d1,const void *d2);
++int mix_select (const struct direct *name);
++int mix_msgfsort (const struct dirent **d1,const struct dirent **d2);
+ long mix_addset (SEARCHSET **set,unsigned long start,unsigned long size);
+ long mix_burp (MAILSTREAM *stream,MIXBURP *burp,unsigned long *reclaimed);
+ long mix_burp_check (SEARCHSET *set,size_t size,char *file);
+@@ -587,7 +587,7 @@
+  * Returns: T if mix file name, NIL otherwise
+  */
+ 
+-int mix_rselect (struct direct *name)
++int mix_rselect (const struct direct *name)
+ {
+   return mix_dirfmttest (name->d_name);
+ }
+@@ -1146,7 +1146,7 @@
+  * ".mix" with no suffix was used by experimental versions
+  */
+ 
+-int mix_select (struct direct *name)
++int mix_select (const struct direct *name)
+ {
+   char c,*s;
+ 				/* make sure name has prefix */
+@@ -1165,10 +1165,10 @@
+  * Returns: -1 if d1 < d2, 0 if d1 == d2, 1 d1 > d2
+  */
+ 
+-int mix_msgfsort (const void *d1,const void *d2)
++int mix_msgfsort (const struct dirent **d1,const struct dirent **d2)
+ {
+-  char *n1 = (*(struct direct **) d1)->d_name + sizeof (MIXNAME) - 1;
+-  char *n2 = (*(struct direct **) d2)->d_name + sizeof (MIXNAME) - 1;
++  char *n1 = (*d1)->d_name + sizeof (MIXNAME) - 1;
++  char *n2 = (*d2)->d_name + sizeof (MIXNAME) - 1;
+   return compare_ulong (*n1 ? strtoul (n1,NIL,16) : 0,
+ 			*n2 ? strtoul (n2,NIL,16) : 0);
+ }
+diff -ur a/src/osdep/unix/mmdf.c b/src/osdep/unix/mmdf.c
+--- a/src/osdep/unix/mmdf.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/mmdf.c	2023-10-17 22:25:37.095313031 -0400
+@@ -33,6 +33,7 @@
+ #include "mail.h"
+ #include "osdep.h"
+ #include <time.h>
++#include <utime.h>
+ #include <sys/stat.h>
+ #include "pseudo.h"
+ #include "fdstring.h"
+diff -ur a/src/osdep/unix/mtx.c b/src/osdep/unix/mtx.c
+--- a/src/osdep/unix/mtx.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/mtx.c	2023-10-17 22:26:48.973160400 -0400
+@@ -37,6 +37,7 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <errno.h>
++#include <utime.h>
+ extern int errno;		/* just in case */
+ #include "mail.h"
+ #include "osdep.h"
+diff -ur a/src/osdep/unix/mx.c b/src/osdep/unix/mx.c
+--- a/src/osdep/unix/mx.c	2011-07-22 20:20:09.000000000 -0400
++++ b/src/osdep/unix/mx.c	2023-10-17 22:33:25.621907970 -0400
+@@ -30,6 +30,7 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <errno.h>
++#include <utime.h>
+ extern int errno;		/* just in case */
+ #include "mail.h"
+ #include "osdep.h"
+@@ -98,8 +99,8 @@
+ long mx_append_msg (MAILSTREAM *stream,char *flags,MESSAGECACHE *elt,
+ 		    STRING *st,SEARCHSET *set);
+ 
+-int mx_select (struct direct *name);
+-int mx_numsort (const void *d1,const void *d2);
++int mx_select (const struct direct *name);
++int mx_numsort (const struct dirent **d1,const struct dirent **d2);
+ char *mx_file (char *dst,char *name);
+ long mx_lockindex (MAILSTREAM *stream);
+ void mx_unlockindex (MAILSTREAM *stream);
+@@ -1110,7 +1111,7 @@
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int mx_select (struct direct *name)
++int mx_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -1125,10 +1126,10 @@
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int mx_numsort (const void *d1,const void *d2)
++int mx_numsort (const struct dirent **d1,const struct dirent **d2)
+ {
+-  return atoi ((*(struct direct **) d1)->d_name) -
+-    atoi ((*(struct direct **) d2)->d_name);
++  return atoi ((*d1)->d_name) -
++    atoi ((*d2)->d_name);
+ }
+ 
+ 
+diff -ur a/src/osdep/unix/news.c b/src/osdep/unix/news.c
+--- a/src/osdep/unix/news.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/news.c	2023-10-17 22:29:32.461013229 -0400
+@@ -76,8 +76,8 @@
+ long news_delete (MAILSTREAM *stream,char *mailbox);
+ long news_rename (MAILSTREAM *stream,char *old,char *newname);
+ MAILSTREAM *news_open (MAILSTREAM *stream);
+-int news_select (struct direct *name);
+-int news_numsort (const void *d1,const void *d2);
++int news_select (const struct direct *name);
++int news_numsort (const struct dirent **d1,const struct dirent **d2);
+ void news_close (MAILSTREAM *stream,long options);
+ void news_fast (MAILSTREAM *stream,char *sequence,long flags);
+ void news_flags (MAILSTREAM *stream,char *sequence,long flags);
+@@ -402,7 +402,7 @@
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int news_select (struct direct *name)
++int news_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -417,10 +417,10 @@
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int news_numsort (const void *d1,const void *d2)
++int news_numsort (const struct dirent **d1,const struct dirent **d2)
+ {
+-  return atoi ((*(struct direct **) d1)->d_name) -
+-    atoi ((*(struct direct **) d2)->d_name);
++  return atoi ((*d1)->d_name) -
++    atoi ((*d2)->d_name);
+ }
+ 
+ 
+diff -ur a/src/osdep/unix/tenex.c b/src/osdep/unix/tenex.c
+--- a/src/osdep/unix/tenex.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/tenex.c	2023-10-17 22:26:15.349497223 -0400
+@@ -42,6 +42,8 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <errno.h>
++#include <time.h>
++#include <utime.h>
+ extern int errno;		/* just in case */
+ #include "mail.h"
+ #include "osdep.h"
+diff -ur a/src/osdep/unix/unix.c b/src/osdep/unix/unix.c
+--- a/src/osdep/unix/unix.c	2011-07-22 20:20:10.000000000 -0400
++++ b/src/osdep/unix/unix.c	2023-10-17 22:24:46.358134773 -0400
+@@ -45,6 +45,7 @@
+ #include "mail.h"
+ #include "osdep.h"
+ #include <time.h>
++#include <utime.h>
+ #include <sys/stat.h>
+ #include "unix.h"
+ #include "pseudo.h"
+diff -ur a/src/tmail/tmail.c b/src/tmail/tmail.c
+--- a/src/tmail/tmail.c	2011-07-22 20:19:58.000000000 -0400
++++ b/src/tmail/tmail.c	2023-10-17 22:36:32.723585260 -0400
+@@ -27,6 +27,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <ctype.h>
+ #include <pwd.h>
+ #include <errno.h>
+ extern int errno;		/* just in case */

--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -25,10 +25,15 @@ stdenv.mkDerivation rec {
     (if stdenv.isDarwin then libkrb5 else pam)  # Matches the make target.
   ];
 
-  patches = [ (fetchpatch {
-    url = "https://salsa.debian.org/holmgren/uw-imap/raw/dcb42981201ea14c2d71c01ebb4a61691b6f68b3/debian/patches/1006_openssl1.1_autoverify.patch";
-    sha256 = "09xb58awvkhzmmjhrkqgijzgv7ia381ablf0y7i1rvhcqkb5wga7";
-  }) ];
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/holmgren/uw-imap/raw/dcb42981201ea14c2d71c01ebb4a61691b6f68b3/debian/patches/1006_openssl1.1_autoverify.patch";
+      sha256 = "09xb58awvkhzmmjhrkqgijzgv7ia381ablf0y7i1rvhcqkb5wga7";
+    })
+    # Required to build with newer versions of clang. Fixes call to undeclared functions errors
+    # and incompatible function pointer conversions.
+    ./clang-fix.patch
+  ];
 
   postPatch = ''
     sed -i src/osdep/unix/Makefile -e 's,/usr/local/ssl,${openssl.dev},'


### PR DESCRIPTION
## Description of changes

* Include missing headers to fix calls to undeclared functions; and
* Adjust function declarations to fix incompatible function pointer conversion errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
