### PR TITLE
libtiff: 4.5.1 -> 4.6.0

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libtiff";
-  version = "4.5.1";
+  version = "4.6.0";
 
   src = fetchFromGitLab {
     owner = "libtiff";
     repo = "libtiff";
     rev = "v${version}";
-    hash = "sha256-qQEthy6YhNAQmdDMyoCIvK8f3Tx25MgqhJZW74CB93E=";
+    hash = "sha256-qCg5qjsPPynCHIg0JsPJldwVdcYkI68zYmyNAKUCoyw=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libtiff/headers.patch
+++ b/pkgs/development/libraries/libtiff/headers.patch
@@ -2,7 +2,7 @@ export private headers for freeimage
 --- i/libtiff/Makefile.am
 +++ w/libtiff/Makefile.am
 @@ -36,8 +36,12 @@ EXTRA_DIST = \
- 	tiffconf.h.cmake.in
+ 	tif_win32_versioninfo.rc
 
  libtiffinclude_HEADERS = \
 +	tif_config.h \

--- a/pkgs/development/libraries/libtiff/headers.patch
+++ b/pkgs/development/libraries/libtiff/headers.patch
@@ -1,5 +1,4 @@
-diff --git i/libtiff/Makefile.am w/libtiff/Makefile.am
-index 44522b62..d66e5948 100644
+export private headers for freeimage
 --- i/libtiff/Makefile.am
 +++ w/libtiff/Makefile.am
 @@ -36,8 +36,12 @@ EXTRA_DIST = \

--- a/pkgs/development/libraries/libtiff/rename-version.patch
+++ b/pkgs/development/libraries/libtiff/rename-version.patch
@@ -1,3 +1,4 @@
+fix case-insensitive build
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -34,7 +34,7 @@ docfiles = \

--- a/pkgs/development/libraries/libtiff/rename-version.patch
+++ b/pkgs/development/libraries/libtiff/rename-version.patch
@@ -7,15 +7,15 @@ fix case-insensitive build
  	TODO \
 -	VERSION
 +	VERSION.txt
-
+ 
  EXTRA_DIST = \
- 	cmake \
-@@ -61,7 +61,7 @@ SUBDIRS = port libtiff tools build contrib test doc
-
+ 	placeholder.h \
+@@ -68,7 +68,7 @@ NEW_LIBTIFF_RELEASE_DATE=$(shell date +"%Y%m%d")
  release:
-	(rm -f $(top_srcdir)/RELEASE-DATE && echo $(LIBTIFF_RELEASE_DATE) > $(top_srcdir)/RELEASE-DATE)
+ 	@(echo --- Setting release date to $(NEW_LIBTIFF_RELEASE_DATE) and release version to $(LIBTIFF_VERSION) ---)
+ 	(rm -f $(top_srcdir)/RELEASE-DATE && echo $(NEW_LIBTIFF_RELEASE_DATE) > $(top_srcdir)/RELEASE-DATE)
 -	(rm -f $(top_srcdir)/VERSION && echo $(LIBTIFF_VERSION) > $(top_srcdir)/VERSION)
-+	(rm -f $(top_srcdir)/VERSION.txt && echo $(LIBTIFF_VERSION) > $(top_srcdir)/VERSION.txt)
-	(rm -f $(top_srcdir)/libtiff/tiffvers.h && sed 's,LIBTIFF_VERSION,$(LIBTIFF_VERSION),;s,LIBTIFF_RELEASE_DATE,$(LIBTIFF_RELEASE_DATE),;s,LIBTIFF_MAJOR_VERSION,$(LIBTIFF_MAJOR_VERSION),;s,LIBTIFF_MINOR_VERSION,$(LIBTIFF_MINOR_VERSION),;s,LIBTIFF_MICRO_VERSION,$(LIBTIFF_MICRO_VERSION),' $(top_srcdir)/libtiff/tiffvers.h.in > $(top_srcdir)/libtiff/tiffvers.h)
-
++	(rm -f $(top_srcdir)/VERSION && echo $(LIBTIFF_VERSION) > $(top_srcdir)/VERSION.txt)
+ 	(rm -f $(top_builddir)/libtiff/tiffvers.h && sed 's,LIBTIFF_VERSION,$(LIBTIFF_VERSION),;s,LIBTIFF_RELEASE_DATE,$(NEW_LIBTIFF_RELEASE_DATE),;s,LIBTIFF_MAJOR_VERSION,$(LIBTIFF_MAJOR_VERSION),;s,LIBTIFF_MINOR_VERSION,$(LIBTIFF_MINOR_VERSION),;s,LIBTIFF_MICRO_VERSION,$(LIBTIFF_MICRO_VERSION),' $(top_srcdir)/libtiff/tiffvers.h.in > $(top_builddir)/libtiff/tiffvers.h && sed -i 's,@,,g' $(top_builddir)/libtiff/tiffvers.h)
+ 
  pkgconfigdir = $(libdir)/pkgconfig


### PR DESCRIPTION
## Description of changes

Changes: http://www.simplesystems.org/libtiff/releases/v4.6.0.html

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
