### PR TITLE
mecab: add libiconv as buildInputs

### DIFF
--- a/pkgs/tools/text/mecab/base.nix
+++ b/pkgs/tools/text/mecab/base.nix
@@ -1,4 +1,4 @@
-{ fetchurl }:
+{ fetchurl, libiconv }:
 
 finalAttrs: {
   version = "0.996";
@@ -8,6 +8,8 @@ finalAttrs: {
     name = "mecab-${finalAttrs.version}.tar.gz";
     hash = "sha256-4HMyV4MTW3LmZhRceBu0j62lg9UiT7JJD7bBQDumnFk=";
   };
+
+  buildInputs = [ libiconv ];
 
   configureFlags = [
     "--with-charset=utf8"

--- a/pkgs/tools/text/mecab/default.nix
+++ b/pkgs/tools/text/mecab/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, mecab-ipadic }:
+{ lib, stdenv, fetchurl, mecab-ipadic, libiconv }:
 
 let
-  mecab-base = import ./base.nix { inherit fetchurl; };
+  mecab-base = import ./base.nix { inherit fetchurl libiconv; };
 in
 stdenv.mkDerivation (finalAttrs: ((mecab-base finalAttrs) // {
   pname = "mecab";

--- a/pkgs/tools/text/mecab/nodic.nix
+++ b/pkgs/tools/text/mecab/nodic.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, libiconv }:
 
 let
-  mecab-base = import ./base.nix { inherit fetchurl; };
+  mecab-base = import ./base.nix { inherit fetchurl libiconv; };
 in
 stdenv.mkDerivation (finalAttrs: ((mecab-base finalAttrs) // {
   pname = "mecab-nodic";


### PR DESCRIPTION


## Description of changes

 #257480 added utf8 support but mecab depends on libiconv to convert between
charsets. Thus, on MacOS it doesn't works
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
