### PR TITLE
onlyoffice-bin_latest: 7.4.1 -> 7.5.1, improve inclusion of noto fonts

### DIFF
--- a/pkgs/applications/office/onlyoffice-bin/7_5.nix
+++ b/pkgs/applications/office/onlyoffice-bin/7_5.nix
@@ -76,11 +76,11 @@ let
 
   derivation = stdenv.mkDerivation rec {
     pname = "onlyoffice-desktopeditors";
-    version = "7.4.1";
+    version = "7.5.1";
     minor = null;
     src = fetchurl {
       url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
-      sha256 = "sha256-vaBF3GJyLBldWdEruOeVpRvwGNwaRl7IKPguDLRoe8M=";
+      sha256 = "sha256-Hf5CNbUUMuHZHDY3fgD4qpF4UASevscK8DTZlauyHhY=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/applications/office/onlyoffice-bin/7_5.nix
+++ b/pkgs/applications/office/onlyoffice-bin/7_5.nix
@@ -26,6 +26,7 @@
 , libdrm
 , makeWrapper
 , mesa
+, noto-fonts-cjk-sans
 , nspr
 , nss
 , pulseaudio
@@ -53,18 +54,6 @@ let
 
   # TODO: Find out which of these fonts we'd be allowed to distribute along
   #       with this package, or how to make this easier for users otherwise.
-
-  # Not using the `noto-fonts-cjk` package from nixpkgs, because it was
-  # reported that its `.ttc` file is not picked up by OnlyOffice, see:
-  # https://github.com/NixOS/nixpkgs/pull/116343#discussion_r593979816
-  noto-fonts-cjk = fetchurl {
-    url =
-      let
-        version = "v20201206-cjk";
-      in
-      "https://github.com/googlefonts/noto-cjk/raw/${version}/NotoSansCJKsc-Regular.otf";
-    sha256 = "sha256-aJXSVNJ+p6wMAislXUn4JQilLhimNSedbc9nAuPVxo4=";
-  };
 
   runtimeLibs = lib.makeLibraryPath [
     curl
@@ -134,10 +123,6 @@ let
       dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
     '';
 
-    preConfigure = ''
-      cp --no-preserve=mode,ownership ${noto-fonts-cjk} opt/onlyoffice/desktopeditors/fonts/
-    '';
-
     installPhase = ''
       runHook preInstall
 
@@ -179,12 +164,14 @@ in
 
 # In order to download plugins, OnlyOffice uses /usr/bin/curl so we have to wrap it.
 # Curl still needs to be in runtimeLibs because the library is used directly in other parts of the code.
+# Fonts are also discovered by looking in /usr/share/fonts, so adding fonts to targetPkgs will include them
 buildFHSEnv {
   name = derivation.name;
 
   targetPkgs = pkgs': [
     curl
     derivation
+    noto-fonts-cjk-sans
   ];
 
   runScript = "/bin/onlyoffice-desktopeditors";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34089,9 +34089,9 @@ with pkgs;
   okteto = callPackage ../development/tools/okteto { };
 
   onlyoffice-bin_7_2 = callPackage ../applications/office/onlyoffice-bin/7_2.nix { };
-  onlyoffice-bin_7_4 = callPackage ../applications/office/onlyoffice-bin/7_4.nix { };
+  onlyoffice-bin_7_5 = callPackage ../applications/office/onlyoffice-bin/7_5.nix { };
   onlyoffice-bin = onlyoffice-bin_7_2;
-  onlyoffice-bin_latest = onlyoffice-bin_7_4;
+  onlyoffice-bin_latest = onlyoffice-bin_7_5;
 
   onmetal-image = callPackage ../tools/virtualization/onmetal-image { };
 


### PR DESCRIPTION
## Description of changes

[Changelog](https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md#751). The wlroots bug is still happening, so only the `_latest` package is being updated.

[OnlyOffice gathers system fonts from `/usr/share/fonts`](https://helpcenter.onlyoffice.com/installation/docs-community-install-fonts-linux.aspx), so I moved Noto CJK fonts into the FHS instead of using the custom packaging as previously done. This is better because updates follow the main package instead of having to be done manually here, and we get all CJK fonts instead of just Simplified Chinese.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
