### PR TITLE
invidious: fix build with clang 16

### DIFF
--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -57,7 +57,20 @@ let
     preBuild = preBuild + lib.optionalString stdenv.isLinux ''
       sed -e '/^build crypto\/fipsmodule\/CMakeFiles\/fipsmodule\.dir\/bcm\.c\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=stringop-overflow/' \
           -i build.ninja
-    '';
+    '' + lib.optionalString stdenv.cc.isClang (
+      # Silence warnings that cause build failures with newer versions of clang.
+      let
+        clangVersion = lib.getVersion stdenv.cc;
+      in
+      lib.optionalString (lib.versionAtLeast clangVersion "13") ''
+        sed -e '/^build crypto\/CMakeFiles\/crypto\.dir\/x509\/t_x509\.c\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=unused-but-set-variable/' \
+            -e '/^build tool\/CMakeFiles\/bssl\.dir\/digest\.cc\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=unused-but-set-variable/' \
+            -i build.ninja
+      '' + lib.optionalString (lib.versionAtLeast clangVersion "16") ''
+        sed -e '/^build crypto\/CMakeFiles\/crypto\.dir\/trust_token\/trust_token\.c\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=single-bit-bitfield-constant-conversion/' \
+            -i build.ninja
+      ''
+    );
   });
 in
 stdenv.mkDerivation rec {

--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -57,6 +57,11 @@ let
     preBuild = preBuild + lib.optionalString stdenv.isLinux ''
       sed -e '/^build crypto\/fipsmodule\/CMakeFiles\/fipsmodule\.dir\/bcm\.c\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=stringop-overflow/' \
           -i build.ninja
+    '' + lib.optionalString stdenv.cc.isGNU ''
+      # Silence warning that causes build failures with GCC.
+      sed -e '/^build ssl\/test\/CMakeFiles\/bssl_shim\.dir\/settings_writer\.cc\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=ignored-attributes/' \
+          -e '/^build ssl\/test\/CMakeFiles\/handshaker\.dir\/settings_writer\.cc\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=ignored-attributes/' \
+          -i build.ninja
     '' + lib.optionalString stdenv.cc.isClang (
       # Silence warnings that cause build failures with newer versions of clang.
       let


### PR DESCRIPTION
## Description of changes

Suppress warnings that cause build failures with newer clang versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
