### PR TITLE
autosuspend: fix build

### DIFF
--- a/pkgs/os-specific/linux/autosuspend/default.nix
+++ b/pkgs/os-specific/linux/autosuspend/default.nix
@@ -22,26 +22,27 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = with python3.pkgs; [
+    dbus-python
+    icalendar
+    jsonpath-ng
+    lxml
+    mpd2
     portalocker
     psutil
-    dbus-python
+    python-dateutil
+    pytz
+    requests
+    requests-file
+    tzlocal
   ];
 
   nativeCheckInputs = with python3.pkgs; [
+    freezegun
+    pytest-datadir
+    pytest-httpserver
+    pytest-mock
     pytestCheckHook
     python-dbusmock
-    pytest-httpserver
-    dateutils
-    freezegun
-    pytest-mock
-    requests
-    requests-file
-    icalendar
-    tzlocal
-    jsonpath-ng
-    mpd2
-    lxml
-    pytest-datadir
   ];
 
   # Disable tests that need root

--- a/pkgs/os-specific/linux/autosuspend/default.nix
+++ b/pkgs/os-specific/linux/autosuspend/default.nix
@@ -3,7 +3,21 @@
 , python3
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      # autosuspend is incompatible with tzlocal v5
+      # See https://github.com/regebro/tzlocal#api-change
+      tzlocal = super.tzlocal.overridePythonAttrs (prev: {
+        src = prev.src.override {
+          version = "4.3.1";
+          hash = "sha256-7jLvjCCAPBmpbtNmrd09SnKe9jCctcc1mgzC7ut/pGo=";
+        };
+      });
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
   pname = "autosuspend";
   version = "6.0.0";
 
@@ -21,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
       --replace '--cov-config=setup.cfg' ""
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python.pkgs; [
     dbus-python
     icalendar
     jsonpath-ng
@@ -36,7 +50,7 @@ python3.pkgs.buildPythonApplication rec {
     tzlocal
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python.pkgs; [
     freezegun
     pytest-datadir
     pytest-httpserver


### PR DESCRIPTION
## Description of changes

Failing build on Hydra: https://hydra.nixos.org/build/238622730

tzlocal has been upgraded to v5 in https://github.com/NixOS/nixpkgs/pull/251878

However tzlocal v5 has some [breaking changes](https://github.com/NixOS/nixpkgs/pull/251878), and autosuspend is incompatible with tzlocal v5 because it still uses pytz objects.

To fix that, we need to downgrade the tzlocal dependency to the v4 release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
