### PR TITLE
sd-image: remove populateFirmwareCommands in favor of firmwarePartitionContents

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image-aarch64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64.nix
@@ -1,6 +1,11 @@
 # To build, use:
 # nix-build nixos -I nixos-config=nixos/modules/installer/sd-card/sd-image-aarch64.nix -A config.system.build.sdImage
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
   imports = [
@@ -16,56 +21,63 @@
   # The serial ports listed here are:
   # - ttyS0: for Tegra (Jetson TX1)
   # - ttyAMA0: for QEMU's -machine virt
-  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
+  boot.kernelParams = [
+    "console=ttyS0,115200n8"
+    "console=ttyAMA0,115200n8"
+    "console=tty0"
+  ];
 
   sdImage = {
-    populateFirmwareCommands = let
-      configTxt = pkgs.writeText "config.txt" ''
-        [pi3]
-        kernel=u-boot-rpi3.bin
+    firmwarePartitionContents =
+      let
+        configTxt = pkgs.writeText "config.txt" ''
+          [pi3]
+          kernel=u-boot-rpi3.bin
 
-        # Otherwise the serial output will be garbled.
-        core_freq=250
+          # Otherwise the serial output will be garbled.
+          core_freq=250
 
-        [pi02]
-        kernel=u-boot-rpi3.bin
+          [pi02]
+          kernel=u-boot-rpi3.bin
 
-        [pi4]
-        kernel=u-boot-rpi4.bin
-        enable_gic=1
-        armstub=armstub8-gic.bin
+          [pi4]
+          kernel=u-boot-rpi4.bin
+          enable_gic=1
+          armstub=armstub8-gic.bin
 
-        # Otherwise the resolution will be weird in most cases, compared to
-        # what the pi3 firmware does by default.
-        disable_overscan=1
+          # Otherwise the resolution will be weird in most cases, compared to
+          # what the pi3 firmware does by default.
+          disable_overscan=1
 
-        # Supported in newer board revisions
-        arm_boost=1
+          # Supported in newer board revisions
+          arm_boost=1
 
-        [cm4]
-        # Enable host mode on the 2711 built-in XHCI USB controller.
-        # This line should be removed if the legacy DWC2 controller is required
-        # (e.g. for USB device mode) or if USB support is not required.
-        otg_mode=1
+          [cm4]
+          # Enable host mode on the 2711 built-in XHCI USB controller.
+          # This line should be removed if the legacy DWC2 controller is required
+          # (e.g. for USB device mode) or if USB support is not required.
+          otg_mode=1
 
-        [all]
-        # Boot in 64-bit mode.
-        arm_64bit=1
+          [all]
+          # Boot in 64-bit mode.
+          arm_64bit=1
 
-        # U-Boot needs this to work, regardless of whether UART is actually used or not.
-        # Look in arch/arm/mach-bcm283x/Kconfig in the U-Boot tree to see if this is still
-        # a requirement in the future.
-        enable_uart=1
+          # U-Boot needs this to work, regardless of whether UART is actually used or not.
+          # Look in arch/arm/mach-bcm283x/Kconfig in the U-Boot tree to see if this is still
+          # a requirement in the future.
+          enable_uart=1
 
-        # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
-        # when attempting to show low-voltage or overtemperature warnings.
-        avoid_warnings=1
-      '';
-      in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
+          # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
+          # when attempting to show low-voltage or overtemperature warnings.
+          avoid_warnings=1
+        '';
+      in
+      pkgs.runCommand "firmwarePartitionContents" { } ''
+        mkdir $out
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $out)
 
         # Add the config
-        cp ${configTxt} firmware/config.txt
+        cp ${configTxt} $out/config.txt
 
         # Add pi3 specific files
         cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
@@ -77,12 +89,12 @@
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2710-rpi-zero-2-w.dtb firmware/
 
         # Add pi4 specific files
-        cp ${pkgs.ubootRaspberryPi4_64bit}/u-boot.bin firmware/u-boot-rpi4.bin
-        cp ${pkgs.raspberrypi-armstubs}/armstub8-gic.bin firmware/armstub8-gic.bin
-        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-4-b.dtb firmware/
-        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-400.dtb firmware/
-        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-cm4.dtb firmware/
-        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-cm4s.dtb firmware/
+        cp ${pkgs.ubootRaspberryPi4_64bit}/u-boot.bin $out/u-boot-rpi4.bin
+        cp ${pkgs.raspberrypi-armstubs}/armstub8-gic.bin $out/armstub8-gic.bin
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-4-b.dtb $out
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-400.dtb $out
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-cm4.dtb $out
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-cm4s.dtb $out
       '';
     populateRootCommands = ''
       mkdir -p ./files/boot

--- a/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix
@@ -34,7 +34,7 @@
   ];
 
   sdImage = {
-    populateFirmwareCommands =
+    firmwarePartitionContents =
       let
         configTxt = pkgs.writeText "config.txt" ''
           # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
@@ -52,11 +52,12 @@
           enable_uart=1
         '';
       in
-      ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPi2}/u-boot.bin firmware/u-boot-rpi2.bin
-        cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin firmware/u-boot-rpi3.bin
-        cp ${configTxt} firmware/config.txt
+      pkgs.runCommand "firmwarePartitionContents" { } ''
+        mkdir $out
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $out)
+        cp ${pkgs.ubootRaspberryPi2}/u-boot.bin $out/u-boot-rpi2.bin
+        cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin $out/u-boot-rpi3.bin
+        cp ${configTxt} $out/config.txt
       '';
     populateRootCommands = ''
       mkdir -p ./files/boot

--- a/nixos/modules/installer/sd-card/sd-image-powerpc64le.nix
+++ b/nixos/modules/installer/sd-card/sd-image-powerpc64le.nix
@@ -29,7 +29,6 @@
   boot.kernelParams = [ "console=hvc0" ];
 
   sdImage = {
-    populateFirmwareCommands = "";
     populateRootCommands =
       ''
         mkdir -p ./files/boot

--- a/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
@@ -20,7 +20,7 @@
   boot.kernelPackages = pkgs.linuxKernel.packages.linux_rpi1;
 
   sdImage = {
-    populateFirmwareCommands =
+    firmwarePartitionContents =
       let
         configTxt = pkgs.writeText "config.txt" ''
           # u-boot refuses to start (gets stuck at rainbow polygon) without this,
@@ -38,11 +38,12 @@
           kernel=u-boot-rpi1.bin
         '';
       in
-      ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf *.dtb $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin firmware/u-boot-rpi0.bin
-        cp ${pkgs.ubootRaspberryPi}/u-boot.bin firmware/u-boot-rpi1.bin
-        cp ${configTxt} firmware/config.txt
+      pkgs.runCommand "firmwarePartitionContents" { } ''
+        mkdir $out
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $out)
+        cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin $out/u-boot-rpi0.bin
+        cp ${pkgs.ubootRaspberryPi}/u-boot.bin $out/u-boot-rpi1.bin
+        cp ${configTxt} $out/config.txt
       '';
     populateRootCommands = ''
       mkdir -p ./files/boot

--- a/nixos/modules/installer/sd-card/sd-image-riscv64-qemu.nix
+++ b/nixos/modules/installer/sd-card/sd-image-riscv64-qemu.nix
@@ -31,7 +31,6 @@
   ];
 
   sdImage = {
-    populateFirmwareCommands = "";
     populateRootCommands = ''
       mkdir -p ./files/boot
       ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot

--- a/nixos/modules/installer/sd-card/sd-image-x86_64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-x86_64.nix
@@ -23,7 +23,6 @@
   boot.consoleLogLevel = lib.mkDefault 7;
 
   sdImage = {
-    populateFirmwareCommands = "";
     populateRootCommands = ''
       mkdir -p ./files/boot
       ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot

--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -51,6 +51,22 @@ in
         "fileName"
       ];
     })
+    (mkRemovedOptionModule [ "sdImage" "populateFirmwareCommands" ] ''
+      Use sdImage.firmwarePartitionContents instead.
+
+      For example, if your sdImage.populateFirmwareCommands were:
+
+        '''
+          cp ''${pkgs.myBootLoader}/u-boot.bin firmware/
+        '''
+
+      You need to convert it to a derivation creating a directory:
+
+        pkgs.runCommand "myFirmware" {} '''
+          mkdir $out
+          cp ''${pkgs.myBootLoader}/u-boot.bin $out/
+        '''
+    '')
     ../../profiles/all-hardware.nix
     ../../image/file-options.nix
   ];
@@ -115,12 +131,17 @@ in
       '';
     };
 
-    populateFirmwareCommands = mkOption {
-      example = literalExpression "'' cp \${pkgs.myBootLoader}/u-boot.bin firmware/ ''";
+    firmwarePartitionContents = mkOption {
+      type = types.nullOr types.path;
+      default = null;
       description = ''
-        Shell commands to populate the ./firmware directory.
-        All files in that directory are copied to the
-        /boot/firmware partition on the SD image.
+        Directory representing /boot/firmware partition on the SD image.
+      '';
+      example = literalExpression ''
+        pkgs.runCommand "myFirmware" {} '''
+          mkdir $out
+          cp ''${pkgs.myBootLoader}/u-boot.bin $out/
+        '''
       '';
     };
 
@@ -251,9 +272,17 @@ in
 
         mkfs.vfat --invariant -i ${config.sdImage.firmwarePartitionID} -n ${config.sdImage.firmwarePartitionName} firmware_part.img
 
-        # Populate the files intended for /boot/firmware
-        mkdir firmware
-        ${config.sdImage.populateFirmwareCommands}
+        ${if (!isNull config.sdImage.firmwarePartitionContents)
+          then
+          ''
+          # Copy the files intended for /boot/firmware
+          test -d ${config.sdImage.firmwarePartitionContents} \
+              || (echo "Output of sdImage.firmwarePartitionContents is not a directory"; exit 1)
+          cp -rv ${config.sdImage.firmwarePartitionContents} firmware
+          ''
+          else
+          "mkdir firmware"
+        }
 
         find firmware -exec touch --date=2000-01-01 {} +
         # Copy the populated /boot/firmware into the SD image

--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -146,6 +146,7 @@ in
     };
 
     populateRootCommands = mkOption {
+      type = types.lines;
       example = literalExpression "''\${config.boot.loader.generic-extlinux-compatible.populateCmd} -c \${config.system.build.toplevel} -d ./files/boot''";
       description = ''
         Shell commands to populate the ./files directory.
@@ -156,6 +157,7 @@ in
     };
 
     postBuildCommands = mkOption {
+      type = types.lines;
       example = literalExpression "'' dd if=\${pkgs.myBootLoader}/SPL of=$img bs=1024 seek=1 conv=notrunc ''";
       default = "";
       description = ''


### PR DESCRIPTION
This converts `sdImage.populateFirmwareCommands` into a
derivation that can be used to obtain firmware partition contents.

For example for `sd-image-armv7l-multiplatform`,
given a `test_firmware.nix` file containing

```nix
{
  imports = [
    <nixpkgs/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix>
  ];
  nixpkgs = {
    crossSystem.system = "armv7l-linux";
    overlays = [
    ];
  };
}
```

we can now do

```sh
nix-build '<nixpkgs/nixos>' \
  -A config.sdImage.firmwarePartitionContents \
  -I nixos-config=./test_firmware.nix
```

## Description of changes

See above. Prior discussion at https://github.com/NixOS/nixpkgs/pull/241534#issuecomment-1764896962

Resolves https://github.com/NixOS/nixpkgs/issues/108048

CC @samueldr @SFrijters 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
