### PR TITLE
tandoor-recipes: Simplify test setup

### DIFF
--- a/nixos/tests/tandoor-recipes.nix
+++ b/nixos/tests/tandoor-recipes.nix
@@ -3,33 +3,8 @@ import ./make-test-python.nix ({ lib, ... }: {
   meta.maintainers = with lib.maintainers; [ ambroisie ];
 
   nodes.machine = { pkgs, ... }: {
-    # Setup using Postgres
     services.tandoor-recipes = {
       enable = true;
-
-      extraConfig = {
-        DB_ENGINE = "django.db.backends.postgresql";
-        POSTGRES_HOST = "/run/postgresql";
-        POSTGRES_USER = "tandoor_recipes";
-        POSTGRES_DB = "tandoor_recipes";
-      };
-    };
-
-    services.postgresql = {
-      enable = true;
-      ensureDatabases = [ "tandoor_recipes" ];
-      ensureUsers = [
-        {
-          name = "tandoor_recipes";
-          ensurePermissions."DATABASE tandoor_recipes" = "ALL PRIVILEGES";
-        }
-      ];
-    };
-
-    systemd.services = {
-      tandoor-recipes = {
-        after = [ "postgresql.service" ];
-      };
     };
   };
 

--- a/nixos/tests/tandoor-recipes.nix
+++ b/nixos/tests/tandoor-recipes.nix
@@ -8,11 +8,11 @@ import ./make-test-python.nix ({ lib, ... }: {
     };
   };
 
-  testScript = ''
+  testScript = {nodes, ...}: ''
     machine.wait_for_unit("tandoor-recipes.service")
 
     with subtest("Web interface gets ready"):
         # Wait until server accepts connections
-        machine.wait_until_succeeds("curl -fs localhost:8080")
+        machine.wait_until_succeeds("curl -fs ${nodes.machine.services.tandoor-recipes.address}:${toString nodes.machine.services.tandoor-recipes.port}")
   '';
 })


### PR DESCRIPTION
## Description of changes

The original test succeeds with this much simpler setup code. So either the original test wasn't testing the extra setup, or the extra setup was unnecessary.

@ofborg test tandoor-recipes

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).