### PR TITLE
passExtensions.pass-file: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17109,6 +17109,12 @@
     githubId = 1901799;
     name = "Nathan van Doorn";
   };
+  taranarmo = {
+    email = "taranarmo@gmail.com";
+    github = "taranarmo";
+    githubId = 11619234;
+    name = "Sergey Volkov";
+  };
   tari = {
     email = "peter@taricorp.net";
     github = "tari";

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -12,4 +12,5 @@ with pkgs;
   pass-tomb = callPackage ./tomb.nix {};
   pass-update = callPackage ./update.nix {};
   pass-genphrase = callPackage ./genphrase.nix {};
+  pass-file = callPackage ./file.nix {};
 }

--- a/pkgs/tools/security/pass/extensions/file.nix
+++ b/pkgs/tools/security/pass/extensions/file.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "pass-file";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dvogt23";
+    repo = pname;
+    rev = version;
+    hash = "sha256-18KvmcfLwelyk9RV/IMaj6O/nkQEQz84eUEB/mRaKE4=";
+  };
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "A pass extension that allows to add files to password-store.";
+    homepage = "https://github.com/dvogt23/pass-file";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ taranarmo ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Pass extension to save files inside its storage
https://github.com/dvogt23/pass-file
It is a bash file and subcommand of pass. I am new to the NixOS thus I wasn't able to connect the extension to pass to test it properly. Though makefile was provided by the author and I used it to build the package.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
