### PR TITLE
kodi.packages.sendtokodi: init at 0.9.557

### DIFF
--- a/pkgs/applications/video/kodi/addons/sendtokodi/default.nix
+++ b/pkgs/applications/video/kodi/addons/sendtokodi/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildKodiAddon, fetchFromGitHub, addonUpdateScript, kodi, inputstreamhelper }:
+
+buildKodiAddon rec {
+  pname = "sendtokodi";
+  namespace = "plugin.video.sendtokodi";
+  version = "0.9.557";
+
+  src = fetchFromGitHub {
+    owner = "firsttris";
+    repo = "plugin.video.sendtokodi";
+    rev = "v${version}";
+    hash = "sha256-Ga+9Q7x8+sEmQmteHbSyCahZ/T/l28BAEM84w7bf7z8=";
+  };
+
+  patches = [
+    ./use-packaged-deps.patch
+  ];
+
+  propagatedBuildInputs = [
+    inputstreamhelper
+  ];
+
+  postPatch = ''
+    # Remove vendored youtube-dl and yt-dlp libraries.
+    rm -r lib/
+  '';
+
+  passthru = {
+    # Instead of the vendored libraries, we propagate youtube-dl and yt-dlp via
+    # the Python path.
+    pythonPath = with kodi.pythonPackages; makePythonPath [ youtube-dl yt-dlp ];
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/firsttris/plugin.video.sendtokodi";
+    description = "Plays various stream sites on Kodi using youtube-dl";
+    license = licenses.mit;
+    maintainers = teams.kodi.members ++ [ maintainers.pks ];
+  };
+}

--- a/pkgs/applications/video/kodi/addons/sendtokodi/use-packaged-deps.patch
+++ b/pkgs/applications/video/kodi/addons/sendtokodi/use-packaged-deps.patch
@@ -1,0 +1,16 @@
+diff --git a/service.py b/service.py
+index 1d7b6e4..9782993 100644
+--- a/service.py
++++ b/service.py
+@@ -241,9 +241,9 @@ def playlistIndex(url, playlist):
+ 
+ # Use the chosen resolver while forcing to use youtube_dl on legacy python 2 systems (dlp is python 3.6+)
+ if xbmcplugin.getSetting(int(sys.argv[1]),"resolver") == "0" or sys.version_info[0] == 2:
+-    from lib.youtube_dl import YoutubeDL
++    from youtube_dl import YoutubeDL
+ else:
+-    from lib.yt_dlp import YoutubeDL
++    from yt_dlp import YoutubeDL
+     
+ # patch broken strptime (see above)
+ patch_strptime()

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -164,6 +164,8 @@ let self = rec {
 
   routing = callPackage ../applications/video/kodi/addons/routing { };
 
+  sendtokodi = callPackage ../applications/video/kodi/addons/sendtokodi { };
+
   signals = callPackage ../applications/video/kodi/addons/signals { };
 
   simplejson = callPackage ../applications/video/kodi/addons/simplejson { };


### PR DESCRIPTION
## Description of changes

The [sendtokodi addon](https://github.com/firsttris/plugin.video.sendtokodi) plays various stream sites on Kodi using youtube-dl. This is especially useful when using remote control apps like [Kore](https://kodi.wiki/view/Kore) which can share arbitrary URLs of media with Kodi using this addon.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).