### PR TITLE
darwin.CoreSymbolication: refactor, unstable-2018-04-08 -> unstable-2018-06-17

### DIFF
--- a/pkgs/os-specific/darwin/CoreSymbolication/default.nix
+++ b/pkgs/os-specific/darwin/CoreSymbolication/default.nix
@@ -1,19 +1,23 @@
-{ fetchFromGitHub, stdenv }:
+{ lib, fetchFromGitHub, stdenv }:
 
-# Reverse engineered CoreSymbolication to make dtrace buildable
-
-stdenv.mkDerivation rec {
-  name = "CoreSymbolication";
+stdenv.mkDerivation {
+  pname = "core-symbolication";
+  version = "unstable-2018-04-08";
 
   src = fetchFromGitHub {
-    repo = name;
+    repo = "CoreSymbolication";
     owner = "matthewbauer";
     rev = "671fcb66c82eac1827f3f53dc4cc4e9b1b94da0a";
-    sha256 = "0qpw46gwgjxiwqqjxksb8yghp2q8dwad6hzaf4zl82xpvk9n5ahj";
+    hash = "sha256-0qpw46gwgjxiwqqjxksb8yghp2q8dwad6hzaf4zl82xpvk9n5ahj";
   };
 
-  installPhase = ''
-    mkdir -p $out/include
-    cp -r CoreSymbolication $out/include
-  '';
+  makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  meta = with lib; {
+    description = "Reverse engineered headers for Apple's CoreSymbolication framework";
+    homepage = "https://github.com/matthewbauer/CoreSymbolication";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ matthewbauer ];
+  };
 }

--- a/pkgs/os-specific/darwin/CoreSymbolication/default.nix
+++ b/pkgs/os-specific/darwin/CoreSymbolication/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "core-symbolication";
-  version = "unstable-2018-04-08";
+  version = "unstable-2018-06-17";
 
   src = fetchFromGitHub {
     repo = "CoreSymbolication";
     owner = "matthewbauer";
-    rev = "671fcb66c82eac1827f3f53dc4cc4e9b1b94da0a";
-    hash = "sha256-0qpw46gwgjxiwqqjxksb8yghp2q8dwad6hzaf4zl82xpvk9n5ahj";
+    rev = "24c87c23664b3ee05dc7a5a87d647ae476a680e4";
+    hash = "sha256-PzvLq94eNhP0+rLwGMKcMzxuD6MlrNI7iT/eV0obtSE=";
   };
 
   makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Things done:
 - Renamed the package name to conform to the [package name convention](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-naming)
   This should be nonbreaking, as I have not done anything about it's path.
 - Added `version`
 - Swapped out the `installPhase` in favour of setting `PREFIX` in `makeFlags`, as this should have the same effect AFAIK?
 - Added a meta block
   - Moved the comment (or rather the similar one from the repo) at the top into `meta.description`
   - Marked license as `mit`. While it doesn't explicitly say "MIT LICENSE" anywhere, the text in the README is equal or extremely similar to the MIT license.
   - Added @matthewbauer as maintainer, since this seems to be your package? Are you okay with this?

I don't own a darwin machine myself, so I'd be happy if any darwin maintainers could have a look at this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
