### PR TITLE
ocamlPackages.sail: 0.15 → 0.16

### DIFF
--- a/pkgs/development/ocaml-modules/sail/default.nix
+++ b/pkgs/development/ocaml-modules/sail/default.nix
@@ -13,20 +13,20 @@
 , z3
 , linksem
 , num
+, yojson
 }:
 
 buildDunePackage rec {
   pname = "sail";
-  version = "0.15";
+  version = "0.16";
 
   src = fetchFromGitHub {
     owner = "rems-project";
     repo = "sail";
     rev = version;
-    hash = "sha256-eNdFOSzkniNvSCZeORRJ/IYAu+9P4HSouwmhd4BQLPk=";
+    hash = "sha256-HY/rgWi0S7ZiAWZF0fVIRK6fpoJ7Xp5EQcxoPRCPJ5Y=";
   };
 
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   nativeBuildInputs = [
@@ -43,6 +43,7 @@ buildDunePackage rec {
     linenoise
     pprint
     linksem
+    yojson
   ];
 
   preBuild = ''


### PR DESCRIPTION
## Description of changes

https://github.com/rems-project/sail/blob/0.16/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
