### PR TITLE
librda: init at 0.0.5-unstable-2023-09-15

### DIFF
--- a/pkgs/by-name/li/librda/package.nix
+++ b/pkgs/by-name/li/librda/package.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, testers
+, autoreconfHook
+, glib
+, gobject-introspection
+, gtk3
+, intltool
+, pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "librda";
+  version = "0.0.5-unstable-2023-09-15";
+
+  src = fetchFromGitHub {
+    owner = "ArcticaProject";
+    repo = "librda";
+    rev = "d7ed1368145e39b0c761947a32fa50493e70f554";
+    hash = "sha256-k6dmwIndLy9S7f0AU7FIm1S7MYfyvDuhMLMuNgHGsYo=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "bin"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    glib
+    gobject-introspection
+    intltool
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    description = "Remote Desktop Awareness Shared Library";
+    homepage = "https://github.com/ArcticaProject/librda";
+    license = licenses.gpl2Plus;
+    mainProgram = "rdacheck";
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "rda"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

Recent versions of Ayatana indicators started depending on [librda](https://github.com/ArcticaProject/librda) to build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
