### PR TITLE
chromium{Beta,Dev},google-chrome-{beta,dev}: drop

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -162,6 +162,10 @@
 
 - The `users.users.<name>.passwordFile` has been renamed to `users.users.<name>.hashedPasswordFile` to avoid possible confusions. The option is in fact the file-based version of `hashedPassword`, not `password`, and expects a file containing the {manpage}`crypt(3)` hash of the user password.
 
+- `chromiumBeta` and `chromiumDev` have been removed due to the lack of maintenance in nixpkgs. Consider using `chromium` instead.
+
+- `google-chrome-beta` and `google-chrome-dev` have been removed due to the lack of maintenance in nixpkgs. Consider using `google-chrome` instead.
+
 - The `services.ananicy.extraRules` option now has the type of `listOf attrs` instead of `string`.
 
 - `buildVimPluginFrom2Nix` has been renamed to `buildVimPlugin`, which now

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -151,10 +151,6 @@ def channel_name_to_attr_name(channel_name):
     """Maps a channel name to the corresponding main Nixpkgs attribute name."""
     if channel_name == 'stable':
         return 'chromium'
-    if channel_name == 'beta':
-        return 'chromiumBeta'
-    if channel_name == 'dev':
-        return 'chromiumDev'
     if channel_name == 'ungoogled-chromium':
         return 'ungoogled-chromium'
     print(f'Error: Unexpected channel: {channel_name}', file=sys.stderr)
@@ -204,6 +200,10 @@ with urlopen(RELEASES_URL) as resp:
         # If we've already found a newer release for this channel, we're
         # no longer interested in it.
         if channel_name in channels:
+            continue
+
+        # We only look for channels that are listed in our version pin file.
+        if channel_name not in last_channels:
             continue
 
         # If we're back at the last release we used, we don't need to

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,30 +1,4 @@
 {
-  beta = {
-    deps = {
-      gn = {
-        rev = "811d332bd90551342c5cbd39e133aa276022d7f8";
-        hash = "sha256-WCq+PNkWxWpssUOQyQbAZ5l6k+hg+qGMsoaMG0Ybj0o=";
-        url = "https://gn.googlesource.com/gn";
-        version = "2023-08-01";
-      };
-    };
-    hash = "sha256-spzY2u5Wk52BrKCk9aQOEp/gbppaGVLCQxXa+3JuajA=";
-    hash_deb_amd64 = "sha256-eTeEeNa4JuCW81+SUAyrKi3S0/TJNTAoTktWQ0JsgYc=";
-    version = "117.0.5938.22";
-  };
-  dev = {
-    deps = {
-      gn = {
-        rev = "cc56a0f98bb34accd5323316e0292575ff17a5d4";
-        hash = "sha256-SwlET5h5xtDlQvlt8wbG73ZfUWJr4hlWc+uQsBH5x9M=";
-        url = "https://gn.googlesource.com/gn";
-        version = "2023-08-10";
-      };
-    };
-    hash = "sha256-W0fZuvv9jz03ibQqB6MG45aw2zPklfxoFzZzr+kRuJk=";
-    hash_deb_amd64 = "sha256-XWxRFLFxBqnvKcoB5HErwVbtHCGYRteLeTv44zVMwIc=";
-    version = "118.0.5966.0";
-  };
   stable = {
     chromedriver = {
       hash_darwin = "sha256-ugsxRhIPtDD7Y4/PsIc8Apqrtyo4uiVKoLmtRvQaJ3k=";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -134,6 +134,8 @@ mapAliases ({
   chefdk = throw "chefdk has been removed due to being deprecated upstream by Chef Workstation"; # Added 2023-03-22
   chocolateDoom = chocolate-doom; # Added 2023-05-01
   chrome-gnome-shell = gnome-browser-connector; # Added 2022-07-27
+  chromiumBeta = throw "'chromiumBeta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18
+  chromiumDev = throw "'chromiumDev' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18
   citra = citra-nightly; # added 2022-05-17
   clang-ocl = throw "'clang-ocl' has been replaced with 'rocmPackages.clang-ocl'"; # Added 2023-10-08
   inherit (libsForQt5.mauiPackages) clip; # added 2022-05-17
@@ -317,6 +319,8 @@ mapAliases ({
   godot-headless = throw "godot-headless has been renamed to godot3-headless to distinguish from version 4"; # Added 2023-07-16
   godot-server = throw "godot-server has been renamed to godot3-server to distinguish from version 4"; # Added 2023-07-16
 
+  google-chrome-beta = throw "'google-chrome-beta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'google-chrome' instead."; # Added 2023-10-18
+  google-chrome-dev = throw "'google-chrome-dev' has been removed due to the lack of maintenance in nixpkgs. Consider using 'google-chrome' instead."; # Added 2023-10-18
   google-gflags = throw "'google-gflags' has been renamed to/replaced by 'gflags'"; # Converted to throw 2023-09-10
   go-thumbnailer = thud; # Added 2023-09-21
   gometer = throw "gometer has been removed from nixpkgs because goLance stopped offering Linux support"; # Added 2023-02-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30866,10 +30866,6 @@ with pkgs;
 
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
-  chromiumBeta = lowPrio (chromium.override { channel = "beta"; });
-
-  chromiumDev = lowPrio (chromium.override { channel = "dev"; });
-
   chuck = callPackage ../applications/audio/chuck {
     inherit (darwin) DarwinTools;
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon CoreAudio CoreMIDI CoreServices Kernel MultitouchSupport;
@@ -32269,10 +32265,6 @@ with pkgs;
   googleearth-pro = libsForQt5.callPackage ../applications/misc/googleearth-pro { };
 
   google-chrome = callPackage ../applications/networking/browsers/google-chrome { };
-
-  google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
-
-  google-chrome-dev = google-chrome.override { chromium = chromiumDev; channel = "dev"; };
 
   go-graft = callPackage ../applications/networking/go-graft { };
 


### PR DESCRIPTION
## Description of changes

This is mainly due to the lack of maintenance in nixpkgs. `google-chrome-{beta,dev}` depend on `chromium{Beta,Dev}`'s version info.

`chromium{Beta,Dev}` are rarely updated and explicitly blocklisted by `hydra.nixos.org`, meaning they are almost always outdated and not cached in `cache.nixos.org`.

`chromium{Beta,Dev}` were intended to fix the build derivation of each new major release (if something broke) *before* stable reached that new major release.
Allowing for fast bumps in nixpkgs, especially if the stable bump contains very important critical security fixes.

Something that can easily be replicated by using an early-stable release or by manually entering an dev/beta version string in stable's `upstream-info.nix`.

This resolves exposing end-users to outdated and vulnerable `google-chrome-{beta,dev}` and `chromium{Beta,Dev}` versions.

**Deadline: 2023-10-29 UTC** (which is one day before the "Restrict all breaking changes with the exception of desktop environments" in our `23.11` release schedule #258640).

Ref: #255197

cc (`chromium{,Beta,Dev}`): @primeos @thefloweringash @networkException @emilylange
cc (`google-chrome{,-beta,-dev}`): @primeos 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
