### PR TITLE
pam_mktemp: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19138,6 +19138,12 @@
     githubId = 43315;
     name = "William Roe";
   };
+  wladmis = {
+    email = "dev@wladmis.org";
+    github = "wladmis";
+    githubId = 5000261;
+    name = "Wladmis";
+  };
   wldhx = {
     email = "wldhx+nixpkgs@wldhx.me";
     github = "wldhx";

--- a/pkgs/os-specific/linux/pam_mktemp/default.nix
+++ b/pkgs/os-specific/linux/pam_mktemp/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, pam
+, e2fsprogs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pam_mktemp";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "https://openwall.com/pam/modules/${pname}/${pname}-${version}.tar.gz";
+    hash = "sha256-Zs+AwYQ5yjRW25ZALy7qwUsaBQPMHRvn8rFtXwefPz0=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "inherit_private_prefix_from_home.patch";
+      url = "https://git.altlinux.org/gears/p/pam_mktemp.git?p=pam_mktemp.git;a=commitdiff_plain;h=3d2e8ad6da6a44c047bf7a8afa1e1bb2a6e36a55";
+      hash = "sha256-xe44fi2xH9jqlStlIR4QPB0KS7spflRdOsvNPEmxJpU";
+     })
+    (fetchpatch {
+      name = "allow_private_prefix_to_be_stricter.patch";
+      url = "https://git.altlinux.org/gears/p/pam_mktemp.git?p=pam_mktemp.git;a=commitdiff_plain;h=bb2cee0c695d22310e5364c30d74bccb0dbf3205";
+      hash = "sha256-TouysUVlNnl+m7lJ2VKPxUTYD2om1Jh5FEJ6NHMAI4U=";
+    })
+  ];
+
+  patchFlags = "-p2";
+
+  dontConfigure = true;
+
+  buildInputs = [ pam e2fsprogs ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://www.openwall.com/pam/";
+    description = "PAM for login service to provide per-user private directories";
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ wladmis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28548,6 +28548,8 @@ with pkgs;
 
   pam_ldap = callPackage ../os-specific/linux/pam_ldap { };
 
+  pam_mktemp = callPackage ../os-specific/linux/pam_mktemp { };
+
   pam_mount = callPackage ../os-specific/linux/pam_mount { };
 
   pam_mysql = callPackage ../os-specific/linux/pam_mysql { };


### PR DESCRIPTION
## Description of changes

pam_mktemp: init at 1.1.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

pam_mktemp is a PAM module that may be used with a PAM-aware login service to provide per-user private directories under /tmp as part of PAM session or account management. When an interactive (shell) session is started, a directory is created and the environment variables TMPDIR and TMP are set to the name of the directory. 

Homepage: https://www.openwall.com/pam/
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
