### PR TITLE
gtk2: fix build with clang 16

### DIFF
--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.isDarwin [
     ./patches/2.0-gnome_bugzilla_557780_306776_freeciv_darwin.patch
     ./patches/2.0-darwin-x11.patch
+    # Fixes an incompatible function pointer conversion and implicit int errors with clang 16.
+    ./patches/2.0-clang.patch
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/gtk/patches/2.0-clang.patch
+++ b/pkgs/development/libraries/gtk/patches/2.0-clang.patch
@@ -1,0 +1,49 @@
+diff --git a/gtk/gtkscale.c b/gtk/gtkscale.c
+index 4317523fb8..3c09cd3ae8 100644
+--- a/gtk/gtkscale.c
++++ b/gtk/gtkscale.c
+@@ -1471,7 +1471,7 @@ gtk_scale_add_mark (GtkScale        *scale,
+   mark->position = position;
+  
+   priv->marks = g_slist_insert_sorted_with_data (priv->marks, mark,
+-                                                 (GCompareFunc) compare_marks,
++                                                 (GCompareDataFunc) compare_marks,
+                                                  GINT_TO_POINTER (
+                                                    gtk_range_get_inverted (GTK_RANGE (scale)) 
+                                                    ));
+diff --git a/tests/testmenubars.c b/tests/testmenubars.c
+index 416a939861..c65e82be26 100644
+--- a/tests/testmenubars.c
++++ b/tests/testmenubars.c
+@@ -21,7 +21,7 @@
+ #include <gtk/gtk.h>
+ 
+ static GtkWidget *
+-create_menu (depth)
++create_menu (int depth, gboolean _unused)
+ {
+     GtkWidget *menu;
+     GtkWidget *menuitem;
+@@ -35,19 +35,19 @@ create_menu (depth)
+     gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
+     gtk_widget_show (menuitem);
+     gtk_menu_item_set_submenu (GTK_MENU_ITEM (menuitem),
+-			       create_menu (depth - 1));
++			       create_menu (depth - 1, _unused));
+ 
+     menuitem = gtk_menu_item_new_with_mnemonic ("Two");
+     gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
+     gtk_widget_show (menuitem);
+     gtk_menu_item_set_submenu (GTK_MENU_ITEM (menuitem),
+-			       create_menu (depth - 1));
++			       create_menu (depth - 1, _unused));
+ 
+     menuitem = gtk_menu_item_new_with_mnemonic ("Three");
+     gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
+     gtk_widget_show (menuitem);
+     gtk_menu_item_set_submenu (GTK_MENU_ITEM (menuitem),
+-			       create_menu (depth - 1));
++			       create_menu (depth - 1, _unused));
+ 
+     return menu;
+ }


### PR DESCRIPTION
## Description of changes

* Resolve incompatible function pointer conversion error; and
* Fix signature of `create_menu` in `tests/testmenubars.c`.
* 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
