### PR TITLE
build-support/php: make validation check a non blocking process 

### DIFF
--- a/pkgs/build-support/php/build-composer-project.nix
+++ b/pkgs/build-support/php/build-composer-project.nix
@@ -13,6 +13,7 @@ let
       composerNoDev = previousAttrs.composerNoDev or true;
       composerNoPlugins = previousAttrs.composerNoPlugins or true;
       composerNoScripts = previousAttrs.composerNoScripts or true;
+      composerStrictValidation = previousAttrs.composerStrictValidation or true;
 
       nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [
         composer
@@ -69,6 +70,7 @@ let
         composerNoDev = previousAttrs.composerNoDev or true;
         composerNoPlugins = previousAttrs.composerNoPlugins or true;
         composerNoScripts = previousAttrs.composerNoScripts or true;
+        composerStrictValidation = previousAttrs.composerStrictValidation or true;
       };
 
       COMPOSER_CACHE_DIR="/dev/null";

--- a/pkgs/build-support/php/build-composer-repository.nix
+++ b/pkgs/build-support/php/build-composer-repository.nix
@@ -32,6 +32,7 @@ let
       composerNoDev = previousAttrs.composerNoDev or true;
       composerNoPlugins = previousAttrs.composerNoPlugins or true;
       composerNoScripts = previousAttrs.composerNoScripts or true;
+      composerStrictValidation = previousAttrs.composerStrictValidation or true;
 
       name = "${previousAttrs.pname}-${previousAttrs.version}-composer-repository";
 

--- a/pkgs/build-support/php/hooks/composer-install-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-install-hook.sh
@@ -35,14 +35,16 @@ composerInstallConfigureHook() {
         cp composer.lock $out/
 
         echo
-        echo 'No composer.lock file found, consider adding one to your repository to ensure reproducible builds.'
-        echo "In the meantime, a composer.lock file has been generated for you in $out/composer.lock"
+        echo -e "\e[31mERROR: No composer.lock found\e[0m"
         echo
-        echo 'To fix the issue:'
-        echo "1. Copy the composer.lock file from $out/composer.lock to the project's source:"
-        echo "  cp $out/composer.lock <path>"
-        echo '2. Add the composerLock attribute, pointing to the copied composer.lock file:'
-        echo '  composerLock = ./composer.lock;'
+        echo -e '\e[31mNo composer.lock file found, consider adding one to your repository to ensure reproducible builds.\e[0m'
+        echo -e "\e[31mIn the meantime, a composer.lock file has been generated for you in $out/composer.lock\e[0m"
+        echo
+        echo -e '\e[31mTo fix the issue:\e[0m'
+        echo -e "\e[31m1. Copy the composer.lock file from $out/composer.lock to the project's source:\e[0m"
+        echo -e "\e[31m  cp $out/composer.lock <path>\e[0m"
+        echo -e '\e[31m2. Add the composerLock attribute, pointing to the copied composer.lock file:\e[0m'
+        echo -e '\e[31m  composerLock = ./composer.lock;\e[0m'
         echo
 
         exit 1
@@ -51,15 +53,15 @@ composerInstallConfigureHook() {
     echo "Validating consistency between composer.lock and ${composerRepository}/composer.lock"
     if ! @cmp@ -s "composer.lock" "${composerRepository}/composer.lock"; then
         echo
-        echo "ERROR: vendorHash is out of date"
+        echo -e "\e[31mERROR: vendorHash is out of date\e[0m"
         echo
-        echo "composer.lock is not the same in $composerRepository"
+        echo -e "\e[31mcomposer.lock is not the same in $composerRepository\e[0m"
         echo
-        echo "To fix the issue:"
-        echo '1. Set vendorHash to an empty string: `vendorHash = "";`'
-        echo '2. Build the derivation and wait for it to fail with a hash mismatch'
-        echo '3. Copy the "got: sha256-..." value back into the vendorHash field'
-        echo '   You should have: vendorHash = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=";'
+        echo -e "\e[31mTo fix the issue:\e[0m"
+        echo -e '\e[31m1. Set vendorHash to an empty string: `vendorHash = "";`\e[0m'
+        echo -e '\e[31m2. Build the derivation and wait for it to fail with a hash mismatch\e[0m'
+        echo -e '\e[31m3. Copy the "got: sha256-..." value back into the vendorHash field\e[0m'
+        echo -e '\e[31m   You should have: vendorHash = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=";\e[0m'
         echo
 
         exit 1

--- a/pkgs/build-support/php/hooks/composer-install-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-install-hook.sh
@@ -107,7 +107,26 @@ composerInstallBuildHook() {
 composerInstallCheckHook() {
     echo "Executing composerInstallCheckHook"
 
-    composer validate --no-ansi --no-interaction
+    if ! composer validate --strict --no-ansi --no-interaction --quiet; then
+        if [ ! -z "${composerStrictValidation-}" ]; then
+            echo
+            echo -e "\e[31mERROR: composer files validation failed\e[0m"
+            echo
+            echo -e '\e[31mThe validation of the composer.json and composer.lock failed.\e[0m'
+            echo -e '\e[31mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
+            echo
+            exit 1
+        else
+            echo
+            echo -e "\e[33mWARNING: composer files validation failed\e[0m"
+            echo
+            echo -e '\e[33mThe validation of the composer.json and composer.lock failed.\e[0m'
+            echo -e '\e[33mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
+            echo
+            echo -e '\e[33mThis check is not blocking, but it is recommended to fix the issue.\e[0m'
+            echo
+        fi
+    fi
 
     echo "Finished composerInstallCheckHook"
 }

--- a/pkgs/build-support/php/hooks/composer-repository-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-repository-hook.sh
@@ -3,6 +3,7 @@ declare version
 declare composerNoDev
 declare composerNoPlugins
 declare composerNoScripts
+declare composerStrictValidation
 
 preConfigureHooks+=(composerRepositoryConfigureHook)
 preBuildHooks+=(composerRepositoryBuildHook)
@@ -65,7 +66,26 @@ composerRepositoryBuildHook() {
 composerRepositoryCheckHook() {
     echo "Executing composerRepositoryCheckHook"
 
-    composer validate --no-ansi --no-interaction
+    if ! composer validate --strict --no-ansi --no-interaction --quiet; then
+        if [ ! -z "${composerStrictValidation-}" ]; then
+            echo
+            echo -e "\e[31mERROR: composer files validation failed\e[0m"
+            echo
+            echo -e '\e[31mThe validation of the composer.json and composer.lock failed.\e[0m'
+            echo -e '\e[31mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
+            echo
+            exit 1
+        else
+            echo
+            echo -e "\e[33mWARNING: composer files validation failed\e[0m"
+            echo
+            echo -e '\e[33mThe validation of the composer.json and composer.lock failed.\e[0m'
+            echo -e '\e[33mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
+            echo
+            echo -e '\e[33mThis check is not blocking, but it is recommended to fix the issue.\e[0m'
+            echo
+        fi
+    fi
 
     echo "Finished composerRepositoryCheckHook"
 }

--- a/pkgs/build-support/php/hooks/composer-repository-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-repository-hook.sh
@@ -31,14 +31,16 @@ composerRepositoryConfigureHook() {
         cp composer.lock $out/
 
         echo
-        echo 'No composer.lock file found, consider adding one to your repository to ensure reproducible builds.'
-        echo "In the meantime, a composer.lock file has been generated for you in $out/composer.lock"
+        echo -e "\e[31mERROR: No composer.lock found\e[0m"
         echo
-        echo 'To fix the issue:'
-        echo "1. Copy the composer.lock file from $out/composer.lock to the project's source:"
-        echo "  cp $out/composer.lock <path>"
-        echo '2. Add the composerLock attribute, pointing to the copied composer.lock file:'
-        echo '  composerLock = ./composer.lock;'
+        echo -e '\e[31mNo composer.lock file found, consider adding one to your repository to ensure reproducible builds.\e[0m'
+        echo -e "\e[31mIn the meantime, a composer.lock file has been generated for you in $out/composer.lock\e[0m"
+        echo
+        echo -e '\e[31mTo fix the issue:\e[0m'
+        echo -e "\e[31m1. Copy the composer.lock file from $out/composer.lock to the project's source:\e[0m"
+        echo -e "\e[31m  cp $out/composer.lock <path>\e[0m"
+        echo -e '\e[31m2. Add the composerLock attribute, pointing to the copied composer.lock file:\e[0m'
+        echo -e '\e[31m  composerLock = ./composer.lock;\e[0m'
         echo
 
         exit 1


### PR DESCRIPTION
This PR:

1. Add the color red for error messages, orange for warnings. Exemple:
  ![image](https://github.com/NixOS/nixpkgs/assets/252042/185ead40-167f-4eab-8937-2da4b75900e2)
2. Make the `composer validate` a step that can be skipped by the user by adding the `composerStrictValidation` set to `false`; by default and to preserve the current behaviour, it is set to `true`. 
3. The Grumphp update has been removed - after thinking twice, I won't provide the update until the upstream repo is updated.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
