### PR TITLE
haskellPackages: llvm-ffi switch to LLVM-16

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2657,7 +2657,7 @@ self: super: {
   tomland = doJailbreak super.tomland;
 
   llvm-ffi = super.llvm-ffi.override {
-    LLVM = pkgs.llvmPackages_13.libllvm;
+    LLVM = pkgs.llvmPackages_16.libllvm;
   };
 
   # libfuse3 fails to mount fuse file systems within the build environment


### PR DESCRIPTION
Make `llvm-ffi` use LLVM-16.

However, Hydra currently chooses `llvm-ffi-14.0` where it should use `llvm-ffi-16.0`, instead.
