### PR TITLE
babashka: Install shell completions

### DIFF
--- a/pkgs/development/interpreters/babashka/completions/bb.bash
+++ b/pkgs/development/interpreters/babashka/completions/bb.bash
@@ -1,0 +1,5 @@
+_bb_tasks() {
+    COMPREPLY=( $(compgen -W "$(bb tasks |tail -n +3 |cut -f1 -d ' ')" -- ${COMP_WORDS[COMP_CWORD]}) );
+}
+# autocomplete filenames as well
+complete -f -F _bb_tasks bb

--- a/pkgs/development/interpreters/babashka/completions/bb.fish
+++ b/pkgs/development/interpreters/babashka/completions/bb.fish
@@ -1,0 +1,9 @@
+function __bb_complete_tasks
+  if not test "$__bb_tasks"
+    set -g __bb_tasks (bb tasks |tail -n +3 |cut -f1 -d ' ')
+  end
+
+  printf "%s\n" $__bb_tasks
+end
+
+complete -c bb -a "(__bb_complete_tasks)" -d 'tasks'

--- a/pkgs/development/interpreters/babashka/completions/bb.zsh
+++ b/pkgs/development/interpreters/babashka/completions/bb.zsh
@@ -1,0 +1,6 @@
+_bb_tasks() {
+    local matches=(`bb tasks |tail -n +3 |cut -f1 -d ' '`)
+    compadd -a matches
+    _files # autocomplete filenames as well
+}
+compdef _bb_tasks bb

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -4,6 +4,7 @@
 , removeReferencesTo
 , fetchurl
 , writeScript
+, installShellFiles
 }:
 
 let
@@ -20,7 +21,7 @@ let
 
     executable = "bb";
 
-    nativeBuildInputs = [ removeReferencesTo ];
+    nativeBuildInputs = [ removeReferencesTo installShellFiles ];
 
     extraNativeImageBuildArgs = [
       "-H:+ReportExceptionStackTraces"
@@ -42,6 +43,9 @@ let
     # graalvm-ce anyway.
     postInstall = ''
       remove-references-to -t ${graalvmDrv} $out/bin/${executable}
+      installShellCompletion --cmd bb --bash ${./completions/bb.bash}
+      installShellCompletion --cmd bb --zsh ${./completions/bb.zsh}
+      installShellCompletion --cmd bb --fish ${./completions/bb.fish}
     '';
 
     passthru.updateScript = writeScript "update-babashka" ''

--- a/pkgs/development/interpreters/babashka/wrapped.nix
+++ b/pkgs/development/interpreters/babashka/wrapped.nix
@@ -3,6 +3,7 @@
 , babashka-unwrapped
 , callPackage
 , makeWrapper
+, installShellFiles
 , rlwrap
 , clojureToolsBabashka ? callPackage ./clojure-tools.nix { }
 , jdkBabashka ? clojureToolsBabashka.jdk
@@ -23,7 +24,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontUnpack = true;
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase =
     let unwrapped-bin = "${babashka-unwrapped}/bin/bb"; in
@@ -37,6 +38,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         --set-default DEPS_CLJ_TOOLS_DIR $out/clojure_tools \
         --set-default JAVA_HOME ${jdkBabashka}
 
+      installShellCompletion --cmd bb --bash ${babashka-unwrapped}/share/bash-completion/completions/bb.bash
+      installShellCompletion --cmd bb --zsh ${babashka-unwrapped}/share/fish/vendor_completions.d/bb.fish
+      installShellCompletion --cmd bb --fish ${babashka-unwrapped}/share/zsh/site-functions/_bb
     '' +
     lib.optionalString withRlwrap ''
       substituteInPlace $out/bin/bb \


### PR DESCRIPTION
## Description of changes

Add babashka shell completions as per https://book.babashka.org/#_terminal_tab_completion

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
