### PR TITLE
ps3netsrv: replace with webman mod fork

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -315,6 +315,8 @@
 
 - `win-virtio` package was renamed to `virtio-win` to be consistent with the upstream package name.
 
+- `ps3netsrv` has been replaced with the webman-mod fork, the executable has been renamed from `ps3netsrv++` to `ps3netsrv` and cli parameters have changed.
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/pkgs/servers/ps3netsrv/default.nix
+++ b/pkgs/servers/ps3netsrv/default.nix
@@ -1,31 +1,34 @@
-{ lib, stdenv, fetchFromGitHub }:
-
-stdenv.mkDerivation {
+{ lib, stdenv, fetchzip, mbedtls, meson, ninja, fetchFromGitHub }:
+let
+  webManModVersion = "1.47.42";
+in
+stdenv.mkDerivation rec {
   pname = "ps3netsrv";
-  version = "1.1.0";
+  version = "20220813";
 
-  enableParallelBuilding = true;
-
-  src = fetchFromGitHub {
-    owner = "dirkvdb";
-    repo = "ps3netsrv--";
-    rev = "e54a66cbf142b86e2cffc1701984b95adb921e81";
-    sha256 = "sha256-SpPyRhPwOhTONAYH/eqLGmVl2XzhA1r1nUwKj7+rGyY=";
-    fetchSubmodules = true;
+  src = fetchzip {
+    url = "https://github.com/aldostools/webMAN-MOD/releases/download/${webManModVersion}/${pname}_${version}.zip";
+    hash = "sha256-ynFuCD+tp8E/DDdB/HU9BCmwKcmQy6NBx26MKnP4W0o=";
   };
 
-  buildPhase = "make CXX=$CXX";
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ps3netsrv++ $out/bin
+  sourceRoot = "./source/${pname}";
+
+  buildInputs = [
+    meson
+    ninja
+    mbedtls
+  ];
+
+  postInstall = ''
+    install -Dm644 ../LICENSE.TXT $out/usr/share/licenses/${pname}/LICENSE.TXT
   '';
 
   meta = {
-    description = "C++ implementation of the ps3netsrv server";
-    homepage = "https://github.com/dirkvdb/ps3netsrv--";
-    license = lib.licenses.mit;
+    description = "PS3 Net Server (mod by aldostools)";
+    homepage = "https://github.com/aldostools/webMAN-MOD/";
+    license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ makefu ];
-    mainProgram = "ps3netsrv++";
+    mainProgram = "ps3netsrv";
   };
 }


### PR DESCRIPTION
## Description of changes

because the original project is not compatible with the latest cfw (https://github.com/dirkvdb/ps3netsrv--/issues/18) the package is replaced with the working fork. The package follows the AUR pkgbuild.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

