### PR TITLE
google-fonts: unstable-2022-11-14 → unstable-2023-10-20

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -6,7 +6,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "google-fonts";
-  version = "unstable-2022-11-14";
+  version = "unstable-2023-10-20";
 
   # Adobe Blank is split out in a separate output,
   # because it causes crashes with `libfontconfig`.
@@ -16,8 +16,8 @@ stdenvNoCC.mkDerivation {
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
-    rev = "83e116a566eda04a2469a11ee562cef1d7b33e4f";
-    sha256 = "sha256-sSabk+VWkoXj1Nzv9ufgIU/nkfKf4XkZU1SO+j+eSPA=";
+    rev = "990be3ed8f77e31c26bf07b148d6a74b8e6241cf";
+    sha256 = "sha256-ffLXzaniHkWxGQpvlJpiO6/SAdbI3FONgTaq8Xu+WY0=";
   };
 
   postPatch = ''

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -29,6 +29,7 @@ stdenvNoCC.mkDerivation {
     rm -rv ofl/cabincondensed \
       ofl/signikanegative \
       ofl/signikanegativesc \
+      ofl/*_todelist \
       axisregistry/tests/data
 
     if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -67,5 +67,6 @@ stdenvNoCC.mkDerivation {
     platforms = platforms.all;
     hydraPlatforms = [];
     maintainers = with maintainers; [ manveru ];
+    sourceProvenance = [ sourceTypes.binaryBytecode ];
   };
 }


### PR DESCRIPTION
## Description of changes

- Updated `google-fonts` to `unstable-2023-10-20`
- Defined `meta.sourceProvenance`


## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).