### PR TITLE
lyra: patch meson.build

### DIFF
--- a/pkgs/development/libraries/lyra/default.nix
+++ b/pkgs/development/libraries/lyra/default.nix
@@ -13,12 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja ];
 
-  postPatch = "sed -i s#/usr#$out#g meson.build";
-
-  postInstall = ''
-    mkdir -p $out/include
-    cp -R $src/include/* $out/include
-  '';
+  patches = [ ./meson.patch ];
 
   meta = with lib; {
     homepage = "https://github.com/bfgroup/Lyra";

--- a/pkgs/development/libraries/lyra/meson.patch
+++ b/pkgs/development/libraries/lyra/meson.patch
@@ -1,0 +1,91 @@
+diff --git a/data/build.jam b/data/build.jam
+index c88b8f5..7f89ab5 100644
+--- a/data/build.jam
++++ b/data/build.jam
+@@ -76,7 +76,7 @@ local meson_build_header_join_str = ",
+ # ----
+ 
+ project('Lyra','cpp',
+-	version: '1.6',
++	version: '1.6.1',
+ 	default_options : ['cpp_std=c++11', 'cpp_eh=none', 'b_lto=true', 'warning_level=3'],
+ 	license: 'BSL-1.0')
+ 
+@@ -88,15 +88,25 @@ $(lyra_headers_relative:J=$(meson_build_header_join_str))
+ "
+ ]
+ 
+-inc_dir = [include_directories('include')]
+-
+-lyra_lib = shared_library('lyra',
+-	sources : src,
+-	include_directories: inc_dir,
+-	install: true,
+-	install_dir : '/usr/lib')
+-
+-lyra_dep = declare_dependency(include_directories: inc_dir, link_with: lyra_lib)
++fs = import('fs')
++foreach header : src
++	# use substring to drop `include/` prefix
++	install_headers(header, subdir : fs.parent(header.substring(8)))
++endforeach
++
++inc_dir = include_directories('include')
++
++lyra_dep = declare_dependency(include_directories: inc_dir)
++
++pkg = import('pkgconfig')
++pkg.generate(
++	subdirs : 'lyra',
++	filebase : 'lyra',
++	version : meson.project_version(),
++	name : meson.project_name(),
++	description : 'A simple to use, composing, header only, command line arguments parser for C++ 11 and beyond.',
++	url: 'https://github.com/bfgroup/Lyra',
++)
+ " ;
+ 
+ .meson_build_file = $(.meson_build_file:J=) ;
+diff --git a/meson.build b/meson.build
+index aace962..e44a500 100644
+--- a/meson.build
++++ b/meson.build
+@@ -31,7 +31,7 @@
+ # ----
+ 
+ project('Lyra','cpp',
+-	version: '1.6',
++	version: '1.6.1',
+ 	default_options : ['cpp_std=c++11', 'cpp_eh=none', 'b_lto=true', 'warning_level=3'],
+ 	license: 'BSL-1.0')
+ 
+@@ -68,12 +68,22 @@ src = [
+ 	'include/lyra/version.hpp'
+ ]
+ 
+-inc_dir = [include_directories('include')]
++fs = import('fs')
++foreach header : src
++	# use substring to drop `include/` prefix
++	install_headers(header, subdir : fs.parent(header.substring(8)))
++endforeach
+ 
+-lyra_lib = shared_library('lyra',
+-	sources : src,
+-	include_directories: inc_dir,
+-	install: true,
+-	install_dir : '/usr/lib')
++inc_dir = include_directories('include')
+ 
+-lyra_dep = declare_dependency(include_directories: inc_dir, link_with: lyra_lib)
++lyra_dep = declare_dependency(include_directories: inc_dir)
++
++pkg = import('pkgconfig')
++pkg.generate(
++	subdirs : 'lyra',
++	filebase : 'lyra',
++	version : meson.project_version(),
++	name : meson.project_name(),
++	description : 'A simple to use, composing, header only, command line arguments parser for C++ 11 and beyond.',
++	url: 'https://github.com/bfgroup/Lyra',
++)


### PR DESCRIPTION


## Description of changes

This commit does following things:

1.  Now lyra can automatically generate pkgconfig file.
2.  Lyra is a pure header library, but it generated an empty `.so` file before due to incorrectly `meson.build`. Now it's fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
