### PR TITLE
lomiri.trust-store: init at unstable-2023-10-17

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -17,6 +17,7 @@ let
     gmenuharness = callPackage ./development/gmenuharness { };
     libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
+    trust-store = callPackage ./development/trust-store { };
     u1db-qt = callPackage ./development/u1db-qt { };
 
     #### QML / QML-related

--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -1,0 +1,119 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, testers
+, boost
+, cmake
+, cmake-extras
+, dbus
+, dbus-cpp
+, doxygen
+, gettext
+, glog
+, graphviz
+, gtest
+, libapparmor
+, newt
+, pkg-config
+, process-cpp
+, properties-cpp
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "trust-store";
+  version = "unstable-2023-10-17";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/trust-store";
+    rev = "7aa7ab5b7f3843e24c13ae6d9b8607455296d60e";
+    hash = "sha256-j+4FZzbG3qh1pGRapFuuMiwT4Lv9P6Ji9/3Z0uGvXmw=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+    "bin"
+  ];
+
+  postPatch = ''
+    # pkg-config patching hook expects prefix variable
+    substituteInPlace data/trust-store.pc.in \
+      --replace 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
+
+    substituteInPlace src/core/trust/terminal_agent.h \
+      --replace '/bin/whiptail' '${lib.getExe' newt "whiptail"}'
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    sed -i CMakeLists.txt -e '/add_subdirectory(tests)/d'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    gettext
+    graphviz
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    cmake-extras
+    dbus-cpp
+    glog
+    libapparmor
+    newt
+    process-cpp
+    properties-cpp
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    # Requires mirclient API, unavailable in Mir 2.x
+    # https://gitlab.com/ubports/development/core/trust-store/-/issues/2
+    "-DTRUST_STORE_MIR_AGENT_ENABLED=OFF"
+    "-DTRUST_STORE_ENABLE_DOC_GENERATION=ON"
+  ];
+
+  # Not working
+  # - remote_agent_test cases using unix domain socket fail to do *something*, with std::system_error "Invalid argument" + follow-up "No such file or directory".
+  #   potentially something broken/missing on our end
+  # - dbus_test hangs indefinitely waiting for a std::future, not provicient enough to debug this.
+  #   same hang on upstream CI
+  doCheck = false;
+
+  preCheck = ''
+    export XDG_DATA_HOME=$TMPDIR
+  '';
+
+  # Starts & talks to DBus
+  enableParallelChecking = false;
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    description = "Common implementation of a trust store to be used by trusted helpers";
+    homepage = "https://gitlab.com/ubports/development/core/trust-store";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "trust-store"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[trust-store](https://gitlab.com/ubports/development/core/trust-store), under Mir 1.x, lets applications spawn a prompt with elevated priority and persists their results. In our Mir 2.x world, it's lacking a Wayland implementation so it can only spawn a new terminal with a `whiplash` TUI prompt. Will be used by Lomiri's location service and the security & privacy plugin for the system settings app.

I have been unable to get the tests fully working. `dbus_test` seems generally busted even on upstream's CI, hanging indefinitely waiting for (I think) some DBus call/signal. The UnixDomainSocket\* parts of `remote_agent_test` seemingly fail with a `std::system_error: Invalid argument` happening when `boost::asio::write`ing to come child process' socket. I don't understand enough C++, Boost, Unix sockets etc to say what the problem is, nor do I have enough spare time to debug this right now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  They all need very specific arguments to not instantly throw exceptions & exit, builds further down the line can seemingly call them properly though.
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
