### PR TITLE
Pgadmin4: fix build. Also fix flask-security-too

### DIFF
--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, setuptools
 
 # extras: babel
 , babel
@@ -11,7 +12,6 @@
 , bcrypt
 , bleach
 , flask-mailman
-, qrcode
 
 # extras: fsqla
 , flask-sqlalchemy
@@ -22,17 +22,17 @@
 , cryptography
 , phonenumbers
 , webauthn
+, qrcode
 
 # propagates
-, blinker
 , email-validator
 , flask
 , flask-login
 , flask-principal
 , flask-wtf
-, itsdangerous
 , passlib
 , importlib-resources
+, wtforms
 
 # tests
 , argon2-cffi
@@ -47,32 +47,30 @@
 
 buildPythonPackage rec {
   pname = "flask-security-too";
-  version = "5.3.0";
-  format = "pyproject";
+  version = "5.3.2";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "Flask-Security-Too";
     inherit version;
-    hash = "sha256-n12DCRPqxm8YhFeVrl99BEvdDYNq6rzP662rain3k1Q=";
+    hash = "sha256-wLUHXfDWSp7zWwTIjTH79AWlkkNzb21tChpLSEWr8+U=";
   };
 
-  postPatch = ''
-    # This should be removed after updating to version 5.3.0.
-    sed -i '/filterwarnings =/a ignore:pkg_resources is deprecated:DeprecationWarning' pytest.ini
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
-    blinker
     email-validator
     flask
     flask-login
     flask-principal
     flask-wtf
-    itsdangerous
     passlib
     importlib-resources
+    wtforms
   ];
 
   passthru.optional-dependencies = {
@@ -84,7 +82,6 @@ buildPythonPackage rec {
       bcrypt
       bleach
       flask-mailman
-      qrcode
     ];
     fsqla = [
       flask-sqlalchemy
@@ -95,6 +92,7 @@ buildPythonPackage rec {
       cryptography
       phonenumbers
       webauthn
+      qrcode
     ];
   };
 

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -21,6 +21,7 @@
 # extras: mfa
 , cryptography
 , phonenumbers
+, webauthn
 
 # propagates
 , blinker
@@ -31,10 +32,10 @@
 , flask-wtf
 , itsdangerous
 , passlib
+, importlib-resources
 
 # tests
 , argon2-cffi
-, flask-mongoengine
 , mongoengine
 , mongomock
 , peewee
@@ -47,7 +48,7 @@
 buildPythonPackage rec {
   pname = "flask-security-too";
   version = "5.3.0";
-  format = "setuptools";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -71,6 +72,7 @@ buildPythonPackage rec {
     flask-wtf
     itsdangerous
     passlib
+    importlib-resources
   ];
 
   passthru.optional-dependencies = {
@@ -92,12 +94,12 @@ buildPythonPackage rec {
     mfa = [
       cryptography
       phonenumbers
+      webauthn
     ];
   };
 
   nativeCheckInputs = [
     argon2-cffi
-    flask-mongoengine
     mongoengine
     mongomock
     peewee
@@ -111,6 +113,11 @@ buildPythonPackage rec {
   ++ passthru.optional-dependencies.fsqla
   ++ passthru.optional-dependencies.mfa;
 
+
+  disabledTests = [
+    # needs /etc/resolv.conf
+    "test_login_email_whatever"
+  ];
 
   pythonImportsCheck = [
     "flask_security"

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -9,6 +9,7 @@
 , yarn
 , fixup_yarn_lock
 , nodejs
+, fetchpatch
 , server-mode ? true
 }:
 
@@ -26,7 +27,61 @@ let
 
   # keep the scope, as it is used throughout the derivation and tests
   # this also makes potential future overrides easier
-  pythonPackages = python3.pkgs.overrideScope (final: prev: rec { });
+  pythonPackages = python3.pkgs.overrideScope (final: prev: rec {
+    # pgadmin 7.8 is incompatible with Flask >= 2.3
+    flask = prev.flask.overridePythonAttrs (oldAttrs: rec {
+      version = "2.2.5";
+      src = oldAttrs.src.override {
+        pname = "Flask";
+        inherit version;
+        hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
+      };
+      format = "setuptools";
+    });
+    # downgrade needed for older Flask
+    httpbin = prev.httpbin.overridePythonAttrs (oldAttrs: rec {
+      version = "0.7.0";
+      src = oldAttrs.src.override {
+        inherit version;
+        hash = "sha256-y7N3kMkVdfTxV1f0KtQdn3KesifV7b6J5OwXVIbbjfo=";
+      };
+      format = "setuptools";
+      patches = [
+        (fetchpatch {
+          # Replaces BaseResponse class with Response class for Werkezug 2.1.0 compatibility
+          # https://github.com/postmanlabs/httpbin/pull/674
+          url = "https://github.com/postmanlabs/httpbin/commit/5cc81ce87a3c447a127e4a1a707faf9f3b1c9b6b.patch";
+          hash = "sha256-SbEWjiqayMFYrbgAPZtSsXqSyCDUz3z127XgcKOcrkE=";
+        })
+      ];
+      pytestFlagsArray = [
+        "test_httpbin.py"
+      ];
+      propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ final.pythonPackages.brotlipy ];
+    });
+    # downgrade needed for older httpbin
+    werkzeug = prev.werkzeug.overridePythonAttrs (oldAttrs: rec {
+      version = "2.2.3";
+      format = "setuptools";
+      src = oldAttrs.src.override {
+        pname = "Werkzeug";
+        inherit version;
+        hash = "sha256-LhzMlBfU2jWLnebxdOOsCUOR6h1PvvLWZ4ZdgZ39Cv4=";
+      };
+    });
+    # Downgrade needed for older Flask
+    flask-security-too = prev.flask-security-too.overridePythonAttrs (oldAttrs: rec {
+      version = "5.1.2";
+      src = oldAttrs.src.override {
+        inherit version;
+        hash = "sha256-lZzm43m30y+2qjxNddFEeg9HDlQP9afq5VtuR25zaLc=";
+      };
+      postPatch = ''
+        # This should be removed after updating to version 5.3.0.
+        sed -i '/filterwarnings =/a ignore:pkg_resources is deprecated:DeprecationWarning' pytest.ini
+      '';
+    });
+  });
 
   offlineCache = fetchYarnDeps {
     yarnLock = ./yarn.lock;


### PR DESCRIPTION
## Description of changes

In the recent major Flask update `flask-security-too` has been updated. Unfortunately it doesn't build as is and needs fixing (including the removal of `flask-mongoengine`). 

Also, `pgadmin4` doesn't build, since it isn't yet compatible with the newer Flask ecosystem. This PR includes the `flask-security-too` and `pgadmin4` fixes (It doesn't make sense for two separate PRs because `pgadmin4` relies on `flask-security-too`).  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
