### PR TITLE
workflows/auto-merge{,-enable,-abort}: init

### DIFF
--- a/.github/workflows/auto-merge-abort.yml
+++ b/.github/workflows/auto-merge-abort.yml
@@ -1,0 +1,26 @@
+# This action aborts auto-merging by removing the label
+# when changes are pushed.
+
+name: "abort auto merge"
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge-abort:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: abort auto merge
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == false && contains(github.event.pull_request.labels.*.name, 'auto-merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label on new commits
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: auto-merge

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -1,0 +1,36 @@
+# This action ensures the "auto-merge" label can only by used
+# by Nixpkgs Committers.
+
+name: "enable auto merge"
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: enable auto merge
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == false && github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user is committer
+        id: checkUserIsCommitter
+        uses: tspascoal/get-user-teams-membership@v3
+        with:
+          organization: NixOS
+          team: Nixpkgs Committers
+          username: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GH_READ_ORG_TOKEN }} # requires scope read:org
+
+      - name: Remove label if user isn't committer
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ failure() || steps.checkUserIsCommitter.outputs.isTeamMember == 'false' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: auto-merge

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,43 @@
+# This action merges PRs that are tagged with `auto-merge`
+# once all checks have succeeded.
+
+name: "auto merge"
+
+on:
+  workflow_run:
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: auto merge
+    if: github.repository_owner == 'NixOS' && github.event.workflow.pull_requests[0].merged == false && contains(github.event.workflow.pull_requests[0].labels.*.name, 'auto-merge') && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make sure all checks have passed
+        uses: arup-group/action-all-checks-passed@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge pull request
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            })
+
+      - name: Remove label on failure
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ failure() }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: auto-merge


### PR DESCRIPTION
## Description of changes
Add GitHub workflow for auto-merging PRs once checks all succeed based on a label that only committers can set.

This is very much WIP, not tested at all and I'm not that familiar with GitHub actions, but it seems feasible.

@delroth [shared this idea on Matrix](https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$CdzV5mNDPxohBv_NMz6zrwmIgTR5EQ3pYoiPn364LpU?via=nixos.org&via=matrix.org&via=nixos.dev).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).