### PR TITLE
haproxy: 2.9.2 -> 2.9.3; Enable QUIC support

### DIFF
--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -1,21 +1,41 @@
-import ./make-test-python.nix ({ pkgs, ...}: {
+import ./make-test-python.nix ({ lib, pkgs, ...}: {
   name = "haproxy";
   nodes = {
-    machine = { ... }: {
-      services.haproxy = {
+    server = { ... }: {
+     services.haproxy = {
         enable = true;
         config = ''
+          global
+            limited-quic
+
           defaults
+            mode http
             timeout connect 10s
+            timeout client 10s
+            timeout server 10s
+
+            log /dev/log local0 debug err
+            option logasap
+            option httplog
+            option httpslog
 
           backend http_server
-            mode http
-            server httpd [::1]:8000
+            server httpd [::1]:8000 alpn http/1.1
 
           frontend http
-            bind *:80
-            mode http
+            bind :80
+            bind :443 ssl strict-sni crt /etc/ssl/fullchain.pem alpn h2,http/1.1
+            bind quic4@:443 ssl strict-sni crt /etc/ssl/fullchain.pem alpn h3 allow-0rtt
+
+            http-after-response add-header alt-svc 'h3=":443"; ma=60' if { ssl_fc }
+
             http-request use-service prometheus-exporter if { path /metrics }
+            use_backend http_server
+
+          frontend http-cert-auth
+            bind :8443 ssl strict-sni crt /etc/ssl/fullchain.pem verify required ca-file /etc/ssl/cacert.crt
+            bind quic4@:8443 ssl strict-sni crt /etc/ssl/fullchain.pem verify required ca-file /etc/ssl/cacert.crt alpn h3
+
             use_backend http_server
         '';
       };
@@ -30,24 +50,75 @@ import ./make-test-python.nix ({ pkgs, ...}: {
           }];
         };
       };
+      networking.firewall.allowedTCPPorts = [ 80 443 8443 ];
+      networking.firewall.allowedUDPPorts = [ 443 8443 ];
+     };
+    client = { ... }: {
+      environment.systemPackages = [ pkgs.curlHTTP3 ];
     };
   };
   testScript = ''
+    # Helpers
+    def cmd(command):
+      print(f"+{command}")
+      r = os.system(command)
+      if r != 0:
+        raise Exception(f"Command {command} failed with exit code {r}")
+
+    def openssl(command):
+      cmd(f"${pkgs.openssl}/bin/openssl {command}")
+
+    # Generate CA.
+    openssl("req -new -newkey rsa:4096 -nodes -x509 -days 7 -subj '/C=ZZ/ST=Cloud/L=Unspecified/O=NixOS/OU=Tests/CN=CA Certificate' -keyout cacert.key -out cacert.crt")
+
+    # Generate and sign Server.
+    openssl("req -newkey rsa:4096 -nodes -subj '/CN=server/OU=Tests/O=NixOS' -keyout server.key -out server.csr")
+    openssl("x509 -req -in server.csr -out server.crt -CA cacert.crt -CAkey cacert.key -days 7")
+    cmd("cat server.crt server.key > fullchain.pem")
+
+    # Generate and sign Client.
+    openssl("req -newkey rsa:4096 -nodes -subj '/CN=client/OU=Tests/O=NixOS' -keyout client.key -out client.csr")
+    openssl("x509 -req -in client.csr -out client.crt -CA cacert.crt -CAkey cacert.key -days 7")
+    cmd("cat client.crt client.key > client.pem")
+
+    # Start the actual test.
     start_all()
-    machine.wait_for_unit("multi-user.target")
-    machine.wait_for_unit("haproxy.service")
-    machine.wait_for_unit("httpd.service")
-    assert "We are all good!" in machine.succeed("curl -fk http://localhost:80/index.txt")
-    assert "haproxy_process_pool_allocated_bytes" in machine.succeed(
-        "curl -fk http://localhost:80/metrics"
-    )
+    server.copy_from_host("fullchain.pem", "/etc/ssl/fullchain.pem")
+    server.copy_from_host("cacert.crt", "/etc/ssl/cacert.crt")
+    server.succeed("chmod 0644 /etc/ssl/fullchain.pem /etc/ssl/cacert.crt")
+
+    client.copy_from_host("cacert.crt", "/etc/ssl/cacert.crt")
+    client.copy_from_host("client.pem", "/root/client.pem")
+
+    server.wait_for_unit("multi-user.target")
+    server.wait_for_unit("haproxy.service")
+    server.wait_for_unit("httpd.service")
+
+    assert "We are all good!" in client.succeed("curl -f http://server/index.txt")
+    assert "haproxy_process_pool_allocated_bytes" in client.succeed("curl -f http://server/metrics")
+
+    with subtest("https"):
+      assert "We are all good!" in client.succeed("curl -f --cacert /etc/ssl/cacert.crt https://server/index.txt")
+
+    with subtest("https-cert-auth"):
+      # Client must succeed in authenticating with the right certificate.
+      assert "We are all good!" in client.succeed("curl -f --cacert /etc/ssl/cacert.crt --cert-type pem --cert /root/client.pem https://server:8443/index.txt")
+      # Client must fail without certificate.
+      client.fail("curl --cacert /etc/ssl/cacert.crt https://server:8443/index.txt")
+
+    with subtest("h3"):
+      assert "We are all good!" in client.succeed("curl -f --http3-only --cacert /etc/ssl/cacert.crt https://server/index.txt")
+
+    with subtest("h3-cert-auth"):
+      # Client must succeed in authenticating with the right certificate.
+      assert "We are all good!" in client.succeed("curl -f --http3-only --cacert /etc/ssl/cacert.crt --cert-type pem --cert /root/client.pem https://server:8443/index.txt")
+      # Client must fail without certificate.
+      client.fail("curl -f --http3-only --cacert /etc/ssl/cacert.crt https://server:8443/index.txt")
 
     with subtest("reload"):
-        machine.succeed("systemctl reload haproxy")
+        server.succeed("systemctl reload haproxy")
         # wait some time to ensure the following request hits the reloaded haproxy
-        machine.sleep(5)
-        assert "We are all good!" in machine.succeed(
-            "curl -fk http://localhost:80/index.txt"
-        )
+        server.sleep(5)
+        assert "We are all good!" in client.succeed("curl -f http://server/index.txt")
   '';
 })

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,39 +1,44 @@
 { useLua ? true
 , usePcre ? true
-# QUIC "is currently supported as an experimental feature" so shouldn't be enabled by default
-, useQuicTls ? false
 , withPrometheusExporter ? true
+, sslLibrary ? "quictls"
 , stdenv
 , lib
 , fetchurl
 , nixosTests
 , zlib
 , libxcrypt
-, openssl ? null
-, quictls ? null
-, lua5_3 ? null
-, pcre ? null
-, systemd ? null
+, wolfssl
+, libressl
+, quictls
+, openssl
+, lua5_4
+, pcre2
+, systemd
 }:
 
-assert useLua -> lua5_3 != null;
-assert usePcre -> pcre != null;
-assert useQuicTls -> quictls != null;
-assert !useQuicTls -> openssl != null;
-
-let sslPkg = if useQuicTls then quictls else openssl;
+assert lib.assertOneOf "sslLibrary" sslLibrary [ "quictls" "openssl" "libressl" "wolfssl" ];
+let
+  sslPkgs = {
+    inherit quictls openssl libressl;
+    wolfssl = wolfssl.override {
+      variant = "haproxy";
+      extraConfigureFlags = [ "--enable-quic" ];
+    };
+  };
+  sslPkg = sslPkgs.${sslLibrary};
 in stdenv.mkDerivation (finalAttrs: {
   pname = "haproxy";
-  version = "2.9.2";
+  version = "2.9.3";
 
   src = fetchurl {
     url = "https://www.haproxy.org/download/${lib.versions.majorMinor finalAttrs.version}/src/haproxy-${finalAttrs.version}.tar.gz";
-    hash = "sha256-hRrugw7CjBeRJGqf1EePZD0RWlY92Qf2YSzDgalSqzw=";
+    hash = "sha256-7VF8ZavYaUVBH2vLGMfsZXpwaTHLeB6igwY7oKdYWMA=";
   };
 
   buildInputs = [ sslPkg zlib libxcrypt ]
-    ++ lib.optional useLua lua5_3
-    ++ lib.optional usePcre pcre
+    ++ lib.optional useLua lua5_4
+    ++ lib.optional usePcre pcre2
     ++ lib.optional stdenv.isLinux systemd;
 
   # TODO: make it work on bsd as well
@@ -46,20 +51,23 @@ in stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildFlags = [
-    "USE_OPENSSL=yes"
-    "SSL_LIB=${sslPkg}/lib"
-    "SSL_INC=${sslPkg}/include"
     "USE_ZLIB=yes"
-  ] ++ lib.optionals useQuicTls [
-    "USE_QUIC=1"
+    "USE_OPENSSL=yes"
+    "SSL_INC=${lib.getDev sslPkg}/include"
+    "SSL_LIB=${lib.getDev sslPkg}/lib"
+    "USE_QUIC=yes"
+  ] ++ lib.optionals (sslLibrary == "openssl") [
+    "USE_QUIC_OPENSSL_COMPAT=yes"
+  ] ++ lib.optionals (sslLibrary == "wolfssl") [
+    "USE_OPENSSL_WOLFSSL=yes"
   ] ++ lib.optionals usePcre [
-    "USE_PCRE=yes"
-    "USE_PCRE_JIT=yes"
+    "USE_PCRE2=yes"
+    "USE_PCRE2_JIT=yes"
   ] ++ lib.optionals useLua [
     "USE_LUA=yes"
     "LUA_LIB_NAME=lua"
-    "LUA_LIB=${lua5_3}/lib"
-    "LUA_INC=${lua5_3}/include"
+    "LUA_LIB=${lua5_4}/lib"
+    "LUA_INC=${lua5_4}/include"
   ] ++ lib.optionals stdenv.isLinux [
     "USE_SYSTEMD=yes"
     "USE_GETADDRINFO=1"
@@ -84,7 +92,7 @@ in stdenv.mkDerivation (finalAttrs: {
       tens of thousands of connections is clearly realistic with todays
       hardware.
     '';
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ vifino ];
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "haproxy";
   };


### PR DESCRIPTION
## Description of changes
This enables switching SSL Libraries.
In addition, this switches to PCRE2 and Lua 5.4 from PCRE and Lua 5.3.
Should have no functional differences, apart from the added QUIC support which needs to be configured in HAProxy.

This also adds more test cases, specifically for SSL, mutual TLS and QUIC.

According to the recent [SSL Library Support Wiki Page](https://github.com/haproxy/wiki/wiki/SSL-Libraries-Support-Status), OpenSSL 3.X is not the best choice by far.

I would really like WolfSSL, as that seems to be the one with the best performance yet there are still many unimplemented features.
It requires a different build config, but that's the way wolfssl intends to be used.

However, in order to make this easier to merge without worrying about breakage, it still defaults to OpenSSL (3.X) 
A future PR might flip the switch, though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
