### PR TITLE
python311Packages.catppuccin: fix build and refactor

### DIFF
--- a/pkgs/development/python-modules/catppuccin/default.nix
+++ b/pkgs/development/python-modules/catppuccin/default.nix
@@ -1,27 +1,47 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, python
+, fetchFromGitHub
+, poetry-core
+, poetry-dynamic-versioning
 , pygments
+, rich
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "catppuccin";
   version = "1.3.2";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-iRQF9U6QvbyOSdp0OALc/Efl4IL1w17WGOZRbhzlqGA=";
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "python";
+    rev = "v${version}";
+    hash = "sha256-spPZdQ+x3isyeBXZ/J2QE6zNhyHRfyRQGiHreuXzzik=";
   };
 
-  propagatedBuildInputs = [ pygments ];
+  nativeBuildInputs = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  passthru.optional-dependencies = {
+    pygments = [ pygments ];
+    rich = [ rich ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    "tests/test_flavour.py" # would download a json to check correctness of flavours
+  ];
 
   pythonImportsCheck = [ "catppuccin" ];
 
-  meta = with lib; {
+  meta = {
     description = "Soothing pastel theme for Python";
     homepage = "https://github.com/catppuccin/python";
-    maintainers = with maintainers; [ fufexan ];
-    license = licenses.mit;
+    maintainers = with lib.maintainers; [ fufexan tomasajt ];
+    license = lib.licenses.mit;
   };
 }


### PR DESCRIPTION
## Description of changes

This PR fixes the build failure introduced after a mass update (https://github.com/NixOS/nixpkgs/pull/251878)
I noticed this issue after not being able to build `catppuccin-gtk`

I also went ahead and refactored the package to not use `fetchPypi`, as there were some issues with the optional dependencies being required in the downloaded wheel.

I also added myself as a maintainer, if that's not a problem.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
