### PR TITLE
lomiri.morph-browser: init at 1.1.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -539,6 +539,7 @@ in {
   mongodb = handleTest ./mongodb.nix {};
   moodle = handleTest ./moodle.nix {};
   moonraker = handleTest ./moonraker.nix {};
+  morph-browser = handleTest ./morph-browser.nix { };
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};
   moosefs = handleTest ./moosefs.nix {};

--- a/nixos/tests/morph-browser.nix
+++ b/nixos/tests/morph-browser.nix
@@ -1,0 +1,53 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "morph-browser-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+
+    environment = {
+      systemPackages = with pkgs.lomiri; [
+        suru-icon-theme
+        morph-browser
+      ];
+      variables = {
+        UITK_ICON_THEME = "suru";
+      };
+    };
+
+    i18n.supportedLocales = [ "all" ];
+
+    fonts.packages = with pkgs; [
+      # Intended font & helps with OCR
+      ubuntu_font_family
+    ];
+  };
+
+  enableOCR = true;
+
+  testScript =
+    ''
+      machine.wait_for_x()
+
+      with subtest("morph browser launches"):
+          machine.execute("morph-browser >&2 &")
+          machine.wait_for_text(r"Web Browser|New|sites|Bookmarks")
+          machine.screenshot("morph_open")
+
+      with subtest("morph browser displays HTML"):
+          machine.send_chars("file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html\n")
+          machine.wait_for_text("Valgrind Documentation")
+          machine.screenshot("morph_htmlcontent")
+
+      machine.succeed("pkill -f morph-browser")
+
+      with subtest("morph browser localisation works"):
+          machine.execute("env LANG=de_DE.UTF-8 morph-browser >&2 &")
+          machine.wait_for_text(r"Web-Browser|Neuer|Seiten|Lesezeichen")
+          machine.screenshot("morph_localised")
+    '';
+})

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -11,7 +11,6 @@
 , lomiri-ui-extras
 , lomiri-ui-toolkit
 , pkg-config
-, python3
 , qqc2-suru-style
 , qtbase
 , qtdeclarative
@@ -91,9 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeCheckInputs = [
-    (python3.withPackages (ps: with ps; [
-      flake8
-    ]))
     xvfb-run
   ];
 
@@ -101,6 +97,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
       # Exclude tests
       "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
+        # Don't care about linter failures
+        "^flake8"
+
         # Runs into ShapeMaterial codepath in lomiri-ui-toolkit which needs OpenGL, see LUITK for details
         "^tst_QmlTests"
       ]})")

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -1,0 +1,134 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, cmake
+, content-hub
+, gettext
+, libapparmor
+, lomiri-action-api
+, lomiri-ui-extras
+, lomiri-ui-toolkit
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+, qtquickcontrols2
+, qtsystems
+, qtwebengine
+, wrapQtAppsHook
+, xvfb-run
+}:
+
+let
+  listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "morph-browser";
+  version = "1.0.3";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/morph-browser";
+    rev = finalAttrs.version;
+    hash = "sha256-gzrNIIRTnIiL5T1HYy2x9mGawZwW6vhCt3b5k3NhpKI=";
+  };
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/morph-browser/-/merge_requests/575 merged & in release
+    (fetchpatch {
+      name = "0001-morph-browser-tst_SessionUtilsTests-Set-permissions-on-temporary-xdg-runtime-directory.patch";
+      url = "https://gitlab.com/ubports/development/core/morph-browser/-/commit/e90206105b8b287fbd6e45ac37ca1cd259981928.patch";
+      hash = "sha256-5htFn+OGVVBn3mJQaZcF5yt0mT+2QRlKyKFesEhklfA=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/morph-browser/-/merge_requests/576 merged & in release
+    (fetchpatch {
+      name = "0002-morph-browser-Call-i18n-bindtextdomain-with-buildtime-determined-locale-path.patch";
+      url = "https://gitlab.com/ubports/development/core/morph-browser/-/commit/0527a1e01fb27c62f5e0011274f73bad400e9691.patch";
+      hash = "sha256-zx/pP72uNqAi8TZR4bKeONuqcJyK/vGtPglTA+5R5no=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/{Morph,Ubuntu}/CMakeLists.txt \
+      --replace '/usr/lib/''${CMAKE_LIBRARY_ARCHITECTURE}/qt5/qml' "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+
+    # Don't use absolute paths in desktop file
+    substituteInPlace src/app/webbrowser/morph-browser.desktop.in.in \
+      --replace 'Icon=@CMAKE_INSTALL_FULL_DATADIR@/morph-browser/morph-browser.svg' 'Icon=morph-browser' \
+      --replace 'X-Lomiri-Splash-Image=@CMAKE_INSTALL_FULL_DATADIR@/morph-browser/morph-browser-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/morph-browser.svg'
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'add_subdirectory(tests)' ""
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libapparmor
+    qtbase
+    qtdeclarative
+    qtwebengine
+
+    # QML
+    content-hub
+    lomiri-action-api
+    lomiri-ui-extras
+    lomiri-ui-toolkit
+    qtquickcontrols2
+    qtsystems
+  ];
+
+  nativeCheckInputs = [
+    (python3.withPackages (ps: with ps; [
+      flake8
+    ]))
+    xvfb-run
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
+      # Exclude tests
+      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
+        # Runs into ShapeMaterial codepath in lomiri-ui-toolkit which needs OpenGL, see LUITK for details
+        "^tst_QmlTests"
+      ]})")
+    ]))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    export QT_PLUGIN_PATH=${listToQtVar qtbase.qtPluginPrefix [ qtbase ]}
+    export QML2_IMPORT_PATH=${listToQtVar qtbase.qtQmlPrefix ([ lomiri-ui-toolkit qtwebengine qtdeclarative qtquickcontrols2 qtsystems ] ++ lomiri-ui-toolkit.propagatedBuildInputs)}
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/splash}
+
+    ln -s $out/share/{morph-browser,icons/hicolor/scalable/apps}/morph-browser.svg
+    ln -s $out/share/{morph-browser/morph-browser-splash.svg,lomiri-app-launch/splash/morph-browser.svg}
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "Lightweight web browser tailored for Ubuntu Touch";
+    homepage = "https://gitlab.com/ubports/development/core/morph-browser";
+    changelog = "https://gitlab.com/ubports/development/core/morph-browser/-/blob/${finalAttrs.version}/ChangeLog";
+    license = with licenses; [ gpl3Only cc-by-sa-30 ];
+    mainProgram = "morph-browser";
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -12,6 +12,7 @@
 , lomiri-ui-toolkit
 , pkg-config
 , python3
+, qqc2-suru-style
 , qtbase
 , qtdeclarative
 , qtquickcontrols2
@@ -26,13 +27,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "morph-browser";
-  version = "1.0.3";
+  version = "1.1.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/morph-browser";
     rev = finalAttrs.version;
-    hash = "sha256-gzrNIIRTnIiL5T1HYy2x9mGawZwW6vhCt3b5k3NhpKI=";
+    hash = "sha256-C5iXv8VS8Mm1ryxK7Vi5tVmiM01OSIFiTyH0vP9B/xA=";
   };
 
   patches = [
@@ -84,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-action-api
     lomiri-ui-extras
     lomiri-ui-toolkit
+    qqc2-suru-style
     qtquickcontrols2
     qtsystems
   ];

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitLab
 , fetchpatch
 , gitUpdater
+, nixosTests
 , cmake
 , content-hub
 , gettext
@@ -121,7 +122,10 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/share/{morph-browser/morph-browser-splash.svg,lomiri-app-launch/splash/morph-browser.svg}
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru = {
+    updateScript = gitUpdater { };
+    tests.standalone = nixosTests.morph-browser;
+  };
 
   meta = with lib; {
     description = "Lightweight web browser tailored for Ubuntu Touch";

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Core Apps
     lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };
+    morph-browser = callPackage ./applications/morph-browser { };
 
     #### Data
     lomiri-schemas = callPackage ./data/lomiri-schemas { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Morph Browser](https://gitlab.com/ubports/development/core/morph-browser) is the Lomiri web browser. Last time I checked, neither Firefox nor Chrome work under Lomiri (Wayland), so this might be necessary for everyday use.

![image](https://github.com/NixOS/nixpkgs/assets/23431373/7bb2da6a-ee64-4e64-aa36-0eb584747b9f)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
