### PR TITLE
aalib: fix build with clang 16

### DIFF
--- a/pkgs/development/libraries/aalib/clang.patch
+++ b/pkgs/development/libraries/aalib/clang.patch
@@ -1,0 +1,74 @@
+diff -ur a/configure b/configure
+--- a/configure	2001-04-26 10:44:54.000000000 -0400
++++ b/configure	2023-10-21 23:19:52.941161475 -0400
+@@ -1005,7 +1005,7 @@
+ #line 1006 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:1011: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes
+diff -ur a/src/aafire.c b/src/aafire.c
+--- a/src/aafire.c	2001-04-26 11:30:03.000000000 -0400
++++ b/src/aafire.c	2023-10-21 23:46:54.478750904 -0400
+@@ -1,3 +1,4 @@
++#include <stdlib.h>
+ #include <stdio.h>
+ #include "aalib.h"
+ 
+diff -ur a/src/aainfo.c b/src/aainfo.c
+--- a/src/aainfo.c	2001-04-26 10:37:31.000000000 -0400
++++ b/src/aainfo.c	2023-10-21 23:31:54.141133353 -0400
+@@ -1,4 +1,4 @@
+-
++#include <stdlib.h>
+ #include "aalib.h"
+ #include "aaint.h"
+ int main(int argc, char **argv)
+diff -ur a/src/aakbdreg.c b/src/aakbdreg.c
+--- a/src/aakbdreg.c	2023-10-21 23:19:00.787207960 -0400
++++ b/src/aakbdreg.c	2023-10-21 23:23:49.667253541 -0400
+@@ -1,4 +1,5 @@
+ #include <malloc.h>
++#include <string.h>
+ #include "config.h"
+ #include "aalib.h"
+ #include "aaint.h"
+diff -ur a/src/aamoureg.c b/src/aamoureg.c
+--- a/src/aamoureg.c	2023-10-21 23:19:00.787725591 -0400
++++ b/src/aamoureg.c	2023-10-21 23:26:51.821477807 -0400
+@@ -1,4 +1,5 @@
+ #include <malloc.h>
++#include <string.h>
+ #include "config.h"
+ #include "aalib.h"
+ #include "aaint.h"
+diff -ur a/src/aaregist.c b/src/aaregist.c
+--- a/src/aaregist.c	2023-10-21 23:19:00.788130179 -0400
++++ b/src/aaregist.c	2023-10-21 23:19:38.929729034 -0400
+@@ -1,4 +1,5 @@
+ #include <malloc.h>
++#include <string.h>
+ #include "config.h"
+ #include "aalib.h"
+ #include "aaint.h"
+diff -ur a/src/aasavefont.c b/src/aasavefont.c
+--- a/src/aasavefont.c	2001-04-26 10:37:31.000000000 -0400
++++ b/src/aasavefont.c	2023-10-21 23:51:09.216521714 -0400
+@@ -1,3 +1,5 @@
++#include <stdlib.h>
++#include <stdio.h>
+ #include "aalib.h"
+ int main(int argc, char **argv)
+ {
+diff -ur a/src/aatest.c b/src/aatest.c
+--- a/src/aatest.c	2001-04-26 10:37:31.000000000 -0400
++++ b/src/aatest.c	2023-10-21 23:43:16.758422704 -0400
+@@ -1,3 +1,5 @@
++#include <stdlib.h>
++#include <string.h>
+ #include "aalib.h"
+ int main(int argc, char **argv)
+ {

--- a/pkgs/development/libraries/aalib/darwin.patch
+++ b/pkgs/development/libraries/aalib/darwin.patch
@@ -18,9 +18,9 @@ index def65fe..f4f8efb 100644
 @@ -1,4 +1,4 @@
 -#include <malloc.h>
 +#include <stdlib.h>
+ #include <string.h>
  #include "config.h"
  #include "aalib.h"
- #include "aaint.h"
 diff --git a/src/aalib.c b/src/aalib.c
 index 11fecc8..e3063b4 100644
 --- a/src/aalib.c
@@ -40,9 +40,9 @@ index 0380828..bb55fe3 100644
 @@ -1,4 +1,4 @@
 -#include <malloc.h>
 +#include <stdlib.h>
+ #include <string.h>
  #include "config.h"
  #include "aalib.h"
- #include "aaint.h"
 diff --git a/src/aarec.c b/src/aarec.c
 index 70f4ebc..ee43e8a 100644
 --- a/src/aarec.c
@@ -61,9 +61,9 @@ index 54abec0..765155e 100644
 @@ -1,4 +1,4 @@
 -#include <malloc.h>
 +#include <stdlib.h>
+ #include <string.h>
  #include "config.h"
  #include "aalib.h"
- #include "aaint.h"
 diff --git a/src/aax.c b/src/aax.c
 index adcbd82..36e3294 100644
 --- a/src/aax.c

--- a/pkgs/development/libraries/aalib/default.nix
+++ b/pkgs/development/libraries/aalib/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "man" "info" ];
   setOutputFlags = false; # Doesn't support all the flags
 
-  patches = lib.optionals stdenv.isDarwin [ ./darwin.patch ];
+  patches = [ ./clang.patch ] # Fix implicit `int` on `main` error with newer versions of clang
+    ++ lib.optionals stdenv.isDarwin [ ./darwin.patch ];
 
   # The fuloong2f is not supported by aalib still
   preConfigure = ''


### PR DESCRIPTION
## Description of changes

* Modify `configure` to fix an implicit `int` error; and
* Add missing headers to fix use of undeclared library function errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
