### PR TITLE
nixos/tandoor-recipes: Fix support for `SCRIPT_NAME` setting

### DIFF
--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -88,7 +88,7 @@ in
         Group = "tandoor_recipes";
         DynamicUser = true;
         StateDirectory = "tandoor-recipes";
-        WorkingDirectory = "/var/lib/tandoor-recipes";
+        WorkingDirectory = env.MEDIA_ROOT;
         RuntimeDirectory = "tandoor-recipes";
 
         BindReadOnlyPaths = [

--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -22,7 +22,7 @@ let
     ${lib.toShellVars env}
     eval "$(${config.systemd.package}/bin/systemctl show -pUID,GID,MainPID tandoor-recipes.service)"
     exec ${pkgs.util-linux}/bin/nsenter \
-      -t $MainPID -m -S $UID -G $GID \
+      -t $MainPID -m -S $UID -G $GID --wdns=${env.MEDIA_ROOT} \
       ${pkg}/bin/tandoor-recipes "$@"
   '';
 in

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -955,6 +955,7 @@ in {
   systemd-homed = handleTest ./systemd-homed.nix {};
   systemtap = handleTest ./systemtap.nix {};
   tandoor-recipes = handleTest ./tandoor-recipes.nix {};
+  tandoor-recipes-script-name = handleTest ./tandoor-recipes-script-name.nix {};
   tang = handleTest ./tang.nix {};
   taskserver = handleTest ./taskserver.nix {};
   tayga = handleTest ./tayga.nix {};

--- a/nixos/tests/tandoor-recipes-script-name.nix
+++ b/nixos/tests/tandoor-recipes-script-name.nix
@@ -1,0 +1,95 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  {
+    name = "tandoor-recipes-script-name";
+
+    nodes.machine =
+      { pkgs, nodes, ... }:
+      {
+        services.tandoor-recipes = {
+          enable = true;
+          extraConfig = {
+            SCRIPT_NAME = "/any/path";
+            STATIC_URL = "${nodes.machine.services.tandoor-recipes.extraConfig.SCRIPT_NAME}/static/";
+          };
+        };
+      };
+
+    testScript =
+      { nodes, ... }:
+      let
+        inherit (nodes.machine.services.tandoor-recipes) address port;
+        inherit (nodes.machine.services.tandoor-recipes.extraConfig) SCRIPT_NAME;
+      in
+      ''
+        from html.parser import HTMLParser
+
+        origin_url = "http://${address}:${toString port}"
+        base_url = f"{origin_url}${SCRIPT_NAME}"
+        login_path = "/admin/login/"
+        login_url = f"{base_url}{login_path}"
+
+        cookie_jar_path = "/tmp/cookies.txt"
+        curl = f"curl --cookie {cookie_jar_path} --cookie-jar {cookie_jar_path} --fail --header 'Origin: {origin_url}' --show-error --silent"
+
+        print("Wait for the service to respond")
+        machine.wait_for_unit("tandoor-recipes.service")
+        machine.wait_until_succeeds(f"{curl} {login_url}")
+
+        username = "username"
+        password = "password"
+
+        print("Create admin user")
+        machine.succeed(
+            f"DJANGO_SUPERUSER_PASSWORD='{password}' /var/lib/tandoor-recipes/tandoor-recipes-manage createsuperuser --no-input --username='{username}' --email=nobody@example.com"
+        )
+
+        print("Get CSRF token for later requests")
+        csrf_token = machine.succeed(f"grep csrftoken {cookie_jar_path} | cut --fields=7").rstrip()
+
+        print("Log in as admin user")
+        machine.succeed(
+            f"{curl} --data 'csrfmiddlewaretoken={csrf_token}' --data 'username={username}' --data 'password={password}' {login_url}"
+        )
+
+        print("Get the contents of the logged in main page")
+        logged_in_page = machine.succeed(f"{curl} --location {base_url}")
+
+        class UrlParser(HTMLParser):
+            def __init__(self):
+                super().__init__()
+
+                self.urls: list[str] = []
+
+            def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+                if tag == "form":
+                    for name, value in attrs:
+                        if name == "action" and value is not None:
+                            assert not value.endswith(login_path)
+                            break
+
+                if tag != "a":
+                    return
+
+                for name, value in attrs:
+                    if name == "href" and value is not None:
+                        if value.startswith(base_url):
+                            self.urls.append(value)
+                        elif value.startswith("/"):
+                            self.urls.append(f"{origin_url}{value}")
+                        else:
+                            print("Ignoring external URL: {value}")
+
+                        break
+
+        parser = UrlParser()
+        parser.feed(logged_in_page)
+
+        for url in parser.urls:
+            with subtest(f"Verify that {url} can be reached"):
+                machine.succeed(f"{curl} {url}")
+      '';
+
+    meta.maintainers = with lib.maintainers; [ l0b0 ];
+  }
+)

--- a/pkgs/applications/misc/tandoor-recipes/default.nix
+++ b/pkgs/applications/misc/tandoor-recipes/default.nix
@@ -165,7 +165,7 @@ python.pkgs.pythonPackages.buildPythonPackage rec {
     updateScript = ./update.sh;
 
     tests = {
-      inherit (nixosTests) tandoor-recipes;
+      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name;
     };
   };
 


### PR DESCRIPTION
## Description of changes

- Run `tandoor-recipes` from within its `MEDIA_ROOT` directory.
- Verify that all `href` attributes emitted as part of the entrypoint
  page after logging in are reachable.

Closes #262857 - the goal of that issue can now be achieved by setting the following:

```nix
{
  services.tandoor-recipes.extraConfig = {
    SCRIPT_NAME = "/any/path";
    STATIC_URL = "${nodes.machine.services.tandoor-recipes.extraConfig.SCRIPT_NAME}/static/";
  };
}
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).