### PR TITLE
kodi.packages.netflix: 1.20.2 -> 1.22.3

### DIFF
--- a/pkgs/applications/video/kodi/addons/netflix/default.nix
+++ b/pkgs/applications/video/kodi/addons/netflix/default.nix
@@ -3,13 +3,13 @@
 buildKodiAddon rec {
   pname = "netflix";
   namespace = "plugin.video.netflix";
-  version = "1.20.2";
+  version = "1.22.3";
 
   src = fetchFromGitHub {
     owner = "CastagnaIT";
     repo = namespace;
     rev = "v${version}";
-    sha256 = "sha256-k2O8a0P+TzQVoFQJkzmdqmkKh3Aj7OlsnuhJfUwxOmI=";
+    sha256 = "sha256-8NGj8n1p8euqYYdPDSeFh2ZE9lly5ThSmg69yXY3Te8=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.20.3
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.20.4
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.20.5
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.20.6
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.20.7
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.20.8
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.21.0
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.22.0
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.22.1
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.22.2
- https://github.com/CastagnaIT/plugin.video.netflix/releases/tag/v1.22.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).