### PR TITLE
lomiri.lomiri-indicator-network: init at 1.0.1

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -34,6 +34,7 @@ let
     hfd-service = callPackage ./services/hfd-service { };
     history-service = callPackage ./services/history-service { };
     lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
+    lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
     lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     mediascanner2 = callPackage ./services/mediascanner2 { };
   };

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -1,0 +1,138 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, nixosTests
+, testers
+, cmake
+, cmake-extras
+, dbus
+, doxygen
+, gettext
+, glib
+, gmenuharness
+, gtest
+, intltool
+, libsecret
+, libqofono
+, libqtdbusmock
+, libqtdbustest
+, lomiri-api
+, lomiri-url-dispatcher
+, networkmanager
+, ofono
+, pkg-config
+, python3
+, qtdeclarative
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-indicator-network";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-indicator-network";
+    rev = finalAttrs.version;
+    hash = "sha256-JrxJsdLd35coEJ0nYcYtPRQONLfKciNmBbLqXrEaOX0=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  patches = [
+    # Fix pkg-config file
+    # Remove when version > 1.0.0
+    (fetchpatch {
+      name = "0001-lomiri-indicator-network-Fix-pkg-config-file-for-liblomiri-connectivity-qt1.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/commit/a67ac8e1a1b96f4dcad01dd4c1685fed9831eaa3.patch";
+      hash = "sha256-D3AhEJus0MysmfMg7eWFNI20Z5cTeHwiFTP0OuoQook=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace '/usr/lib/systemd/user' "$out/lib/systemd/user" \
+      --replace '/etc/xdg/autostart' "$out/etc/xdg/autostart"
+
+    # Don't disregard GNUInstallDirs requests, {DOCDIR}/../<different-name> to preserve preferred name
+    substituteInPlace doc/CMakeLists.txt \
+      --replace 'INSTALL_DOCDIR ''${CMAKE_INSTALL_DATAROOTDIR}/doc/lomiri-connectivity-doc' 'INSTALL_DOCDIR ''${CMAKE_INSTALL_DOCDIR}/../lomiri-connectivity-doc'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    gettext
+    intltool
+    pkg-config
+    qtdeclarative
+  ];
+
+  buildInputs = [
+    cmake-extras
+    dbus
+    glib
+    libqofono
+    libsecret
+    lomiri-api
+    lomiri-url-dispatcher
+    networkmanager
+    ofono
+    qtbase
+  ];
+
+  nativeCheckInputs = [
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    gmenuharness
+    gtest
+    libqtdbusmock
+    libqtdbustest
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DGSETTINGS_LOCALINSTALL=ON"
+    "-DGSETTINGS_COMPILE=ON"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_UBUNTU_COMPAT=ON" # in case
+    "-DBUILD_DOC=ON" # lacks QML docs, needs qdoc: https://github.com/NixOS/nixpkgs/pull/245379
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    ayatana-indicators = [
+      "lomiri-indicator-network"
+    ];
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      vm = nixosTests.ayatana-indicators;
+    };
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana indiator exporting the network settings menu through D-Bus";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-indicator-network";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "lomiri-connectivity-qt1"
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[`lomiri-indicator-network`](https://gitlab.com/ubports/development/core/lomiri-indicator-network) is a Lomiri-specific ~~Ayatana indicator~~ ([in-between an AppIndicator and an Ayatana indicator, but closer to the latter for our purposes](https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/issues/82)) for the network state.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
