### PR TITLE
nixos-rebuild: Locally own the nixos-rebuild (bash) completions

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
+++ b/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+# We're faking a `nix build` command-line to re-use Nix's own completion
+# for the few options passed through to Nix.
+_nixos-rebuild_pretend-nix() {
+  COMP_LINE="nix build ${COMP_LINE}"
+  # number of prepended chars
+  (( COMP_POINT = COMP_POINT + 10))
+
+  COMP_WORDS=(
+    nix build
+    "${COMP_WORDS[@]}"
+  )
+  # Add the amount of prepended words
+  (( COMP_CWORD = COMP_CWORD + 2))
+  _complete_nix "nix"
+}
+
+_nixos-rebuild() {
+  local curr="$2"
+  local prev="$3"
+  local subcommandGiven=0
+  local word
+  local subcommand
+
+  __load_completion nix
+
+  # Arrays are re-ordered by the completion, so it's fine to sort them in logical chunks
+  local all_args=(
+    --verbose -v
+
+    # nixos-rebuild options
+    --fast
+    --no-build-nix
+    --profile-name -p # name
+    --rollback
+    --specialisation -c # name
+    --use-remote-sudo
+    --build-host # host
+    --target-host # host
+    # Used with list-generations
+    --json
+
+    # generation switching options
+    --install-bootloader
+
+    # nix-channel options
+    --upgrade
+    --upgrade-all
+
+    # flakes options
+    --commit-lock-file
+    --flake # flake-uri
+    --override-input # input-name flake-uri
+    --recreate-lock-file
+    --update-input
+    --no-flake
+    --no-registries
+    --no-update-lock-file
+    --no-write-lock-file
+
+    # Nix-copy options
+    --use-substitutes --substitute-on-destination -s
+
+    # Nix options
+    --option
+    --impure
+    --builders # builder-spec
+    --show-trace
+    --keep-failed -K
+    --keep-going -k
+    --max-jobs -j # number
+    --log-format # format
+    -I # NIX_PATH
+  )
+
+  local all_subcommands=(
+    boot
+    build
+    build-vm
+    build-vm-with-bootloader
+    dry-activate
+    dry-build
+    edit
+    list-generations
+    switch
+    test
+  )
+
+  # Suggest arguments that can be consumed under some conditions only
+  for word in "${COMP_WORDS[@]}"; do
+    for subcommand in "${all_subcommands[@]}"; do
+      if [[ "$word" == "$subcommand" ]]; then
+        subcommandGiven=1
+      fi
+    done
+  done
+
+  # Fake out a way to complete the second arg to some options
+  case "${COMP_WORDS[COMP_CWORD-2]}" in
+    "--override-input")
+      prev="--override-input_2"
+      ;;
+    "--option")
+      prev="--option_2"
+      ;;
+  esac
+
+  case "$prev" in
+    --max-jobs|-j)
+      COMPREPLY=( )
+      ;;
+
+    --profile-name|-p)
+      if [[ "$curr" == "" ]]; then
+        COMPREPLY=( /nix/var/nix/profiles/* )
+      else
+        COMPREPLY=( "$curr"* )
+      fi
+      ;;
+
+    --build-host|--target-host|-t|-h)
+      _known_hosts_real "$curr"
+    ;;
+
+    --specialisation|-c)
+      COMPREPLY=()
+      ;;
+
+    -I)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --builders)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --flake)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --override-input)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --override-input_2)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --log-format)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --option)
+      _nixos-rebuild_pretend-nix
+      ;;
+    --option_2)
+      _nixos-rebuild_pretend-nix
+      ;;
+
+    *)
+      if [[ "$curr" == -* ]] || (( subcommandGiven )); then
+        COMPREPLY=( $(compgen -W "${all_args[*]}" -- "$2") )
+      else
+        COMPREPLY=( $(compgen -W "${all_subcommands[*]}" -- "$2") )
+      fi
+    ;;
+  esac
+}
+
+complete -F _nixos-rebuild nixos-rebuild

--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -28,6 +28,9 @@ substituteAll {
   ];
   postInstall = ''
     installManPage ${./nixos-rebuild.8}
+
+    installShellCompletion \
+      --bash ${./_nixos-rebuild}
   '';
 
   # run some a simple installer tests to make sure nixos-rebuild still works for them

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -117,11 +117,11 @@ while [ "$#" -gt 0 ]; do
         specialisation="$1"
         shift 1
         ;;
-      --build-host|h)
+      --build-host)
         buildHost="$1"
         shift 1
         ;;
-      --target-host|t)
+      --target-host)
         targetHost="$1"
         shift 1
         ;;

--- a/pkgs/shells/bash/nix-bash-completions/default.nix
+++ b/pkgs/shells/bash/nix-bash-completions/default.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # Nix 2.4+ provides its own completion for the nix command, see https://github.com/hedning/nix-bash-completions/issues/20
-    substituteInPlace _nix --replace 'nix nixos-option' 'nixos-option'
+    # NixOS provides its own completions for nixos-rebuild now.
+    substituteInPlace _nix \
+      --replace 'nix nixos-option' 'nixos-option' \
+      --replace 'nixos-rebuild nixos-install' 'nixos-install'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

I've finally been irritated enough about the `nixos-rebuild` completion being incorrect this week to finally take a look at fixing this.

The [nix-bash-completions](https://github.com/hedning/nix-bash-completions) project is currently pretty inactive. This is why I've made the completions here in this repo.

I also believe that the completions should benefit from proximity with the implementation, which is why it's living with the `nixos-rebuild` implementation.

Note that the implementation is bespoke, as (as bad as it sounds) I didn't want to have any licensing issues in "importing" code into this repo directly.

It also calls into the Nix completion to complete some of the options it could complete. For now, I believe only `--option` has useful completion, but I haven't tested with the flake-centric options.

This is my first time writing a completion, and learning about the intricacies of them, so please advise if I did any faux-pas.

There is *technically* a breaking change in 61d5040ef113029678055d05e3d6b90cd97169ef, but given it was entirely and thoroughly broken, I don't think it needs a set of release notes.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - (N/A) x86_64-darwin
  - (N/A) aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
