### PR TITLE
crate2nix: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -10,18 +10,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "crate2nix";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "kolloch";
+    owner = "nix-community";
     repo = pname;
     rev = version;
-    sha256 = "sha256-JaF9/H3m4Wrc5MtXcONkOAgKVkswLVw0yZe0dBr2e4Y=";
+    sha256 = "sha256-nyX1lfaA0eBSB/BaxPzCsyD8p/hxCwNIvr4Ru3i/YX0=";
   };
 
   sourceRoot = "${src.name}/crate2nix";
 
-  cargoSha256 = "sha256-PD7R1vcb3FKd4hfpViKyvfCExJ5H1Xo2HPYden5zpxQ=";
+  cargoSha256 = "sha256-3+emOr3hh+DDkboJbYyJFZgkzmcdA9jdronz7wM4x28=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -32,6 +32,13 @@ rustPlatform.buildRustPackage rec {
   postFixup = ''
     wrapProgram $out/bin/crate2nix \
         --suffix PATH ":" ${lib.makeBinPath [ cargo nix nix-prefetch-git ]}
+
+    rm -rf $out/lib $out/bin/crate2nix.d
+    mkdir -p \
+      $out/share/bash-completion/completions \
+      $out/share/zsh/vendor-completions
+    $out/bin/crate2nix completions -s 'bash' -o $out/share/bash-completion/completions
+    $out/bin/crate2nix completions -s 'zsh' -o $out/share/zsh/vendor-completions
   '';
 
   meta = with lib; {
@@ -40,9 +47,10 @@ rustPlatform.buildRustPackage rec {
       Crate2nix generates Nix files from Cargo.toml/lock files
       so that you can build every crate individually in a Nix sandbox.
     '';
-    homepage = "https://github.com/kolloch/crate2nix";
+    homepage = "https://github.com/nix-community/crate2nix";
     license = licenses.asl20;
     maintainers = with maintainers; [ kolloch cole-h ];
     platforms = platforms.all;
   };
 }
+


### PR DESCRIPTION
...and add shell completions for bash/zsh

## Description of changes

https://github.com/nix-community/crate2nix/releases/tag/0.11.0

@amjoseph-nixpkgs 
https://github.com/nix-community/crate2nix/issues/264

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x ] `sandbox = false`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).