### PR TITLE
postgresqlPackages.pg_uuidv7: init at 1.3.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, postgresql
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pg_uuidv7";
+  version = "1.3.0";
+
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner = "fboulnois";
+    repo = "pg_uuidv7";
+    rev = "v${version}";
+    hash = "sha256-kHxS9tL7fpKhjJ8Xx5tee1fv10zVcTt2FgUQSaRdNZo=";
+  };
+
+  installPhase = ''
+      install -D -t $out/lib pg_uuidv7${postgresql.dlSuffix}
+      install -D {sql/pg_uuidv7--${lib.versions.majorMinor version}.sql,pg_uuidv7.control} -t $out/share/postgresql/extension
+  '';
+
+  meta = with lib; {
+    description = "A tiny Postgres extension to create version 7 UUIDs";
+    homepage = "https://github.com/fboulnois/pg_uuidv7";
+    changelog = "https://github.com/fboulnois/pg_uuidv7/blob/main/CHANGELOG.md";
+    maintainers = with maintainers; [ gaelreyrol ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.mpl20;
+    broken = versionOlder postgresql.version "13";
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -77,6 +77,8 @@ self: super: {
 
     pg_safeupdate = super.callPackage ./ext/pg_safeupdate.nix { };
 
+    pg_uuidv7 = super.callPackage ./ext/pg_uuidv7.nix { };
+
     promscale_extension = super.callPackage ./ext/promscale_extension.nix { };
 
     repmgr = super.callPackage ./ext/repmgr.nix { };


### PR DESCRIPTION
## Description of changes

This PR adds the Postgres extension pg_uuidv7: https://github.com/fboulnois/pg_uuidv7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
