### PR TITLE
python311Packages.duecredit: unbreak, cleanup

### DIFF
--- a/pkgs/development/python-modules/duecredit/default.nix
+++ b/pkgs/development/python-modules/duecredit/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, pytest
+, pythonOlder
+, setuptools
 , pytestCheckHook
 , vcrpy
 , citeproc-py
@@ -13,16 +13,20 @@
 buildPythonPackage rec {
   pname = "duecredit";
   version = "0.9.2";
-  disabled = isPy27;
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-Dg/Yfp5GzmyUMI6feAwgP+g22JYoQE+L9a+Wp0V77Rw=";
   };
 
+  nativeBuildInputs = [ setuptools ];
   propagatedBuildInputs = [ citeproc-py requests six ];
 
-  nativeCheckInputs = [ pytest pytestCheckHook vcrpy ];
+  nativeCheckInputs = [ pytestCheckHook vcrpy ];
+  disabledTests = [ "test_import_doi" ];  # tries to access network
 
   preCheck = ''
     export HOME=$(mktemp -d)
@@ -33,6 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/duecredit/duecredit";
     description = "Simple framework to embed references in code";
+    changelog = "https://github.com/duecredit/duecredit/releases/tag/${version}";
     license = licenses.bsd2;
     maintainers = with maintainers; [ bcdarwin ];
   };

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -1,14 +1,33 @@
-{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, lxml, matplotlib
-, nibabel, numpy, pandas, scikit-learn, scipy, joblib, requests }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pytestCheckHook
+, hatch-vcs
+, lxml
+, matplotlib
+, nibabel
+, numpy
+, pandas
+, scikit-learn
+, scipy
+, joblib
+, requests
+}:
 
 buildPythonPackage rec {
   pname = "nilearn";
   version = "0.10.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-koo2Tn7XfRXQK38icZfqfHj0Ty/ngP61VdbXz5Iy+EY=";
   };
+
+  nativeBuildInputs = [ hatch-vcs ];
 
   nativeCheckInputs = [ pytestCheckHook ];
   disabledTests = [ "test_clean_confounds" ];  # https://github.com/nilearn/nilearn/issues/2608
@@ -30,6 +49,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://nilearn.github.io";
     description = "A module for statistical learning on neuroimaging data";
+    changelog = "https://github.com/nilearn/nilearn/releases/tag/${version}";
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -8,7 +8,6 @@
 , numpy
 , pandas
 , feedparser
-, typeguard
 }:
 
 buildPythonPackage rec {
@@ -35,7 +34,6 @@ buildPythonPackage rec {
     invoke
     pandas
     pytestCheckHook
-    typeguard
   ];
 
   disabledTests = [
@@ -49,6 +47,8 @@ buildPythonPackage rec {
     # can't find mypy stubs for pandas:
     "tests/test_mypy.py"
     "tests/pandas_/test_mypy_dataframe.py"
+    # typeguard release broke nptyping compatibility:
+    "tests/test_typeguard.py"
     # tries to build wheel of package, broken/unnecessary under Nix:
     "tests/test_wheel.py"
   ];

--- a/pkgs/development/python-modules/pybids/default.nix
+++ b/pkgs/development/python-modules/pybids/default.nix
@@ -46,8 +46,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "bids" ];
-  # looks for missing data:
-  disabledTests = [ "test_config_filename" ];
+  disabledTests = [
+    # looks for missing data:
+    "test_config_filename"
+    # regression associated with formulaic >= 0.6.0
+    # (see https://github.com/bids-standard/pybids/issues/1000)
+    "test_split"
+  ];
 
   meta = with lib; {
     description = "Python tools for querying and manipulating BIDS datasets";


### PR DESCRIPTION
python311Packages.pybids: unbreak
python311Packages.nilearn: unbreak, cleanup
python311Packages.nptyping: unbreak

## Description of changes

Unbreak a bunch of `staging-next` regressions; minor cleanup.

Note that in `pybids` I've disabled a failing test which is a known regression due to formulaic >= 0.6.  Alternately, we could revert the `formulaic` bump.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).