### PR TITLE
gdc: 11.4.0 -> 13.2.0, bootstrap from gdc11

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -243,6 +243,9 @@ let
     ]
     ++ lib.optionals (langD) [
       "--with-target-system-zlib=yes"
+      # libphobos is only enabled by default on a handful of tested platforms.
+      # it is required to bootstrap gdc>=12
+      "--enable-libphobos"
     ]
     # On mips64-unknown-linux-gnu libsanitizer defines collide with
     # glibc's definitions and fail the build. It was fixed in gcc-13+.

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -30,6 +30,7 @@
 , javaAwtGtk ? false
 , langAda ? false
 , langGo ? false
+, langD ? false, gdc ? null
 , withoutTargetLibc ? null
 , threadsCross ? null
 }:
@@ -52,6 +53,7 @@ in
   ++ optionals javaAwtGtk [ pkg-config ]
   ++ optionals (with stdenv.targetPlatform; isVc4 || isRedox && flex != null) [ flex ]
   ++ optionals langAda [ gnat-bootstrap ]
+  ++ optionals (langD && lib.versionAtLeast version "12") [ gdc ]
   # The builder relies on GNU sed (for instance, Darwin's `sed' fails with
   # "-i may not be used with stdin"), and `stdenvNative' doesn't provide it.
   ++ optionals buildPlatform.isDarwin [ gnused ]

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -3,6 +3,7 @@
 , version, buildPlatform, hostPlatform, targetPlatform
 , gnat-bootstrap ? null
 , langAda ? false
+, langD ? false, gdc ? null
 , langFortran
 , langJava ? false
 , langJit ? false
@@ -14,7 +15,10 @@
 }:
 
 assert langJava -> lib.versionOlder version "7";
-assert langAda -> gnat-bootstrap != null; let
+assert langAda -> gnat-bootstrap != null;
+assert langD && lib.versionAtLeast version "12" -> gdc != null;
+
+let
   needsLib
     =  (lib.versionOlder version "7" && (langJava || langGo))
     || (lib.versions.major version == "4" && lib.versions.minor version == "9" && targetPlatform.isDarwin);
@@ -27,6 +31,8 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
   export lib=$out;
 '' + lib.optionalString langAda ''
   export PATH=${gnat-bootstrap}/bin:$PATH
+'' + lib.optionalString (langD && lib.versionAtLeast version "12") ''
+  export PATH=${gdc}/bin:$PATH
 ''
 
 # For a cross-built native compiler, i.e. build!=(host==target), the

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -3,7 +3,7 @@
 , langAda ? false
 , langObjC ? stdenv.targetPlatform.isDarwin
 , langObjCpp ? stdenv.targetPlatform.isDarwin
-, langD ? false
+, langD ? false, gdc ? null
 , langGo ? false
 , reproducibleBuild ? true
 , profiledCompiler ? false
@@ -94,9 +94,7 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 assert langGo -> langCC;
 assert (atLeast6 && !is7 && !is8) -> (langAda -> gnat-bootstrap != null);
 
-# TODO: fixup D bootstapping, probably by using gdc11 (and maybe other changes).
-#   error: GDC is required to build d
-assert atLeast12 -> !langD;
+assert atLeast12 -> (langD -> gdc != null);
 
 # threadsCross is just for MinGW
 assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
@@ -152,6 +150,7 @@ let inherit version;
         enableShared
         fetchpatch
         fetchurl
+        gdc
         gettext
         gmp
         gnat-bootstrap

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -126,6 +126,9 @@ in
 # Fix detection of bootstrap compiler Ada support (cctools as) on Nix Darwin
 ++ optional (atLeast12 && stdenv.isDarwin && langAda) ./ada-cctools-as-detection-configure.patch
 
+# Fix detection of bootstrap compiler GDC support (cctools as) on Nix Darwin
+++ optional (atLeast12 && stdenv.isDarwin && langD) ./gdc-cctools-as-detection-configure.patch
+
 # Use absolute path in GNAT dylib install names on Darwin
 ++ optional (atLeast12 && stdenv.isDarwin && langAda) ./gnat-darwin-dylib-install-name.patch
 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -74,7 +74,7 @@ in
 ++ optional langFortran (if atLeast12 then ./gcc-12-gfortran-driving.patch else ./gfortran-driving.patch)
 ++ optional atLeast7 ./ppc-musl.patch
 ++ optional is12 ./12/lambda-ICE-PR109241.patch # backport ICE fix on ccache code
-++ optional (atLeast9 && langD) ./libphobos.patch
+++ optional (atLeast9 && langD) (if atLeast13 then ./gcc-13-libphobos.patch else ./libphobos.patch)
 
 
 

--- a/pkgs/development/compilers/gcc/patches/gcc-13-libphobos.patch
+++ b/pkgs/development/compilers/gcc/patches/gcc-13-libphobos.patch
@@ -116,3 +116,15 @@ index 925c53c5f..b4bbde11a 100755
  
  ac_ext=d
  ac_compile='$GDC -c $GDCFLAGS conftest.$ac_ext >&5'
+diff --git a/libphobos/libdruntime/Makefile.in b/libphobos/libdruntime/Makefile.in
+index 797d6435a..ec5776f93 100644
+--- a/libphobos/libdruntime/Makefile.in
++++ b/libphobos/libdruntime/Makefile.in
+@@ -2488,6 +2488,7 @@ uninstall-am: uninstall-toolexeclibDATA \
+ 
+ .PRECIOUS: Makefile
+ 
++.NOTPARALLEL:
+ 
+ # Compile D into normal object files
+ .d.o:

--- a/pkgs/development/compilers/gcc/patches/gcc-13-libphobos.patch
+++ b/pkgs/development/compilers/gcc/patches/gcc-13-libphobos.patch
@@ -1,0 +1,118 @@
+diff --git a/Makefile.in b/Makefile.in
+index 06a9398e1..3f788feaf 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -869,7 +869,7 @@ BASE_FLAGS_TO_PASS = \
+ 	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
+ 	"GNATBIND=$(GNATBIND)" \
+ 	"GNATMAKE=$(GNATMAKE)" \
+-	"GDC=$(GDC)" \
++	"`echo 'GDC=$(GDC)' | sed -e 's/-idirafter [^ ]*//g'`" \
+ 	"GDCFLAGS=$(GDCFLAGS)" \
+ 	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
+ 	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
+@@ -883,7 +883,7 @@ BASE_FLAGS_TO_PASS = \
+ 	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
+ 	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
+ 	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
+-	"GDC_FOR_TARGET=$(GDC_FOR_TARGET)" \
++	"`echo 'GDC_FOR_TARGET=$(GDC_FOR_TARGET)' | sed -e 's/-idirafter [^ ]*//g'`" \
+ 	"GDCFLAGS_FOR_TARGET=$(GDCFLAGS_FOR_TARGET)" \
+ 	"GM2_FOR_TARGET=$(GM2_FOR_TARGET)" \
+ 	"GM2FLAGS_FOR_TARGET=$(GM2FLAGS_FOR_TARGET)" \
+@@ -959,7 +959,7 @@ EXTRA_HOST_FLAGS = \
+ 	'DSYMUTIL=$(DSYMUTIL)' \
+ 	'GFORTRAN=$(GFORTRAN)' \
+ 	'GOC=$(GOC)' \
+-	'GDC=$(GDC)' \
++	"`echo 'GDC=$(GDC)' | sed -e 's/-idirafter [^ ]*//g'`" \
+ 	'GM2=$(GM2)' \
+ 	'LD=$(LD)' \
+ 	'LIPO=$(LIPO)' \
+@@ -1040,8 +1040,11 @@ EXTRA_TARGET_FLAGS = \
+ 	'STAGE1_LDFLAGS=$$(POSTSTAGE1_LDFLAGS)' \
+ 	'STAGE1_LIBS=$$(POSTSTAGE1_LIBS)' \
+ 	"TFLAGS=$$TFLAGS"
++EXTRA_TARGET_FLAGS_D = \
++	"`echo $(EXTRA_TARGET_FLAGS) | sed -e 's/-idirafter [^ ]*//g'`"
+ 
+ TARGET_FLAGS_TO_PASS = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS)
++TARGET_FLAGS_TO_PASS_D = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS_D)
+ 
+ # Flags to pass down to gcc.  gcc builds a library, libgcc.a, so it
+ # unfortunately needs the native compiler and the target ar and
+@@ -53638,7 +53641,7 @@ check-target-libphobos:
+ 	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
+ 	$(NORMAL_TARGET_EXPORTS) \
+ 	(cd $(TARGET_SUBDIR)/libphobos && \
+-	  $(MAKE) $(TARGET_FLAGS_TO_PASS)   check)
++	  $(MAKE) $(TARGET_FLAGS_TO_PASS_D)   check)
+ 
+ @endif target-libphobos
+ 
+@@ -53653,7 +53656,7 @@ install-target-libphobos: installdirs
+ 	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
+ 	$(NORMAL_TARGET_EXPORTS) \
+ 	(cd $(TARGET_SUBDIR)/libphobos && \
+-	  $(MAKE) $(TARGET_FLAGS_TO_PASS)  install)
++	  $(MAKE) $(TARGET_FLAGS_TO_PASS_D)  install)
+ 
+ @endif target-libphobos
+ 
+@@ -53668,7 +53671,7 @@ install-strip-target-libphobos: installdirs
+ 	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
+ 	$(NORMAL_TARGET_EXPORTS) \
+ 	(cd $(TARGET_SUBDIR)/libphobos && \
+-	  $(MAKE) $(TARGET_FLAGS_TO_PASS)  install-strip)
++	  $(MAKE) $(TARGET_FLAGS_TO_PASS_D)  install-strip)
+ 
+ @endif target-libphobos
+ 
+diff --git a/Makefile.tpl b/Makefile.tpl
+index dfbd74b68..0d065ab34 100644
+--- a/Makefile.tpl
++++ b/Makefile.tpl
+@@ -797,8 +797,11 @@ EXTRA_TARGET_FLAGS = \
+ 	'STAGE1_LDFLAGS=$$(POSTSTAGE1_LDFLAGS)' \
+ 	'STAGE1_LIBS=$$(POSTSTAGE1_LIBS)' \
+ 	"TFLAGS=$$TFLAGS"
++EXTRA_TARGET_FLAGS_D = \
++	"`echo $(EXTRA_TARGET_FLAGS) | sed -e 's/-idirafter [^ ]*//g'`"
+ 
+ TARGET_FLAGS_TO_PASS = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS)
++TARGET_FLAGS_TO_PASS_D = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS_D)
+ 
+ # Flags to pass down to gcc.  gcc builds a library, libgcc.a, so it
+ # unfortunately needs the native compiler and the target ar and
+diff --git a/libphobos/Makefile.in b/libphobos/Makefile.in
+index 8d62c31da..c34d7072b 100644
+--- a/libphobos/Makefile.in
++++ b/libphobos/Makefile.in
+@@ -376,6 +376,7 @@ AM_MAKEFLAGS = \
+ 	"LIBCFLAGS=$(LIBCFLAGS)" \
+ 	"LIBCFLAGS_FOR_TARGET=$(LIBCFLAGS_FOR_TARGET)" \
+ 	"MAKE=$(MAKE)" \
++	"`echo 'MAKEFLAGS=$(MAKEFLAGS)' | sed -e 's/-j[0-9]+/-j1/'`" \
+ 	"MAKEINFO=$(MAKEINFO) $(MAKEINFOFLAGS)" \
+ 	"PICFLAG=$(PICFLAG)" \
+ 	"PICFLAG_FOR_TARGET=$(PICFLAG_FOR_TARGET)" \
+@@ -705,6 +706,7 @@ uninstall-am:
+ 
+ .PRECIOUS: Makefile
+ 
++.NOTPARALLEL:
+ 
+ # GNU Make needs to see an explicit $(MAKE) variable in the command it
+ # runs to enable its job server during parallel builds.  Hence the
+diff --git a/libphobos/configure b/libphobos/configure
+index 925c53c5f..b4bbde11a 100755
+--- a/libphobos/configure
++++ b/libphobos/configure
+@@ -5138,6 +5138,7 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
++GDC=`$as_echo "$GDC" | sed -e 's/-idirafter [^ ]*//g'`
+ 
+ ac_ext=d
+ ac_compile='$GDC -c $GDCFLAGS conftest.$ac_ext >&5'

--- a/pkgs/development/compilers/gcc/patches/gdc-cctools-as-detection-configure.patch
+++ b/pkgs/development/compilers/gcc/patches/gdc-cctools-as-detection-configure.patch
@@ -1,0 +1,20 @@
+As originally implemented, the error message check
+described in the configure script
+breaks detection of Ada compiler support on x86_64-darwin,
+because the assembler in the version of cctools currently used
+unconditionally emits a deprecation message to stdout,
+with no way to disable it.
+diff --git a/configure b/configure
+index 117a7ef23..a98af1b85 100755
+--- a/configure
++++ b/configure
+@@ -5692,8 +5692,7 @@ module conftest; int main() { return 0; }
+ EOF
+ acx_cv_d_compiler_works=no
+ if test "x$GDC" != xno; then
+-  errors=`(${GDC} -c conftest.d) 2>&1 || echo failure`
+-  if test x"$errors" = x && test -f conftest.$ac_objext; then
++  if ${GDC} -c conftest.d && test -f conftest.$ac_objext; then
+     acx_cv_d_compiler_works=yes
+   fi
+   rm -f conftest.*

--- a/pkgs/development/compilers/gcc/patches/libphobos.patch
+++ b/pkgs/development/compilers/gcc/patches/libphobos.patch
@@ -117,3 +117,16 @@ index b3cb5f3..25adf2b 100755
  
  ac_ext=d
  ac_compile='$GDC -c $GDCFLAGS conftest.$ac_ext >&5'
+diff --git a/libphobos/libdruntime/Makefile.in b/libphobos/libdruntime/Makefile.in
+index cb2e372bc..02f79faf4 100644
+--- a/libphobos/libdruntime/Makefile.in
++++ b/libphobos/libdruntime/Makefile.in
+@@ -2329,6 +2329,8 @@ uninstall-am: uninstall-toolexeclibDATA \
+ .PRECIOUS: Makefile
+ 
+ 
++.NOTPARALLEL:
++
+ # Compile D into normal object files
+ .d.o:
+ 	$(GDC) $(GDCFLAGS) $(MULTIFLAGS) $(D_EXTRA_DFLAGS) -c -o $@ $<

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16245,15 +16245,34 @@ with pkgs;
   gcc-arm-embedded-12 = callPackage ../development/compilers/gcc-arm-embedded/12 { };
   gcc-arm-embedded = gcc-arm-embedded-12;
 
-  # It would be better to match the default gcc so that there are no linking errors
-  # when using C/C++ libraries in D packages, but right now versions >= 12 are broken.
-  gdc = gdc11;
+  # Has to match the default gcc so that there are no linking errors when
+  # using C/C++ libraries in D packages
+  gdc = gdc13;
   gdc11 = wrapCC (gcc11.cc.override {
     name = "gdc";
-    langCC = false;
-    langC = false;
+    langCC = true; # required to bootstrap newer gdc
+    langC = true;
     langD = true;
     profiledCompiler = false;
+    gdc = null; # gdc>=12 requires gdc to bootstrap
+  });
+
+  gdc12 = wrapCC (gcc12.cc.override {
+    name = "gdc";
+    langCC = true;
+    langC = true;
+    langD = true;
+    profiledCompiler = false;
+    gdc = gdc11; # gdc>=12 requires gdc to bootstrap
+  });
+
+  gdc13 = wrapCC (gcc13.cc.override {
+    name = "gdc";
+    langCC = true;
+    langC = true;
+    langD = true;
+    profiledCompiler = false;
+    gdc = gdc11; # gdc>=12 requires gdc to bootstrap
   });
 
   gforth = callPackage ../development/compilers/gforth { };
@@ -38442,7 +38461,9 @@ with pkgs;
 
   tinyfugue = callPackage ../games/tinyfugue { };
 
-  titanion = callPackage ../games/titanion { };
+  titanion = callPackage ../games/titanion {
+    gdc = gdc11;
+  };
 
   tome2 = callPackage ../games/tome2 { };
 
@@ -38452,13 +38473,17 @@ with pkgs;
     SDL2_image = SDL2_image_2_0_5;
   };
 
-  torus-trooper = callPackage ../games/torus-trooper { };
+  torus-trooper = callPackage ../games/torus-trooper {
+    gdc = gdc11;
+  };
 
   trackballs = callPackage ../games/trackballs { };
 
   try = callPackage ../tools/admin/try { };
 
-  tumiki-fighters = callPackage ../games/tumiki-fighters { };
+  tumiki-fighters = callPackage ../games/tumiki-fighters {
+    gdc = gdc11;
+  };
 
   tuxpaint = callPackage ../games/tuxpaint { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16255,6 +16255,9 @@ with pkgs;
     langD = true;
     profiledCompiler = false;
     gdc = null; # gdc>=12 requires gdc to bootstrap
+  } // {
+    # GDC doesn't support aarch64-darwin yet
+    meta.broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   });
 
   gdc12 = wrapCC (gcc12.cc.override {
@@ -16264,6 +16267,16 @@ with pkgs;
     langD = true;
     profiledCompiler = false;
     gdc = gdc11; # gdc>=12 requires gdc to bootstrap
+    stdenv =
+      if stdenv.hostPlatform == stdenv.targetPlatform
+         && stdenv.buildPlatform == stdenv.hostPlatform
+         && stdenv.buildPlatform.isDarwin
+         && stdenv.buildPlatform.isx86_64
+      then overrideCC stdenv gdc11
+      else stdenv;
+  } // {
+    # GDC doesn't support aarch64-darwin yet
+    meta.broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   });
 
   gdc13 = wrapCC (gcc13.cc.override {
@@ -16273,6 +16286,16 @@ with pkgs;
     langD = true;
     profiledCompiler = false;
     gdc = gdc11; # gdc>=12 requires gdc to bootstrap
+    stdenv =
+      if stdenv.hostPlatform == stdenv.targetPlatform
+         && stdenv.buildPlatform == stdenv.hostPlatform
+         && stdenv.buildPlatform.isDarwin
+         && stdenv.buildPlatform.isx86_64
+      then overrideCC stdenv gdc11
+      else stdenv;
+  } // {
+    # GDC doesn't support aarch64-darwin yet
+    meta.broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   });
 
   gforth = callPackage ../development/compilers/gforth { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Bootstraps gdc12 and gdc13 from gdc11
- Makes gdc13 the default

Related to #241628 #174125

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
