### PR TITLE
nixos/release-combined: drop nixos-rebuild-install-bootloader

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -97,7 +97,6 @@ in rec {
         (onSystems ["x86_64-linux"] "nixos.tests.installer.simpleUefiSystemdBoot")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.simple")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.swraid")
-        (onSystems ["x86_64-linux"] "nixos.tests.nixos-rebuild-install-bootloader")
         (onSystems ["x86_64-linux"] "nixos.tests.nixos-rebuild-specialisations")
         (onFullSupported "nixos.tests.ipv6")
         (onFullSupported "nixos.tests.keymap.azerty")


### PR DESCRIPTION
... at least until it's fixed.  /cc PR #262724 again.