### PR TITLE
kak-lsp: fix build on Darwin

### DIFF
--- a/pkgs/tools/misc/kak-lsp/default.nix
+++ b/pkgs/tools/misc/kak-lsp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, Security, SystemConfiguration }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, CoreServices, Security, SystemConfiguration }:
 
 rustPlatform.buildRustPackage rec {
   pname = "kak-lsp";
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-g63Kfi4xJZO/+fq6eK2iB1dUGoSGWIIRaJr8BWO/txM=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreServices Security SystemConfiguration ];
 
   meta = with lib; {
     description = "Kakoune Language Server Protocol Client";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9734,7 +9734,7 @@ with pkgs;
   kaffeine = libsForQt5.callPackage ../applications/video/kaffeine { };
 
   kak-lsp = callPackage ../tools/misc/kak-lsp {
-    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+    inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
   };
 
   kakoune-cr = callPackage ../tools/misc/kakoune-cr { crystal = crystal_1_2; };


### PR DESCRIPTION
## Description of changes

Added required CoreServices dependency on Darwin (aarch64 at least). I'm not sure why it is now required and wasn't a few weeks ago -- presumably something about the Rust toolchain? Howerver, it does seems to be a legitamate dependency.

Without this, build fails with:

```
error: linking with `/nix/store/ybr7a0lvp4dzr14f1l3882x5qb68vkls-clang-wrapper-11.1.0/bin/cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/bin:/nix/store/8mdcavvgk4jf5blq6mspls97iki29l38-cargo-1.72.0/bin:/nix/store/8057g3ixa1i7bxbs43xpgydydl4avsgp-cargo-auditable-0.6.1/bin:/nix/store/qnfrjk7bpxanl6s60y2197q0r782h9q5-auditable-cargo-1.72.0/bin:/nix/store/8mdcavvgk4jf5blq6mspls97iki29l38-cargo-1.72.0/bin:/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/bin:/nix/store/ybr7a0lvp4dzr14f1l3882x5qb68vkls-clang-wrapper-11.1.0/bin:/nix/store/6m1ncyha74vyyksinykcsic5gc1b29i7-clang-11.1.0/bin:/nix/store/g9pvwpwpgkhzlq0kv4bbllclm18kv0gj-coreutils-9.3/bin:/nix/store/7yafaqqhz1i9s4jmsj51g28c22yhq3kq-cctools-binutils-darwin-wrapper-11.1.0-973.0.1/bin:/nix/store/5v4ycnqpfammvlwpadyc26by7hy604cz-cctools-binutils-darwin-11.1.0-973.0.1/bin:/nix/store/g9pvwpwpgkhzlq0kv4bbllclm18kv0gj-coreutils-9.3/bin:/nix/store/cnjxsppdzfbwvmkdrkpps6j75a2xqgks-findutils-4.9.0/bin:/nix/store/fmb75iiyrc7bhr0al97izqch5pzrh5dy-diffutils-3.10/bin:/nix/store/c9606i14wkrcjavx5kvhaghxfpgy204k-gnused-4.9/bin:/nix/store/xrqvjyn24z6ljnh9583c13iarks1faa3-gnugrep-3.11/bin:/nix/store/gg71r49xcnn2l565cwz11ws3q38liwdw-gawk-5.2.2/bin:/nix/store/h1y472wdyk5jn7qsgwhcblaj9j42xrx9-gnutar-1.35/bin:/nix/store/5m5mvssdqh2liqz0d6bhjp7sql1bsi62-gzip-1.13/bin:/nix/store/p2i1j2pj8wjmy445xjlcfzq64r7gad50-bzip2-1.0.8-bin/bin:/nix/store/221p2yp3dlb6dxr93iidq4gpx9i25n81-gnumake-4.4.1/bin:/nix/store/zqx1fik7mcyg1037s015kfbw2zq0qhqn-bash-5.2-p15/bin:/nix/store/9ahpbnv7xxyp72f6a08qm0pyrzg85l7x-patch-2.7.6/bin:/nix/store/nws79v3asz8a9cyyn8f76kwykjr6lhkb-xz-5.4.4-bin/bin:/nix/store/f2zhjzawah3klb72plmq79kldymn93gc-file-5.45/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/ybr7a0lvp4dzr14f1l3882x5qb68vkls-clang-wrapper-11.1.0/bin/cc" "-arch" "arm64" "/private/tmp/nix-build-kak-lsp-14.2.0.drv-0/rustcoRixb3/symbols.o" "/private/tmp/nix-build-kak-lsp-14.2.0.drv-0/source/target/aarch64-apple-darwin/release/deps/kak_lsp-e6562ae60fd40469.kak_lsp.f56ce52223958bad-cgu.04.rcgu.o" "-L" "/private/tmp/nix-build-kak-lsp-14.2.0.drv-0/source/target/aarch64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-kak-lsp-14.2.0.drv-0/source/target/release/deps" "-L" "/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/lib" "/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-9a5dde18cc747729.rlib" "-framework" "CoreFoundation" "-framework" "SystemConfiguration" "-framework" "CoreFoundation" "-framework" "CoreServices" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/private/tmp/nix-build-kak-lsp-14.2.0.drv-0/source/target/aarch64-apple-darwin/release/deps/kak_lsp-e6562ae60fd40469" "-Wl,-dead_strip" "-nodefaultlibs" "/private/tmp/nix-build-kak-lsp-14.2.0.drv-0/source/target/aarch64-apple-darwin/release/deps/kak_lsp_audit_data.o" "-Wl,-u,_AUDITABLE_VERSION_INFO"
  = note: ld: framework not found CoreServices
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `kak-lsp` (bin "kak-lsp") due to previous error
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [/] (Package updates) Added a release notes entry if the change is major or breaking
  - [/] (Module updates) Added a release notes entry if the change is significant
  - [/] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Note: Built with sandbox=true, even though not in nix.conf.

Without this, recent `master` started failing to build on Darwin with an error that CoreServices is not available.
With this, the build completes successfully again.


