### PR TITLE
perlPackages.CryptHSXKPasswd: fix deps and shebang for Darwin

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4954,7 +4954,12 @@ with self; {
       url = "mirror://cpan/authors/id/B/BA/BARTB/Crypt-HSXKPasswd-v3.6.tar.gz";
       hash = "sha256-lZ3MX58BG/ALha0i31ZrerK/XqHTYrDeD7WuKfvEWLM=";
     };
-    buildInputs = [ Clone DateTime FileHomeDir FileShare FileShareDir GetoptLong JSON ListMoreUtils MathRound Readonly TextUnidecode TypeTiny ];
+    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+    propagatedBuildInputs = [ Clone DateTime FileHomeDir FileShare FileShareDir GetoptLong JSON ListMoreUtils MathRound Readonly TextUnidecode TypeTiny ];
+    postInstall = lib.optionalString stdenv.isDarwin ''
+      shortenPerlShebang $out/bin/hsxkpasswd
+    '';
+
     meta = {
       description = "A secure memorable password generator";
       homepage = "http://www.bartb.ie/hsxkpasswd";


### PR DESCRIPTION
## Description of changes

cf https://github.com/NixOS/nixpkgs/pull/237446#discussion_r1367689297

- fix shebang for Darwin:

<details>
<summary>Details</summary>


```
[nix-shell:~]$ hsxkpasswd
/nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/bin/hsxkpasswd: line 3: use: command not found
/nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/bin/hsxkpasswd: line 4: use: command not found
/nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/bin/hsxkpasswd: line 5: syntax error near unexpected token `('
/nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/bin/hsxkpasswd: line 5: `use English qw( -no_match_vars );
```


</details>

- propagate build deps:

<details>
<summary>Details</summary>

```
[nix-shell:~]$ perl $(which hsxkpasswd)
Can't locate File/HomeDir.pm in @INC (you may need to install the File::HomeDir module) (@INC contains: /nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/lib/perl5/site_perl /nix/store/6inma8zgm16n4dx6yn5niykv7d3zyi0q-perl5.38.0-Type-Tiny-1.012000/lib/perl5/site_perl /nix/store/8cjfmyfxnrpqgadd4by98arlxc1y3dgi-perl5.38.0-Text-Unidecode-1.30/lib/perl5/site_perl /nix/store/an28h7bzdr8wz1bb96vgf49fimz490x8-perl5.38.0-Readonly-2.05/lib/perl5/site_perl /nix/store/g7qh05q38pwxph9p7pami7hqx800p6jf-perl5.38.0-Math-Round-0.07/lib/perl5/site_perl /nix/store/mz737vi0r169z52fvvy8p0b6jxz2r1wj-perl5.38.0-List-MoreUtils-XS-0.430/lib/perl5/site_perl /nix/store/q1dfa32hdkvj4rphlaavsxjpm7qrvf06-perl5.38.0-Exporter-Tiny-1.002002/lib/perl5/site_perl /nix/store/60qahrn5j6dl9i758vsxb4c2v9vn5grz-perl5.38.0-List-MoreUtils-0.430/lib/perl5/site_perl /nix/store/sabjhcsdli3nwrwjajm4k0xwqv0pw4pg-perl5.38.0-JSON-4.02/lib/perl5/site_perl /nix/store/g324aw8jvf691h809ifa320m57kijnr7-perl5.38.0-Getopt-Long-2.52/lib/perl5/site_perl /nix/store/8k43s0334yx3ijrmnkgyx34d3rklpxqi-perl5.38.0-File-Share-0.25/lib/perl5/site_perl /nix/store/llc6hs533lcp6w61rdz4bq7skannl41g-perl5.38.0-File-Which-1.23/lib/perl5/site_perl /nix/store/kmmh41s3fq0clai505igw1k0bz7xliyp-perl5.38.0-File-HomeDir-1.006/lib/perl5/site_perl /nix/store/a3r7kks14yy5cvzq59y0zja834yimmaj-perl5.38.0-Class-Singleton-1.6/lib/perl5/site_perl /nix/store/7bf2big4c1bg76hvl9d61a31vh3cz52n-perl5.38.0-DateTime-TimeZone-2.44/lib/perl5/site_perl /nix/store/25fy4b48qjy49fg14bp9vvvz4i6x1sps-perl5.38.0-Dist-CheckConflicts-0.11/lib/perl5/site_perl /nix/store/p3j47p8px0q6h2wk7f4z3khwikw9hzxp-perl5.38.0-Package-Stash-0.39/lib/perl5/site_perl /nix/store/nnj8mnh6dip283by12madjh85dylwbqp-perl5.38.0-Sub-Exporter-Progressive-0.001013/lib/perl5/site_perl /nix/store/zwqy7qrz5dqv07hv3k060hi1r7688pzq-perl5.38.0-Module-Implementation-0.09/lib/perl5/site_perl /nix/store/zghkkyz3dm1421a64p6j4fsbb56qh056-perl5.38.0-B-Hooks-EndOfScope-0.24/lib/perl5/site_perl /nix/store/6paslgar1ys3qp2b0kdpjl81mkz8rnj4-perl5.38.0-namespace-clean-0.27/lib/perl5/site_perl /nix/store/6jsqvky4jc6jdfw1q3d350bkf13xkhis-perl5.38.0-Sub-Identify-0.14/lib/perl5/site_perl /nix/store/5fkk5w8zsvpjlfmlfgkjryhg2fzihq0y-perl5.38.0-namespace-autoclean-0.29/lib/perl5/site_perl /nix/store/0lav1z5nzwn25rz9650cwl3wzm3pcqh6-perl5.38.0-Try-Tiny-0.30/lib/perl5/site_perl /nix/store/yxchg1ln1w7a9iix4lh9p5p9xq65r6v0-perl5.38.0-Sub-Quote-2.006006/lib/perl5/site_perl /nix/store/pr44xw1vdmpbqbi9s487qs59dqjfmv2l-perl5.38.0-Role-Tiny-2.001004/lib/perl5/site_perl /nix/store/cmb4f1dhnq77y3m5dyfmn57mn5i6p8v6-perl5.38.0-Module-Runtime-0.016/lib/perl5/site_perl /nix/store/bi6z545lga482fbyhis14s1x20sb83w8-perl5.38.0-MRO-Compat-0.13/lib/perl5/site_perl /nix/store/ndznzdrjpa5k45gwnwnxm77frnprf4hv-perl5.38.0-Specio-0.46/lib/perl5/site_perl /nix/store/lmqybkx2v77afzp129n8yvrdk3qmahf3-perl5.38.0-Devel-StackTrace-2.04/lib/perl5/site_perl /nix/store/scvsga2mxmlp5a1gvrkcsvy3yxj9qxa2-perl5.38.0-Class-Data-Inheritable-0.08/lib/perl5/site_perl /nix/store/gm3xj68d07c3j1byg6vjqiqvm78nrhyv-perl5.38.0-Exception-Class-1.44/lib/perl5/site_perl /nix/store/9gg4n44gblw6pp2ii85s6qpxlidlngc1-perl5.38.0-Eval-Closure-0.14/lib/perl5/site_perl /nix/store/ajrq3jy3wbrn4p8rrh5pwin6jlxpj1kr-perl5.38.0-Params-ValidationCompiler-0.30/lib/perl5/site_perl /nix/store/8r3q8974pdmj0nd4d1g089421j1hx26h-perl5.38.0-Class-Inspector-1.36/lib/perl5/site_perl /nix/store/5kyxdljscam009w8nhb4zr7qwcp3vj6v-perl5.38.0-File-ShareDir-1.118/lib/perl5/site_perl /nix/store/ib9h6a4i19dmx6lzkfrgpx0dmlxyhsd0-perl5.38.0-DateTime-Locale-1.28/lib/perl5/site_perl /nix/store/b9mwk34111dpjnpgsnk42k125dbm71z9-perl5.38.0-DateTime-1.54/lib/perl5/site_perl /nix/store/yj8mb2m7plvbbn2967fvwna5njvgryjv-perl5.38.0-Clone-0.45/lib/perl5/site_perl /nix/store/9i7rbbhxi1nnqibla22s785svlngcnvw-perl-5.38.0/lib/perl5/site_perl /Library/Perl/5.30/darwin-thread-multi-2level /Library/Perl/5.30 /Network/Library/Perl/5.30/darwin-thread-multi-2level /Network/Library/Perl/5.30 /Library/Perl/Updates/5.30.3 /System/Library/Perl/5.30/darwin-thread-multi-2level /System/Library/Perl/5.30 /System/Library/Perl/Extras/5.30/darwin-thread-multi-2level /System/Library/Perl/Extras/5.30) at /nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/bin/hsxkpasswd line 11.
BEGIN failed--compilation aborted at /nix/store/8w6bl63pfff4lylvm58srcf3m3dnf27m-perl5.38.0-Crypt-HSXKPasswd-3.6/bin/hsxkpasswd line 11.
```


</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
