### PR TITLE
minimeters: init at 0.8.8

### DIFF
--- a/pkgs/by-name/mi/minimeters/package.nix
+++ b/pkgs/by-name/mi/minimeters/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, appimageTools
+, requireFile
+, unzip
+, autoPatchelfHook
+, openssl
+, SDL2
+, pulseaudio
+, freetype
+}:
+
+stdenv.mkDerivation {
+  pname = "minimeters";
+  version = "0.8.8";
+
+  src = requireFile {
+    name = "MiniMeters-Linux-v0.8.8.zip";
+    hash = "sha256-6Gi3Y1WWOyU5o/qwPTEV0MkbDnGm/n9P4GWQKM8v/iU=";
+    url = ''https://directmusic.itch.io/minimeters (Legacy versions, extract "MiniMeters 0.8.8.zip")'';
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+  sourceRoot = "."; # stdenv tries to go into the vst3 subfolder
+
+  nativeBuildInputs = [ appimageTools.appimage-exec autoPatchelfHook unzip ];
+  buildInputs = [ openssl SDL2 stdenv.cc.cc stdenv.cc.libc freetype ];
+
+  # Technically ALSA is also supported but it runs *horribly*, so we force pulse:
+  # The upstream distribution also ships PortAudio for some reason, but it doesn't
+  # appear to be used on Linux.
+  runtimeDependencies = [ pulseaudio ];
+
+  postUnpack = ''
+    # we cannot use appimageTools.extract because the propietary binary is a zip
+    appimage-exec.sh -x extracted MiniMeters.AppImage
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{share,bin,lib/{clap,vst3}}
+    cp -r extracted/usr/share/{icons,applications} $out/share
+    cp extracted/usr/bin/MiniMeters $out/bin
+    cp MiniMetersServer.clap $out/lib/clap || >&2 echo "clap plugin missing"
+    cp -r MiniMetersServer.vst3 $out/lib/vst3
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple standalone audio metering app";
+    homepage = "https://minimeters.app";
+    changelog = "https://minimeters.app/changelog";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ckie ];
+    # some darwin/windows builds are also available, but not packaged
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Ran binary, tested VST3 with carla, don't know how to test CLAP.

https://minimeters.app/

![minimeters next to a cut-off neofetch showing just the nix logo](https://github.com/NixOS/nixpkgs/assets/25263210/fc19425b-0156-480f-952c-9a492ceffd02)

### Why v0.8.8?
Newer versions (v0.8.14 as of writing) *are* available, but they are broken in Linux+X11, developer response in the MiniMeters discord (unfortunately) https://discord.com/channels/795450567178453032/1165672857330790472/1165686621769830400

Developer says they'll look into it.




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
