### PR TITLE
python3Packages.formbox: 0.4.1 -> 0.4.3

### DIFF
--- a/pkgs/development/python-modules/formbox/default.nix
+++ b/pkgs/development/python-modules/formbox/default.nix
@@ -1,26 +1,24 @@
-{ lib, buildPythonPackage, pythonOlder, fetchFromSourcehut, flit-core, bleach, markdown }:
+{ lib, buildPythonPackage, pythonOlder, fetchzip, flit-core, mistune, nh3 }:
 
 buildPythonPackage rec {
   pname = "formbox";
-  version = "0.4.1";
+  version = "0.4.3";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
-  src = fetchFromSourcehut {
-    owner = "~cnx";
-    repo = pname;
-    rev = version;
-    hash = "sha256-zOvXmSeBiwc0Z5mRMwMsHLU3A/iP7rpjXm0T0I2gUTk=";
+  src = fetchzip {
+    url = "https://trong.loang.net/~cnx/formbox/snapshot/formbox-${version}.tar.gz";
+    hash = "sha256-sRu0otyeYpxot/Fyiz3wyQJsJvl8nsgIVitzT8frxLE=";
   };
 
   nativeBuildInputs = [ flit-core ];
-  propagatedBuildInputs = [ bleach markdown ];
+  propagatedBuildInputs = [ mistune nh3 ];
   doCheck = false; # there's no test
   pythonImportsCheck = [ "formbox" ];
 
   meta = with lib; {
     description = "A script to format mbox as HTML/XML";
-    homepage = "https://sr.ht/~cnx/formbox";
+    homepage = "https://trong.loang.net/~cnx/formbox";
     license = licenses.agpl3Plus;
     maintainers = [ maintainers.McSinyx ];
   };


### PR DESCRIPTION
## Description of changes

New version uses `nh3` instead of the deprecated `bleach` for sanitization.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).