### PR TITLE
alpine-make-rootfs: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3880,6 +3880,12 @@
     githubId = 50051176;
     name = "Daniel Rolls";
   };
+  danielsidhion = {
+    email = "nixpkgs@sidhion.com";
+    github = "DanielSidhion";
+    githubId = 160084;
+    name = "Daniel Sidhion";
+  };
   daniyalsuri6 = {
     email = "daniyal.suri@gmail.com";
     github = "daniyalsuri6";

--- a/pkgs/by-name/al/alpine-make-rootfs/package.nix
+++ b/pkgs/by-name/al/alpine-make-rootfs/package.nix
@@ -1,0 +1,33 @@
+{ stdenvNoCC, lib, fetchFromGitHub, makeWrapper, apk-tools, coreutils, findutils, gnugrep, gnused, gnutar, gzip, rsync, util-linux, wget
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "alpine-make-rootfs";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "alpinelinux";
+    repo = "alpine-make-rootfs";
+    rev = "v${version}";
+    hash = "sha256-B5qYQ6ah4hFZfb3S5vwgevh7aEHI3YGLoA+IyipaDck=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/alpine-make-rootfs --set PATH ${lib.makeBinPath [
+      apk-tools coreutils findutils gnugrep gnused gnutar gzip rsync util-linux wget
+    ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alpinelinux/alpine-make-rootfs";
+    description = "Make customized Alpine Linux rootfs (base image) for containers";
+    mainProgram = "alpine-make-rootfs";
+    maintainers = with maintainers; [ danielsidhion ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

[alpine-make-rootfs](https://github.com/alpinelinux/alpine-make-rootfs) is a tool a bit similar to the already-packaged [alpine-make-vm-image](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/virtualization/alpine-make-vm-image/default.nix). Instead of creating a full vm image, it only creates an Alpine Linux rootfs.

I've been using this already on my own projects, thought I'd package it to make it easy for others to use it as well.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
