### PR TITLE
rpi-imager: 1.7.5 -> 1.8.1

### DIFF
--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , wrapQtAppsHook
 , cmake
+, pkg-config
 , util-linux
 , curl
 , libarchive
@@ -12,23 +13,25 @@
 , qttools
 , qtquickcontrols2
 , qtgraphicaleffects
+, xz
 , nix-update-script
 , enableTelemetry ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "rpi-imager";
-  version = "1.7.5";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-yB+H1zWL40KzxOrBuvg7nBC3zmWilsOgOW7ndiDWuDA=";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-drHiZ0eYYvJg6/v3oEozGAbBKm1KLpec+kYZWwpT9yM=";
   };
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     util-linux
     wrapQtAppsHook
   ];
@@ -48,6 +51,7 @@ stdenv.mkDerivation rec {
     qttools
     qtquickcontrols2
     qtgraphicaleffects
+    xz
   ];
 
   sourceRoot = "${src.name}/src";

--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -14,18 +14,19 @@
 , qtquickcontrols2
 , qtgraphicaleffects
 , xz
+, testers
 , nix-update-script
 , enableTelemetry ? false
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rpi-imager";
   version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
-    repo = pname;
-    rev = "refs/tags/v${version}";
+    repo = finalAttrs.pname;
+    rev = "refs/tags/v${finalAttrs.version}";
     sha256 = "sha256-drHiZ0eYYvJg6/v3oEozGAbBKm1KLpec+kYZWwpT9yM=";
   };
 
@@ -54,33 +55,25 @@ stdenv.mkDerivation rec {
     xz
   ];
 
-  sourceRoot = "${src.name}/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
 
   /* By default, the builder checks for JSON support in lsblk by running "lsblk --json",
     but that throws an error, as /sys/dev doesn't exist in the sandbox.
     This patch removes the check. */
   patches = [ ./lsblkCheckFix.patch ];
 
-  doInstallCheck = true;
-
-  installCheckPhase = ''
-    runHook preInstallCheck
-
-    # Without this, the tests fail because they cannot create the QT Window
-    export QT_QPA_PLATFORM=offscreen
-    $out/bin/rpi-imager --version
-
-    runHook postInstallCheck
-  '';
-
   passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "QT_QPA_PLATFORM=offscreen rpi-imager --version";
+    };
     updateScript = nix-update-script { };
   };
 
   meta = with lib; {
     description = "Raspberry Pi Imaging Utility";
     homepage = "https://www.raspberrypi.com/software/";
-    changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${version}";
+    changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${finalAttrs.version}";
     downloadPage = "https://github.com/raspberrypi/rpi-imager/";
     license = licenses.asl20;
     maintainers = with maintainers; [ ymarkus anthonyroussel ];
@@ -88,4 +81,4 @@ stdenv.mkDerivation rec {
     # does not build on darwin
     broken = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${finalAttrs.version}";
     downloadPage = "https://github.com/raspberrypi/rpi-imager/";
     license = licenses.asl20;
+    mainProgram = "rpi-imager";
     maintainers = with maintainers; [ ymarkus anthonyroussel ];
     platforms = platforms.all;
     # does not build on darwin


### PR DESCRIPTION
## Description of changes

https://github.com/raspberrypi/rpi-imager/releases/tag/v1.8.1
https://github.com/raspberrypi/rpi-imager/compare/v1.7.5...v1.8.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
