### PR TITLE
batman-adv: 2023.1 -> 2023.2

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,9 +1,9 @@
 {
-  version = "2023.1";
+  version = "2023.2";
 
   sha256 = {
-    batman-adv = lib.fakeSha256;
-    alfred = lib.fakeSha256;
-    batctl = lib.fakeSha256;
+    batman-adv = "sha256-OQfc1X4sW/2dQHE5YLlAK/HaT4DFm1/wN3ifu7vY+iU=";
+    alfred = "sha256-qSBgKFZPieW/t3FK4piDoWEPYr4+YcCW4f6zYgBxjg4=";
+    batctl = "sha256-cLX5MfpjYyVpe9829tE0oDxJBvTBfLdlCjxxSQFDbsg=";
   };
 }

--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -2,8 +2,8 @@
   version = "2023.1";
 
   sha256 = {
-    batman-adv = "sha256-9GpyhmYKXsNQahvn72C0ccUaxwVQWX1ZgEBHmre5Nrg=";
-    alfred = "sha256-Q4BIJI83N1fTqL3ny8bbZoX00BBdEw2i9aVPKQkMaXQ=";
-    batctl = "sha256-5b9HMF2VWrsZkkS9Dl//q5YQixr/q9DZcFUz+AWTlfE=";
+    batman-adv = lib.fakeSha256;
+    alfred = lib.fakeSha256;
+    batctl = lib.fakeSha256;
   };
 }


### PR DESCRIPTION
## Description of changes

Update batman-adv to 2023.2. From https://www.open-mesh.org/news/113:


      batman-adv

          support latest kernels (4.14 - 6.5)
          bugs squashed:
              avoid potential invalid memory access when processing ELP/OGM2 packets
              drop pending DAT worker when interface shuts down
              inform network stack about automatically adjusted MTUs
              keep user defined MTU limit when MTU is recalculated
              fix packet memory leak when sending OGM2 via inactive interfaces
              fix TT memory leak for roamed back clients

      alfred

          receive data with valid source on unix sock without active interface

      Happy routing,

      The B.A.T.M.A.N. team

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
