### PR TITLE
Revert "nixos/systemd-boot: Avoid remote mypy executions"

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -49,7 +49,7 @@ let
     '';
   };
 
-  checkedSystemdBootBuilder = pkgs.runCommandLocal "systemd-boot" {
+  checkedSystemdBootBuilder = pkgs.runCommand "systemd-boot" {
     nativeBuildInputs = [ pkgs.mypy ];
   } ''
     install -m755 ${systemdBootBuilder} $out


### PR DESCRIPTION
Reverts NixOS/nixpkgs#261640

Fixes https://hydra.nixos.org/build/239231445