### PR TITLE
mold: 2.2.0 -> 2.3.0 + set `allowedRequisites` to `null` for `useMoldLinker`

### DIFF
--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -11,6 +11,8 @@
 , zstd
 
 , buildPackages
+, clangStdenv
+, gccStdenv
 , hello
 , mold
 , mold-wrapped
@@ -89,11 +91,13 @@ stdenv.mkDerivation rec {
       in
       {
         version = testers.testVersion { package = mold; };
+      } // lib.optionalAttrs stdenv.isLinux {
+        adapter-gcc = helloTest "adapter-gcc" (hello.override (old: { stdenv = useMoldLinker gccStdenv; }));
+        adapter-llvm = helloTest "adapter-llvm" (hello.override (old: { stdenv = useMoldLinker clangStdenv; }));
         wrapped = helloTest "wrapped" (hello.overrideAttrs (previousAttrs: {
           nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [ mold-wrapped ];
           NIX_CFLAGS_LINK = toString (previousAttrs.NIX_CFLAGS_LINK or "") + " -fuse-ld=mold";
         }));
-        adapter = helloTest "adapter" (hello.override (old: { stdenv = useMoldLinker old.stdenv; }));
       };
   };
 

--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mold";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "rui314";
     repo = "mold";
     rev = "v${version}";
-    hash = "sha256-ePX80hzzIzSJdGUX96GyxYWcdbXxXyuyNQqj5RDSkKU=";
+    hash = "sha256-TgDGAYdJjqGQradB7UJlV2emvG7q4F9ctzPaGRUgvxU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -197,16 +197,10 @@ rec {
       '';
     };
   in stdenv.override (old: {
-    cc = stdenv.cc.override {
-      inherit bintools;
-    };
-    allowedRequisites =
-      (lib.optional (stdenv.allowedRequisites or null != null) stdenv.allowedRequisites)
-        ++ [ bintools pkgs.mold ]
-        # need to `outputSpecified = false` to make getLib work
-        ++ (builtins.map (p: lib.getLib (p // { outputSpecified = false; })) pkgs.mold.buildInputs);
-      # gcc >12.1.0 supports '-fuse-ld=mold'
-      # the wrap ld above in bintools supports gcc <12.1.0 and shouldn't harm >12.1.0
+    allowedRequisites = null;
+    cc = stdenv.cc.override { inherit bintools; };
+    # gcc >12.1.0 supports '-fuse-ld=mold'
+    # the wrap ld above in bintools supports gcc <12.1.0 and shouldn't harm >12.1.0
     # https://github.com/rui314/mold#how-to-use
     } // lib.optionalAttrs (stdenv.cc.isClang || (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12")) {
     mkDerivationFromStdenv = extendMkDerivationArgs old (args: {


### PR DESCRIPTION
## Description of changes

https://github.com/rui314/mold/releases/tag/v2.3.0

Fixes #261825.

@Artturin, would it be appropriate to set `allowedRequisites` to `null` for `useMoldLinker`? The explicit whitelist seems to be only causing troubles.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
