### PR TITLE
release: block on `aarch64` on `*-darwin` channels

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -87,55 +87,101 @@ let
       lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
       pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
 
-      darwin-tested = if supportDarwin.x86_64 then pkgs.releaseTools.aggregate
+      darwin-tested = if supportDarwin.x86_64 || supportDarwin.aarch64 then pkgs.releaseTools.aggregate
         { name = "nixpkgs-darwin-${jobs.tarball.version}";
           meta.description = "Release-critical builds for the Nixpkgs darwin channel";
-          constituents =
-            [ jobs.tarball
-              jobs.release-checks
-              jobs.cabal2nix.x86_64-darwin
-              jobs.ghc.x86_64-darwin
-              jobs.git.x86_64-darwin
-              jobs.go.x86_64-darwin
-              jobs.mariadb.x86_64-darwin
-              jobs.nix.x86_64-darwin
-              jobs.nixpkgs-review.x86_64-darwin
-              jobs.nix-info.x86_64-darwin
-              jobs.nix-info-tested.x86_64-darwin
-              jobs.openssh.x86_64-darwin
-              jobs.openssl.x86_64-darwin
-              jobs.pandoc.x86_64-darwin
-              jobs.postgresql.x86_64-darwin
-              jobs.python3.x86_64-darwin
-              jobs.ruby.x86_64-darwin
-              jobs.rustc.x86_64-darwin
-              # blocking ofBorg CI 2020-02-28
-              # jobs.stack.x86_64-darwin
-              jobs.stdenv.x86_64-darwin
-              jobs.vim.x86_64-darwin
-              jobs.cachix.x86_64-darwin
-              jobs.darwin.linux-builder.x86_64-darwin
+          constituents = [
+            jobs.tarball
+            jobs.release-checks
+          ]
+          ++ optionals supportDarwin.x86_64 [
+            jobs.cabal2nix.x86_64-darwin
+            jobs.ghc.x86_64-darwin
+            jobs.git.x86_64-darwin
+            jobs.go.x86_64-darwin
+            jobs.mariadb.x86_64-darwin
+            jobs.nix.x86_64-darwin
+            jobs.nixpkgs-review.x86_64-darwin
+            jobs.nix-info.x86_64-darwin
+            jobs.nix-info-tested.x86_64-darwin
+            jobs.openssh.x86_64-darwin
+            jobs.openssl.x86_64-darwin
+            jobs.pandoc.x86_64-darwin
+            jobs.postgresql.x86_64-darwin
+            jobs.python3.x86_64-darwin
+            jobs.ruby.x86_64-darwin
+            jobs.rustc.x86_64-darwin
+            # blocking ofBorg CI 2020-02-28
+            # jobs.stack.x86_64-darwin
+            jobs.stdenv.x86_64-darwin
+            jobs.vim.x86_64-darwin
+            jobs.cachix.x86_64-darwin
+            jobs.darwin.linux-builder.x86_64-darwin
 
-              # UI apps
-              # jobs.firefox-unwrapped.x86_64-darwin
-              jobs.qt5.qtmultimedia.x86_64-darwin
-              jobs.inkscape.x86_64-darwin
-              jobs.gimp.x86_64-darwin
-              jobs.emacs.x86_64-darwin
-              jobs.wireshark.x86_64-darwin
-              jobs.transmission_3-gtk.x86_64-darwin
-              jobs.transmission_4-gtk.x86_64-darwin
+            # UI apps
+            # jobs.firefox-unwrapped.x86_64-darwin
+            jobs.qt5.qtmultimedia.x86_64-darwin
+            jobs.inkscape.x86_64-darwin
+            jobs.gimp.x86_64-darwin
+            jobs.emacs.x86_64-darwin
+            jobs.wireshark.x86_64-darwin
+            jobs.transmission_3-gtk.x86_64-darwin
+            jobs.transmission_4-gtk.x86_64-darwin
 
-              # Tests
-              /*
-              jobs.tests.cc-wrapper.default.x86_64-darwin
-              jobs.tests.cc-wrapper.llvmPackages.clang.x86_64-darwin
-              jobs.tests.cc-wrapper.llvmPackages.libcxx.x86_64-darwin
-              jobs.tests.stdenv-inputs.x86_64-darwin
-              jobs.tests.macOSSierraShared.x86_64-darwin
-              jobs.tests.stdenv.hooks.patch-shebangs.x86_64-darwin
-              */
-            ];
+            # Tests
+            /*
+            jobs.tests.cc-wrapper.default.x86_64-darwin
+            jobs.tests.cc-wrapper.llvmPackages.clang.x86_64-darwin
+            jobs.tests.cc-wrapper.llvmPackages.libcxx.x86_64-darwin
+            jobs.tests.stdenv-inputs.x86_64-darwin
+            jobs.tests.macOSSierraShared.x86_64-darwin
+            jobs.tests.stdenv.hooks.patch-shebangs.x86_64-darwin
+            */
+          ]
+          ++ optionals supportDarwin.aarch64 [
+            jobs.cabal2nix.aarch64-darwin
+            jobs.ghc.aarch64-darwin
+            jobs.git.aarch64-darwin
+            jobs.go.aarch64-darwin
+            jobs.mariadb.aarch64-darwin
+            jobs.nix.aarch64-darwin
+            jobs.nixpkgs-review.aarch64-darwin
+            jobs.nix-info.aarch64-darwin
+            jobs.nix-info-tested.aarch64-darwin
+            jobs.openssh.aarch64-darwin
+            jobs.openssl.aarch64-darwin
+            jobs.pandoc.aarch64-darwin
+            jobs.postgresql.aarch64-darwin
+            jobs.python3.aarch64-darwin
+            jobs.ruby.aarch64-darwin
+            jobs.rustc.aarch64-darwin
+            # blocking ofBorg CI 2020-02-28
+            # jobs.stack.aarch64-darwin
+            jobs.stdenv.aarch64-darwin
+            jobs.vim.aarch64-darwin
+            jobs.cachix.aarch64-darwin
+            jobs.darwin.linux-builder.aarch64-darwin
+
+            # UI apps
+            # jobs.firefox-unwrapped.aarch64-darwin
+            jobs.qt5.qtmultimedia.aarch64-darwin
+            jobs.inkscape.aarch64-darwin
+            jobs.gimp.aarch64-darwin
+            jobs.emacs.aarch64-darwin
+            jobs.wireshark.aarch64-darwin
+            jobs.transmission_3-gtk.aarch64-darwin
+            jobs.transmission_4-gtk.aarch64-darwin
+
+            # Tests
+            /*
+            jobs.tests.cc-wrapper.default.aarch64-darwin
+            jobs.tests.cc-wrapper.llvmPackages.clang.aarch64-darwin
+            jobs.tests.cc-wrapper.llvmPackages.libcxx.aarch64-darwin
+            jobs.tests.stdenv-inputs.aarch64-darwin
+            jobs.tests.macOSSierraShared.aarch64-darwin
+            jobs.tests.stdenv.hooks.patch-shebangs.aarch64-darwin
+            */
+          ];
         } else null;
 
       unstable = pkgs.releaseTools.aggregate


### PR DESCRIPTION
## Description of changes

As of #260429, `aarch64` blocks on `nixpkgs-unstable` and it would be great for stable users if it also applied to `nixpkgs-23.05-darwin` 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).