### PR TITLE
wdisplays: unstable-2021-04-03 -> 1.1.1

### DIFF
--- a/pkgs/tools/graphics/wdisplays/default.nix
+++ b/pkgs/tools/graphics/wdisplays/default.nix
@@ -1,23 +1,19 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, gtk3, libepoxy, wayland, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wdisplays";
-  version = "unstable-2021-04-03";
+  version = "1.1.1";
 
   nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
 
   buildInputs = [ gtk3 libepoxy wayland ];
 
   src = fetchFromGitHub {
-    owner = "luispabon";
+    owner = "artizirk";
     repo = "wdisplays";
-    rev = "7f2eac0d2aa81b5f495da7950fd5a94683f7868e";
-    sha256 = "sha256-cOF3+T34zPro58maWUouGG+vlLm2C5NfcH7PZhSvApE=";
+    rev = finalAttrs.version;
+    sha256 = "sha256-dtvP930ChiDRT60xq6xBDU6k+zHnkrAkxkKz2FxlzRs=";
   };
-
-  patchPhase = ''
-    substituteInPlace ./resources/wdisplays.desktop.in --replace "@app_id@" "wdisplays"
-  '';
 
   meta = with lib; {
     description = "A graphical application for configuring displays in Wayland compositors";
@@ -27,4 +23,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "wdisplays";
   };
-}
+})


### PR DESCRIPTION

## Description of changes
ChangeLogs:
* https://github.com/artizirk/wdisplays/releases/tag/1.1
* https://github.com/artizirk/wdisplays/releases/tag/1.1.1

The original repo re-appeared now[1], but I have zero reason to trust them to not delete it any time again. The fork I switched to after it disappeared back in 2021 was marked as archived a while later. The one that people contribute to and is also used by Fedora[2] and AUR[3] is artizirk/wdisplays which is used now.

[1] https://github.com/cyclopsian/wdisplays
[2] https://src.fedoraproject.org/rpms/wdisplays/blob/f09a1e35d560de153b1bc0939382c37e863e7137/f/wdisplays.spec
[3] https://aur.archlinux.org/packages/wdisplays

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
