### PR TITLE
lomiri.mediascanner2: init at 0.115

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -26,6 +26,7 @@ let
     biometryd = callPackage ./services/biometryd { };
     hfd-service = callPackage ./services/hfd-service { };
     lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
+    mediascanner2 = callPackage ./services/mediascanner2 { };
   };
 in
   lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -1,0 +1,122 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, boost
+, cmake
+, cmake-extras
+, dbus
+, dbus-cpp
+, gdk-pixbuf
+, glib
+, gst_all_1
+, gtest
+, libapparmor
+, libexif
+, pkg-config
+, properties-cpp
+, qtbase
+, qtdeclarative
+, shared-mime-info
+, sqlite
+, taglib
+, udisks
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mediascanner2";
+  version = "0.115";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/mediascanner2";
+    rev = finalAttrs.version;
+    hash = "sha256-UEwFe65VB2asxQhuWGEAVow/9rEvZxry4dd2/60fXN4=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postPatch = ''
+    substituteInPlace src/qml/MediaScanner.*/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+
+    # Lomiri desktop doesn't identify itself under Canonical's name anymore
+    substituteInPlace src/daemon/scannerdaemon.cc \
+      --replace 'Unity8' 'Lomiri'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gst_all_1.gstreamer # GST_PLUGIN_SYSTEM_PATH_1_0 setup hook
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost
+    cmake-extras
+    dbus
+    dbus-cpp
+    gdk-pixbuf
+    glib
+    libapparmor
+    libexif
+    properties-cpp
+    qtbase
+    qtdeclarative
+    shared-mime-info
+    sqlite
+    taglib
+    udisks
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+  ]);
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export XDG_DATA_DIRS=${shared-mime-info}/share:$XDG_DATA_DIRS
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+      --prefix XDG_DATA_DIRS : ${shared-mime-info}/share
+    )
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Media scanner service & access library";
+    homepage = "https://gitlab.com/ubports/development/core/mediascanner2";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    mainProgram = "mediascanner-service-2.0";
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "mediascanner-2.0"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[mediascanner2](https://gitlab.com/ubports/development/core/mediascanner2) is a service that scans & indexes media files on the system. Lomiri's music app will use it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
