### PR TITLE
themix-gui: init at 1.15.1

### DIFF
--- a/pkgs/by-name/th/themix-gui/package.nix
+++ b/pkgs/by-name/th/themix-gui/package.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, sassc
+, gdk-pixbuf
+, glib
+, gobject-introspection
+, librsvg
+, gtk3
+, python3
+, fetchFromGitHub
+, wrapGAppsHook
+}:
+
+let
+  py = python3.withPackages (p: [
+    p.pygobject3
+  ]);
+  pname = "themix-gui";
+  version = "1.15.1";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "themix-project";
+    repo = "themix-gui";
+    rev = version;
+    hash = "sha256-xFtwNx1c7Atb+9yorZhs/uVkkoxbZiELJ0SZ88L7KMs=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    py
+    sassc
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    glib
+    gtk3
+    librsvg
+    py
+  ];
+
+  postPatch = ''
+    substituteInPlace gui.sh packaging/bin/{oomox,themix}-gui --replace python3 ${lib.getExe py}
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    make DESTDIR=/ APPDIR=$out/opt/oomox PREFIX=$out install_gui install_import_xresources install_export_xresources
+    python -O -m compileall $out/opt/oomox/oomox_gui -d /opt/oomox/oomox_gui
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Graphical application for designing themes and exporting them using plugins";
+    longDescription = ''
+      Graphical application for generating different color variations of
+      Oomox (Numix-based) and Materia (ex-Flat-Plat) themes (GTK2, GTK3,
+      Cinnamon, GNOME, Openbox, Xfwm), Archdroid, Gnome-Color, Numix, Papirus
+      and Suru++ icon themes. Have a hack for HiDPI in gtk2. Its Base16 plugin
+      also allowing a lot of app themes support like Alacritty, Emacs, GTK4,
+      KDE, VIM and many more.
+    '';
+    homepage = "https://github.com/themix-project/themix-gui";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "themix-gui";
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds themix-gui, including oomox-gui; project page at https://github.com/themix-project/themix-gui.
Fixes #151564.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
