### PR TITLE
python311Packages.langchain: 0.0.291 -> 0.0.320; python311Packages.langsmith: 0.0.37 -> 0.0.49

### DIFF
--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -6,8 +6,10 @@
 , pythonRelaxDepsHook
 , poetry-core
 , aiohttp
+, anyio
 , async-timeout
 , dataclasses-json
+, jsonpatch
 , langsmith
 , numexpr
 , numpy
@@ -86,7 +88,7 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.0.291";
+  version = "0.0.320";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -95,17 +97,10 @@ buildPythonPackage rec {
     owner = "hwchase17";
     repo = "langchain";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Ilmu4l+DCu2soX5kANegk/DMvr2x9AXUcQ1aZOKbQJc=";
+    hash = "sha256-Yw3gGt/OvrQ4IYauFUt6pBWOecy+PaWiGXoo5dWev5M=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";
-
-  postPatch = ''
-    substituteInPlace langchain/utilities/bash.py \
-      --replace '"env", ["-i", "bash", ' '"${lib.getExe bash}", ['
-    substituteInPlace tests/unit_tests/test_bash.py \
-      --replace "/bin/sh" "${bash}/bin/sh"
-  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -128,6 +123,8 @@ buildPythonPackage rec {
     aiohttp
     numexpr
     langsmith
+    anyio
+    jsonpatch
   ] ++ lib.optionals (pythonOlder "3.11") [
     async-timeout
   ];

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "langsmith";
-  version = "0.0.37";
+  version = "0.0.49";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     rev = "refs/tags/v${version}";
-    hash = "sha256-xtyGL1Voyoik3fN//xhPNetC+yera4Wd+DZJTnLhW7g=";
+    hash = "sha256-vOa9FNzeJB8QgJ6FW+4vxNfDnBbrKtByIwW3sGP8/ho=";
   };
 
   sourceRoot = "${src.name}/python";
@@ -44,6 +44,11 @@ buildPythonPackage rec {
   disabledTests = [
     # These tests require network access
     "integration_tests"
+  ];
+
+  disabledTestPaths = [
+    # due to circular import
+    "tests/integration_tests/test_client.py"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Description of changes

- langchain
Diff: https://github.com/langchain-ai/langchain/compare/refs/tags/v0.0.291...v0.0.320
Changelog: https://github.com/hwchase17/langchain/releases/tag/v0.0.320

- langsmith
Diff: https://github.com/langchain-ai/langsmith-sdk/compare/refs/tags/v0.0.37...v0.0.49
Changelog: https://github.com/langchain-ai/langsmith-sdk/releases/tag/v0.0.49

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
