### PR TITLE
{ungoogled-,}chromium: 118.0.5993.70 -> 118.0.5993.88, fix update.py

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -148,36 +148,39 @@ let
       else throw "no chromium Rosetta Stone entry for os: ${platform.config}";
   };
 
+  recompressTarball = { version, sha256 ? "" }: fetchzip {
+    name = "chromium-${version}.tar.zstd";
+    url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
+    inherit sha256;
+
+    nativeBuildInputs = [ zstd ];
+
+    postFetch = ''
+      echo removing unused code from tarball to stay under hydra limit
+      rm -r $out/third_party/{rust-src,llvm}
+
+      echo moving remains out of \$out
+      mv $out source
+
+      echo recompressing final contents into new tarball
+      # try to make a deterministic tarball
+      tar \
+        --use-compress-program "zstd -T$NIX_BUILD_CORES" \
+        --sort name \
+        --mtime 1970-01-01 \
+        --owner=root --group=root \
+        --numeric-owner --mode=go=rX,u+rw,a-s \
+        -cf $out source
+    '';
+  };
+
+
   base = rec {
     pname = "${packageName}-unwrapped";
     inherit (upstream-info) version;
     inherit packageName buildType buildPath;
 
-    src = fetchzip {
-      name = "chromium-${version}.tar.zstd";
-      url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-      inherit (upstream-info) sha256;
-
-      nativeBuildInputs = [ zstd ];
-
-      postFetch = ''
-        echo removing unused code from tarball to stay under hydra limit
-        rm -r $out/third_party/{rust-src,llvm}
-
-        echo moving remains out of \$out
-        mv $out source
-
-        echo recompressing final contents into new tarball
-        # try to make a deterministic tarball
-        tar \
-          --use-compress-program "zstd -T$NIX_BUILD_CORES" \
-          --sort name \
-          --mtime 1970-01-01 \
-          --owner=root --group=root \
-          --numeric-owner --mode=go=rX,u+rw,a-s \
-          -cf $out source
-      '';
-    };
+    src = recompressTarball { inherit version; inherit (upstream-info) sha256; };
 
     nativeBuildInputs = [
       ninja pkg-config
@@ -486,6 +489,7 @@ let
       chromiumDeps = {
         gn = gnChromium;
       };
+      inherit recompressTarball;
     };
   }
   # overwrite `version` with the exact same `version` from the same source,

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -21,12 +21,11 @@ from urllib.request import urlopen
 
 RELEASES_URL = 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/all/versions/all/releases'
 DEB_URL = 'https://dl.google.com/linux/chrome/deb/pool/main/g'
-BUCKET_URL = 'https://commondatastorage.googleapis.com/chromium-browser-official'
 
 PIN_PATH = dirname(abspath(__file__)) + '/upstream-info.nix'
 UNGOOGLED_FLAGS_PATH = dirname(abspath(__file__)) + '/ungoogled-flags.toml'
 COMMIT_MESSAGE_SCRIPT = dirname(abspath(__file__)) + '/get-commit-message.py'
-
+NIXPKGS_PATH = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], cwd=dirname(PIN_PATH)).strip()
 
 def load_as_json(path):
     """Loads the given nix file as JSON."""
@@ -40,6 +39,23 @@ def save_dict_as_nix(path, input):
     formatted = subprocess.check_output(['nixfmt'], input=nix)
     with open(path, 'w') as out:
         out.write(formatted.decode())
+
+def prefetch_src_sri_hash(attr_path, version):
+    """Prefetches the fixed-output-derivation source tarball and returns its SRI-Hash."""
+    print(f'nix-build (FOD prefetch) {attr_path} {version}')
+    out = subprocess.run(
+        ["nix-build", "--expr", f'(import ./. {{}}).{attr_path}.browser.passthru.recompressTarball {{ version = "{version}"; }}'],
+        cwd=NIXPKGS_PATH,
+        stderr=subprocess.PIPE
+    ).stderr.decode()
+
+    for line in iter(out.split("\n")):
+        match = re.match(r"\s+got:\s+(.+)$", line)
+        if match:
+            print(f'Hash: {match.group(1)}')
+            return match.group(1)
+    print(f'{out}\n\nError: Expected hash in nix-build stderr output.', file=sys.stderr)
+    sys.exit(1)
 
 def nix_prefetch_url(url, algo='sha256'):
     """Prefetches the content of the given URL."""
@@ -206,7 +222,10 @@ with urlopen(RELEASES_URL) as resp:
             google_chrome_suffix = channel_name
 
         try:
-            channel['sha256'] = nix_prefetch_url(f'{BUCKET_URL}/chromium-{release["version"]}.tar.xz')
+            channel['sha256'] = prefetch_src_sri_hash(
+                channel_name_to_attr_name(channel_name),
+                release["version"]
+            )
             channel['sha256bin64'] = nix_prefetch_url(
                 f'{DEB_URL}/google-chrome-{google_chrome_suffix}/' +
                 f'google-chrome-{google_chrome_suffix}_{release["version"]}-1_amd64.deb')

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -54,12 +54,12 @@
         version = "2023-08-10";
       };
       ungoogled-patches = {
-        rev = "118.0.5993.70-1";
-        sha256 = "0k6684cy1ks6yba2bdz17g244f05qy9769cvis4h2jzhgbf5rysh";
+        rev = "118.0.5993.88-1";
+        sha256 = "17j47d64l97ascp85h8cnfnr5wr4va3bdk95wmagqss7ym5c7zsf";
       };
     };
-    sha256 = "1g8rllmnmhmmpjzrmi3cww0nszxicq0kim2wd0l0ip2mzk2p8qlp";
-    sha256bin64 = "1bq170l0g9yq17x6xlg6fjar6gv3hdi0zijwmx4s02pmw6727484";
-    version = "118.0.5993.70";
+    sha256 = "sha256-CTkw92TiRD2tkYu5a5dy8fjpR2MMOMCvcbxXhJ36Bp8=";
+    sha256bin64 = "06rbsjh4khhl408181ns5nsdwasklb277fdjfajdv5h1j9a190k3";
+    version = "118.0.5993.88";
   };
 }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -41,9 +41,9 @@
         version = "2023-08-10";
       };
     };
-    sha256 = "1g8rllmnmhmmpjzrmi3cww0nszxicq0kim2wd0l0ip2mzk2p8qlp";
-    sha256bin64 = "1bq170l0g9yq17x6xlg6fjar6gv3hdi0zijwmx4s02pmw6727484";
-    version = "118.0.5993.70";
+    sha256 = "sha256-CTkw92TiRD2tkYu5a5dy8fjpR2MMOMCvcbxXhJ36Bp8=";
+    sha256bin64 = "06rbsjh4khhl408181ns5nsdwasklb277fdjfajdv5h1j9a190k3";
+    version = "118.0.5993.88";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

https://chromereleases.googleblog.com/2023/10/stable-channel-update-for-desktop_17.html

This update includes 1 security fix.

## Things done

- Built on platform(s)
  - [x] x86_64-linux (**ungoogled-chromium**)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (**ungoogled-chromium**)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
