### PR TITLE
piper-tts: 1.2.0 -> 2023.9.27-1; piper-phonemize: 1.1.0 -> 2023.9.27-2

### DIFF
--- a/pkgs/development/libraries/piper-phonemize/default.nix
+++ b/pkgs/development/libraries/piper-phonemize/default.nix
@@ -17,8 +17,8 @@ let
     src = fetchFromGitHub {
       owner = "rhasspy";
       repo = "espeak-ng";
-      rev = "61504f6b76bf9ebbb39b07d21cff2a02b87c99ff";
-      hash = "sha256-RBHL11L5uazAFsPFwul2QIyJREXk9Uz8HTZx9JqmyIQ=";
+      rev = "0f65aa301e0d6bae5e172cc74197d32a6182200f";
+      hash = "sha256-2V0D3QO+v9OqffpNmwJQd3NIBd/IFeLkjaJ3Y0HHw7E=";
     };
 
     patches = [
@@ -28,18 +28,23 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "piper-phonemize";
-  version = "1.1.0";
+  version = "2023.9.27-2";
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "piper-phonemize";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-cMer7CSLOXv3jc9huVA3Oy5cjXjOX9XuEXpIWau1BNQ=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Rwl8D5ZX9sGdxEch+l7pXdbf4nPCuSfGrK5x/EQ+O60=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DONNXRUNTIME_DIR=${onnxruntime.dev}"
+    "-DESPEAK_NG_DIR=${espeak-ng'}"
   ];
 
   buildInputs = [

--- a/pkgs/tools/audio/piper/default.nix
+++ b/pkgs/tools/audio/piper/default.nix
@@ -7,6 +7,7 @@
 , pkg-config
 
 # runtime
+, fmt
 , onnxruntime
 , pcaudiolib
 , piper-phonemize
@@ -18,20 +19,24 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "piper";
-  version = "1.2.0";
+  version = "2023.9.27-1";
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "piper";
-    rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-6WNWqJt0PO86vnf+3iHaRRg2KwBOEj4aicmB+P2phlk=";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-U7yOiqNvE0WqZB8qaKf3U7gnTJ6q+9W5lviW79b6h/o=";
   };
-
-  sourceRoot = "${finalAttrs.src.name}/src/cpp";
 
   nativeBuildInputs = [
     cmake
     pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DFMT_DIR=${fmt}"
+    "-DSPDLOG_DIR=${spdlog.src}"
+    "-DPIPER_PHONEMIZE_DIR=${piper-phonemize}"
   ];
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/rhasspy/piper-phonemize/releases/tag/2023.9.27-2

https://github.com/rhasspy/piper/releases/tag/2023.9.9-1
https://github.com/rhasspy/piper/releases/tag/2023.9.27-1

## Description of changes

Tested using

```
❯ echo 'Welcome to the world of speech synthesis!' | ./result/bin/piper --model ./en_US-ryan-medium.onnx --output-raw | aplay -r 22050 -f S16_LE -t raw -
Playing raw data 'stdin' : Signed 16 bit Little Endian, Rate 22050 Hz, Mono
[2023-10-23 01:13:00.308] [piper] [info] Loaded voice in 0.188423989 second(s)
[2023-10-23 01:13:00.308] [piper] [info] Initialized piper
[2023-10-23 01:13:00.413] [piper] [info] Waiting for audio to finish playing...
[2023-10-23 01:13:00.522] [piper] [info] Real-time factor: 0.050550829374326506 (infer=0.102119553 sec, audio=2.020136054421769 sec)
[2023-10-23 01:13:00.522] [piper] [info] Terminated piper
````

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
