### PR TITLE
python-matter-server: include server extra

### DIFF
--- a/pkgs/development/python-modules/home-assistant-chip-clusters/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-clusters/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-chip-clusters";
-  version = "2023.6.0";
+  version = "2023.10.1";
   format = "wheel";
 
   src = fetchPypi {
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     pname = "home_assistant_chip_clusters";
     dist = "py3";
     python = "py3";
-    hash = "sha256-8LYB3BEDHOj6ItfFRK7ewbhjN604xXKY0YlymNjEO+g=";
+    hash = "sha256-KI5idrD8SIpzSYopELYWJJaaiAFQzwRwhFBfb4BEw2o=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/home-assistant-chip-clusters/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-clusters/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "chip.clusters"
+    "chip.clusters.ClusterObjects"
+    "chip.tlv"
   ];
 
   doCheck = false; # no tests

--- a/pkgs/development/python-modules/home-assistant-chip-core/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-core/default.nix
@@ -78,12 +78,17 @@ buildPythonPackage rec {
     pygobject3
   ];
 
+  pythonNamespaces = [
+    "chip"
+    "chip.clusters"
+  ];
+
   pythonImportsCheck = [
     "chip"
     "chip.ble"
-    # https://github.com/project-chip/connectedhomeip/pull/24376
-    #"chip.configuration"
+    "chip.configuration"
     "chip.discovery"
+    "chip.exceptions"
     "chip.native"
     "chip.storage"
   ];

--- a/pkgs/development/python-modules/home-assistant-chip-core/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-core/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-chip-core";
-  version = "2023.6.0";
+  version = "2023.10.1";
   format = "wheel";
 
   disabled = pythonOlder "3.7";
@@ -41,7 +41,7 @@ buildPythonPackage rec {
       };
       "x86_64-linux" = {
         name = "x86_64";
-        hash = "sha256-bRP82jTVSJS46WuO8MVWFvte+2mCOSsGFDBaXdmdPHI=";
+        hash = "sha256-mffjJtn0LmRz9DOWMMw9soYDDm/M1C5Tdj6YbWHaq2o=";
       };
     }.${stdenv.system} or (throw "Unsupported system");
   in fetchPypi {

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pythonOlder
 
 # build
@@ -29,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "python-matter-server";
-  version = "3.7.0";
+  version = "4.0.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
@@ -38,17 +37,8 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "python-matter-server";
     rev = "refs/tags/${version}";
-    hash = "sha256-t++7jQreibGpJRjJawicxjFIye5X6R1dpFqiM6yvRf0=";
+    hash = "sha256-7MBQo4jzBU/n7gVdGzVHlQl8Vj3OjfK4gk1vhLQQUE0=";
   };
-
-  patches = [
-    # https://github.com/home-assistant-libs/python-matter-server/pull/379
-    (fetchpatch {
-      name = "relax-setuptools-dependency.patch";
-      url = "https://github.com/home-assistant-libs/python-matter-server/commit/1bbc945634db92ea081051645b03c3d9c358fb15.patch";
-      hash = "sha256-kTu1+IwDrcdqelyK/vfhxw8MQBis5I1jag7YTytKQhs=";
-    })
-  ];
 
   nativeBuildInputs = [
     setuptools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19653,7 +19653,11 @@ with pkgs;
 
   mermerd = callPackage ../development/tools/database/mermerd { };
 
-  python-matter-server = with python3Packages; toPythonApplication python-matter-server;
+  python-matter-server = with python3Packages; toPythonApplication (
+    python-matter-server.overridePythonAttrs (oldAttrs: {
+      propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ oldAttrs.passthru.optional-dependencies.server;
+    })
+  );
 
   minify = callPackage ../development/web/minify { };
 


### PR DESCRIPTION
## Description of changes
cc #255774

- Fixes PEP420 namespacing issue in the `home-assistant-chip-core` package.
- Includes the `server` extra on the `python-matter-server` top-level attribute
- Improves import coverage, to show working imports

<details><summary><del>That got everything a bit closer to something working, but I'm still seeing the following problem:</del></summary>
<pre>
❯ ./result/bin/matter-server
Traceback (most recent call last):
  File "/nix/store/g69q2dd43bprq1cm00p9wiksfgi9cqry-python3.10-python-matter-server-3.7.0/bin/.matter-server-wrapped", line 6, in <module>
    from matter_server.server.__main__ import main
  File "/nix/store/g69q2dd43bprq1cm00p9wiksfgi9cqry-python3.10-python-matter-server-3.7.0/lib/python3.10/site-packages/matter_server/server/__init__.py", line 3, in <module>
    from .server import MatterServer
  File "/nix/store/g69q2dd43bprq1cm00p9wiksfgi9cqry-python3.10-python-matter-server-3.7.0/lib/python3.10/site-packages/matter_server/server/server.py", line 13, in <module>
    from ..common.helpers.api import APICommandHandler, api_command
  File "/nix/store/g69q2dd43bprq1cm00p9wiksfgi9cqry-python3.10-python-matter-server-3.7.0/lib/python3.10/site-packages/matter_server/common/helpers/api.py", line 8, in <module>
    from matter_server.common.helpers.util import parse_value
  File "/nix/store/g69q2dd43bprq1cm00p9wiksfgi9cqry-python3.10-python-matter-server-3.7.0/lib/python3.10/site-packages/matter_server/common/helpers/util.py", line 24, in <module>
    from chip.clusters.ClusterObjects import ClusterAttributeDescriptor
  File "/nix/store/fzxz98r2qyrx37lxml1sb4h5hk1my7l4-python3.10-home-assistant-chip-core-2023.6.0/lib/python3.10/site-packages/chip/clusters/__init__.py", line 25, in <module>
    from . import Attribute, CHIPClusters, Command
  File "/nix/store/fzxz98r2qyrx37lxml1sb4h5hk1my7l4-python3.10-home-assistant-chip-core-2023.6.0/lib/python3.10/site-packages/chip/clusters/Attribute.py", line 39, in <module>
    from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
ModuleNotFoundError: No module named 'chip.clusters.ClusterObjects'
</pre></details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
