### PR TITLE
cgal_5: 5.5.2 → 5.5.3

### DIFF
--- a/pkgs/development/libraries/CGAL/default.nix
+++ b/pkgs/development/libraries/CGAL/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchFromGitHub
+, fetchurl
 , cmake
 , boost
 , gmp
@@ -8,13 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "cgal";
-  version = "5.5.2";
+  version = "5.5.3";
 
-  src = fetchFromGitHub {
-    owner = "CGAL";
-    repo = "releases";
-    rev = "CGAL-${version}";
-    sha256 = "sha256-olMPT/8Q0bf+rooJoNc0k8NrO//O7z0yqBoP8KX39yQ=";
+  src = fetchurl {
+    url = "https://github.com/CGAL/cgal/releases/download/v${version}/CGAL-${version}.tar.xz";
+    hash = "sha256-CgT2YmkyVjKLBbq/q7XjpbfbL1pY1S48Ug350IKN3XM=";
   };
 
   # note: optional component libCGAL_ImageIO would need zlib and opengl;


### PR DESCRIPTION
## Description of changes

Bug-fix release: https://www.cgal.org/2023/07/28/cgal553/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
