### PR TITLE
nixos/flatpak: pass system icons and fonts

### DIFF
--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -32,6 +32,8 @@ in {
 
     security.polkit.enable = true;
 
+    fonts.fontDir.enable = true;
+
     services.dbus.packages = [ pkgs.flatpak ];
 
     systemd.packages = [ pkgs.flatpak ];

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -97,6 +97,10 @@ stdenv.mkDerivation (finalAttrs: {
     # The icon validator needs to access the gdk-pixbuf loaders in the Nix store
     # and cannot bind FHS paths since those are not available on NixOS.
     finalAttrs.passthru.icon-validator-patch
+
+    # Try mounting fonts and icons from NixOS locations if FHS locations don't exist.
+    # https://github.com/NixOS/nixpkgs/issues/119433
+    ./fix-fonts-icons.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/flatpak/fix-fonts-icons.patch
+++ b/pkgs/development/libraries/flatpak/fix-fonts-icons.patch
@@ -1,0 +1,87 @@
+diff --git a/common/flatpak-run.c b/common/flatpak-run.c
+index 94ad013..5c9f55e 100644
+--- a/common/flatpak-run.c
++++ b/common/flatpak-run.c
+@@ -871,6 +871,49 @@ out:
+   return res;
+ }
+ 
++static void
++get_nix_closure (GHashTable *closure, const gchar *source_path)
++{
++  if (g_file_test (source_path, G_FILE_TEST_IS_SYMLINK))
++    {
++      g_autofree gchar *path = g_malloc(PATH_MAX);
++      realpath(source_path, path);
++      if (g_str_has_prefix(path, "/nix/store/"))
++        {
++          *strchr(path + strlen("/nix/store/"), '/') = 0;
++          g_hash_table_add(closure, g_steal_pointer (&path));
++        }
++    }
++  else if (g_file_test (source_path, G_FILE_TEST_IS_DIR))
++    {
++      g_autoptr(GDir) dir = g_dir_open(source_path, 0, NULL);
++      const gchar *file_name;
++      while ((file_name = g_dir_read_name(dir)))
++        {
++          g_autofree gchar *path = g_build_filename (source_path, file_name, NULL);
++          get_nix_closure (closure, path);
++        }
++    }
++}
++
++static void
++add_nix_store_symlink_targets (FlatpakBwrap *bwrap, const gchar *source_path)
++{
++  GHashTable *closure = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
++
++  get_nix_closure(closure, source_path);
++
++  GHashTableIter iter;
++  gpointer path;
++  g_hash_table_iter_init(&iter, closure);
++  while (g_hash_table_iter_next(&iter, &path, NULL))
++    {
++      flatpak_bwrap_add_args (bwrap, "--ro-bind", path, path, NULL);
++    }
++
++  g_hash_table_destroy(closure);
++}
++
+ static void
+ add_font_path_args (FlatpakBwrap *bwrap)
+ {
+@@ -898,6 +946,18 @@ add_font_path_args (FlatpakBwrap *bwrap)
+                               "\t<remap-dir as-path=\"%s\">/run/host/fonts</remap-dir>\n",
+                               SYSTEM_FONTS_DIR);
+     }
++  else if (g_file_test ("/run/current-system/sw/share/X11/fonts", G_FILE_TEST_EXISTS))
++    {
++      add_nix_store_symlink_targets (bwrap, "/run/current-system/sw/share/X11/fonts");
++      flatpak_bwrap_add_args (bwrap,
++                              "--ro-bind",
++                              "/run/current-system/sw/share/X11/fonts",
++                              "/run/host/fonts",
++                              NULL);
++      g_string_append_printf (xml_snippet,
++                              "\t<remap-dir as-path=\"%s\">/run/host/fonts</remap-dir>\n",
++                              "/run/current-system/sw/share/X11/fonts");
++    }
+ 
+   if (g_file_test ("/usr/local/share/fonts", G_FILE_TEST_EXISTS))
+     {
+@@ -998,6 +1058,13 @@ add_icon_path_args (FlatpakBwrap *bwrap)
+                               "--ro-bind", "/usr/share/icons", "/run/host/share/icons",
+                               NULL);
+     }
++  else if (g_file_test ("/run/current-system/sw/share/icons", G_FILE_TEST_IS_DIR))
++    {
++      add_nix_store_symlink_targets (bwrap, "/run/current-system/sw/share/icons");
++      flatpak_bwrap_add_args (bwrap,
++                              "--ro-bind", "/run/current-system/sw/share/icons", "/run/host/share/icons",
++                              NULL);
++    }
+ 
+   user_icons_path = g_build_filename (g_get_user_data_dir (), "icons", NULL);
+   user_icons = g_file_new_for_path (user_icons_path);


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/119433

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add another patch to Flatpak that mounts the NixOS system font and icon directories into the sandbox if the standard FHS ones don't exist. The FHS paths are still checked so that the Flatpak build still works on non-NixOS systems. Since these directories contain symlinks into `/nix/store`, the patch also walks the tree of symlinks to collect a list of `/nix/store` paths to expose to the sandbox.

Also, change the default for `fonts.fontDir.enable` from `false` to `services.flatpak.enable`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
