### PR TITLE
python3.buildEnv: support extending NIX_PYTHONPATH

### DIFF
--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -58,7 +58,7 @@ let
                   makeWrapper "$path/bin/$prg" "$out/bin/$prg" \
                     --set NIX_PYTHONPREFIX "$out" \
                     --set NIX_PYTHONEXECUTABLE ${pythonExecutable} \
-                    --set NIX_PYTHONPATH ${pythonPath} \
+                    --prefix NIX_PYTHONPATH : ${pythonPath} \
                     ${lib.optionalString (!permitUserSite) ''--set PYTHONNOUSERSITE "true"''} \
                     ${lib.concatStringsSep " " makeWrapperArgs}
                 fi


### PR DESCRIPTION
Allow devshells to extend `$NIX_PYTHONPATH`, to effectively support nested virtualenvs.

@moduon MT-1075

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


I'm trying to set up a devshell where:
- Most python dependencies are pure.
- Some python modules I'm developing in a meta-repo are impure.

In this specific scenario, some pure dependencies depend on impure ones.

For example, I'm developing odoo and some addons, but while doing so I want to have [click-odoo-contrib](https://github.com/acsone/click-odoo-contrib) at my fingertips while developing. Thus, I add it to my devshell. Sounds nice, but when I try to execute it, I get an `ImportError`:

```shell
➤ click-odoo-listdb --help
Traceback (most recent call last):
  File "/nix/store/p8ivjzvbbkm6jqc9vyvhh6r6p4qvv2qj-python3.10-click-odoo-contrib-1.17.0/bin/.click-odoo-listdb-wrapped", line 6, in <module>
    from click_odoo_contrib.listdb import main
  File "/nix/store/r6djzp9sdnmgpaz9k413y1jdhn9aizr5-odoo-dev-16.0-python3-3.10.12-env/lib/python3.10/site-packages/click_odoo_contrib/listdb.py", line 6, in <module>
    import click_odoo
  File "/nix/store/r6djzp9sdnmgpaz9k413y1jdhn9aizr5-odoo-dev-16.0-python3-3.10.12-env/lib/python3.10/site-packages/click_odoo/__init__.py", line 4, in <module>
    from .compat import odoo  # noqa
  File "/nix/store/r6djzp9sdnmgpaz9k413y1jdhn9aizr5-odoo-dev-16.0-python3-3.10.12-env/lib/python3.10/site-packages/click_odoo/compat.py", line 11, in <module>
    import odoo
ModuleNotFoundError: No module named 'odoo'
```

That's expected. Odoo is installed as an editable dependency in an impure venv, because I'm developing it.

How could one pure package, packaged by nix, such as `click-odoo-contrib`, import an impure one installed in a venv in editable mode? The solution is to [customize the site](https://stackoverflow.com/a/15209116/1468388). It turns out that's already handled by Nix in these lines: https://github.com/NixOS/nixpkgs/blob/8fbb1f3325795de2777cff080bf49aa3f77523a5/pkgs/development/interpreters/python/sitecustomize.py#L20-L22

As you can see in that code, it supports multiple paths separated by colon.

However, without this patch, any binary produced from a Nix python environment will ignore any `NIX_PYTHONPATH` variable and replace it with what it wants.

Now, after this is done, I can just add to my devshell an environment variable in the shape of `NIX_PYTHONPATH = "$PRJ_ROOT_DIR/.venv/${python.sitePackages}"`, and magically `click-odoo-listdb` will be able to import `odoo` if it is installed into that venv.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
