### PR TITLE
python311packages.jedi-language-server: 0.41.0 -> 0.41.1

### DIFF
--- a/pkgs/development/python-modules/jedi-language-server/default.nix
+++ b/pkgs/development/python-modules/jedi-language-server/default.nix
@@ -2,11 +2,11 @@
 , buildPythonPackage
 , docstring-to-markdown
 , fetchFromGitHub
+, cattrs
 , jedi
 , lsprotocol
 , poetry-core
 , pygls
-, pydantic
 , pyhamcrest
 , pytestCheckHook
 , python-lsp-jsonrpc
@@ -16,8 +16,8 @@
 
 buildPythonPackage rec {
   pname = "jedi-language-server";
-  version = "0.41.0";
-  format = "pyproject";
+  version = "0.41.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "pappasam";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-1ujEhoxWcCM1g640aLE60YGiNQLB+G7t7oLVZXW8AMM=";
+    hash = "sha256-+ABxH1iF9FDQ7q6dAQowe3AJSgz+wgCy4JS35WpcnTs=";
   };
 
   pythonRelaxDeps = [
@@ -38,10 +38,10 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    cattrs
     docstring-to-markdown
     jedi
     lsprotocol
-    pydantic
     pygls
   ];
 


### PR DESCRIPTION
## Description of changes
Changelog: https://github.com/pappasam/jedi-language-server/releases/tag/v0.41.1

This PR bumps the version of the `jedi-language-server` python package to `0.41.1` and allows it to be built again.

There used to be a dependency on `pydantic` v2, which is not yet packaged, but that dependency was removed in this version.

I added `cattrs` as a dependency, as the package also specifies it in its dependency list.
Though it is already propagated from another dependency. Should I keep it or remove it?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
