### PR TITLE
Xfce updates 2023-10-18

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
@@ -2,6 +2,8 @@
 , mkXfceDerivation
 , glib
 , gtk3
+, gtk-layer-shell
+, libX11
 , libxfce4ui
 , vte
 , xfconf
@@ -15,9 +17,10 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-terminal";
-  version = "1.1.0";
+  version = "1.1.1";
+  odd-unstable = false;
 
-  sha256 = "sha256-ilxiP1Org5/uSQOzfRgODmouH0BmK3CmCJj1kutNuII=";
+  sha256 = "sha256-LDfZTZ2EaboIYz+xQNC2NKpJiN8qqfead2XzpKVpL6c=";
 
   nativeBuildInputs = [
     libxslt
@@ -28,6 +31,8 @@ mkXfceDerivation {
   buildInputs = [
     glib
     gtk3
+    gtk-layer-shell
+    libX11
     libxfce4ui
     vte
     xfconf

--- a/pkgs/desktops/xfce/core/xfce4-dev-tools/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-dev-tools/default.nix
@@ -14,9 +14,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-dev-tools";
-  version = "4.18.0";
+  version = "4.18.1";
 
-  sha256 = "sha256-VgQiTRMPD1VeUkUnFkX78C2VrsrXFWCdmupL8PQc7+c=";
+  sha256 = "sha256-JUyFlifNVhSnIMaI9qmgCtGIgkpmzYybMfuhPgJiDOg=";
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
## Description of changes

Long waited `XDT_CHECK_PACKAGE_BINARY` `XDT_CHECK_OPTIONAL_FEATURE` marco :upside_down_face: In theory we can starting looking at the xfce4-notifyd bump without using release tarballs next, basically I am watching actions from debian unstable since there is no "https://github.com/xfce-mirror/xfce4-terminal/commit/20dc2c2dddf88c775b617034736b583103e5a4cb" there yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
