### PR TITLE
llef: init at unstable-2023-10-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13609,6 +13609,13 @@
     githubId = 13149442;
     name = "Nico Pulido-Mateo";
   };
+  nrabulinski = {
+    email = "1337-nix@nrab.lol";
+    matrix = "@niko:nrab.lol";
+    github = "nrabulinski";
+    githubId = 24574288;
+    name = "Nikodem Rabuliński";
+  };
   nrdxp = {
     email = "tim.deh@pm.me";
     matrix = "@timdeh:matrix.org";

--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -59,6 +59,12 @@ in let
   inherit (releaseInfo) release_version version;
   inherit (import ../common/common-let.nix { inherit lib fetchFromGitHub release_version gitRelease officialRelease monorepoSrc'; }) llvm_meta monorepoSrc;
 
+  lldbPlugins = lib.makeExtensible (lldbPlugins: let
+    callPackage = newScope (lldbPlugins // { inherit stdenv; inherit (tools) lldb; });
+  in {
+    llef = callPackage ../common/lldb-plugins/llef.nix {};
+  });
+
   tools = lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake ninja libxml2 python3 release_version version monorepoSrc buildLlvmTools; });
     mkExtraBuildCommands0 = cc: ''
@@ -359,4 +365,4 @@ in let
   });
   noExtend = extensible: lib.attrsets.removeAttrs extensible [ "extend" ];
 
-in { inherit tools libraries release_version; } // (noExtend libraries) // (noExtend tools)
+in { inherit tools libraries release_version lldbPlugins; } // (noExtend libraries) // (noExtend tools)

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -59,6 +59,12 @@ in let
   inherit (releaseInfo) release_version version;
   inherit (import ../common/common-let.nix { inherit lib fetchFromGitHub release_version gitRelease officialRelease monorepoSrc'; }) llvm_meta monorepoSrc;
 
+  lldbPlugins = lib.makeExtensible (lldbPlugins: let
+    callPackage = newScope (lldbPlugins // { inherit stdenv; inherit (tools) lldb; });
+  in {
+    llef = callPackage ../common/lldb-plugins/llef.nix {};
+  });
+
   tools = lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake ninja libxml2 python3 release_version version monorepoSrc buildLlvmTools; });
     major = lib.versions.major release_version;
@@ -370,4 +376,4 @@ in let
   });
   noExtend = extensible: lib.attrsets.removeAttrs extensible [ "extend" ];
 
-in { inherit tools libraries release_version; } // (noExtend libraries) // (noExtend tools)
+in { inherit tools libraries release_version lldbPlugins; } // (noExtend libraries) // (noExtend tools)

--- a/pkgs/development/compilers/llvm/common/lldb-plugins/llef.nix
+++ b/pkgs/development/compilers/llvm/common/lldb-plugins/llef.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, lldb
+}:
+
+stdenv.mkDerivation {
+  pname = "llef";
+  version = "unstable-2023-10-18";
+
+  src = fetchFromGitHub {
+    owner = "foundryzero";
+    repo = "llef";
+    rev = "629bd75f44c356f7a3576a6436d3919ce111240d";
+    hash = "sha256-JtCHG89s436Di/6+V7Le4CZnkIPh/RYIllfXEO/B7+8";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/llef
+    cp -r llef.py arch commands common handlers $out/share/llef
+    makeWrapper ${lib.getExe lldb} $out/bin/llef \
+      --add-flags "-o 'settings set stop-disassembly-display never'" \
+      --add-flags "-o \"command script import $out/share/llef/llef.py\""
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "LLEF is a plugin for LLDB to make it more useful for RE and VR";
+    homepage = "https://github.com/foundryzero/llef";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ nrabulinski ];
+    mainProgram = "llef";
+  };
+}

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -176,6 +176,7 @@ stdenv.mkDerivation (rec {
     broken =
       (lib.versionOlder release_version "11" && stdenv.isDarwin && stdenv.isAarch64)
         || (((lib.versions.major release_version) == "13") && stdenv.isDarwin);
+    mainProgram = "lldb";
   };
 } // lib.optionalAttrs enableManpages {
   pname = "lldb-manpages";


### PR DESCRIPTION
## Description of changes

[LLEF](https://github.com/foundryzero/llef) is an LLDB plugin to make it more usable for low-level RE and VR. Similar to [GEF](https://github.com/hugsy/gef), but for LLDB.
I packaged it the same way we currently package similar GDB plugins, such as the aforementioned [GEF](https://github.com/NixOS/nixpkgs/blob/d26b6de226ec3248acdd930f7228f9bfd0f1e101/pkgs/development/tools/misc/gef/default.nix) or [pwndbg](https://github.com/NixOS/nixpkgs/blob/d26b6de226ec3248acdd930f7228f9bfd0f1e101/pkgs/development/tools/misc/pwndbg/default.nix). I did not need to add any Python dependencies as (at least as of now) LLEF doesn't need any.

I also added `meta.mainProgram` to `lldb` as I used `lib.getExe` as an argument to `makeWrapper`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
