### PR TITLE
nixos/top-level: fail more helpfully on forbidden dependencies 

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -68,16 +68,23 @@ let
     else showWarnings config.warnings baseSystem;
 
   # Replace runtime dependencies
-  system = foldr ({ oldDependency, newDependency }: drv:
+  systemWithReplacedDependencies = foldr ({ oldDependency, newDependency }: drv:
       pkgs.replaceDependency { inherit oldDependency newDependency drv; }
     ) baseSystemAssertWarn config.system.replaceRuntimeDependencies;
 
-  systemWithBuildDeps = system.overrideAttrs (o: {
-    systemBuildClosure = pkgs.closureInfo { rootPaths = [ system.drvPath ]; };
-    buildCommand = o.buildCommand + ''
-      ln -sn $systemBuildClosure $out/build-closure
-    '';
-  });
+  system = systemWithReplacedDependencies.overrideAttrs (o:
+    lib.optionalAttrs config.system.includeBuildDependencies {
+      systemBuildClosure = pkgs.closureInfo { rootPaths = [ system.drvPath ]; };
+      buildCommand = o.buildCommand + ''
+        ln -sn $systemBuildClosure $out/build-closure
+      '';
+    } // lib.optionalAttrs (config.system.forbiddenDependenciesRegex != "") rec {
+      systemWithoutExtraDependencies = systemWithReplacedDependencies.overrideAttrs (_: { systemWithoutExtraDependencies = null; extraDependencies = []; closureInfo = null; });
+      closureInfo = pkgs.closureInfo { rootPaths = [
+        # override to avoid infinite recursion (and to allow using extraDependencies to add forbidden dependencies)
+        systemWithoutExtraDependencies
+      ]; };
+    });
 
 in
 
@@ -167,6 +174,8 @@ in
       description = lib.mdDoc ''
         A POSIX Extended Regular Expression that matches store paths that
         should not appear in the system closure, with the exception of {option}`system.extraDependencies`, which is not checked.
+
+        Similar to the disallowedRequisites field on derivations.
       '';
     };
 
@@ -293,7 +302,11 @@ in
         ''
           if [[ $forbiddenDependenciesRegex != "" && -n $closureInfo ]]; then
             if forbiddenPaths="$(grep -E -- "$forbiddenDependenciesRegex" $closureInfo/store-paths)"; then
-              echo -e "System closure $out contains the following disallowed paths:\n$forbiddenPaths"
+              ${config.nix.package}/bin/nix-store --load-db < $closureInfo/registration --store $PWD
+              echo "System depends on paths forbidden by system.forbiddenDependenciesRegex:"
+              for path in $forbiddenPaths; do
+                PAGER= ${config.nix.package}/bin/nix --offline --store $PWD why-depends --experimental-features nix-command $systemWithoutExtraDependencies $path
+              done
               exit 1
             fi
           fi
@@ -321,14 +334,9 @@ in
     }
     // lib.optionalAttrs (config.system.forbiddenDependenciesRegex != "") {
       inherit (config.system) forbiddenDependenciesRegex;
-      closureInfo = pkgs.closureInfo { rootPaths = [
-        # override to avoid  infinite recursion (and to allow using extraDependencies to add forbidden dependencies)
-        (config.system.build.toplevel.overrideAttrs (_: { extraDependencies = []; closureInfo = null; }))
-      ]; };
     };
 
-
-    system.build.toplevel = if config.system.includeBuildDependencies then systemWithBuildDeps else system;
+    system.build.toplevel = system;
 
   };
 


### PR DESCRIPTION
## Description of changes

The forbiddenDependenciesRegex option is useful for detecting unwanted dependencies, but not particularly helpful at discovering why they exist. This PR improves the situation using `nix why-depends` (in an awfully hacky, but working, way).

cc @nikstur with whom I came up with this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
