### PR TITLE
libayatana-common: Enable Lomiri features

### DIFF
--- a/pkgs/development/libraries/libayatana-common/default.nix
+++ b/pkgs/development/libraries/libayatana-common/default.nix
@@ -4,11 +4,11 @@
 , gitUpdater
 , testers
 , cmake
-, cmake-extras
 , glib
 , gobject-introspection
 , gtest
 , intltool
+, lomiri
 , pkg-config
 , systemd
 , vala
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Queries via pkg_get_variable, can't override prefix
     substituteInPlace data/CMakeLists.txt \
-      --replace 'DESTINATION "''${SYSTEMD_USER_UNIT_DIR}"' 'DESTINATION "${placeholder "out"}/lib/systemd/user"'
+      --replace 'pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemd_user_unit_dir)' 'set(SYSTEMD_USER_UNIT_DIR ''${CMAKE_INSTALL_PREFIX}/lib/systemd/user)'
   '';
 
   strictDeps = true;
@@ -42,8 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    cmake-extras
+    lomiri.cmake-extras
     glib
+    lomiri.lomiri-url-dispatcher
     systemd
   ];
 
@@ -53,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
-    "-DENABLE_LOMIRI_FEATURES=OFF"
+    "-DENABLE_LOMIRI_FEATURES=ON"
     "-DGSETTINGS_LOCALINSTALL=ON"
     "-DGSETTINGS_COMPILE=ON"
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22437,9 +22437,7 @@ with pkgs;
 
   libavif = callPackage ../development/libraries/libavif { };
 
-  libayatana-common = callPackage ../development/libraries/libayatana-common {
-    inherit (lomiri) cmake-extras;
-  };
+  libayatana-common = callPackage ../development/libraries/libayatana-common { };
 
   libb2 = callPackage ../development/libraries/libb2 { };
 


### PR DESCRIPTION
## Description of changes

Working towards #99090.

Enable Lomiri features in `libayatana-common`. This will make even vanilla Ayatana indicators depend on LUD whose GUI tool depends on LUITK, which is not great for closure size: `61.4M` -> `847.9M`. We can introduce a `lib` output to LUD with only the library, which would solve this and bring it down to `61.5M`, but I haven't tested if I moved everything correctly with that change or if something might break somewhere - I needed to `moveToOutput` afew things out of `lib`.

I plan to revisit this once Lomiri is far enough to build & launch into the DE on master, at which point testing the fallout of that should be easier for me. With nothing outside of Lomiri currently using `libayatana-common` anyway, this shouldn't be a problem for now. I've taken note of this in the Lomiri tracking issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
