### PR TITLE
asm-lsp: init at v0.4.2

### DIFF
--- a/pkgs/by-name/as/asm-lsp/package.nix
+++ b/pkgs/by-name/as/asm-lsp/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+}:
+let
+  pname = "asm-lsp";
+  version = "0.4.2";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "bergercookie";
+    repo = "asm-lsp";
+    rev = "v${version}";
+    hash = "sha256-EGgYOU6y23ULjnMGNjYhgF0JMPgvRuQ4UOWqwJxhBpU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  cargoHash = "sha256-x8Cj39Wki+pdoNIO8QPGK29KFJrHtDMoZJIXFEldno0=";
+
+  meta = {
+    description = "Language server for NASM/GAS/GO Assembly";
+    homepage = "https://github.com/bergercookie/asm-lsp";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ NotAShelf ];
+    mainProgram = pname;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds asm-lsp

https://github.com/bergercookie/asm-lsp

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
