### PR TITLE
wolfssl: ASM/AES-NI/SP Math support; easier variant override

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -5,37 +5,63 @@
 , autoreconfHook
 , util-linux
 , openssl
+# The primary --enable-XXX variant. 'all' enables most features, but causes build-errors for some software,
+# requiring to build a special variant for that software. Example: 'haproxy'
+, variant ? "all"
+, extraConfigureFlags ? []
+, enableLto ? !(stdenv.isDarwin || stdenv.hostPlatform.isStatic || stdenv.cc.isClang)
 }:
-
-stdenv.mkDerivation rec {
-  pname = "wolfssl";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wolfssl-${variant}";
   version = "5.6.3";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
-    rev = "refs/tags/v${version}-stable";
+    rev = "refs/tags/v${finalAttrs.version}-stable";
     hash = "sha256-UN4zs+Rxh/bsLD1BQA+f1YN/UOJ6OB2HduhoetEp10Y=";
   };
 
   postPatch = ''
     patchShebangs ./scripts
-    # ocsp tests require network access
-    sed -i -e '/ocsp\.test/d' -e '/ocsp-stapling\.test/d' scripts/include.am
+    # ocsp stapling tests require network access, so skip them
+    sed -i -e'2s/.*/exit 77/' scripts/ocsp-stapling.test
     # ensure test detects musl-based systems too
     substituteInPlace scripts/ocsp-stapling2.test \
       --replace '"linux-gnu"' '"linux-"'
   '';
 
-  # Almost same as Debian but for now using --enable-all --enable-reproducible-build instead of --enable-distro to ensure options.h gets installed
   configureFlags = [
-    "--enable-all"
-    "--enable-base64encode"
+    "--enable-${variant}"
+    "--enable-reproducible-build"
+  ] ++ lib.optionals (variant == "all") [
+    # Extra feature flags to add while building the 'all' variant.
+    # Since they conflict while building other variants, only specify them for this one.
     "--enable-pkcs11"
     "--enable-writedup"
-    "--enable-reproducible-build"
-    "--enable-tls13"
-  ];
+    "--enable-base64encode"
+  ] ++ [
+    # We're not on tiny embedded machines.
+    # Increase TLS session cache from 33 sessions to 20k.
+    "--enable-bigcache"
+
+    # Use WolfSSL's Single Precision Math with timing-resistant cryptography.
+    "--enable-sp=yes${lib.optionalString (!stdenv.isx86_32) ",asm"}"
+    "--enable-sp-math-all"
+    "--enable-harden"
+  ] ++ lib.optionals (stdenv.hostPlatform.isx86_64) [
+    # Enable AVX/AVX2/AES-NI instructions, gated by runtime detection via CPUID.
+    "--enable-intelasm"
+    "--enable-aesni"
+  ] ++ lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [
+    # No runtime detection under ARM and no platform function checks like for X86.
+    # However, all ARM macOS systems have the supported extensions autodetected in the configure script.
+    "--enable-armasm=inline"
+  ] ++ extraConfigureFlags;
+
+  # LTO should help with the C implementations.
+  env.NIX_CFLAGS_COMPILE = lib.optionalString enableLto "-flto";
+  env.NIX_LDFLAGS_COMPILE = lib.optionalString enableLto "-flto";
 
   outputs = [
     "dev"
@@ -60,19 +86,19 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-     # fix recursive cycle:
-     # wolfssl-config points to dev, dev propagates bin
-     moveToOutput bin/wolfssl-config "$dev"
-     # moveToOutput also removes "$out" so recreate it
-     mkdir -p "$out"
+    # fix recursive cycle:
+    # wolfssl-config points to dev, dev propagates bin
+    moveToOutput bin/wolfssl-config "$dev"
+    # moveToOutput also removes "$out" so recreate it
+    mkdir -p "$out"
   '';
 
   meta = with lib; {
     description = "A small, fast, portable implementation of TLS/SSL for embedded devices";
     homepage = "https://www.wolfssl.com/";
-    changelog = "https://github.com/wolfSSL/wolfssl/releases/tag/v${version}-stable";
+    changelog = "https://github.com/wolfSSL/wolfssl/releases/tag/v${finalAttrs.version}-stable";
     platforms = platforms.all;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ fab vifino ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Before this PR, building a custom variant of WolfSSL (like upstream expects you to) was rather painful.
So I added some parameters to make it easier.

I also enabled the detection of AES-NI/AVX1/AVX2 instructions and the Single Precision Math implementation in WolfSSL, so that it is very competitive against other implementations.

For ARM such a runtime detection is not implemented, so I only enabled it for Darwin AArch64, where the configure script will enable the supported instructions.

I want this for #262401.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
