### PR TITLE
python311Packages.psycopg2: fix cross

### DIFF
--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -8,6 +8,7 @@
 , openssl
 , sphinxHook
 , sphinx-better-theme
+, buildPackages
 }:
 
 buildPythonPackage rec {
@@ -19,20 +20,29 @@ buildPythonPackage rec {
   # c.f. https://github.com/NixOS/nixpkgs/pull/104151#issuecomment-729750892
   disabled = pythonOlder "3.6" || isPyPy;
 
+  outputs = [ "out" "doc" ];
+
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-pSRtLmg6ly4hh6hxS1ws+BVsBkYp+amxqHPBcw2eJFo=";
   };
 
-  outputs = [ "out" "doc" ];
+  postPatch = ''
+    # Preferably upstream would not depend on pg_config because config scripts are incompatible with cross-compilation, however postgresql's pc file is lacking information.
+    # some linker flags are added but the linker ignores them because they're incompatible
+    # https://github.com/psycopg/psycopg2/blob/89005ac5b849c6428c05660b23c5a266c96e677d/setup.py
+    substituteInPlace setup.py \
+      --replace "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${lib.getExe' buildPackages.postgresql "pg_config"}"'
+  '';
 
   nativeBuildInputs = [
-    postgresql
     sphinxHook
     sphinx-better-theme
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = [
+    postgresql
+  ] ++ lib.optionals stdenv.isDarwin [
     openssl
   ];
 
@@ -44,6 +54,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "psycopg2"
   ];
+
+  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ buildPackages.postgresql ];
 
   meta = with lib; {
     description = "PostgreSQL database adapter for the Python programming language";


### PR DESCRIPTION
```nix
> /nix/store/iipxk03rab2vagl196i084b4918a65pn-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: skipping incompatible /nix/store/sk7c7f10fxn7iypqgaaq9l0s9ipkk0mc-postgresql-14.9-lib/lib/libpq.so when searching for -lpq
> /nix/store/iipxk03rab2vagl196i084b4918a65pn-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: cannot find -lpq: No such file or directory
> /nix/store/iipxk03rab2vagl196i084b4918a65pn-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: skipping incompatible /nix/store/sk7c7f10fxn7iypqgaaq9l0s9ipkk0mc-postgresql-14.9-lib/lib/libpq.so when searching for -lpq
```

Closes https://github.com/NixOS/nixpkgs/pull/262010

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
