### PR TITLE
Agda 2.6.4 updates

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -47,6 +47,7 @@ let
     "lagda.org"
     "lagda.rst"
     "lagda.tex"
+    "lagda.typ"
   ];
 
   defaults =

--- a/pkgs/build-support/agda/lib.nix
+++ b/pkgs/build-support/agda/lib.nix
@@ -6,7 +6,7 @@
   * interfaceFile "Everything.agda" == "Everything.agdai"
   * interfaceFile "src/Everything.lagda.tex" == "src/Everything.agdai"
   */
-  interfaceFile = agdaFile: lib.head (builtins.match ''(.*\.)l?agda(\.(md|org|rst|tex))?'' agdaFile) + "agdai";
+  interfaceFile = agdaFile: lib.head (builtins.match ''(.*\.)l?agda(\.(md|org|rst|tex|typ))?'' agdaFile) + "agdai";
 
   /* Takes an arbitrary derivation and says whether it is an agda library package
   *  that is not marked as broken.

--- a/pkgs/development/libraries/agda/1lab/default.nix
+++ b/pkgs/development/libraries/agda/1lab/default.nix
@@ -2,14 +2,13 @@
 
 mkDerivation rec {
   pname = "1lab";
-  version = "unstable-2023-03-07";
+  version = "unstable-2023-10-11";
 
   src = fetchFromGitHub {
     owner = "plt-amy";
     repo = pname;
-    # Last commit that compiles with Agda 2.6.3
-    rev = "c6ee57a2da327def241324b4775ec2c67cdab2af";
-    hash = "sha256-zDqFaDZxAdFxYM6l2zc7ZTi4XwMThw1AQwHfvhOxzdg=";
+    rev = "c6e0c3c714486fd6c89ace31443428ba48871685";
+    hash = "sha256-PC75NtT0e99HVyFedox+6xz/CY2zP2g4Vzqruj5Bjhc=";
   };
 
   # We don't need anything in support; avoid installing LICENSE.agda

--- a/pkgs/development/libraries/agda/agda-categories/default.nix
+++ b/pkgs/development/libraries/agda/agda-categories/default.nix
@@ -1,14 +1,14 @@
 { lib, mkDerivation, fetchFromGitHub, standard-library }:
 
 mkDerivation rec {
-  version = "0.1.7.1a";
+  version = "0.1.7.2";
   pname = "agda-categories";
 
   src = fetchFromGitHub {
     owner = "agda";
     repo = "agda-categories";
     rev = "v${version}";
-    sha256 = "sha256-VlxRDxXg+unzYlACUU58JQUHXxtg0fI5dEQvlBRxJtU=";
+    sha256 = "sha256-lQzAfPqkdb0pG5seYVODPngSLrJxhbH1jf0K6qqoj3c=";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -24,5 +24,6 @@ mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with maintainers; [ mudri alexarice turion ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -1,14 +1,14 @@
 { lib, mkDerivation, fetchFromGitHub }:
 
 mkDerivation rec {
-  version = "unstable-2022-01-14";
+  version = "unstable-2023-10-04";
   pname = "agda-prelude";
 
   src = fetchFromGitHub {
     owner = "UlfNorell";
     repo = "agda-prelude";
-    rev = "3d143d6d0a3f75966602480665623e87233ff93e";
-    hash = "sha256-ILhXDq788vrceMp5mCiQUMrJxeLPtS4yGtvMHMYxzg8=";
+    rev = "ff3b13253612caf0784a06e2d7d0f30be16c32e4";
+    hash = "sha256-A05uDv3fJqKncea9AL6eQa0XAskLZwAIUl1OAOVeP8I=";
   };
 
   preConfigure = ''
@@ -24,6 +24,5 @@ mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with maintainers; [ mudri alexarice turion ];
-    broken = true;
   };
 }

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "cubical";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "agda";
     rev = "v${version}";
-    hash = "sha256-47GOfZYwvE9TbGzdy/xSYZagTbjs/oeDpwjYUvI7z3k=";
+    hash = "sha256-2quAZ/j7kQaFkh9W5Bj1y7YQj9BT7FwHqVWyj8T4AH8=";
   };
 
   # The cubical library has several `Everything.agda` files, which are

--- a/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
+++ b/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
@@ -26,5 +26,6 @@ mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ryanorendorff ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/agda/standard-library/default.nix
+++ b/pkgs/development/libraries/agda/standard-library/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "standard-library";
-  version = "1.7.2";
+  version = "1.7.3";
 
   src = fetchFromGitHub {
     repo = "agda-stdlib";
     owner = "agda";
     rev = "v${version}";
-    hash = "sha256-vvbyfC5+Yyx18IDikSbAAcTHHtU6krlz45Fd2YlwsBg=";
+    hash = "sha256-vtL6VPvTXhl/mepulUm8SYyTjnGsqno4RHDmTIy22Xg=";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/262645 bumps Agda to 2.6.4. This PR updates some Agda packages to work with 2.6.4, and marks the broken ones as broken.

Tested with `nixosTests.agda` and `agda.tests.allPackages`.