### PR TITLE
alacritty-theme: init at unstable-2023-10-12

### DIFF
--- a/pkgs/data/themes/alacritty-theme/default.nix
+++ b/pkgs/data/themes/alacritty-theme/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, nix-update-script
+, stdenvNoCC
+, ... }:
+
+stdenvNoCC.mkDerivation (self: {
+  name = "alacritty-theme";
+  version = "unstable-2023-10-12";
+
+  src = fetchFromGitHub {
+    owner = "alacritty";
+    repo = "alacritty-theme";
+    rev = "4cb179606c3dfc7501b32b6f011f9549cee949d3";
+    hash = "sha256-Ipe6LHr83oBdBMV3u4xrd+4zudHXiRBamUa/cOuHleY=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  preferLocalBuild = true;
+
+  sourceRoot = "${self.src.name}/themes";
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out *.yaml
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = with lib; {
+    description = "Collection of Alacritty color schemes";
+    homepage = "https://alacritty.org/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.nicoo ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29020,6 +29020,8 @@ with pkgs;
 
   aileron = callPackage ../data/fonts/aileron { };
 
+  alacritty-theme = callPackage ../data/themes/alacritty-theme { };
+
   albatross = callPackage ../data/themes/albatross { };
 
   alegreya = callPackage ../data/fonts/alegreya { };


### PR DESCRIPTION
## Description of changes

Added new derivation under `data/themes/alacritty-theme`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
