### PR TITLE
qdigidoc: 4.2.12 -> 4.4.0

### DIFF
--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 , fetchurl
 , cmake
+, flatbuffers
 , gettext
 , pkg-config
 , libdigidocpp
@@ -16,12 +17,12 @@
 
 mkDerivation rec {
   pname = "qdigidoc";
-  version = "4.2.12";
+  version = "4.4.0";
 
   src = fetchurl {
     url =
       "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4-${version}.tar.gz";
-    hash = "sha256-6bso1qvhVhbBfrcTq4S+aHtHli7X2A926N4r45ztq4E=";
+    hash = "sha256-5zo0yoY0wufm9DWRIccxJ5g4DXn75nT4fd2h+5QP4oQ=";
   };
 
   tsl = fetchurl {
@@ -37,6 +38,7 @@ mkDerivation rec {
   '';
 
   buildInputs = [
+    flatbuffers
     libdigidocpp
     opensc
     openldap


### PR DESCRIPTION
## Description of changes

Simple update.

Fixes #257461
cc @gekoke

Note to reviewers: running the program will create `~/.digidocpp`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): launched successfully without crashing
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).