### PR TITLE
nixos/distrobox: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -113,6 +113,8 @@
 
 - [virt-manager](https://virt-manager.org/), an UI for managing virtual machines in libvirt, is now available as `programs.virt-manager`.
 
+- [Distrobox](https://github.com/89luca89/distrobox), a tool for creating tightly integrated containers with the home directory, is available to be configured at [programs.distrobox](#opt-programs.distrobox.enable).
+
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
 - `network-online.target` has been fixed to no longer time out for systems with `networking.useDHCP = true` and `networking.useNetworkd = true`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -163,6 +163,7 @@
   ./programs/dconf.nix
   ./programs/digitalbitbox/default.nix
   ./programs/direnv.nix
+  ./programs/distrobox.nix
   ./programs/dmrconfig.nix
   ./programs/droidcam.nix
   ./programs/ecryptfs.nix

--- a/nixos/modules/programs/distrobox.nix
+++ b/nixos/modules/programs/distrobox.nix
@@ -1,0 +1,103 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.distrobox;
+
+  # Since it's in POSIX sh so we'll quote everything as much as possible.
+  # Ideally, we'll go with single-quoted strings but this prevents dynamic
+  # values with shell expansions.
+  toDistroboxConf = lib.generators.toKeyValue {
+    listsAsDuplicateKeys = false;
+    mkKeyValue = lib.generators.mkKeyValueDefault {
+      mkValueString = v:
+        if v == true then "1"
+        else if v == false then "0"
+        else if lib.isString v then ''"${v}"''
+        else if lib.isPath v then lib.escapeShellArg v
+        else if lib.isList v then ''"${lib.concatStringsSep " " v}"''
+        else lib.generators.mkValueStringDefault { } v;
+    } "=";
+  };
+
+  distroboxConf = { }: {
+    type = with lib.types;
+      let
+        valueType = (oneOf [
+          bool
+          float
+          int
+          path
+          str
+          (listOf valueType)
+        ]) // {
+          description = "Distrobox config value";
+        };
+      in
+      attrsOf valueType;
+
+    generate = name: value: pkgs.writeText name (toDistroboxConf value);
+  };
+
+  settingsFormat = distroboxConf { };
+
+  settingsFile = pkgs.writeText "distrobox-settings" ''
+    ${toDistroboxConf cfg.settings}
+    ${cfg.extraConfig}
+  '';
+in
+{
+  meta.maintainers = with lib.maintainers; [ foo-dogsquared ];
+
+  options.programs.distrobox = {
+    enable = lib.mkEnableOption "Distrobox";
+
+    package = lib.mkPackageOption pkgs "distrobox" { };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        System-wide settings for Distrobox to be generated at
+        {file}`/etc/distrobox/distrobox.conf`.
+
+        For more options, you could look at the list of variables and their
+        default values from the source code of each Distrobox command [such as
+        the ones from
+        `distrobox-create`](https://github.com/89luca89/distrobox/blob/9309e1ebe5c70fd1f9b5286fd3a76f3e7bd995bd/distrobox-create#L48-L76).
+
+        ::: {.note}
+        You don't have surround the string values with double quotes since the
+        module will add them for you.
+        :::
+      '';
+      example = lib.literalExpression ''
+        {
+          container_additional_volumes = [
+            "/nix/store:/nix/store:r"
+            "/etc/profiles/per-user:/etc/profiles/per-user:r"
+          ];
+
+          container_image_default = "registry.opensuse.org/opensuse/distrobox-packaging:latest";
+          container_command = "sh -norc";
+          unshare_ipc = true;
+          unshare_netns = true;
+        }
+      '';
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Extra configuration to be appended to
+        {file}`/etc/distrobox/distrobox.conf`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."distrobox/distrobox.conf".source = settingsFile;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add a NixOS module for configuring [Distrobox](https://github.com/89luca89/distrobox).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
