### PR TITLE
nixos/firefox: preserve old wrapper args when overriding

### DIFF
--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -220,23 +220,20 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [
-      (cfg.package.override {
+      (cfg.package.override (old: {
         extraPrefs = cfg.autoConfig;
-        extraNativeMessagingHosts = with pkgs; optionals nmh.ff2mpv [
-          ff2mpv
-        ] ++ optionals nmh.euwebid [
-          web-eid-app
-        ] ++ optionals nmh.gsconnect [
-          gnomeExtensions.gsconnect
-        ] ++ optionals nmh.jabref [
-          jabref
-        ] ++ optionals nmh.passff [
-          passff-host
-        ];
+        extraNativeMessagingHosts =
+          old.extraNativeMessagingHosts or []
+          ++ optional nmh.ff2mpv ff2mpv
+          ++ optional nmh.euwebid web-eid-app
+          ++ optional nmh.gsconnect gnomeExtensions.gsconnect
+          ++ optional nmh.jabref jabref
+          ++ optional nmh.passff passff-host;
         cfg = let
           # copy-pasted from the wrapper; TODO: figure out fix
           applicationName = cfg.package.binaryName or (lib.getName cfg.package);
 
+          oldCfg = old.cfg or {};
           nixpkgsConfig = pkgs.config.${applicationName} or {};
           optionConfig = cfg.wrapperConfig;
           nmhConfig = {
@@ -246,8 +243,8 @@ in
             enableUgetIntegrator = nmh.ugetIntegrator;
             enableFXCastBridge = nmh.fxCast;
           };
-        in nixpkgsConfig // optionConfig // nmhConfig;
-      })
+        in oldCfg // nixpkgsConfig // optionConfig // nmhConfig;
+      }))
     ];
 
     environment.etc =


### PR DESCRIPTION
Also some drive-by cleanups

## Description of changes

Fixes cases like

```nix
programs.firefox = {
  enable = true;
  package = pkgs.firefox.override { cfg.enableGnomeExtensions = true; };
};
```

Previously the override for `cfg` would get silently eaten.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
