### PR TITLE
libxmlb: 0.3.10 -> 0.3.14

### DIFF
--- a/pkgs/development/libraries/libxmlb/default.nix
+++ b/pkgs/development/libraries/libxmlb/default.nix
@@ -13,11 +13,12 @@
 , shared-mime-info
 , nixosTests
 , xz
+, zstd
 }:
 
 stdenv.mkDerivation rec {
   pname = "libxmlb";
-  version = "0.3.10";
+  version = "0.3.14";
 
   outputs = [ "out" "lib" "dev" "devdoc" "installedTests" ];
 
@@ -25,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "hughsie";
     repo = "libxmlb";
     rev = version;
-    sha256 = "sha256-uitnVqR2VVNAf8H1Q/u6LezhvfQJ/G2bE0Dv9dyP8+A=";
+    hash = "sha256-lpVXl/n/ecDLbbLQg9T+o4GdGZM7pNXGYTyVogNCl2E=";
   };
 
   patches = [
@@ -47,6 +48,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     xz
+    zstd
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/libxmlb/installed-tests-path.patch
+++ b/pkgs/development/libraries/libxmlb/installed-tests-path.patch
@@ -1,9 +1,6 @@
-diff --git a/meson.build b/meson.build
-index c98e1a7..025d9c8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -110,8 +110,8 @@ else
-   prefix = get_option('prefix')
+@@ -111,7 +111,7 @@ else
    datadir = join_paths(prefix, get_option('datadir'))
    libexecdir = join_paths(prefix, get_option('libexecdir'))
 -  installed_test_bindir = join_paths(libexecdir, 'installed-tests', meson.project_name())
@@ -13,12 +10,11 @@ index c98e1a7..025d9c8 100644
  endif
  
  gio = dependency('gio-2.0', version : '>= 2.45.8')
-diff --git a/meson_options.txt b/meson_options.txt
-index 54ab698..8a7122a 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -3,3 +3,4 @@ option('introspection', type : 'boolean', value : true, description : 'generate
+@@ -3,4 +3,5 @@ option('introspection', type : 'boolean', value : true, description : 'generate
  option('tests', type : 'boolean', value : true, description : 'enable tests')
  option('stemmer', type : 'boolean', value : false, description : 'enable stemmer support')
  option('cli', type : 'boolean', value : true, description : 'build and install the xb-tool CLI')
+ option('zstd', type : 'boolean', value : true, description : 'enable zstd support')
 +option('installed_test_prefix', type: 'string', value: '', description: 'Prefix for installed tests')


### PR DESCRIPTION
Changes:
- https://github.com/hughsie/libxmlb/releases/tag/0.3.14
- https://github.com/hughsie/libxmlb/releases/tag/0.3.13
- https://github.com/hughsie/libxmlb/releases/tag/0.3.12
- https://github.com/hughsie/libxmlb/releases/tag/0.3.11

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
