### PR TITLE
stlink-tool: init at 0-unstable-2020-06-10

### DIFF
--- a/pkgs/by-name/st/stlink-tool/package.nix
+++ b/pkgs/by-name/st/stlink-tool/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, pkg-config
+, fetchFromGitHub
+, libusb1
+}:
+
+# IMPORTANT: You need permissions to access the stlink usb devices.
+# Add services.udev.packages = [ pkgs.stlink ] to your configuration.nix
+stdenv.mkDerivation {
+  pname = "stlink-tool";
+  version = "0-unstable-2020-06-10";
+
+  src = fetchFromGitHub {
+    owner = "jeanthom";
+    repo = "stlink-tool";
+    rev = "8cbdffee012d5a782dd67d1277ed22fa889b9ba9";
+    hash = "sha256-1Mk4rFyIviJ9hcJo1GyzRmlPIemBJtuj3PgvnNhche0=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ libusb1 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-uninitialized";
+
+  installPhase = ''
+    runHook preInstall
+    install -D stlink-tool $out/bin/stlink-tool
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "libusb tool for flashing chinese ST-Link dongles";
+    homepage = "https://github.com/jeanthom/stlink-tool";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.wucke13 ];
+    mainProgram = "stlink-tool";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
