### PR TITLE
sbcl: remove patches, enable checks, allow overriding

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -187,7 +187,6 @@ stdenv.mkDerivation (self: rec {
 
     INSTALL_ROOT=$out sh install.sh
 
-    runHook postInstall
   ''
   + lib.optionalString (!purgeNixReferences) ''
     cp -r src $out/lib/sbcl
@@ -197,6 +196,8 @@ stdenv.mkDerivation (self: rec {
        '(("SYS:SRC;**;*.*.*" #P"$out/lib/sbcl/src/**/*.*")
          ("SYS:CONTRIB;**;*.*.*" #P"$out/lib/sbcl/contrib/**/*.*")))
     EOF
+  '' + ''
+    runHook postInstall
   '';
 
   setupHook = lib.optional purgeNixReferences (writeText "setupHook.sh" ''

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -106,6 +106,10 @@ stdenv.mkDerivation (self: rec {
     "aarch64-linux"
   ]) ''
     rm -f tests/foreign-stack-alignment.impure.lisp
+    # Floating point tests are fragile
+    # https://sourceforge.net/p/sbcl/mailman/message/58728554/
+    rm -f tests/compiler.pure.lisp \
+          tests/float.pure.lisp
   '') + (if purgeNixReferences
     then
       # This is the default location to look for the core; by default in $out/lib/sbcl

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -96,7 +96,9 @@ stdenv.mkDerivation (self: rec {
   );
   buildInputs = lib.optionals coreCompression [ zstd ];
 
-  patches = lib.optionals (version == "2.4.0") [
+  patches = [
+    ./search-for-binaries-in-PATH.patch
+  ] ++ lib.optionals (version == "2.4.0") [
     ./fix-2.4.0-aarch64-darwin.patch
   ];
 

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, clisp, fetchurl, writeText, zstd
+{ lib, stdenv, callPackage, clisp, fetchurl, strace, texinfo, which, writeText, zstd
 , threadSupport ? (stdenv.hostPlatform.isx86 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
 , linkableRuntime ? stdenv.hostPlatform.isx86
 , disableImmobileSpace ? false
@@ -8,7 +8,6 @@
 , purgeNixReferences ? false
 , coreCompression ? lib.versionAtLeast version "2.2.6"
 , markRegionGC ? lib.versionAtLeast version "2.4.0"
-, texinfo
 , version
   # Set this to a lisp binary to use a custom bootstrap lisp compiler for
   # SBCL. Leave as null to use the default. This is useful for local development
@@ -86,7 +85,15 @@ stdenv.mkDerivation (self: rec {
     inherit (versionMap.${version}) sha256;
   };
 
-  nativeBuildInputs = [ texinfo ];
+  nativeBuildInputs = [
+    texinfo
+  ] ++ lib.optionals self.doCheck (
+    [
+      which
+    ] ++ lib.optionals (builtins.elem stdenv.system strace.meta.platforms) [
+      strace
+    ]
+  );
   buildInputs = lib.optionals coreCompression [ zstd ];
 
   patches = lib.optionals (version == "2.4.0") [

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, clisp, fetchurl, fetchpatch, writeText, zstd
+{ lib, stdenv, callPackage, clisp, fetchurl, writeText, zstd
 , threadSupport ? (stdenv.hostPlatform.isx86 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
 , linkableRuntime ? stdenv.hostPlatform.isx86
 , disableImmobileSpace ? false

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -179,7 +179,11 @@ stdenv.mkDerivation (self: rec {
 
   # From the INSTALL docs
   checkPhase = ''
+    runHook preCheck
+
     (cd tests && sh run-tests.sh)
+
+    runHook postCheck
   '';
 
   installPhase = ''

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -161,6 +161,13 @@ stdenv.mkDerivation rec {
     runHook postBuild
   '';
 
+  doCheck = true;
+
+  # From the INSTALL docs
+  checkPhase = ''
+    (cd tests && sh run-tests.sh)
+  '';
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation (self: rec {
   # upstream--somehow some way) in due time.
   disabledTestFiles = lib.optionals (builtins.elem stdenv.hostPlatform.system [
     "x86_64-linux"
-    "x86_64-darwin"
     "aarch64-linux"
   ]) [
     "foreign-stack-alignment.impure.lisp"
@@ -188,7 +187,11 @@ stdenv.mkDerivation (self: rec {
     runHook postBuild
   '';
 
-  doCheck = true;
+  # Tests on ofBorg’s x86_64-darwin platforms are so unstable that a random one
+  # will fail every other run. There’s a deeper problem here; we might as well
+  # disable them entirely so at least the other platforms get to benefit from
+  # testing.
+  doCheck = stdenv.hostPlatform.system != "x86_64-darwin";
 
   # From the INSTALL docs
   checkPhase = ''

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -190,7 +190,7 @@ stdenv.mkDerivation (self: rec {
   '');
 
   meta = with lib; {
-    description = "Lisp compiler";
+    description = "Common Lisp compiler";
     homepage = "https://sbcl.org";
     license = licenses.publicDomain; # and FreeBSD
     maintainers = lib.teams.lisp.members;

--- a/pkgs/development/compilers/sbcl/search-for-binaries-in-PATH.patch
+++ b/pkgs/development/compilers/sbcl/search-for-binaries-in-PATH.patch
@@ -1,0 +1,108 @@
+From 35856b09e3606361b17f21225c759632be1cdf34 Mon Sep 17 00:00:00 2001
+From: Hraban Luyat <hraban@0brg.net>
+Date: Wed, 24 Jan 2024 14:58:53 -0500
+Subject: [PATCH] Search for binaries in tests in PATH, not /usr/bin
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Same as 8ed662fbfeb5dde35eb265f390b55b01f79f70c1 but for tests, and for more
+than just ‘cat’. For the same reasons as that diff.
+---
+ tests/run-program.impure.lisp | 18 ++++++++++--------
+ tests/run-program.test.sh     |  9 ++++-----
+ 2 files changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/tests/run-program.impure.lisp b/tests/run-program.impure.lisp
+index 0eab8884c..b07d1e4fb 100644
+--- a/tests/run-program.impure.lisp
++++ b/tests/run-program.impure.lisp
+@@ -15,7 +15,7 @@
+ 
+ (defun bin-pwd-ignoring-result ()
+   (let ((initially-open-fds (directory "/proc/self/fd/*" :resolve-symlinks nil)))
+-    (sb-ext:run-program "/usr/bin/pwd" nil :input :stream :output :stream :wait nil)
++    (sb-ext:run-program "pwd" nil :search t :input :stream :output :stream :wait nil)
+     (length initially-open-fds)))
+ 
+ (with-test (:name (run-program :autoclose-streams)
+@@ -49,7 +49,7 @@
+ (with-test (:name (run-program :cat 2)
+                   :skipped-on (or (not :sb-thread) :win32))
+   ;; Tests that reading from a FIFO is interruptible.
+-  (let* ((process (run-program "/bin/cat" '()
++  (let* ((process (run-program "cat" '() :search t
+                                :wait nil :output :stream :input :stream))
+          (in (process-input process))
+          (out (process-output process))
+@@ -167,7 +167,7 @@
+   (defparameter *cat-out* (make-synonym-stream '*cat-out-pipe*)))
+ 
+ (with-test (:name (run-program :cat 5) :fails-on :win32)
+-  (let ((cat (run-program "/bin/cat" nil :input *cat-in* :output *cat-out*
++  (let ((cat (run-program "cat" nil :search t :input *cat-in* :output *cat-out*
+                           :wait nil)))
+     (dolist (test '("This is a test!"
+                     "This is another test!"
+@@ -310,14 +310,16 @@
+   (let ((had-error-p nil))
+     (flet ((barf (&optional (format :default))
+              (with-output-to-string (stream)
+-               (run-program #-netbsd "/usr/bin/perl" #+netbsd "/usr/pkg/bin/perl"
++               (run-program #-netbsd "perl" #+netbsd "/usr/pkg/bin/perl"
+                             '("-e" "print \"\\x20\\xfe\\xff\\x0a\"")
++                            :search #-netbsd t #+netbsd nil
+                             :output stream
+                             :external-format format)))
+            (no-barf ()
+              (with-output-to-string (stream)
+-               (run-program "/bin/echo"
++               (run-program "echo"
+                             '("This is a test")
++                            :search t
+                             :output stream))))
+       (handler-case
+           (barf :utf-8)
+@@ -353,9 +355,9 @@
+                ;; If the permitted inputs are :ANY then leave it be
+                (listp (symbol-value 'run-tests::*allowed-inputs*)))
+       (push (namestring file) (symbol-value 'run-tests::*allowed-inputs*)))
+-    (assert (null (run-program "/bin/cat" '() :input file)))
+-    (assert (null (run-program "/bin/cat" '() :output #.(or *compile-file-truename*
+-                                                            *load-truename*)
++    (assert (null (run-program "cat" '() :search t :input file)))
++    (assert (null (run-program "cat" '() :search t :output #.(or *compile-file-truename*
++                                                                 *load-truename*)
+                                       :if-output-exists nil)))))
+ 
+ 
+diff --git a/tests/run-program.test.sh b/tests/run-program.test.sh
+index 48eaef889..c926e5a05 100755
+--- a/tests/run-program.test.sh
++++ b/tests/run-program.test.sh
+@@ -39,9 +39,8 @@ run_sbcl --eval "(defvar *exit-ok* $EXIT_LISP_WIN)" <<'EOF'
+   (assert (not (zerop (sb-ext:process-exit-code
+                        (sb-ext:run-program "false" () :search t :wait t)))))
+   (let ((string (with-output-to-string (stream)
+-                  (our-run-program    "/bin/echo"
+-                                      '("foo" "bar")
+-                                      :output stream))))
++                  (run-program  "echo" '("foo" "bar")
++                                :search t :output stream))))
+     (assert (string= string "foo bar
+ ")))
+   (format t ";;; Smoke tests: PASS~%")
+@@ -103,8 +102,8 @@ run_sbcl --eval "(defvar *exit-ok* $EXIT_LISP_WIN)" <<'EOF'
+   ;; make sure that a stream input argument is basically reasonable.
+   (let ((string (let ((i (make-string-input-stream "abcdef")))
+                   (with-output-to-string (stream)
+-                    (our-run-program "/bin/cat" ()
+-                                        :input i :output stream)))))
++                    (run-program "cat" ()
++                                 :search t :input i :output stream)))))
+     (assert (= (length string) 6))
+     (assert (string= string "abcdef")))
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
## Description of changes

This is a mix of various improvements and refactoring to the SBCL build. Every change is in its own commit, I can create separate small PRs if that's preferred.

Notably:
- Disable the timestamp patches on SBCL which seem to be unnecessary; there are no nix store violation from rebuilding zero-timestamped files, so these patches don't seem to be solving anything that was broken.
- enable `doCheck = true`.
- liberally disable any individual test that causes a problem, without worrying too much about why. It's an improvement over what we had before (which was no tests run at all).

(Ignore the branch name)

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
