### PR TITLE
Patch flutter 3.13.4

### DIFF
--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -83,6 +83,11 @@ let
         cp -r . $out
         ln -sf ${dart} $out/bin/cache/dart-sdk
 
+        # Dart VSCode plugin specifically look for the following file in: 
+        # ${dart}/bin/snapshots/analysis_server.dart.snapshot
+        # https://github.com/Dart-Code/Dart-Code/blob/9d852c8a6a2ac1aa99c7b5e8e9b60840329e4f3c/src/extension/sdk/utils.ts#L507
+        ln -sf $out/bin/cache/dart-sdk/bin/snapshots $out/bin/snapshots
+
         runHook postInstall
       '';
 

--- a/pkgs/development/compilers/flutter/patches/flutter3/change-flutter-root.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/change-flutter-root.patch
@@ -1,0 +1,20 @@
+FLUTTER_HOME should the output path of the wrapped and linked flutter in nix store.
+
+diff --git a/bin/internal/shared.sh b/bin/internal/shared.sh
+index 3532c23114..8e3e97172e 100644
+--- a/bin/internal/shared.sh
++++ b/bin/internal/shared.sh
+@@ -182,7 +182,11 @@ function upgrade_flutter () (
+ # and `//bin/dart`). PROG_NAME and BIN_DIR should already be set by those
+ # entrypoints.
+ function shared::execute() {
+-  export FLUTTER_ROOT="$(cd "${BIN_DIR}/.." ; pwd -P)"
++  if [[ -z $FLUTTER_HOME ]]; then
++    export FLUTTER_ROOT="$(cd "${BIN_DIR}/.." ; pwd -P)"
++  else
++    export FLUTTER_ROOT=$FLUTTER_HOME
++  fi
+
+   # If present, run the bootstrap script first
+   BOOTSTRAP_PATH="$FLUTTER_ROOT/bin/internal/bootstrap.sh"
+com

--- a/pkgs/development/compilers/flutter/patches/flutter3/custom-gradle-plugin-build-dir.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/custom-gradle-plugin-build-dir.patch
@@ -1,0 +1,12 @@
+Force gradle to build the plugin in a different directory specified by FLUTTER_GRADLE_PLUGIN_BUILDDIR
+
+diff --git a/packages/flutter_tools/gradle/build.gradle.kts b/packages/flutter_tools/gradle/build.gradle.kts
+index 289693f9a4..f9b9a46de7 100644
+--- a/packages/flutter_tools/gradle/build.gradle.kts
++++ b/packages/flutter_tools/gradle/build.gradle.kts
+@@ -32,3 +32,5 @@ dependencies {
+     //  * AGP version in buildscript block in packages/flutter_tools/gradle/src/main/flutter.groovy
+     compileOnly("com.android.tools.build:gradle:7.3.0")
+ }
++
++buildDir = File(System.getenv("FLUTTER_GRADLE_PLUGIN_BUILDDIR"))

--- a/pkgs/development/compilers/flutter/patches/flutter3/set-flutter-gradle-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/set-flutter-gradle-cache.patch
@@ -1,0 +1,45 @@
+Patch the gradle calls within flutter android code to explicitly 
+set --project-cache-dir from FLUTTER_GRADLE_PROJECT_CACHE
+
+otherwise gradle build will attempt to write to the sdk directory.
+
+diff --git a/packages/flutter_tools/lib/src/android/gradle.dart b/packages/flutter_tools/lib/src/android/gradle.dart
+index 6d1e3e7345..8ef5c630c8 100644
+--- a/packages/flutter_tools/lib/src/android/gradle.dart
++++ b/packages/flutter_tools/lib/src/android/gradle.dart
+@@ -181,9 +181,11 @@ class AndroidGradleBuilder implements AndroidBuilder {
+        _usage = usage,
+        _gradleUtils = gradleUtils,
+        _androidStudio = androidStudio,
++       _flutterProjectCacheDir = platform.environment["FLUTTER_GRADLE_PROJECT_CACHE"] ?? "${platform.environment["HOME"]}/.gradle_android_cache",
+        _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform),
+        _processUtils = ProcessUtils(logger: logger, processManager: processManager);
+ 
++  final String _flutterProjectCacheDir;
+   final Java? _java;
+   final Logger _logger;
+   final ProcessUtils _processUtils;
+@@ -283,6 +285,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     );
+     final List<String> command = <String>[
+       _gradleUtils.getExecutable(project),
++      '--project-cache-dir=${_flutterProjectCacheDir}',
+       ...options, // suppresses gradle output.
+       taskName,
+     ];
+@@ -358,6 +361,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
+       // This does more than get gradlewrapper. It creates the file, ensures it
+       // exists and verifies the file is executable.
+       _gradleUtils.getExecutable(project),
++      '--project-cache-dir=${_flutterProjectCacheDir}',
+     ];
+ 
+     // All automatically created files should exist.
+@@ -683,6 +687,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     );
+     final List<String> command = <String>[
+       _gradleUtils.getExecutable(project),
++      '--project-cache-dir=${_flutterProjectCacheDir}',
+       '-I=$initScript',
+       '-Pflutter-root=$flutterRoot',
+       '-Poutput-dir=${outputDirectory.path}',

--- a/pkgs/development/compilers/flutter/sdk-symlink.nix
+++ b/pkgs/development/compilers/flutter/sdk-symlink.nix
@@ -6,6 +6,12 @@ let
       name = "${flutter.name}-sdk-links";
       paths = [ flutter flutter.sdk ];
 
+      # The final flutter binary is required to be a git repo.
+      # https://github.com/flutter/flutter/blob/07042fa27cfb0f536776bc87e1f149c0fa3727fc/bin/internal/shared.sh#L224
+      postBuild = ''
+        ln -s ${flutter.sdk}/.git $out/.git
+      '';
+
       passthru = flutter.passthru // {
         # Update the SDK attribute.
         # This allows any modified SDK files to be included


### PR DESCRIPTION
## Description of changes

This PR addresses some of the issues discussed in #260278. The final flutter binary I'm assuming should be pointing to the wrapped-linked version of flutter. 

For issues related to being unable to write under flutter sdk, I couldn't find a way to overwrite the builddir in the gradle build files for the plugin under flutter_tools, so a workaround was to patch it directly.

This has been tested to solve all the issues mentioned in #260278, but the solutions are far from ideal. I'm relatively new to nix so looking for suggestions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
