### PR TITLE
aardvark-dns: 1.7.0 → 1.8.0

### DIFF
--- a/pkgs/tools/networking/aardvark-dns/default.nix
+++ b/pkgs/tools/networking/aardvark-dns/default.nix
@@ -1,29 +1,21 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, fetchpatch
 , nixosTests
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "aardvark-dns";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-bScL8hFV/Kot7P9nJRMDDhB8pllPUsejtJpbjmQ8skI=";
+    hash = "sha256-7nuLHhkVwMc2RYq3rS9bZl39asjFAnsHxnecPypT1HM=";
   };
 
-  cargoHash = "sha256-rrn+ZTAsFs7UTP4xQL3Cy8G6RG7vwT0wMKnXHHIkB90=";
-
-  patches = [
-    (fetchpatch { # https://github.com/containers/aardvark-dns/issues/379
-      url = "https://github.com/containers/aardvark-dns/commit/b13f0434f410934b515f086334414c6f5f55096e.diff";
-      hash = "sha256-6XReIShEe8+WKc5jK5NzCNMEd4INdOn9Sf8UrQLbj+s=";
-    })
-  ];
+  cargoHash = "sha256-WwM4lPWQmfsBjL4M/j3sZkLtH+Wdy9LTv4M4AF0Z6oo=";
 
   passthru.tests = { inherit (nixosTests) podman; };
 


### PR DESCRIPTION
## Description of changes

- Update `aardvark-dns` to 1.8.0
- Drop patch applied upstream

cc @NixOS/podman

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
