### PR TITLE
fix for logmein-hamachi (removed www)

### DIFF
--- a/pkgs/tools/networking/logmein-hamachi/default.nix
+++ b/pkgs/tools/networking/logmein-hamachi/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   version = "2.1.0.203";
 
   src = fetchurl {
-    url = "https://www.vpn.net/installers/${pname}-${version}-${arch}.tgz";
+    url = "https://vpn.net/installers/${pname}-${version}-${arch}.tgz";
     inherit sha256;
   };
 


### PR DESCRIPTION


## Description of changes
changed the hard coded portion of the web address from `www.vpn.net` to `vpn.net`
the changes were done on line 20 inside the `pkgs/tools/networking/logmein-hamachi/default.nix ` file in the `main` branch.
- This was the old line `url = "https://www.vpn.net/installers/${pname}-${version}-${arch}.tgz";`
- This is the fixed line `url = "https://vpn.net/installers/${pname}-${version}-${arch}.tgz";`


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).