### PR TITLE
tmuxPlugins.extrakto unstable-2021...->unstable-2023-10-21

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -216,19 +216,19 @@ in rec {
 
   extrakto = mkTmuxPlugin {
     pluginName = "extrakto";
-    version = "unstable-2021-04-04";
+    version = "unstable-2023-10-21";
     src = fetchFromGitHub {
       owner = "laktak";
       repo = "extrakto";
-      rev = "de8ac3e8a9fa887382649784ed8cae81f5757f77";
-      sha256 = "0mkp9r6mipdm7408w7ls1vfn6i3hj19nmir2bvfcp12b69zlzc47";
+      rev = "f69af5fb5e5ff6a4ae7e30ec91c7e15146ebdf07";
+      sha256 = "sha256-mAe2J81VVrWQKxG3rrAH6oIq47ZFfJtv8OzBiqrr6m8=";
     };
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postInstall = ''
-    for f in extrakto.sh open.sh tmux-extrakto.sh; do
+    for f in extrakto.sh open.sh; do
       wrapProgram $target/scripts/$f \
         --prefix PATH : ${with pkgs; lib.makeBinPath (
-        [ pkgs.fzf pkgs.python3 pkgs.xclip ]
+        [ pkgs.fzf pkgs.python3 pkgs.xclip pkgs.wl-copy ]
         )}
     done
 


### PR DESCRIPTION
:warning: I don't know how to test these changes. The closest I have gotten is to create the following overlay for my own configuration, which I have confirmed to be working. I will try to learn how to test this further if instructed to do so :warning: 

```nix
  nixpkgs.overlays = [
    (self: super: {
      tmuxPlugins =
        super.tmuxPlugins
        // {
          extrakto = super.tmuxPlugins.mkTmuxPlugin {
            pluginName = "extrakto";
            version = "unstable-2023-10-21";
            src = super.fetchFromGitHub {
              owner = "laktak";
              repo = "extrakto";
              rev = "f69af5fb5e5ff6a4ae7e30ec91c7e15146ebdf07";
              sha256 = "sha256-mAe2J81VVrWQKxG3rrAH6oIq47ZFfJtv8OzBiqrr6m8=";
            };
            nativeBuildInputs = [super.pkgs.makeWrapper];
            postInstall = ''
              for f in extrakto.sh open.sh; do
                wrapProgram $target/scripts/$f \
                  --prefix PATH : ${with super.pkgs; lib.makeBinPath [super.pkgs.fzf super.pkgs.python3 super.pkgs.xclip super.pkgs.wl-copy]}
              done
            '';
            meta = {
              homepage = "https://github.com/laktak/extrakto";
              description = "Fuzzy find your text with fzf instead of selecting it by hand";
              license = super.lib.licenses.mit;
              platforms = super.lib.platforms.unix;
              maintainers = with super.lib.maintainers; [kidd];
            };
          };
        };
    })
  ];
```

## Description of changes

The tmux plugin [extrakto](https://github.com/laktak/extrakto) added support for Wayland via `wl-copy`. This commit updates its version in nixpkgs to make use of that.

See PR where Wayland support was added:
https://github.com/laktak/extrakto/pull/87

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
