### PR TITLE
lomiri.content-hub: init at 1.1.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -31,6 +31,7 @@ let
 
     #### Services
     biometryd = callPackage ./services/biometryd { };
+    content-hub = callPackage ./services/content-hub { };
     hfd-service = callPackage ./services/hfd-service { };
     history-service = callPackage ./services/history-service { };
     lomiri-download-manager = callPackage ./services/lomiri-download-manager { };

--- a/pkgs/desktops/lomiri/services/content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/content-hub/default.nix
@@ -1,0 +1,179 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, fetchpatch2
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, dbus-test-runner
+, gettext
+, glib
+, gsettings-qt
+, gtest
+, libapparmor
+, libnotify
+, lomiri-api
+, lomiri-app-launch
+, lomiri-download-manager
+, lomiri-ui-toolkit
+, pkg-config
+, properties-cpp
+, qtbase
+, qtdeclarative
+, qtfeedback
+, qtgraphicaleffects
+, wrapGAppsHook
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "content-hub";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/content-hub";
+    rev = finalAttrs.version;
+    hash = "sha256-IntEpgPCBmOL6K6TU+UhgGb6OHVA9pYurK5VN3woIIw=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "examples"
+  ];
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/33 merged & in release
+    (fetchpatch {
+      name = "0001-content-hub-Migrate-to-GetConnectionCredentials.patch";
+      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/9c0eae42d856b4b6e24fa609ade0e674c7a84cfe.patch";
+      hash = "sha256-IWoCQKSCCk26n7133oG0Ht+iEjavn/IiOVUM+tCLX2U=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/34 merged & in release
+    (fetchpatch {
+      name = "0002-content-hub-import-Lomiri-Content-CMakeLists-Drop-qt-argument-to-qmlplugindump.patch";
+      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/63a4baf1469de31c4fd50c69ed85d061f5e8e80a.patch";
+      hash = "sha256-T+6T9lXne6AhDFv9d7L8JNwdl8f0wjDmvSoNVPkHza4=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/35 merged & in release
+    # fetchpatch2 due to renames, https://github.com/NixOS/nixpkgs/issues/32084
+    (fetchpatch2 {
+      name = "0003-content-hub-Add-more-better-GNUInstallDirs-variables-usage.patch";
+      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/3c5ca4a8ec125e003aca78c14521b70140856c25.patch";
+      hash = "sha256-kYN0eLwMyM/9yK+zboyEsoPKZMZ4SCXodVYsvkQr2F8=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace import/*/Content/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+
+    # Look for peer files in running system
+    substituteInPlace src/com/lomiri/content/service/registry-updater.cpp \
+      --replace '/usr' '/run/current-system/sw'
+
+    # Don't override default theme search path (which honours XDG_DATA_DIRS) with a FHS assumption
+    substituteInPlace import/Lomiri/Content/contenthubplugin.cpp \
+      --replace 'QIcon::setThemeSearchPaths(QStringList() << ("/usr/share/icons/"));' ""
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    qtdeclarative # qmlplugindump
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    cmake-extras
+    glib
+    gsettings-qt
+    libapparmor
+    libnotify
+    lomiri-api
+    lomiri-app-launch
+    lomiri-download-manager
+    lomiri-ui-toolkit
+    properties-cpp
+    qtbase
+    qtdeclarative
+    qtfeedback
+    qtgraphicaleffects
+  ];
+
+  nativeCheckInputs = [
+    dbus-test-runner
+    xvfb-run
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "ENABLE_DOC" false) # needs Qt5 qdoc: https://github.com/NixOS/nixpkgs/pull/245379
+    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true) # in case something still depends on it
+  ];
+
+  preBuild = let
+    listToQtVar = list: suffix: lib.strings.concatMapStringsSep ":" (drv: "${lib.getBin drv}/${suffix}") list;
+  in ''
+    # Executes qmlplugindump
+    export QT_PLUGIN_PATH=${listToQtVar [ qtbase ] qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${listToQtVar [ qtdeclarative lomiri-ui-toolkit qtfeedback qtgraphicaleffects ] qtbase.qtQmlPrefix}
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Starts & talks to D-Bus services, breaks under parallelism
+  enableParallelChecking = false;
+
+  preFixup = ''
+    for exampleExe in content-hub-test-{importer,exporter,sharer}; do
+      moveToOutput bin/$exampleExe $examples
+      moveToOutput share/applications/$exampleExe.desktop $examples
+    done
+    moveToOutput share/icons $examples
+  '';
+
+  postFixup = ''
+    for exampleBin in $examples/bin/*; do
+      wrapGApp $exampleBin
+    done
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Content sharing/picking service";
+    longDescription = ''
+      content-hub is a mediation service to let applications share content between them,
+      even if they are not running at the same time.
+    '';
+    homepage = "https://gitlab.com/ubports/development/core/content-hub";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    mainProgram = "content-hub-service";
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "libcontent-hub"
+      "libcontent-hub-glib"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Content Hub](https://gitlab.com/ubports/development/core/content-hub) is the system Lomiri uses for securely exchanging data between applications. It integrates with D-Bus mediation via AppArmor if present, but doesn't require it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
