### PR TITLE
xfce.xfce4-notifyd: 0.8.2 -> 0.9.2

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
@@ -1,9 +1,12 @@
 { lib
 , mkXfceDerivation
+, dbus
 , glib
 , gtk3
+, gtk-layer-shell
 , libcanberra-gtk3
 , libnotify
+, libX11
 , libxfce4ui
 , libxfce4util
 , sqlite
@@ -14,15 +17,19 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-notifyd";
-  version = "0.8.2";
+  version = "0.9.2";
+  odd-unstable = false;
 
-  sha256 = "sha256-M8L2HWTuQDl/prD7s6uptkW4XDscpk6fc+epoxjFNS8=";
+  sha256 = "sha256-BHhz5LURXLeILxQ+iNQ+50yHd/oIF7twHAqxiBQ2hFE=";
 
   buildInputs = [
+    dbus
     gtk3
+    gtk-layer-shell
     glib
     libcanberra-gtk3
     libnotify
+    libX11
     libxfce4ui
     libxfce4util
     sqlite


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfce4-notifyd/-/compare/xfce4-notifyd-0.8.2...xfce4-notifyd-0.9.2

## Description of changes

https://repology.org/project/xfce4-notifyd/history says this is stable release, we should no longer have issue building this after x-d-t 4.18.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
