### PR TITLE
chromium: fix libpci GPU detection

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -312,9 +312,6 @@ let
       sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
         device/udev_linux/udev?_loader.cc
     '' + ''
-      sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
-        gpu/config/gpu_info_collector_linux.cc
-
       # Allow to put extensions into the system-path.
       sed -i -e 's,/usr,/run/current-system/sw,' chrome/common/chrome_paths.cc
 
@@ -476,9 +473,10 @@ let
 
     postFixup = ''
       # Make sure that libGLESv2 and libvulkan are found by dlopen.
+      # libpci (from pciutils) is needed by dlopen in angle/src/gpu_info_util/SystemInfo_libpci.cpp
       chromiumBinary="$libExecPath/$packageName"
       origRpath="$(patchelf --print-rpath "$chromiumBinary")"
-      patchelf --set-rpath "${lib.makeLibraryPath [ libGL vulkan-loader ]}:$origRpath" "$chromiumBinary"
+      patchelf --set-rpath "${lib.makeLibraryPath [ libGL vulkan-loader pciutils ]}:$origRpath" "$chromiumBinary"
     '';
 
     passthru = {


### PR DESCRIPTION
## Description of changes

Chromium has blocklists that workaround various GPU driver bugs, either by forcing software rendering [1] or by disabling use of certain GPU features [2].

These blocklists can only be applied successfully if the GPU vendor and device is detected correctly. One of the methods used for GPU detection is to load libpci.so via dlopen() at runtime to read the PCI vendor and device ID.

The current derivation already contains a sed command to rewrite the dlopen() to the absolute path of libpci.so in the Nix store, namely

      sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
        gpu/config/gpu_info_collector_linux.cc

However, in Chromium 59 (6 years ago), this code was moved into the ANGLE library used by Chromium [3]. This sed command no longer works. There is similar code in ANGLE now [4] that must be similarly patched to ensure the GPU vendor and device is always detected correctly.

Without libpci some GPUs are not detected correctly. For example, in a VMWare virtual machine opening chrome://gpu in the browser shows:

    VENDOR= 0x0000 [Google Inc. (VMware, Inc.)], DEVICE=0x0000 [ANGLE
     (VMware Inc., SVGA3D; build: RELEASE;  LLVM;, OpenGL 4.1 (Core Profile)
      Mesa 23.0.3)], DRIVER_VENDOR=Mesa, DRIVER_VERSION=23.0.3 *ACTIVE*

Note the VENDOR=0x0000 and DEVICE=0x0000. Adding libpci.so to the library path fixes this:

    VENDOR= 0x15ad [Google Inc. (VMware, Inc.)], DEVICE=0x0405 [ANGLE
     (VMware Inc., SVGA3D; build: RELEASE;  LLVM;, OpenGL 4.1 (Core Profile)
      Mesa 23.0.3)], DRIVER_VENDOR=Mesa, DRIVER_VERSION=23.0.3 *ACTIVE*

Note the VENDOR=0x15ad and DEVICE=0x0405. Also now the blocklist entries are applied correctly, fixing some graphical issues.

Fix this by adding pciutils to the rpath set with patchelf. This avoids having to patch lines in the source code that might get moved around.

[1]: https://chromium.googlesource.com/chromium/src/+/e52f33f30b91b4ddfad649acddc39ab570473b86/gpu/config/software_rendering_list.json
[2]: https://chromium.googlesource.com/chromium/src/+/e52f33f30b91b4ddfad649acddc39ab570473b86/gpu/config/gpu_driver_bug_list.json
[3]: https://github.com/chromium/chromium/commit/873b27d518038be94df98d1128a2e8047e0ef942
[4]: https://github.com/google/angle/blob/05f45adc147393562b518ca1f82a3ccba7ee40f7/src/gpu_info_util/SystemInfo_libpci.cpp#L41

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This might fix graphical issues in Chromium with some weird GPUs. I would expect that this "fixes" at least #239598 because [Chromium actually has the VMWare graphics drivers entirely on the block list (falling back to software rendering)](https://chromium.googlesource.com/chromium/src/+/e52f33f30b91b4ddfad649acddc39ab570473b86/gpu/config/software_rendering_list.json#1680).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I didn't test building this using Nix given the large size of Chromium. However, I ran the modified `patchelf` manually on the current Chromium binary in NixOS and it fixes the issue as described.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
