### PR TITLE
buildPythonPackage: port catch-conflicts to importlib.metadata

### DIFF
--- a/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
+++ b/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
@@ -1,30 +1,34 @@
-import pkg_resources
+from importlib.metadata import PathDistribution
+from pathlib import Path
 import collections
 import sys
+
 
 do_abort = False
 packages = collections.defaultdict(list)
 
-for f in sys.path:
-    for req in pkg_resources.find_distributions(f):
-        if req not in packages[req.project_name]:
-            # some exceptions inside buildPythonPackage
-            if req.project_name in ['setuptools', 'pip', 'wheel']:
-                continue
-            packages[req.project_name].append(req)
+
+for path in sys.path:
+    for dist_info in Path(path).glob("*.dist-info"):
+        dist = PathDistribution(dist_info)
+
+        packages[dist._normalized_name].append(
+            f"{dist._normalized_name} {dist.version} ({dist._path})"
+        )
 
 
 for name, duplicates in packages.items():
     if len(duplicates) > 1:
         do_abort = True
         print("Found duplicated packages in closure for dependency '{}': ".format(name))
-        for dup in duplicates:
-            print("  " + repr(dup))
+        for duplicate in duplicates:
+            print(f"\t{duplicate}")
 
 if do_abort:
     print("")
     print(
-        'Package duplicates found in closure, see above. Usually this '
-        'happens if two packages depend on different version '
-        'of the same dependency.')
+        "Package duplicates found in closure, see above. Usually this "
+        "happens if two packages depend on different version "
+        "of the same dependency."
+    )
     sys.exit(1)

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -107,7 +107,7 @@ in {
     makePythonHook {
       name = "python-catch-conflicts-hook";
       substitutions = {
-        inherit pythonInterpreter pythonSitePackages setuptools;
+        inherit pythonInterpreter pythonSitePackages;
         catchConflicts=../catch_conflicts/catch_conflicts.py;
       };
     } ./python-catch-conflicts-hook.sh) {};


### PR DESCRIPTION
To escape the pkg_resources API deprecation:

> catch-conflicts.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html

<del>Not working quite correct yet. Didn't quite understand what `req` contains.</del>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
