### PR TITLE
mate.mate-indicator-applet: Use Ayatana indicators instead, fix new-s…

### DIFF
--- a/pkgs/desktops/mate/mate-indicator-applet/default.nix
+++ b/pkgs/desktops/mate/mate-indicator-applet/default.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , gettext
 , gtk3
-, libindicator-gtk3
+, libayatana-indicator
 , mate
 , hicolor-icon-theme
 , wrapGAppsHook
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "144fh9f3lag2cqnmb6zxlh8k83ya8kha6rmd7r8gg3z5w3nzpyz4";
   };
 
+  postPatch = ''
+    # Find installed Unity & Ayatana (new-style) indicators
+    substituteInPlace src/applet-main.c \
+      --replace '/usr/share' '/run/current-system/sw/share'
+  '';
+
   nativeBuildInputs = [
     pkg-config
     gettext
@@ -28,10 +34,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    libindicator-gtk3
+    libayatana-indicator
     mate.mate-panel
     hicolor-icon-theme
   ];
+
+  configureFlags = [ "--with-ayatana-indicators" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
…tyle indicator finding

## Description of changes

Lets `mate-indicator-applet` use installed Ayatana indicators by:

- Switching from old Unity indicators library to new Ayatana indicators one
- Fixing hardcoded paths in the code so the applet can find symlinked new-style indicators under `/run/current-system/sw/share/ayatana/indicators`

![Bildschirmfoto_2023-10-20_01-54-41](https://github.com/NixOS/nixpkgs/assets/23431373/6b3ef164-a567-4602-99a9-b5596f3cb2f9)

---

I'm submitting this in case the MATE maintainer(s) are interested in it. I figured this out for https://github.com/NixOS/nixpkgs/pull/243476#discussion_r1366231486 - the switch to Ayatana indicators removes support for the old indicator system, which was too out-of-scope for that PR. And I don't use MATE myself, but I don't know if anyone is currently successfully using this applet for old Unity indicators? Could be made configurable if desired.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
