### PR TITLE
tokyo-night-gtk: unstable-2023-01-17 -> unstable-2023-05-30

### DIFF
--- a/pkgs/data/themes/tokyo-night-gtk/default.nix
+++ b/pkgs/data/themes/tokyo-night-gtk/default.nix
@@ -6,13 +6,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "tokyo-night-gtk";
-  version = "2023.01.17";
+  version = "unstable-2023-05-30";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Tokyo-Night-GTK-Theme";
-    rev = "f7ae3421ac0d415ca57fb6224e093e12b8a980bb";
-    sha256 = "sha256-90V55pRfgiaP1huhD+3456ziJ2EU24iNQHt5Ro+g+M0=";
+    rev = "e9790345a6231cd6001f1356d578883fac52233a";
+    hash = "sha256-Q9UnvmX+GpvqSmTwdjU4hsEsYhA887wPqs5pyqbIhmc=";
   };
 
   propagatedUserEnvPkgs = [

--- a/pkgs/data/themes/tokyo-night-gtk/generic.nix
+++ b/pkgs/data/themes/tokyo-night-gtk/generic.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, writeScript
+, gtk-engine-murrine
+, gnome-themes-extra
+, prefix ? ""
+, type ? ""
+, variantName ? ""
+, variant ? ""
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "${prefix}_${type}-${variantName}";
+  version = "unstable-2023-05-30";
+
+  src = fetchFromGitHub {
+    owner = "Fausto-Korpsvart";
+    repo = "Tokyo-Night-GTK-Theme";
+    rev = "e9790345a6231cd6001f1356d578883fac52233a";
+    hash = "sha256-Q9UnvmX+GpvqSmTwdjU4hsEsYhA887wPqs5pyqbIhmc=";
+  };
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+    gnome-themes-extra
+  ];
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/{${type},${prefix}}
+    cp -a ${type}/Tokyonight-${variant} $out/share/${type}
+    cp -a LICENSE $out/share/${prefix}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl common-updater-scripts tree jq
+      res="$(curl ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+        -sL "https://api.github.com/repos/${finalAttrs.src.owner}/${finalAttrs.src.repo}/commits/HEAD")"
+
+      rev="$(echo $res | jq '.sha' --raw-output)"
+      version="unstable-$(echo $res | jq '.commit | .author | .date' --raw-output | sed 's/T.*$//')"
+      update-source-version ${prefix}-variants.${type}.${variantName} "$version" "$rev" --ignore-same-hash
+
+      commonjq1='.[] .contents .[] | {(.name): .name} | walk(if type=="object" then with_entries(.key|=ascii_downcase) else . end)'
+      commonjq2='reduce inputs as $in (.; . + $in)'
+      commontree="-dJ -L 1 --noreport ${finalAttrs.src}"
+
+      echo $(tree $commontree/icons | jq "$commonjq1" | jq "$commonjq2" | jq '{icons: .}') \
+        $(tree $commontree/themes | jq "$commonjq1" | jq "$commonjq2" | jq '{themes: .}') | \
+        jq 'reduce inputs as $in (.; . + $in)' | sed "s/[tT]okyonight-//g" > \
+        "$(git rev-parse --show-toplevel)/pkgs/data/themes/${prefix}/variants.json"
+    '';
+
+    # For "full" in default.nix
+    ptype = type;
+    pvariant = variant;
+  };
+
+  meta = with lib; {
+    description = "A GTK theme based on the Tokyo Night colour palette";
+    homepage = "https://www.pling.com/p/1681315";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ garaiza-93 Madouura ];
+  };
+})

--- a/pkgs/data/themes/tokyo-night-gtk/variants.json
+++ b/pkgs/data/themes/tokyo-night-gtk/variants.json
@@ -1,0 +1,18 @@
+{
+  "icons": {
+    "dark": "Dark",
+    "dark-cyan": "Dark-Cyan",
+    "light": "Light",
+    "moon": "Moon"
+  },
+  "themes": {
+    "dark-b": "Dark-B",
+    "dark-bl": "Dark-BL",
+    "dark-b-lb": "Dark-B-LB",
+    "dark-bl-lb": "Dark-BL-LB",
+    "storm-b": "Storm-B",
+    "storm-bl": "Storm-BL",
+    "storm-b-lb": "Storm-B-LB",
+    "storm-bl-lb": "Storm-BL-LB"
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35884,7 +35884,9 @@ with pkgs;
 
   tofi = callPackage ../applications/misc/tofi { };
 
-  tokyo-night-gtk = callPackage ../data/themes/tokyo-night-gtk { };
+  tokyo-night-gtk = tokyo-night-gtk-variants.full;
+
+  tokyo-night-gtk-variants = recurseIntoAttrs (callPackage ../data/themes/tokyo-night-gtk { });
 
   topydo = callPackage ../applications/misc/topydo { };
 


### PR DESCRIPTION
## Description of changes
[tokyo-night-gtk: refactor and alias to tokyo-night-gtk-packages.full](https://github.com/NixOS/nixpkgs/commit/1e62b5b22ef0d7f0db1e316ae3ae57fb1d1a8b87)

Why do we do this? This package has a LOT of files!
The user may not need some of these themes and icons and the ~100k extra files in them.
Why not just use passthru for these? See: #211340

```console
nix-repl> np = (import /home/mado/Documents/Development/nixpkgs { }).pkgsCross.aarch64-multiplatform
nix-repl> np.__splicedPackages.tokyo-night-gtk ? __spliced                                           
true
nix-repl> np.__splicedPackages.tokyo-night-gtk-packages.full ? __spliced
true
nix-repl> np.__splicedPackages.tokyo-night-gtk-packages.icons.dark ? __spliced
true
nix-repl> np.__splicedPackages.tokyo-night-gtk-packages.themes.dark-b ? __spliced
true
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
