### PR TITLE
[WIP] mercury-browser-bin: init at 122.0.2

### DIFF
--- a/pkgs/by-name/me/mercury-browser-bin/package.nix
+++ b/pkgs/by-name/me/mercury-browser-bin/package.nix
@@ -1,0 +1,155 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, wrapGAppsHook
+, alsa-lib
+, browserpass
+, bukubrow
+, cairo
+, cups
+, dbus
+, dbus-glib
+, ffmpeg
+, fontconfig
+, freetype
+, fx-cast-bridge
+, glib
+, glibc
+, gnome-browser-connector
+, gtk3
+, harfbuzz
+, libcanberra
+, libdbusmenu
+, libdbusmenu-gtk3
+, libglvnd
+, libjack2
+, libkrb5
+, libnotify
+, libpulseaudio
+, libva
+, lyx
+, mesa
+, nspr
+, nss
+, opensc
+, pango
+, pciutils
+, pipewire
+, plasma5Packages
+, sndio
+, speechd
+, tridactyl-native
+, udev
+, uget-integrator
+, vulkan-loader
+, xdg-utils
+, xorg
+, simd ? "SSE3"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mercury-browser-bin";
+  version = "122.0.2";
+
+  src = fetchurl {
+    url =
+    "https://github.com/Alex313031/Mercury/releases/download/v.${version}/mercury-browser_${version}_${simd}.deb";
+    hash = {
+      AVX2_hash = "sha256-mF2MvfbNUksJECHIMis8GlgiEzGiLe7NImRSnMSR37o=";
+      AVX_hash = "sha256-MbFZlDv2wruNfVcw5GcKl1KLqsstcUbFo/ELfuNK3dg=";
+      SSE4_hash = "sha256-vNRS37uLYIN7WVwaS0sX058oXOWPfwjmIv1VOaJ1v5g=";
+      SSE3_hash = "sha256-txDISoNW9/pXarn/8QfQhSo8AHFqPbrxjXwyUo3f3MA=";
+    }."${simd}_hash";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg wrapGAppsHook ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    browserpass
+    bukubrow
+    cairo
+    cups
+    dbus
+    dbus-glib
+    ffmpeg
+    fontconfig
+    freetype
+    fx-cast-bridge
+    glib
+    glibc
+    gnome-browser-connector
+    gtk3
+    harfbuzz
+    libcanberra
+    libdbusmenu
+    libdbusmenu-gtk3
+    libglvnd
+    libjack2
+    libkrb5
+    libnotify
+    libpulseaudio
+    libva
+    lyx
+    mesa
+    nspr
+    nss
+    opensc
+    pango
+    pciutils
+    pipewire
+    plasma5Packages.plasma-browser-integration
+    sndio
+    speechd
+    tridactyl-native
+    udev
+    uget-integrator
+    vulkan-loader
+    xdg-utils
+    xorg.libxcb
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXxf86vm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/* $out
+
+    substituteInPlace $out/share/applications/mercury-browser.desktop \
+      --replace Exec=mercury-browser Exec=$out/bin/mercury-browser \
+      --replace StartupWMClass=mercury StartupWMClass=mercury-default \
+      --replace Icon=mercury Icon=$out/share/icons/hicolor/512x512/apps/mercury.png
+    addAutoPatchelfSearchPath $out/lib/mercury
+    substituteInPlace $out/bin/mercury-browser \
+      --replace 'export LD_LIBRARY_PATH' "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${
+        lib.makeLibraryPath buildInputs
+      }:$out/lib/mercury" \
+      --replace /usr $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Compiler-optimized private Firefox fork";
+    homepage = "https://thorium.rocks/mercury";
+    maintainers = with lib.maintainers; [ redxtech ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.mpl20;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "mercury-browser";
+  };
+}

--- a/pkgs/by-name/me/mercury-browser-bin/update.sh
+++ b/pkgs/by-name/me/mercury-browser-bin/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-prefetch
+
+set -e
+
+dirname="$(dirname "$0")"
+
+updateHash() {
+	version=$1
+	simd=$2
+
+	hashKey="${simd}_hash"
+
+	url="https://github.com/Alex313031/Mercury/releases/download/v.${version}/mercury-browser_${version}_${simd}.deb"
+	hash=$(nix-prefetch-url --type sha256 "$url")
+	sriHash="$(nix hash to-sri --type sha256 "$hash")"
+
+	sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
+}
+
+updateVersion() {
+	sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(grep -m 1 'version = ' <"$dirname/default.nix" | awk '{ print $3 }' | tr -d '";')
+latestTag=$(curl https://api.github.com/repos/Alex313031/Mercury/tags | jq -r '.[] | .name' | sort --version-sort | tail -1)
+latestVersion="$(expr "$latestTag" : 'v.\(.*\)')"
+
+echo "Current version: ${currentVersion}"
+echo "Latest version: ${latestVersion}"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+	echo "Mercury is up-to-date: ${currentVersion}"
+	exit 0
+fi
+
+updateVersion "$latestVersion"
+
+for simd in AVX2 AVX SSE4 SSE3; do
+	updateHash "$latestVersion" "$simd"
+done


### PR DESCRIPTION
## Description of changes

**Project description:**

Mercury is a firefox fork that implements patches that focus on speed, security, and privacy.

**Highlights:**
* Compiler optimizations include AVX, AES, LTO and PGO.
* Learn more about these compiler optimizations and how they work [Here](https://thorium.rocks/optimizations).
* [Patches and UI changes](https://github.com/Alex313031/Mercury/blob/main/docs/PATCHES.md) that enhance useability, and strengthen privacy/security.
Many of these come from LibreWolf, Waterfox, PlasmaFox, and GNU IceCat

**Homepage:** https://thorium.rocks/mercury

Thanks to @ProminentRetail for the initial `package.nix` file.

Closes #255399

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
