### PR TITLE
nixos/screen: clean up module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -8,7 +8,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- `screen`'s module has been cleaned, and will now require you to set `programs.screen.enable` in order to populate `screenrc` and add the program to the environment.
 
 ## New Services {#sec-release-24.05-new-services}
 

--- a/nixos/modules/programs/screen.nix
+++ b/nixos/modules/programs/screen.nix
@@ -1,33 +1,41 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkOption mkIf types;
   cfg = config.programs.screen;
 in
 
 {
-  ###### interface
-
   options = {
     programs.screen = {
+      enable = lib.mkEnableOption (lib.mdDoc "screen, a basic terminal multiplexer");
 
-      screenrc = mkOption {
-        default = "";
-        description = lib.mdDoc ''
-          The contents of /etc/screenrc file.
+      package = lib.mkPackageOptionMD pkgs "screen" { };
+
+      screenrc = lib.mkOption {
+        type = with lib.types; nullOr lines;
+        example = ''
+          defscrollback 10000
+          startup_message off
         '';
-        type = types.lines;
+        description = lib.mdDoc "The contents of {file}`/etc/screenrc` file";
       };
     };
   };
 
-  ###### implementation
-
-  config = mkIf (cfg.screenrc != "") {
-    environment.etc.screenrc.text = cfg.screenrc;
-
-    environment.systemPackages = [ pkgs.screen ];
+  config = {
+    # TODO: Added in 24.05, remove before 24.11
+    assertions = [
+      {
+        assertion = cfg.screenrc != null -> cfg.enable;
+        message = "`programs.screen.screenrc` has been configured, but `programs.screen.enable` is not true";
+      }
+    ];
+  } // lib.mkIf cfg.enable {
+    environment.etc.screenrc = {
+      enable = cfg.screenrc != null;
+      text = cfg.screenrc;
+    };
+    environment.systemPackages = [ cfg.package ];
     security.pam.services.screen = {};
   };
-
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Cleaned up the screen module. This module has not been touched for quite a while, and I thought it would make sense to make it look more like more modern modules.

Changes made:
 - Added enable option
 - Added package option for easy overriding
 - Changed type of screenrc option for semantic reasons
 - Added example to screenrc option
 - Added release note, urging users to set `programs.screen.enable = true`
 - Cleaned up a bit of spacing, and removed old module comments

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
