### PR TITLE
dssp: 4.4.3 -> 4.4.4.1; libcifpp: 5.2.1 -> 5.2.2

### DIFF
--- a/pkgs/applications/science/biology/dssp/default.nix
+++ b/pkgs/applications/science/biology/dssp/default.nix
@@ -3,6 +3,7 @@
 , cmake
 , eigen
 , fetchFromGitHub
+, fetchpatch
 , libcifpp
 , libmcfp
 , zlib
@@ -15,18 +16,26 @@ let
       inherit (oldAttrs.src) owner repo rev;
       hash = "sha256-Sj10j6HxUoUvQ66cd2B8CO7CVBRd7w9CTovxkwPDOvs=";
     };
+    patches = [
+      (fetchpatch {
+        # https://github.com/PDB-REDO/libcifpp/issues/51
+        name = "fix-build-on-darwin.patch";
+        url = "https://github.com/PDB-REDO/libcifpp/commit/641f06a7e7c0dc54af242b373820f2398f59e7ac.patch";
+        hash = "sha256-eWNfp9nA/+2J6xjZR6Tj+5OM3L5MxdfRi0nBzyaqvS0=";
+      })
+    ];
   });
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dssp";
-  version = "4.4.3";
+  version = "4.4.4.1";
 
   src = fetchFromGitHub {
     owner = "PDB-REDO";
     repo = "dssp";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-zPmRR7sxVNErwabLqA5CNMO4K1qHdmC9FBPjcx91KuM=";
+    hash = "sha256-sy6GBCnTGRD1YP00dKIolkr1RMboLGcd0f4kU8gCOnA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libcifpp/default.nix
+++ b/pkgs/development/libraries/libcifpp/default.nix
@@ -10,23 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcifpp";
-  version = "5.2.1";
+  version = "5.2.2";
 
   src = fetchFromGitHub {
     owner = "PDB-REDO";
     repo = "libcifpp";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-9je4oj5XvclknD14Nh0LnBONHMeO40nY0+mZ9ACQYmY=";
+    hash = "sha256-+OVfMXkBALT8v/30JU8v2gTsw12FM5n1I2COV/b5vGY=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/PDB-REDO/libcifpp/issues/51
-      name = "fix-build-on-darwin.patch";
-      url = "https://github.com/PDB-REDO/libcifpp/commit/641f06a7e7c0dc54af242b373820f2398f59e7ac.patch";
-      hash = "sha256-eWNfp9nA/+2J6xjZR6Tj+5OM3L5MxdfRi0nBzyaqvS0=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes

- dssp
Diff: https://github.com/PDB-REDO/dssp/compare/refs/tags/v4.4.3...v4.4.4.1
Changelog: https://github.com/PDB-REDO/libcifpp/releases/tag/refs/tags/v4.4.4.1

- libcifpp
Diff: https://github.com/PDB-REDO/libcifpp/compare/refs/tags/v5.2.1...v5.2.2
Changelog: https://github.com/PDB-REDO/libcifpp/releases/tag/refs/tags/v5.2.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
