### PR TITLE
kodiPackages.invidious: unstable-2022-11-28 -> 0.2.6

### DIFF
--- a/pkgs/applications/video/kodi/addons/invidious/default.nix
+++ b/pkgs/applications/video/kodi/addons/invidious/default.nix
@@ -1,18 +1,13 @@
-{ lib, buildKodiAddon, fetchFromGitHub, addonUpdateScript, requests, inputstream-adaptive, inputstreamhelper }:
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, requests, inputstream-adaptive, inputstreamhelper }:
 
 buildKodiAddon rec {
   pname = "invidious";
   namespace = "plugin.video.invidious";
-  version = "unstable-2022-11-28";
+  version = "0.2.6";
 
-  # video search doesn't work for the version on kodi.tv
-  # if the result contains channels
-  # https://github.com/TheAssassin/kodi-invidious-plugin/issues/17
-  src = fetchFromGitHub {
-    owner = "TheAssassin";
-    repo = "kodi-invidious-plugin";
-    rev = "85b66525632d94630c9301d9c490fc002a335d77";
-    hash = "sha256-DpsAQUOUYCs3rpWwsk82+00KME4J+Iocu/v781dyyws=";
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/nexus/plugin.video.invidious/plugin.video.invidious-${version}+nexus.0.zip";
+    sha256 = "sha256-XnlnhvtHMh4uQTupW/SSOmaEV8xZrL61/6GoRpyKR0o=";
   };
 
   propagatedBuildInputs = [
@@ -23,10 +18,13 @@ buildKodiAddon rec {
 
   passthru = {
     pythonPath = "resources/lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.invidious";
+    };
   };
 
   meta = with lib; {
-    homepage = "https://github.com/TheAssassin/kodi-invidious-plugin";
+    homepage = "https://github.com/petterreinholdtsen/kodi-invidious-plugin";
     description = "A privacy-friendly way of watching YouTube content";
     license = licenses.mit;
     maintainers = teams.kodi.members;


### PR DESCRIPTION
switch to maintained fork

https://github.com/petterreinholdtsen/kodi-invidious-plugin

which is also listed on kodi.tv:

https://kodi.tv/addons/nexus/plugin.video.invidious/

The original repository is now in archive mode:
https://github.com/TheAssassin/kodi-invidious-plugin/

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
