### PR TITLE
treewide: migrate doc comments

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,4 @@
-/*
+/**
   Library of low-level helper functions for nix expressions.
 
   Please implement (mostly) exhaustive unit tests

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -270,7 +270,7 @@ runTests {
     '';
   };
 
-  /*
+  /**
     testOr = {
       expr = or true false;
       expected = true;

--- a/lib/tests/modules/docs.nix
+++ b/lib/tests/modules/docs.nix
@@ -1,4 +1,4 @@
-/*
+/**
   A basic documentation generating module.
   Declares and defines a `docs` option, suitable for making assertions about
   the extraction "phase" of documentation generation.

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -10,7 +10,7 @@ let
     expected = lib.sort lib.lessThan y;
   };
 
-  /*
+  /**
     Try to convert an elaborated system back to a simple string. If not possible,
     return null. So we have the property:
 
@@ -19,6 +19,13 @@ let
 
     NOTE: This property is not guaranteed when `sys` was elaborated by a different
           version of Nixpkgs.
+
+
+    # Inputs
+
+    `sys`
+
+    : 1\. Function argument
   */
   toLosslessStringMaybe =
     sys:


### PR DESCRIPTION
## Description of changes

Reformat doc-comments according to [RFC145](https://github.com/NixOS/rfcs/pull/145).

- Every doc-comment starts with `/**` and ends with the regular `*/`
- *nixdoc* format is automatically detected and migrated into valid markdown.
- Content and comment itself is re-indented to be a multiple of `2` (No hitting whitespace anymore yay!)

This PR is genrated. Some remaining handwork might still needed.
I'd ask to merge this as is. Only making minor improvements if they can be automated.

Improving docs for individual functions can be done in another PR. 

remaining review decisions:

- [ ] include detected function arguments (`inputs`). Although they might not be complete in some cases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
