### PR TITLE
update to fix logmein-hamachi/default.nix

### DIFF
--- a/pkgs/tools/networking/logmein-hamachi/default.nix
+++ b/pkgs/tools/networking/logmein-hamachi/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   version = "2.1.0.203";
 
   src = fetchurl {
-    url = "https://www.vpn.net/installers/${pname}-${version}-${arch}.tgz";
+    url = "https://vpn.net/installers/${pname}-${version}-${arch}.tgz";
     inherit sha256;
   };
 


### PR DESCRIPTION
## Problem Description
I recently tried to install the package `logmein-hamachi` in NixOS unstable and it kept telling me that it could not download the tgz file for the x64 linux file so i did some poking around and found that for some reason the `www.vpn.net` points to a diferent address  and the `vpn.net` points to the correct ip address so as a temporary workaround I added the ip to my hosts file and pointing the name `www.vpn.net` to the ip of `ven.net` fixed the issue locally as a quick hacky fix.


## Description of changes
changed the hard coded portion of the web address from `www.vpn.net` to `vpn.net`

## Things done
the changes were done on line 20 inside the `pkgs/tools/networking/logmein-hamachi/default.nix ` file in the `nixos-unstable` branch.
- This was the old line `url = "https://www.vpn.net/installers/${pname}-${version}-${arch}.tgz";`
- This is the fixed line `url = "https://vpn.net/installers/${pname}-${version}-${arch}.tgz";`

- Built on platform(s)
  - [x] x86_64-linux