### PR TITLE
python311Packages.pysequoia: 0.1.14 -> 0.1.20

### DIFF
--- a/pkgs/development/python-modules/pysequoia/default.nix
+++ b/pkgs/development/python-modules/pysequoia/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitLab
+, fetchPypi
 , pkg-config
 , rustPlatform
 , cargo
@@ -15,20 +15,18 @@
 
 buildPythonPackage rec {
   pname = "pysequoia";
-  version = "0.1.14";
+  version = "0.1.20";
   format = "pyproject";
 
-  src = fetchFromGitLab {
-    owner = "sequoia-pgp";
-    repo = "pysequoia";
-    rev = "v${version}";
-    hash = "sha256-63kUUxZTG33cB/IiD4AiDpLOI6Uew/fETgqhaGc7zp0=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KavsLp17e4ckX11B0pefiQ1Hma/O9x0VY/uVPiJm4Fs=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-S/j3bGgU46nvVQFs35ih05teVEIJrFN4Ryq4B7rLFDE=";
+    hash = "sha256-7Lw6gR6o2HJ/zyG4b0wz4nmU2AIIAhyK9zaQ6w+/RgE=";
   };
 
   nativeBuildInputs = [
@@ -54,6 +52,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This library provides OpenPGP facilities in Python through the Sequoia PGP library";
+    downloadPage = "https://codeberg.org/wiktor/pysequoia";
     homepage = "https://sequoia-pgp.gitlab.io/pysequoia";
     license = licenses.asl20;
     maintainers = with maintainers; [ doronbehar ];

--- a/pkgs/development/python-modules/pysequoia/default.nix
+++ b/pkgs/development/python-modules/pysequoia/default.nix
@@ -11,6 +11,7 @@
 , pcsclite
 , stdenv
 , darwin
+, libiconv
 }:
 
 buildPythonPackage rec {
@@ -46,6 +47,7 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.CoreFoundation
     darwin.apple_sdk.frameworks.Security
+    libiconv
   ];
 
   pythonImportsCheck = [ "pysequoia" ];
@@ -56,5 +58,7 @@ buildPythonPackage rec {
     homepage = "https://sequoia-pgp.gitlab.io/pysequoia";
     license = licenses.asl20;
     maintainers = with maintainers; [ doronbehar ];
+    # Broken since the 0.1.20 update according to ofborg. The errors are not clear...
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

The source has moved away from gitlab but keeps releasing on pypi, so use that source for the updated version. No packaging changes otherwise.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

 Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python310Packages.pysequoia</li>
    <li>python310Packages.pysequoia.dist</li>
    <li>python311Packages.pysequoia</li>
    <li>python311Packages.pysequoia.dist</li>
  </ul>
</details>
