### PR TITLE
kismet: 2022-08 -> 2023-07. disable coconut.

### DIFF
--- a/pkgs/applications/networking/sniffers/kismet/default.nix
+++ b/pkgs/applications/networking/sniffers/kismet/default.nix
@@ -87,6 +87,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
+    "--disable-wifi-coconut"  # Until https://github.com/kismetwireless/kismet/issues/478
   ] ++ lib.optionals (!withNetworkManager) [
     "--disable-libnm"
   ] ++ lib.optionals (!withPython) [

--- a/pkgs/applications/networking/sniffers/kismet/default.nix
+++ b/pkgs/applications/networking/sniffers/kismet/default.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kismet";
-  version = "2022-08-R1";
+  version = "2023-07-R1";
 
   src = fetchurl {
     url = "https://www.kismetwireless.net/code/${pname}-${version}.tar.xz";
-    hash = "sha256-IUnM6sVSZQhlP00C3PemlOPaPcAAojcqHuS/mYgnl4E=";
+    hash = "sha256-8IVI4mymX6HlZ7Heu+ocpNDnIGvduWpPY5yQFxhz6Pc=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Update to kismet, for full details please see the [release notes](https://www.kismetwireless.net/posts/kismet-2023-07-r1/)

Note: This does not build support for the [WiFi Coconut](https://shop.hak5.org/products/wifi-coconut) as there is currently an [open blocker](https://github.com/kismetwireless/kismet/issues/478).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
