### PR TITLE
python3Packages.sphinxext-rediraffe: init at 0.2.7

### DIFF
--- a/pkgs/development/python-modules/sphinxext-rediraffe/default.nix
+++ b/pkgs/development/python-modules/sphinxext-rediraffe/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-rediraffe";
+  version = "0.2.7";
+
+  format = "wheel";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit version format;
+    dist = "py3";
+    python = "py3";
+    pname = "sphinxext_rediraffe";
+    hash = "sha256-nkMKUtRAOEf0/7Oo3W38NKn+Q1JTBRMfUu2Jl0Ol/Yw=";
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+  pythonImportsCheck = [
+    "sphinxext.rediraffe"
+  ];
+
+  meta = with lib; {
+    description = "Sphinx extension to redirect files";
+    homepage = "https://github.com/wpilibsuite/sphinxext-rediraffe";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zmitchell ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13094,6 +13094,8 @@ self: super: with self; {
 
   sphinx-book-theme = callPackage ../development/python-modules/sphinx-book-theme { };
 
+  sphinxext-rediraffe = callPackage ../development/python-modules/sphinxext-rediraffe { };
+
   sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
 
   sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This package is a Sphinx extension used to automatically detect moved pages and automatically generate redirects. It is intended to be used on [nix.dev](https://nix.dev). The repository is here: [sphinxext-rediraffe](https://github.com/wpilibsuite/sphinxext-rediraffe). The package has been tested against a local checkout of [nix.dev](https://nix.dev) that was ported to use `nixpkgs` rather than `poetry2nix` to build the site.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
