### PR TITLE
ocamlPackages.brr: 0.0.4 → 0.0.6; note: 0.0.2 → 0.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/brr/default.nix
+++ b/pkgs/development/ocaml-modules/brr/default.nix
@@ -2,18 +2,17 @@
 , ocaml, findlib, ocamlbuild, topkg
 , js_of_ocaml-compiler
 , js_of_ocaml-toplevel
-, note
 }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-brr";
-  version = "0.0.4";
+  version = "0.0.6";
   src = fetchurl {
     url = "https://erratique.ch/software/brr/releases/brr-${version}.tbz";
-    hash = "sha256-v+Ik1tdRBVnNDqhmNoJuLelL3k5OhxIsUorGdTb9sbw=";
+    hash = "sha256-paYZlzujXsG1S+s/4/kAPBlDuV1Ljorw7okAu4qaAV0=";
   };
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
-  propagatedBuildInputs = [ js_of_ocaml-compiler js_of_ocaml-toplevel note ];
+  propagatedBuildInputs = [ js_of_ocaml-compiler js_of_ocaml-toplevel ];
   inherit (topkg) buildPhase installPhase;
 
   meta = {

--- a/pkgs/development/ocaml-modules/note/default.nix
+++ b/pkgs/development/ocaml-modules/note/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, brr }:
 
 lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
   "note is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-note";
-  version = "0.0.2";
+  version = "0.0.3";
   src = fetchurl {
     url = "https://erratique.ch/software/note/releases/note-${version}.tbz";
-    hash = "sha256-b35XcaDUXQLqwkNfsJKX5A1q1pAhw/mgdwyOdacZiiY=";
+    hash = "sha256-ZZOvCnyz7UWzFtGFI1uC0ZApzyylgZYM/HYIXGVXY2k=";
   };
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
   inherit (topkg) buildPhase installPhase;
+
+  propagatedBuildInputs = [ brr ];
 
   meta = {
     homepage = "https://erratique.ch/software/note";


### PR DESCRIPTION
## Description of changes

https://github.com/dbuenzli/brr/blob/v0.0.6/CHANGES.md
https://github.com/dbuenzli/note/blob/v0.0.3/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
