### PR TITLE
kodi.packages.youtube: 7.0.1 -> 7.0.2.2

### DIFF
--- a/pkgs/applications/video/kodi/addons/youtube/default.nix
+++ b/pkgs/applications/video/kodi/addons/youtube/default.nix
@@ -1,13 +1,15 @@
-{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six, requests, infotagger, inputstreamhelper }:
+{ lib, buildKodiAddon, fetchFromGitHub, six, requests, infotagger, inputstreamhelper }:
 
 buildKodiAddon rec {
   pname = "youtube";
   namespace = "plugin.video.youtube";
   version = "7.0.1";
 
-  src = fetchzip {
-    url = "https://mirrors.kodi.tv/addons/nexus/${namespace}/${namespace}-${version}.zip";
-    sha256 = "sha256-Wdju7d2kFX0V1J1TB75qEVq0UWN2xYYFNlD8UTt1New=";
+  src = fetchFromGitHub {
+    owner = "anxdpanic";
+    repo = "plugin.video.youtube";
+    rev = "v${version}";
+    hash = "sha256-BHCVui+enKFH3elz6DovXMDxMQx/2+/BrIw3KQr9TfE=";
   };
 
   propagatedBuildInputs = [
@@ -19,9 +21,6 @@ buildKodiAddon rec {
 
   passthru = {
     pythonPath = "resources/lib";
-    updateScript = addonUpdateScript {
-      attrPath = "kodi.packages.youtube";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi/addons/youtube/default.nix
+++ b/pkgs/applications/video/kodi/addons/youtube/default.nix
@@ -3,13 +3,13 @@
 buildKodiAddon rec {
   pname = "youtube";
   namespace = "plugin.video.youtube";
-  version = "7.0.1";
+  version = "7.0.2.2";
 
   src = fetchFromGitHub {
     owner = "anxdpanic";
     repo = "plugin.video.youtube";
     rev = "v${version}";
-    hash = "sha256-BHCVui+enKFH3elz6DovXMDxMQx/2+/BrIw3KQr9TfE=";
+    hash = "sha256-BUeE/8oQYBiq4XgIp4nv0hjEQz3nnkDWCnAf4kpptwk=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/anxdpanic/plugin.video.youtube/blob/v7.0.2.2/changelog.txt

Note that the update also requires a change to the source URL, which now
points to the [official GitHub repository of the addon](https://github.com/CastagnaIT/plugin.video.netflix). This is required
because the update version is not availbale via the official addon
repository. The updated source can be cross-checked via the [official addon page](https://kodi.tv/addons/nexus/plugin.video.youtube/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).