### PR TITLE
postgresqlPackages.tsja: init at 0.5.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -833,6 +833,7 @@ in {
   trezord = handleTest ./trezord.nix {};
   trickster = handleTest ./trickster.nix {};
   trilium-server = handleTestOn ["x86_64-linux"] ./trilium-server.nix {};
+  tsja = handleTest ./tsja.nix {};
   tsm-client-gui = handleTest ./tsm-client-gui.nix {};
   txredisapi = handleTest ./txredisapi.nix {};
   tuptime = handleTest ./tuptime.nix {};

--- a/nixos/tests/tsja.nix
+++ b/nixos/tests/tsja.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix ({ pkgs, lib, ...} : {
+  name = "tsja";
+  meta = {
+    maintainers = with lib.maintainers; [ chayleaf ];
+  };
+
+  nodes = {
+    master =
+      { config, ... }:
+
+      {
+        services.postgresql = {
+          enable = true;
+          extraPlugins = with config.services.postgresql.package.pkgs; [
+            tsja
+          ];
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    master.wait_for_unit("postgresql")
+    master.succeed("sudo -u postgres psql -f /run/current-system/sw/share/postgresql/extension/libtsja_dbinit.sql")
+    # make sure "日本語" is parsed as a separate lexeme
+    master.succeed("""
+      sudo -u postgres \\
+        psql -c "SELECT * FROM ts_debug('japanese', 'PostgreSQLで日本語のテキスト検索ができます。')" \\
+          | grep "{日本語}"
+    """)
+  '';
+})

--- a/pkgs/servers/sql/postgresql/ext/tsja.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsja.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchzip
+, nixosTests
+, stdenv
+
+, mecab
+, postgresql
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tsja";
+  version = "0.5.0";
+
+  src = fetchzip {
+    url = "https://www.amris.jp/tsja/tsja-${version}.tar.xz";
+    hash = "sha256-h59UhUG/7biN8NaDiGK6kXDqfhR9uMzt8CpwbJ+PpEM=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace /usr/local/pgsql ${postgresql} \
+      --replace -L/usr/local/lib "" \
+      --replace -I/usr/local/include ""
+    substituteInPlace tsja.c --replace /usr/local/lib/mecab ${mecab}/lib/mecab
+  '';
+
+  buildInputs = [ mecab postgresql ];
+
+  installPhase = ''
+    mkdir -p $out/lib $out/share/postgresql/extension
+    mv libtsja.so $out/lib
+    mv dbinit_libtsja.txt $out/share/postgresql/extension/libtsja_dbinit.sql
+  '';
+
+  passthru.tests.tsja = nixosTests.tsja;
+
+  meta = with lib; {
+    description = "PostgreSQL extension implementing Japanese text search";
+    homepage = "https://www.amris.jp/tsja/index.html";
+    maintainers = with maintainers; [ chayleaf ];
+    # GNU-specific linker options are used
+    platforms = platforms.gnu;
+    license = licenses.gpl2Only;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -83,5 +83,7 @@ self: super: {
 
     rum = super.callPackage ./ext/rum.nix { };
 
+    tsja = super.callPackage ./ext/tsja.nix { };
+
     wal2json = super.callPackage ./ext/wal2json.nix { };
 }

--- a/pkgs/tools/text/mecab/default.nix
+++ b/pkgs/tools/text/mecab/default.nix
@@ -7,7 +7,8 @@ stdenv.mkDerivation (finalAttrs: ((mecab-base finalAttrs) // {
   pname = "mecab";
 
   postInstall = ''
-    sed -i 's|^dicdir = .*$|dicdir = ${mecab-ipadic}|' "$out/etc/mecabrc"
+    mkdir -p $out/lib/mecab/dic
+    ln -s ${mecab-ipadic} $out/lib/mecab/dic/ipadic
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This inits [tsja](https://www.amris.jp/tsja/index.html), a Postgresql extension for Japanese full-text search

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
