### PR TITLE
python311Packages.py-partiql-parser: 0.3.8 -> 0.4.0; python311Packages.moto: 4.2.2 -> 4.2.6; python311Packages.python-jose: refactor, expose extras

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -80,7 +80,8 @@ buildPythonPackage rec {
     python-jose
     trio
     sqlalchemy
-  ] ++ passthru.optional-dependencies.all;
+  ] ++ passthru.optional-dependencies.all
+  ++ python-jose.optional-dependencies.cryptography;
 
   pytestFlagsArray = [
     # ignoring deprecation warnings to avoid test failure from

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -1,54 +1,55 @@
 { lib
-, stdenv
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
 
-# build
+# build-system
 , setuptools
 
-# runtime
-, aws-xray-sdk
+# dependencies
 , boto3
 , botocore
-, cfn-lint
 , cryptography
-, docker
-, flask
-, flask-cors
-, graphql-core
-, idna
 , jinja2
-, jsondiff
-, openapi-spec-validator
-, pyparsing
 , python-dateutil
-, python-jose
-, pyyaml
 , requests
 , responses
-, sshpubkeys
 , werkzeug
 , xmltodict
 
+# optional-dependencies
+, aws-xray-sdk
+, cfn-lint
+, docker
+, ecdsa
+, flask
+, flask-cors
+, graphql-core
+, jsondiff
+, multipart
+, openapi-spec-validator
+, py-partiql-parser
+, pyparsing
+, python-jose
+, pyyaml
+, sshpubkeys
+
 # tests
 , freezegun
-, py-partiql-parser
 , pytestCheckHook
 , pytest-xdist
-, sure
 }:
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "4.2.2";
-  format = "pyproject";
+  version = "4.2.6";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7jTEw/U5ANlTGAlGkgyduhJ6SD4u1A5tv5PUri52Dnw=";
+    hash = "sha256-zgpV1+dWxZpaQ5LHCXqlylPgCqLdP3AACTNWvhXnrvk=";
   };
 
   nativeBuildInputs = [
@@ -56,114 +57,91 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    aws-xray-sdk
     boto3
     botocore
-    cfn-lint
     cryptography
-    docker
-    flask
-    flask-cors
-    graphql-core
-    idna
-    jinja2
-    jsondiff
-    openapi-spec-validator
-    pyparsing
-    python-dateutil
-    python-jose
-    pyyaml
     requests
-    responses
-    sshpubkeys
-    werkzeug
     xmltodict
+    werkzeug
+    python-dateutil
+    responses
+    jinja2
   ];
+
+  passthru.optional-dependencies = {
+    # non-exhaustive list of extras, that was cobbled together for testing
+    all = [
+      aws-xray-sdk
+      cfn-lint
+      docker
+      ecdsa
+      flask
+      flask-cors
+      graphql-core
+      jsondiff
+      multipart
+      openapi-spec-validator
+      py-partiql-parser
+      pyparsing
+      python-jose
+      pyyaml
+      setuptools
+      sshpubkeys
+    ] ++ python-jose.optional-dependencies.cryptography;
+  };
 
   __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [
     freezegun
-    py-partiql-parser
     pytestCheckHook
-    sure
-  ];
+    pytest-xdist
+  ] ++ passthru.optional-dependencies.all;
 
   pytestFlagsArray = [
-    # Disable tests that try to access the network
-    "--deselect=tests/test_cloudformation/test_cloudformation_custom_resources.py::test_create_custom_lambda_resource__verify_cfnresponse_failed"
-    "--deselect=tests/test_cloudformation/test_server.py::test_cloudformation_server_get"
-    "--deselect=tests/test_core/test_decorator_calls.py::test_context_manager"
-    "--deselect=tests/test_core/test_decorator_calls.py::test_decorator_start_and_stop"
-    "--deselect=tests/test_core/test_request_mocking.py::test_passthrough_requests"
-    "--deselect=tests/test_firehose/test_firehose_put.py::test_put_record_batch_http_destination"
-    "--deselect=tests/test_firehose/test_firehose_put.py::test_put_record_http_destination"
-    "--deselect=tests/test_logs/test_integration.py::test_put_subscription_filter_with_lambda"
-    "--deselect=tests/test_sqs/test_integration.py::test_invoke_function_from_sqs_exception"
-    "--deselect=tests/test_sqs/test_sqs_integration.py::test_invoke_function_from_sqs_exception"
-    "--deselect=tests/test_stepfunctions/test_stepfunctions.py::test_state_machine_creation_fails_with_invalid_names"
-    "--deselect=tests/test_stepfunctions/test_stepfunctions.py::test_state_machine_list_executions_with_pagination"
-    "--deselect=tests/test_iotdata/test_iotdata.py::test_update"
-    "--deselect=tests/test_iotdata/test_iotdata.py::test_basic"
-    "--deselect=tests/test_iotdata/test_iotdata.py::test_delete_field_from_device_shadow"
-    "--deselect=tests/test_iotdata/test_iotdata.py::test_publish"
-    "--deselect=tests/test_moto_api/recorder/test_recorder.py::TestRecorder::test_s3_upload_data"
-    "--deselect=tests/test_moto_api/recorder/test_recorder.py::TestRecorder::test_s3_upload_file_using_requests"
+    "-m" "'not network and not requires_docker'"
+
+    # Fails at local name resolution
     "--deselect=tests/test_s3/test_multiple_accounts_server.py::TestAccountIdResolution::test_with_custom_request_header"
-    "--deselect=tests/test_s3/test_s3.py::test_presigned_put_url_with_approved_headers"
-    "--deselect=tests/test_s3/test_s3.py::test_presigned_put_url_with_custom_headers"
-    "--deselect=tests/test_s3/test_s3.py::test_put_chunked_with_v4_signature_in_body"
-    "--deselect=tests/test_s3/test_s3.py::test_upload_from_file_to_presigned_url"
-    "--deselect=tests/test_s3/test_server.py::test_s3_server_bucket_versioning"
     "--deselect=tests/test_s3/test_server.py::test_s3_server_post_cors_multiple_origins"
 
-    # Disable tests that require docker daemon
-    "--deselect=tests/test_core/test_docker.py::test_docker_is_running_and_available"
-    "--deselect=tests/test_events/test_events_lambdatriggers_integration.py::test_creating_bucket__invokes_lambda"
-    "--deselect=tests/test_s3/test_s3_lambda_integration.py::test_objectcreated_put__invokes_lambda"
-    "--deselect=tests/test_sqs/test_sqs_integration.py"
+    # Fails at resolving google.com
+    "--deselect=tests/test_firehose/test_firehose_put.py::test_put_record_http_destination"
+    "--deselect=tests/test_firehose/test_firehose_put.py::test_put_record_batch_http_destination"
 
-    # json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
-    "--deselect=tests/test_cloudformation/test_cloudformation_stack_integration.py::test_lambda_function"
+    # Download recordings returns faulty JSON
+    "--deselect=tests/test_moto_api/recorder/test_recorder.py::TestRecorder::test_ec2_instance_creation_recording_on"
+    "--deselect=tests/test_moto_api/recorder/test_recorder.py::TestRecorder::test_ec2_instance_creation__recording_off"
 
-    # AssertionError: CloudWatch log event was not found.
-    "--deselect=tests/test_logs/test_integration.py::test_subscription_filter_applies_to_new_streams"
+    # Connection Reset by Peer, when connecting to localhost:5678
+    "--deselect=tests/test_moto_api/recorder/test_recorder.py::TestRecorder::test_replay"
 
-    # KeyError: 'global'
-    "--deselect=tests/test_iotdata/test_server.py::test_iotdata_list"
-    "--deselect=tests/test_iotdata/test_server.py::test_publish"
+    # Requires docker, but isn't marked
+    # https://github.com/getmoto/moto/pull/6938
+    "--deselect=tests/test_awslambda/test_lambda_layers_invoked.py::test_invoke_local_lambda_layers"
 
-    # Blocks test execution
-    "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_load_data_from_inmemory_client"
-  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
-    "--deselect=tests/test_utilities/test_threaded_server.py::test_threaded_moto_server__different_port"
-    "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_server_can_handle_multiple_services"
-    "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_server_is_reachable"
-
-    # AssertionError: expected `{0}` to be greater than `{1}`
+    # Racy, expects two timestamp two differ
+    # https://github.com/getmoto/moto/issues/6946
     "--deselect=tests/test_databrew/test_databrew_recipes.py::test_publish_recipe"
   ];
 
   disabledTestPaths = [
-    # xml.parsers.expat.ExpatError: out of memory: line 1, column 0
-    "tests/test_sts/test_sts.py"
+    # Requires pytest-ordering, which is unmaintained
+    # https://github.com/getmoto/moto/issues/6937
     # botocore.exceptions.NoCredentialsError: Unable to locate credentials
+    "tests/test_dynamodb/test_dynamodb_statements.py"
+    "tests/test_lakeformation/test_resource_tags_integration.py"
     "tests/test_redshiftdata/test_redshiftdata.py"
-    # Tries to access the network
-    "tests/test_appsync/test_appsync_schema.py"
-    "tests/test_awslambda/test_lambda_eventsourcemapping.py"
-    "tests/test_awslambda/test_lambda_invoke.py"
-    "tests/test_batch/test_batch_jobs.py"
-    "tests/test_kinesis/test_kinesis.py"
-    "tests/test_kinesis/test_kinesis_stream_consumers.py"
-  ];
+    "tests/test_s3/test_s3_file_handles.py"
+    "tests/test_s3/test_s3.py"
+    "tests/test_s3/test_s3_select.py"
 
-  disabledTests = [
-    # only appears in aarch64 currently, but best to be safe
-    "test_state_machine_list_executions_with_filter"
-    # tests fail with 404 after Werkzeug 2.2 upgrade, see https://github.com/spulec/moto/issues/5341#issuecomment-1206995825
-    "test_appsync_list_tags_for_resource"
-    "test_s3_server_post_to_bucket_redirect"
+    # Tries to access the network
+    "tests/test_batch/test_batch_jobs.py"
+
+    # Threading tests regularly blocks test execution
+    "tests/test_utilities/test_threaded_server.py"
+    "tests/test_s3/test_s3_bucket_policy.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/py-partiql-parser/default.nix
+++ b/pkgs/development/python-modules/py-partiql-parser/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "py-partiql-parser";
-  version = "0.3.8";
+  version = "0.4.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "getmoto";
     repo = "py-partiql-parser";
     rev = "refs/tags/${version}";
-    hash = "sha256-uIO06RRuUuE9qCEg/tTcn68i7vaFAAeFhxdxW9WAbuw=";
+    hash = "sha256-gxoBc7PjS4EQix38VNX6u9cwy4FCjENcUN1euOJJLCo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -1,18 +1,28 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+
+# build-system
+, setuptools
+
+# dependencies
 , ecdsa
 , rsa
-, pycrypto
 , pyasn1
-, pycryptodome
+
+# optional-dependencies
 , cryptography
+, pycrypto
+, pycryptodome
+
+# tests
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-jose";
   version = "3.3.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mpdavis";
@@ -21,27 +31,43 @@ buildPythonPackage rec {
     hash = "sha256-6VGC6M5oyGCOiXcYp6mpyhL+JlcYZKIqOQU9Sm/TkKM=";
   };
 
-  propagatedBuildInputs = [
-    cryptography
-    ecdsa
-    pyasn1
-    pycrypto
-    pycryptodome
-    rsa
-  ];
-
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
   postPatch = ''
     substituteInPlace setup.py \
       --replace '"pytest-runner",' ""
   '';
 
-  pythonImportsCheck = [ "jose" ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    ecdsa
+    pyasn1
+    rsa
+  ];
+
+  passthru.optional-dependencies = {
+    cryptography = [
+      cryptography
+    ];
+    pycrypto = [
+      pycrypto
+    ];
+    pycryptodome = [
+      pycryptodome
+    ];
+  };
+
+  pythonImportsCheck = [
+    "jose"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   meta = with lib; {
+    changelog = "https://github.com/mpdavis/python-jose/releases/tag/${version}";
     homepage = "https://github.com/mpdavis/python-jose";
     description = "A JOSE implementation in Python";
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes

Another try to parallelize the test suite. I'm not sure the test suite will work on all platforms yet.

https://github.com/getmoto/py-partiql-parser/blob/0.4.0/CHANGELOG.md
https://github.com/getmoto/moto/blob/4.2.6/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
