### PR TITLE
python311Packages.jupyterlab-git: 0.42.0 -> 0.50.0rc0

### DIFF
--- a/pkgs/development/python-modules/jupyterlab-git/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git/default.nix
@@ -1,34 +1,41 @@
 { lib
-, stdenv
 , buildPythonPackage
 , fetchPypi
 , git
 , jupyter-server
-, jupyter-packaging
+, hatch-jupyter-builder
+, hatch-nodejs-version
+, hatchling
 , jupyterlab
 , nbdime
 , nbformat
 , pexpect
 , pytest-asyncio
+, pytest-jupyter
 , pytest-tornasync
 , pytestCheckHook
 , pythonOlder
+, traitlets
 }:
 
 buildPythonPackage rec {
   pname = "jupyterlab-git";
-  version = "0.42.0";
+  version = "0.50.0rc0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "jupyterlab_git";
     inherit version;
-    hash = "sha256-GFnox6KnwKWFqsUWY0QYzMShXlH9KFSY3rRJA4RAiCk=";
+    hash = "sha256-euo8j7jt6oUJfZMF3VnbuM4uhibv+eijiXPO4UwZCiU=";
   };
 
   nativeBuildInputs = [
-    jupyter-packaging
+    hatch-jupyter-builder
+    hatch-nodejs-version
+    hatchling
+    jupyterlab
   ];
 
   propagatedBuildInputs = [
@@ -37,17 +44,20 @@ buildPythonPackage rec {
     git
     nbformat
     pexpect
+    traitlets
   ];
 
   nativeCheckInputs = [
     jupyterlab
     pytest-asyncio
+    pytest-jupyter
     pytest-tornasync
     pytestCheckHook
   ];
 
-  # All Tests on darwin fail or are skipped due to sandbox
-  doCheck = !stdenv.isDarwin;
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
 
   disabledTestPaths = [
     "jupyterlab_git/tests/test_handlers.py"
@@ -66,6 +76,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "jupyterlab_git"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Jupyter lab extension for version control with Git";


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/jupyterlab/jupyterlab-git/compare/v0.42.0...v0.50.0rc0

Changelog: https://github.com/jupyterlab/jupyterlab-git/blob/v0.50.0rc0/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
