### PR TITLE
raspberrypi-eeprom: 2023.01.11-138c0 -> 2023.10.30-2712

### DIFF
--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -54,6 +54,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Installation scripts and binaries for the closed sourced Raspberry Pi 4 EEPROMs";
     homepage = "https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md";
     license = with licenses; [ bsd3 unfreeRedistributableFirmware ];
-    maintainers = with maintainers; [ das_j ];
+    maintainers = with maintainers; [ das_j Luflosi ];
   };
 }

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -3,13 +3,13 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";
-  version = "2023.10.18-2712";
+  version = "2023.10.30-2712";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
     rev = "refs/tags/v${version}";
-    hash = "sha256-jjiEGhqRUHR/GPNTNVbJ3yZZLf+o1S8LDsPk7mwWw1I=";
+    hash = "sha256-TKvby0qIXidM5Qk7q+ovLk0DpHsCbdQe7xndrgKrSXk=";
   };
 
   buildInputs = [ python3 ];

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -3,13 +3,13 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";
-  version = "2023.01.11-138c0";
+  version = "2023.10.18-2712";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
-    rev = "v${version}";
-    hash = "sha256-z3VyqdSkvxAgVmtMI/Is9qYrOeDXlyVLwHSSC2+AxcA=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jjiEGhqRUHR/GPNTNVbJ3yZZLf+o1S8LDsPk7mwWw1I=";
   };
 
   buildInputs = [ python3 ];
@@ -24,18 +24,21 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/rpi-eeprom
+    mkdir -p "$out/bin"
+    cp rpi-eeprom-config rpi-eeprom-update rpi-eeprom-digest "$out/bin"
 
-    cp rpi-eeprom-config rpi-eeprom-update rpi-eeprom-digest $out/bin
-    cp -r firmware/{beta,critical,old,stable} $out/share/rpi-eeprom
-    cp -P firmware/default firmware/latest $out/share/rpi-eeprom
+    mkdir -p "$out/lib/firmware/raspberrypi"
+    for dirname in firmware-*; do
+        dirname_suffix="''${dirname/#firmware-}"
+        cp -rP "$dirname" "$out/lib/firmware/raspberrypi/bootloader-$dirname_suffix"
+    done
   '';
 
   fixupPhase = ''
     patchShebangs $out/bin
     for i in rpi-eeprom-update rpi-eeprom-config; do
       wrapProgram $out/bin/$i \
-        --set FIRMWARE_ROOT $out/share/rpi-eeprom \
+        --set FIRMWARE_ROOT "$out/lib/firmware/raspberrypi/bootloader" \
         ${lib.optionalString stdenvNoCC.isAarch64 "--set VCMAILBOX ${libraspberrypi}/bin/vcmailbox"} \
         --prefix PATH : "${lib.makeBinPath ([
           binutils-unwrapped
@@ -51,8 +54,8 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Installation scripts and binaries for the closed sourced Raspberry Pi 4 EEPROMs";
-    homepage = "https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md";
+    description = "Installation scripts and binaries for the closed sourced Raspberry Pi 4 and 5 bootloader EEPROMs";
+    homepage = "https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-4-boot-eeprom";
     license = with licenses; [ bsd3 unfreeRedistributableFirmware ];
     maintainers = with maintainers; [ das_j Luflosi ];
   };


### PR DESCRIPTION
## Description of changes
https://github.com/raspberrypi/rpi-eeprom/releases/tag/v2023.10.18-2712
https://github.com/raspberrypi/rpi-eeprom/releases/tag/v2023.10.30-2712
This release of rpi-eeprom adds support for the Raspberry Pi 5, requiring some changes.
I have only tested this on a Raspberry Pi 4.
Also add myself as maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).