### PR TITLE
python3Packages.flask-security-too: 5.1.2 -> 5.3.1

### DIFF
--- a/pkgs/development/python-modules/blinker/default.nix
+++ b/pkgs/development/python-modules/blinker/default.nix
@@ -2,23 +2,34 @@
 , buildPythonPackage
 , fetchPypi
 , pytestCheckHook
+, pythonOlder
+, setuptools
+, flit-core
+, pytest-asyncio
 }:
 
 buildPythonPackage rec {
   pname = "blinker";
-  version = "1.5";
+  version = "1.6.2";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kj5eL2nBVfLMQtr7vXDhbj/eJNLUqiq3L744YjiJJGI=";
+    hash = "sha256-Sv095m7zqfgGdVn7ehy+VVwX3L4VlxsF0bYlw+er4hM=";
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeBuildInputs = [
+    setuptools
+    flit-core
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook pytest-asyncio ];
 
   pythonImportsCheck = [ "blinker" ];
 
   meta = with lib; {
-    homepage = "https://pythonhosted.org/blinker/";
+    homepage = "https://github.com/pallets-eco/blinker";
     description = "Fast, simple object-to-object and broadcast signaling";
     license = licenses.mit;
     maintainers = with maintainers; [ ];

--- a/pkgs/development/python-modules/flask-login/default.nix
+++ b/pkgs/development/python-modules/flask-login/default.nix
@@ -2,7 +2,7 @@
 , asgiref
 , blinker
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , flask
 , pytestCheckHook
 , pythonAtLeast
@@ -13,15 +13,18 @@
 
 buildPythonPackage rec {
   pname = "flask-login";
-  version = "0.6.2";
+  version = "unstable-2023-10-17";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    pname = "Flask-Login";
-    inherit version;
-    hash = "sha256-wKe6qf3ESM3T3W8JOd9y7sUXey96vmy4L8k00pyqycM=";
+  src = fetchFromGitHub {
+    owner = "maxcountryman";
+    repo = pname;
+    # no new release since Jul 2022
+    # newer release needed for compatibility with newer flask
+    rev = "2204b4eee7b215977ba5a1bf85e2061f7fa65e20";
+    hash = "sha256-7QVPrD5AF1jb5czOh8FxAE778eyLDVhKIH5Mg77kiR4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/flask-mongoengine/default.nix
+++ b/pkgs/development/python-modules/flask-mongoengine/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "flask-mongoengine";
-  version = "1.0.0";
+  version = "unstable-2023-10-17";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -23,9 +23,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "MongoEngine";
     repo = pname;
-    rev = "refs/tags/v${version}";
-    hash = "sha256-YqEtW02VvEeUsLIHLz6+V6juMtWPEIk2tLoKTUdY6YE=";
+    # no new release since 2020. Mostly a dead project, but still used in current Flask applications.
+    # Newer release needed for compatibility with newer flask
+    rev = "d4526139cb1e2e94111ab7de96bb629d574c1690";
+    hash = "sha256-oMQU9Z8boc0q+0KzIQAZ8qSyxiITDY0M9FCg75S9MEY=";
   };
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "v1.0.0";
 
   nativeBuildInputs = [
     setuptools

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -21,6 +21,7 @@
 # extras: mfa
 , cryptography
 , phonenumbers
+, webauthn
 
 # propagates
 , blinker
@@ -31,10 +32,10 @@
 , flask-wtf
 , itsdangerous
 , passlib
+, importlib-resources
 
 # tests
 , argon2-cffi
-, flask-mongoengine
 , mongoengine
 , mongomock
 , peewee
@@ -46,15 +47,15 @@
 
 buildPythonPackage rec {
   pname = "flask-security-too";
-  version = "5.1.2";
-  format = "setuptools";
+  version = "5.3.1";
+  format = "pyproject";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "Flask-Security-Too";
     inherit version;
-    hash = "sha256-lZzm43m30y+2qjxNddFEeg9HDlQP9afq5VtuR25zaLc=";
+    hash = "sha256-Ha/gDGEc44Eef+Fobs13UJOIBqHsPFongYXzGViJXTw=";
   };
 
   postPatch = ''
@@ -71,6 +72,7 @@ buildPythonPackage rec {
     flask-wtf
     itsdangerous
     passlib
+    importlib-resources
   ];
 
   passthru.optional-dependencies = {
@@ -92,12 +94,12 @@ buildPythonPackage rec {
     mfa = [
       cryptography
       phonenumbers
+      webauthn
     ];
   };
 
   nativeCheckInputs = [
     argon2-cffi
-    flask-mongoengine
     mongoengine
     mongomock
     peewee
@@ -111,6 +113,10 @@ buildPythonPackage rec {
   ++ passthru.optional-dependencies.fsqla
   ++ passthru.optional-dependencies.mfa;
 
+  disabledTests = [
+    # needs a /etc/resolv.conf present
+    "test_login_email_whatever"
+  ];
 
   pythonImportsCheck = [
     "flask_security"

--- a/pkgs/development/python-modules/flask/default.nix
+++ b/pkgs/development/python-modules/flask/default.nix
@@ -10,6 +10,9 @@
 , werkzeug
 , pytestCheckHook
 , pythonOlder
+, flit-core
+, setuptools
+, blinker
   # used in passthru.tests
 , flask-limiter
 , flask-restful
@@ -19,19 +22,28 @@
 
 buildPythonPackage rec {
   pname = "flask";
-  version = "2.2.5";
+  version = "2.3.2";
+  format = "pyproject";
 
   src = fetchPypi {
     pname = "Flask";
     inherit version;
-    hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
+    hash = "sha256-jC+avUep6N9/DD8JHOlJfQEdw7Me/89MhabitQ9BFO8=";
   };
+
+  disabled = pythonOlder "3.8";
+
+  nativeBuildInputs = [
+    flit-core
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     click
     itsdangerous
     jinja2
     werkzeug
+    blinker
   ] ++ lib.optional (pythonOlder "3.10") importlib-metadata;
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/mongoengine/default.nix
+++ b/pkgs/development/python-modules/mongoengine/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "mongoengine";
-  version = "0.26.0";
+  version = "0.27.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "MongoEngine";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-mPz9Nyoyke++e9vBWSKunc9VGHCP8pbmldgKty5HIMA=";
+    hash = "sha256-UCd7RpsSNDKh3vgVRYrFYWYVLQuK7WI0n/Moukhq5dM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pymongo/default.nix
+++ b/pkgs/development/python-modules/pymongo/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pymongo";
-  version = "4.3.3";
+  version = "4.5.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-NOlf+wpov/vDtDfy0fJfyRb+899c3u0JktpfQvrpuAc=";
+    hash = "sha256-aB8lLkOz7wVMqRYWNfgbcw9NjK3Siz8rIAT1py+FOYI=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/werkzeug/default.nix
+++ b/pkgs/development/python-modules/werkzeug/default.nix
@@ -9,22 +9,28 @@
 , pytest-xprocess
 , pytestCheckHook
 , markupsafe
-# for passthru.tests
-, moto, sentry-sdk
+, setuptools
+  # for passthru.tests
+, moto
+, sentry-sdk
 }:
 
 buildPythonPackage rec {
   pname = "werkzeug";
-  version = "2.2.3";
-  format = "setuptools";
+  version = "2.3.3";
+  format = "pyproject";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "Werkzeug";
     inherit version;
-    hash = "sha256-LhzMlBfU2jWLnebxdOOsCUOR6h1PvvLWZ4ZdgZ39Cv4=";
+    hash = "sha256-qYfK8Qku3HUj7bE57bIMcFccSo1e7QLgtUe0c5F00JE=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     markupsafe


### PR DESCRIPTION
## Description of changes

Update of flask-security-too to 5.3.1 and the corresponding requirements. 

- `flask-mongoengine`: Update to a specific revision, since no new tag has been released since 2020. See also https://github.com/MongoEngine/flask-mongoengine/issues/525
- `mongoengine` [diff](https://github.com/MongoEngine/mongoengine/compare/v0.26.0...v0.27.0) and [Changelog](https://mongoengine-odm.readthedocs.io/changelog.html#changes-in-0-27-0)
- `werkzeug`: [Changelog](https://werkzeug.palletsprojects.com/en/2.3.x/changes/#version-2-3-3)
- `pymongo`: [Changelog](https://pymongo.readthedocs.io/en/stable/changelog.html#changes-in-version-4-5)
- `blinker`: [Changelog](https://blinker.readthedocs.io/en/stable/#version-1-6-2)
- `flask-login`: No new release tag since 2022. There are important PR's merged on master, which are required for compatibility (e.g. https://github.com/maxcountryman/flask-login/pull/778)
- `flask`: [Changelog](https://flask.palletsprojects.com/en/3.0.x/changes/#version-2-3-2)
- `flask-security-too`: [Changelog](https://github.com/Flask-Middleware/flask-security/blob/master/CHANGES.rst)

These cause a mass-rebuild. If needed this can be targeted at `staging`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
