### PR TITLE
tpm2-totp: init at 0.3.0

### DIFF
--- a/pkgs/by-name/tp/tpm2-totp/package.nix
+++ b/pkgs/by-name/tp/tpm2-totp/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, tpm2-tss
+, autoreconfHook
+, autoconf-archive
+, pkg-config
+, qrencode
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tpm2-totp";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "tpm2-software";
+    repo = "tpm2-totp";
+    rev = "v${version}";
+    hash = "sha256-aeWhI2GQcWa0xAqlmHfcbCMg78UqcD6eanLlEVNVnRM=";
+  };
+
+  preConfigure = ''
+    echo '0.3.0' > VERSION
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    pkg-config
+  ];
+
+  buildInputs = [
+    tpm2-tss
+    qrencode
+  ];
+
+  meta = with lib; {
+    description = "Attest the trustworthiness of a device against a human using time-based one-time passwords";
+    homepage = "https://github.com/tpm2-software/tpm2-totp";
+    changelog = "https://github.com/tpm2-software/tpm2-totp/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.bsd3;
+    mainProgram = "tpm2-totp";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This introduces TPM2 TOTP, a tool to enroll a TOTP secret in your TPM2 and offer you a way to enroll it on your authenticator so that you can put it in your boot phase to show the TOTP in a blocker manner and have a visible verification of your machine's state.

For inspiration and ideas on how to use this: https://trmm.net/Tpmtotp/

cc @edef1c 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
