### PR TITLE
toml-f: 0.3.1 -> 0.4.1

### DIFF
--- a/pkgs/development/libraries/science/chemistry/tblite/default.nix
+++ b/pkgs/development/libraries/science/chemistry/tblite/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , gfortran
 , blas
@@ -25,6 +26,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-R7CAFG/x55k5Ieslxeq+DWq1wPip4cI+Yvn1cBbeVNs=";
   };
+
+  patches = [
+    # toml-f 0.4 compatibility
+    (fetchpatch {
+      url = "https://github.com/tblite/tblite/commit/da759fd02b8fbf470a5c6d3df9657cca6b1d0a9a.diff";
+      hash = "sha256-VaeA2VyK+Eas432HMSpJ0lXxHBBNGpfkUO1eHeWpYl0=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake gfortran ];
 

--- a/pkgs/development/libraries/toml-f/default.nix
+++ b/pkgs/development/libraries/toml-f/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "toml-f";
-  version = "0.3.1";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-8FbnUkeJUP4fiuJCroAVDo6U2M7ZkFLpG2OYrapMYtU=";
+    hash = "sha256-sCU0uMdcXIA5O964hlK37cOrLTlk1CJeTcWD9FhevOs=";
   };
 
   nativeBuildInputs = [ gfortran cmake ];


### PR DESCRIPTION
## Description of changes

https://github.com/toml-f/toml-f/releases/tag/v0.4.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
