### PR TITLE
pixinsight: 1.8.9-2-20230920 -> 1.8.9-3-20240619

### DIFF
--- a/pkgs/applications/graphics/pixinsight/default.nix
+++ b/pkgs/applications/graphics/pixinsight/default.nix
@@ -1,18 +1,60 @@
-{ stdenv, lib, requireFile, wrapQtAppsHook, autoPatchelfHook, makeWrapper, unixtools, fakeroot
-, mailcap, libGL, libpulseaudio, alsa-lib, nss, gd, gst_all_1, nspr, expat, fontconfig
-, dbus, glib, zlib, openssl, libdrm, cups, avahi-compat, xorg, wayland, libudev0-shim
-# Qt 5 subpackages
-, qtbase, qtgamepad, qtserialport, qtserialbus, qtvirtualkeyboard, qtmultimedia, qt3d, mlt
+{ stdenv
+, lib
+, requireFile
+, wrapQtAppsHook
+, autoPatchelfHook
+, makeWrapper
+, unixtools
+, fakeroot
+, mailcap
+, libGL
+, libpulseaudio
+, alsa-lib
+, nss
+, gd
+, gst_all_1
+, nspr
+, expat
+, fontconfig
+, dbus
+, glib
+, zlib
+, openssl
+, libdrm
+, cups
+, avahi-compat
+, xorg
+, wayland
+, libudev0-shim
+, bubblewrap
+, libjpeg8
+, gdk-pixbuf
+, gtk3
+, pango
+  # Qt 6 subpackages
+, qtbase
+, qtserialport
+, qtserialbus
+, qtvirtualkeyboard
+, qtmultimedia
+, qt3d
+, mlt
+, qtlocation
+, qtwebengine
+, qtquick3d
+, qtwayland
+, qtwebview
+, qtscxml
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pixinsight";
-  version = "1.8.9-2";
+  version = "1.8.9-3";
 
   src = requireFile rec {
-    name = "PI-linux-x64-${version}-20230920-c.tar.xz";
+    name = "PI-linux-x64-${finalAttrs.version}-20240619-c.tar.xz";
     url = "https://pixinsight.com/";
-    hash = "sha256-g7paYTYv52XBg0w3d3YhVNrmt+iS20uobaUsvY6F3jM=";
+    hash = "sha256-WZrD+X7zE1i29+YsGJ+wbIXmlVon9bczHvvRAkQXz6M=";
     message = ''
       PixInsight is available from ${url} and requires a commercial (or trial) license.
       After a license has been obtained, PixInsight can be downloaded from the software distribution
@@ -30,6 +72,7 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
     mailcap
     libudev0-shim
+    bubblewrap
   ];
 
   buildInputs = [
@@ -53,15 +96,25 @@ stdenv.mkDerivation rec {
     wayland
     cups
     avahi-compat
+    libjpeg8
+    gdk-pixbuf
+    gtk3
+    pango
     # Qt stuff
     qt3d
     mlt
     qtbase
-    qtgamepad
+    #qtgamepad
     qtserialport
     qtserialbus
     qtvirtualkeyboard
     qtmultimedia
+    qtlocation
+    qtwebengine
+    qtquick3d
+    qtwayland
+    qtwebview
+    qtscxml
   ] ++ (with xorg; [
     libX11
     libXdamage
@@ -86,9 +139,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/opt/PixInsight $out/share/{applications,mime/packages,icons/hicolor}
 
-    fakeroot script -ec "./installer \
+    bwrap --bind /build /build --bind $out/opt /opt --bind /nix /nix --dev /dev fakeroot script -ec "./installer \
       --yes \
-      --install-dir=$out/opt/PixInsight \
       --install-desktop-dir=$out/share/applications \
       --install-mime-dir=$out/share/mime \
       --install-icons-dir=$out/share/icons/hicolor \
@@ -97,6 +149,11 @@ stdenv.mkDerivation rec {
 
     rm -rf $out/opt/PixInsight-old-0
     ln -s $out/opt/PixInsight/bin/PixInsight $out/bin/.
+    ln -s $out/opt/PixInsight/bin/lib $out/lib
+
+    # Remove signatures of plugins, as they are only working if actually installed
+    # under /opt. In the Nix setup, they are causing trouble.
+    find $out/opt/PixInsight/ -name "*.xsgn" -exec rm {} \;
   '';
 
   # Some very exotic Qt libraries are not available in nixpkgs
@@ -118,7 +175,7 @@ stdenv.mkDerivation rec {
   ];
   dontWrapQtApps = true;
   postFixup = ''
-    wrapProgram $out/opt/PixInsight/bin/PixInsight ${builtins.toString qtWrapperArgs}
+    wrapProgram $out/opt/PixInsight/bin/PixInsight ${builtins.toString finalAttrs.qtWrapperArgs}
   '';
 
   meta = with lib; {
@@ -128,7 +185,7 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.sheepforce ];
-    hydraPlatforms = [];
+    hydraPlatforms = [ ];
     mainProgram = "PixInsight";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31489,7 +31489,7 @@ with pkgs;
 
   pixeluvo = callPackage ../applications/graphics/pixeluvo { };
 
-  pixinsight = libsForQt5.callPackage ../applications/graphics/pixinsight { };
+  pixinsight = qt6Packages.callPackage ../applications/graphics/pixinsight { };
 
   planner = callPackage ../applications/office/planner { };
 


### PR DESCRIPTION
## Description of changes

https://pixinsight.com/forum/index.php?threads/pixinsight-1-8-9-2-build-1588-released.21898/

The previous version has been removed from the software distribution and can no longer be downloaded :/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).