### PR TITLE
nixos/release-combined: drop ZFS+i686 from blockers

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -165,7 +165,6 @@ in rec {
         (onFullSupported "nixos.tests.switchTest")
         (onFullSupported "nixos.tests.udisks2")
         (onFullSupported "nixos.tests.xfce")
-        (onSystems ["i686-linux"] "nixos.tests.zfs.installer")
         (onFullSupported "nixpkgs.emacs")
         (onFullSupported "nixpkgs.jdk")
         ["nixpkgs.tarball"]


### PR DESCRIPTION
The current state is certainly very wrong - testing ZFS only on i686. I suspect it was a typo (?) in commit 2de3caf01109891.

The current practical problem is that the test fails, though in a part that looks cross-platform (which adds confusion): https://hydra.nixos.org/build/239290208#tabs-buildsteps

_The usual checklist doesn't really apply here._
