### PR TITLE
latencytop: Adds opt-out of gtk support

### DIFF
--- a/pkgs/os-specific/linux/latencytop/default.nix
+++ b/pkgs/os-specific/linux/latencytop/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, ncurses, glib, pkg-config, gtk2, util-linux }:
+{ lib, stdenv, fetchurl, ncurses, glib, pkg-config, util-linux
+, gtkSupport ? true, gtk2 }:
 
 stdenv.mkDerivation rec {
   pname = "latencytop";
@@ -9,6 +10,8 @@ stdenv.mkDerivation rec {
 
     # Fix #171609
     substituteInPlace fsync.c --replace /bin/mount ${util-linux}/bin/mount
+  '' + lib.optionalString (!gtkSupport) ''
+    sed -i '/HAS_GTK_GUI = 1/d' Makefile
   '';
 
   preInstall = "mkdir -p $out/sbin";
@@ -20,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ncurses glib gtk2 ];
+  buildInputs = [ ncurses glib ] ++ lib.optional gtkSupport gtk2;
 
   meta = {
     homepage = "http://latencytop.org";


### PR DESCRIPTION
## Description of changes
This adds support to opt-out of gtk support

cc @viric 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
