### PR TITLE
dante: fix build with clang 16

### DIFF
--- a/pkgs/servers/dante/clang-osint-m4.patch
+++ b/pkgs/servers/dante/clang-osint-m4.patch
@@ -1,0 +1,34 @@
+diff -ur a/osdep.m4 b/osdep.m4
+--- a/osdep.m4	2017-01-18 09:11:20.000000000 -0500
++++ b/osdep.m4	2023-10-21 12:43:59.464797030 -0400
+@@ -381,6 +381,7 @@
+ unset have_sa_len
+ AC_MSG_CHECKING([for sa_len in sockaddr])
+ AC_TRY_COMPILE([
++#include <stdint.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ ], [struct sockaddr sa;
+@@ -397,12 +398,13 @@
+    unset sa_len_type_found
+    for type in uint8_t "unsigned char"; do
+        AC_TRY_COMPILE([
++#include <stdint.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>], [
+ struct sockaddr sa;
+ $type *sa_len_ptr;
+ sa_len_ptr = &sa.sa_len;
+-sa_len_ptr++; /* use to avoid warning/error */],
++(*sa_len_ptr)++; /* use to avoid warning/error */],
+        [AC_DEFINE_UNQUOTED(sa_len_type, [$type], [sa_len type])
+         sa_len_type_found=t
+         break])
+@@ -636,6 +638,7 @@
+ 		in_port_t, in_addr_t],
+ 		, ,
+ [
++#include <stdint.h>
+ #include <sys/types.h>
+ #include <netinet/in.h>
+ ])

--- a/pkgs/servers/dante/default.nix
+++ b/pkgs/servers/dante/default.nix
@@ -22,12 +22,17 @@ stdenv.mkDerivation rec {
 
   dontAddDisableDepTrack = stdenv.isDarwin;
 
-  patches = lib.optionals remove_getaddrinfo_checks [
+  patches = [
+    # Fixes several issues with `osint.m4` that causes incorrect check failures when using newer
+    # versions of clang: missing `stdint.h` for `uint8_t` and unused `sa_len_ptr`.
+    ./clang-osint-m4.patch
+  ] ++ lib.optionals remove_getaddrinfo_checks [
     (fetchpatch {
       name = "0002-osdep-m4-Remove-getaddrinfo-too-low-checks.patch";
       url = "https://raw.githubusercontent.com/buildroot/buildroot/master/package/dante/0002-osdep-m4-Remove-getaddrinfo-too-low-checks.patch";
       sha256 = "sha256-e+qF8lB5tkiA7RlJ+tX5O6KxQrQp33RSPdP1TxU961Y=";
-    }) ];
+    })
+  ];
 
   postPatch = ''
     substituteInPlace include/redefgen.sh --replace 'PATH=/bin:/usr/bin:/sbin:/usr/sbin' ""


### PR DESCRIPTION
## Description of changes

Fix two configure checks that fail on clang 16 due to unexpected errors:

* Undefined type `uint8_t` by including `stdint.h`; and
* Unused `sa_len_ptr` by incrementing the target of the pointer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
