### PR TITLE
chromium,chromedriver,electron: use sri hashes instead of sha256 everywhere

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -67,16 +67,16 @@ let
   ]);
   clangFormatPython3 = fetchurl {
     url = "https://chromium.googlesource.com/chromium/tools/build/+/e77882e0dde52c2ccf33c5570929b75b4a2a2522/recipes/recipe_modules/chromium/resources/clang-format?format=TEXT";
-    sha256 = "0ic3hn65dimgfhakli1cyf9j3cxcqsf1qib706ihfhmlzxf7256l";
+    hash = "sha256-1BRxXP+0QgejAWdFHJzGrLMhk/MsRDoVdK/GVoyFg0U=";
   };
 
   # The additional attributes for creating derivations based on the chromium
   # source tree.
   extraAttrs = buildFun base;
 
-  githubPatch = { commit, sha256, revert ? false }: fetchpatch {
+  githubPatch = { commit, hash, revert ? false }: fetchpatch {
     url = "https://github.com/chromium/chromium/commit/${commit}.patch";
-    inherit sha256 revert;
+    inherit hash revert;
   };
 
   mkGnFlags =
@@ -118,7 +118,7 @@ let
   libExecPath = "$out/libexec/${packageName}";
 
   ungoogler = ungoogled-chromium {
-    inherit (upstream-info.deps.ungoogled-patches) rev sha256;
+    inherit (upstream-info.deps.ungoogled-patches) rev hash;
   };
 
   # There currently isn't a (much) more concise way to get a stdenv
@@ -148,10 +148,10 @@ let
       else throw "no chromium Rosetta Stone entry for os: ${platform.config}";
   };
 
-  recompressTarball = { version, sha256 ? "" }: fetchzip {
+  recompressTarball = { version, hash ? "" }: fetchzip {
     name = "chromium-${version}.tar.zstd";
     url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-    inherit sha256;
+    inherit hash;
 
     nativeBuildInputs = [ zstd ];
 
@@ -180,7 +180,7 @@ let
     inherit (upstream-info) version;
     inherit packageName buildType buildPath;
 
-    src = recompressTarball { inherit version; inherit (upstream-info) sha256; };
+    src = recompressTarball { inherit version; inherit (upstream-info) hash; };
 
     nativeBuildInputs = [
       ninja pkg-config
@@ -250,7 +250,7 @@ let
       (githubPatch {
         # Reland [clang] Disable autoupgrading debug info in ThinLTO builds
         commit = "54969766fd2029c506befc46e9ce14d67c7ed02a";
-        sha256 = "sha256-Vryjg8kyn3cxWg3PmSwYRG6zrHOqYWBMSdEMGiaPg6M=";
+        hash = "sha256-Vryjg8kyn3cxWg3PmSwYRG6zrHOqYWBMSdEMGiaPg6M=";
         revert = true;
       })
     ];

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -57,7 +57,7 @@ let
       gnChromium = buildPackages.gn.overrideAttrs (oldAttrs: {
         inherit (upstream-info.deps.gn) version;
         src = fetchgit {
-          inherit (upstream-info.deps.gn) url rev sha256;
+          inherit (upstream-info.deps.gn) url rev hash;
         };
       });
     });
@@ -80,12 +80,12 @@ let
   chromeSrc =
     let
       # Use the latest stable Chrome version if necessary:
-      version = if chromium.upstream-info.sha256bin64 != null
+      version = if chromium.upstream-info.hash_deb_amd64 != null
         then chromium.upstream-info.version
         else (import ./upstream-info.nix).stable.version;
-      sha256 = if chromium.upstream-info.sha256bin64 != null
-        then chromium.upstream-info.sha256bin64
-        else (import ./upstream-info.nix).stable.sha256bin64;
+      hash = if chromium.upstream-info.hash_deb_amd64 != null
+        then chromium.upstream-info.hash_deb_amd64
+        else (import ./upstream-info.nix).stable.hash_deb_amd64;
     in fetchurl {
       urls = map (repo: "${repo}/${pkgName}/${pkgName}_${version}-1_amd64.deb") [
         "https://dl.google.com/linux/chrome/deb/pool/main/g"
@@ -93,7 +93,7 @@ let
         "http://mirror.pcbeta.com/google/chrome/deb/pool/main/g"
         "http://repo.fdzh.org/chrome/deb/pool/main/g"
       ];
-      inherit sha256;
+      inherit hash;
   };
 
   mkrpath = p: "${lib.makeSearchPathOutput "lib" "lib64" p}:${lib.makeLibraryPath p}";

--- a/pkgs/applications/networking/browsers/chromium/ungoogled.nix
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled.nix
@@ -6,10 +6,10 @@
 }:
 
 { rev
-, sha256
+, hash
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "ungoogled-chromium";
 
   version = rev;
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ungoogled-software";
     repo = "ungoogled-chromium";
-    inherit rev sha256;
+    inherit rev hash;
   };
 
   dontBuild = true;

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -59,9 +59,9 @@ def prefetch_src_sri_hash(attr_path, version):
 
 def nix_prefetch_url(url, algo='sha256'):
     """Prefetches the content of the given URL."""
-    print(f'nix-prefetch-url {url}')
-    out = subprocess.check_output(['nix-prefetch-url', '--type', algo, url])
-    return out.decode('utf-8').rstrip()
+    print(f'nix store prefetch-file {url}')
+    out = subprocess.check_output(['nix', 'store', 'prefetch-file', '--json', '--hash-type', algo, url])
+    return json.loads(out)['hash']
 
 
 def nix_prefetch_git(url, rev):
@@ -96,9 +96,9 @@ def get_chromedriver(channel):
 
         return {
             'version': channel['version'],
-            'sha256_linux': nix_prefetch_url(get_chromedriver_url('linux64')),
-            'sha256_darwin': nix_prefetch_url(get_chromedriver_url('mac-x64')),
-            'sha256_darwin_aarch64': nix_prefetch_url(get_chromedriver_url('mac-arm64'))
+            'hash_linux': nix_prefetch_url(get_chromedriver_url('linux64')),
+            'hash_darwin': nix_prefetch_url(get_chromedriver_url('mac-x64')),
+            'hash_darwin_aarch64': nix_prefetch_url(get_chromedriver_url('mac-arm64'))
         }
 
 
@@ -113,7 +113,7 @@ def get_channel_dependencies(version):
             'version': datetime.fromisoformat(gn['date']).date().isoformat(),
             'url': gn['url'],
             'rev': gn['rev'],
-            'sha256': gn['sha256']
+            'hash': gn['hash']
         }
     }
 
@@ -222,11 +222,11 @@ with urlopen(RELEASES_URL) as resp:
             google_chrome_suffix = channel_name
 
         try:
-            channel['sha256'] = prefetch_src_sri_hash(
+            channel['hash'] = prefetch_src_sri_hash(
                 channel_name_to_attr_name(channel_name),
                 release["version"]
             )
-            channel['sha256bin64'] = nix_prefetch_url(
+            channel['hash_deb_amd64'] = nix_prefetch_url(
                 f'{DEB_URL}/google-chrome-{google_chrome_suffix}/' +
                 f'google-chrome-{google_chrome_suffix}_{release["version"]}-1_amd64.deb')
         except subprocess.CalledProcessError:
@@ -241,7 +241,7 @@ with urlopen(RELEASES_URL) as resp:
             ungoogled_repo_url = 'https://github.com/ungoogled-software/ungoogled-chromium.git'
             channel['deps']['ungoogled-patches'] = {
                 'rev': release['ungoogled_tag'],
-                'sha256': nix_prefetch_git(ungoogled_repo_url, release['ungoogled_tag'])['sha256']
+                'hash': nix_prefetch_git(ungoogled_repo_url, release['ungoogled_tag'])['hash']
             }
             with open(UNGOOGLED_FLAGS_PATH, 'w') as out:
                 out.write(get_ungoogled_chromium_gn_flags(release['ungoogled_tag']))

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -3,63 +3,63 @@
     deps = {
       gn = {
         rev = "811d332bd90551342c5cbd39e133aa276022d7f8";
-        sha256 = "0jlg3d31p346na6a3yk0x29pm6b7q03ck423n5n6mi8nv4ybwajq";
+        hash = "sha256-WCq+PNkWxWpssUOQyQbAZ5l6k+hg+qGMsoaMG0Ybj0o=";
         url = "https://gn.googlesource.com/gn";
         version = "2023-08-01";
       };
     };
-    sha256 = "0c3adrrgpnhm8g1546ask9pf17qj1sjgb950mj0rv4snxvddi75j";
-    sha256bin64 = "11w1di146mjb9ql30df9yk9x4b9amc6514jzyfbf09mqsrw88dvr";
+    hash = "sha256-spzY2u5Wk52BrKCk9aQOEp/gbppaGVLCQxXa+3JuajA=";
+    hash_deb_amd64 = "sha256-eTeEeNa4JuCW81+SUAyrKi3S0/TJNTAoTktWQ0JsgYc=";
     version = "117.0.5938.22";
   };
   dev = {
     deps = {
       gn = {
         rev = "cc56a0f98bb34accd5323316e0292575ff17a5d4";
-        sha256 = "1ly7z48v147bfdb1kqkbc98myxpgqq3g6vgr8bjx1ikrk17l82ab";
+        hash = "sha256-SwlET5h5xtDlQvlt8wbG73ZfUWJr4hlWc+uQsBH5x9M=";
         url = "https://gn.googlesource.com/gn";
         version = "2023-08-10";
       };
     };
-    sha256 = "16dq27lsywrn2xlgr5g46gdv15p30sihfamli4vkv3zxzfxdjisv";
-    sha256bin64 = "11y09hsy7y1vg65xfilq44ffsmn15dqy80fa57psj1kin4a52v2x";
+    hash = "sha256-W0fZuvv9jz03ibQqB6MG45aw2zPklfxoFzZzr+kRuJk=";
+    hash_deb_amd64 = "sha256-XWxRFLFxBqnvKcoB5HErwVbtHCGYRteLeTv44zVMwIc=";
     version = "118.0.5966.0";
   };
   stable = {
     chromedriver = {
-      sha256_darwin = "0y973bs4dbdrl152bfiq5avsp6h27j3v1kwgcgxk1d0g293322xs";
-      sha256_darwin_aarch64 =
-        "04qrhr52qc9rhmslgsh2yymsix9cv32g39xbpf8576scihfdngv8";
-      sha256_linux = "1hy3s6j20h03ria033kfxd3rq259davvpjny4gpvznzklns71vi1";
+      hash_darwin = "sha256-ugsxRhIPtDD7Y4/PsIc8Apqrtyo4uiVKoLmtRvQaJ3k=";
+      hash_darwin_aarch64 =
+        "sha256-aD/bHIxMm1OQu6un8cTYLPWoq/cC6kd1hTkxLEqGGRM=";
+      hash_linux = "sha256-Ie5wtKXz27/vI97Ku7dqqQicR+tujgFUzANAIKTRw8M=";
       version = "118.0.5993.70";
     };
     deps = {
       gn = {
         rev = "cc56a0f98bb34accd5323316e0292575ff17a5d4";
-        sha256 = "1ly7z48v147bfdb1kqkbc98myxpgqq3g6vgr8bjx1ikrk17l82ab";
+        hash = "sha256-SwlET5h5xtDlQvlt8wbG73ZfUWJr4hlWc+uQsBH5x9M=";
         url = "https://gn.googlesource.com/gn";
         version = "2023-08-10";
       };
     };
-    sha256 = "sha256-CTkw92TiRD2tkYu5a5dy8fjpR2MMOMCvcbxXhJ36Bp8=";
-    sha256bin64 = "06rbsjh4khhl408181ns5nsdwasklb277fdjfajdv5h1j9a190k3";
+    hash = "sha256-CTkw92TiRD2tkYu5a5dy8fjpR2MMOMCvcbxXhJ36Bp8=";
+    hash_deb_amd64 = "sha256-Y4IUVJIBlt2kcrK5c8SiUyvetC3aBhQQIBTCSaDUKxs=";
     version = "118.0.5993.88";
   };
   ungoogled-chromium = {
     deps = {
       gn = {
         rev = "cc56a0f98bb34accd5323316e0292575ff17a5d4";
-        sha256 = "1ly7z48v147bfdb1kqkbc98myxpgqq3g6vgr8bjx1ikrk17l82ab";
+        hash = "sha256-SwlET5h5xtDlQvlt8wbG73ZfUWJr4hlWc+uQsBH5x9M=";
         url = "https://gn.googlesource.com/gn";
         version = "2023-08-10";
       };
       ungoogled-patches = {
         rev = "118.0.5993.88-1";
-        sha256 = "17j47d64l97ascp85h8cnfnr5wr4va3bdk95wmagqss7ym5c7zsf";
+        hash = "sha256-Tv/DSvVHa/xU5SXNtobaJPOSrbMMwYIu0+okSkw7RJ4=";
       };
     };
-    sha256 = "sha256-CTkw92TiRD2tkYu5a5dy8fjpR2MMOMCvcbxXhJ36Bp8=";
-    sha256bin64 = "06rbsjh4khhl408181ns5nsdwasklb277fdjfajdv5h1j9a190k3";
+    hash = "sha256-CTkw92TiRD2tkYu5a5dy8fjpR2MMOMCvcbxXhJ36Bp8=";
+    hash_deb_amd64 = "sha256-Y4IUVJIBlt2kcrK5c8SiUyvetC3aBhQQIBTCSaDUKxs=";
     version = "118.0.5993.88";
   };
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -884,7 +884,7 @@
                     "version": "2023-09-12",
                     "url": "https://gn.googlesource.com/gn",
                     "rev": "991530ce394efb58fcd848195469022fa17ae126",
-                    "sha256": "1zpbaspb2mncbsabps8n1iwzc67nhr79ndc9dnqxx1w1qfvaldg2"
+                    "hash": "sha256-4jWqtsOBh96xbYk1m06G9hj2eQwW6buUXsxWsa5W6/4="
                 }
             }
         },
@@ -1776,7 +1776,7 @@
                     "version": "2023-08-10",
                     "url": "https://gn.googlesource.com/gn",
                     "rev": "cc56a0f98bb34accd5323316e0292575ff17a5d4",
-                    "sha256": "1ly7z48v147bfdb1kqkbc98myxpgqq3g6vgr8bjx1ikrk17l82ab"
+                    "hash": "sha256-SwlET5h5xtDlQvlt8wbG73ZfUWJr4hlWc+uQsBH5x9M="
                 }
             }
         },
@@ -2620,7 +2620,7 @@
                     "version": "2023-06-09",
                     "url": "https://gn.googlesource.com/gn",
                     "rev": "4bd1a77e67958fb7f6739bd4542641646f264e5d",
-                    "sha256": "14h9jqspb86sl5lhh6q0kk2rwa9zcak63f8drp7kb3r4dx08vzsw"
+                    "hash": "sha256-XP+NQG8kjzXPzQ25YaZiPymexZwAGwhpodqgdTWWCZI="
                 }
             }
         },
@@ -3440,7 +3440,7 @@
                     "version": "2023-04-19",
                     "url": "https://gn.googlesource.com/gn",
                     "rev": "5a004f9427a050c6c393c07ddb85cba8ff3849fa",
-                    "sha256": "01xrh9m9m6x8lz0vxwdw2mrhrvnw93zpg09hwdhqakj06agf4jjk"
+                    "hash": "sha256-U0rinjJAToVh4zCBd/9I3O4McxW88b7Bp6ibmmqCuQc="
                 }
             }
         },

--- a/pkgs/development/tools/electron/update.py
+++ b/pkgs/development/tools/electron/update.py
@@ -188,7 +188,7 @@ def get_gn_source(repo):
             "version": datetime.fromisoformat(gn["date"]).date().isoformat(),
             "url": gn["url"],
             "rev": gn["rev"],
-            "sha256": gn["sha256"]
+            "hash": gn["hash"]
         }
     }
 

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -10,17 +10,17 @@ let
   allSpecs = {
     x86_64-linux = {
       system = "linux64";
-      sha256 = upstream-info.sha256_linux;
+      hash = upstream-info.hash_linux;
     };
 
     x86_64-darwin = {
       system = "mac-x64";
-      sha256 = upstream-info.sha256_darwin;
+      hash = upstream-info.hash_darwin;
     };
 
     aarch64-darwin = {
       system = "mac-arm64";
-      sha256 = upstream-info.sha256_darwin_aarch64;
+      hash = upstream-info.hash_darwin_aarch64;
     };
   };
 
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${version}/${spec.system}/chromedriver-${spec.system}.zip";
-    sha256 = spec.sha256;
+    hash = spec.hash;
   };
 
   nativeBuildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
## Description of changes

This pull request removes `sha256` entries in `upstream-info.nix` and `info.json` and replaces them with sri hashes in `hash` fields. This pull request also changes the update scripts accordingly.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
