### PR TITLE
Clean up data writers

### DIFF
--- a/pkgs/build-support/writers/data.nix
+++ b/pkgs/build-support/writers/data.nix
@@ -23,7 +23,7 @@ rec {
   #   writeJSON = makeDataWriter { input = builtins.toJSON; output = "cp $inputPath $out"; };
   #   myConfig = writeJSON "config.json" { hello = "world"; }
   #
-  makeDataWriter = { input ? lib.id, output ? "cp $inputPath $out" }: nameOrPath: data:
+  makeDataWriter = lib.warn "pkgs.writers.makeDataWriter is deprecated. Use pkgs.writeTextFile." ({ input ? lib.id, output ? "cp $inputPath $out" }: nameOrPath: data:
     assert lib.or (types.path.check nameOrPath) (builtins.match "([0-9A-Za-z._])[0-9A-Za-z._-]*" nameOrPath != null);
     let
       name = last (builtins.split "/" nameOrPath);

--- a/pkgs/build-support/writers/data.nix
+++ b/pkgs/build-support/writers/data.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, dasel }:
+{ lib, pkgs, formats, runCommand, dasel }:
 let
   daselBin = lib.getExe dasel;
 
@@ -40,41 +40,25 @@ rec {
         mkdir -p $out/$(dirname "${nameOrPath}")
         mv tmp $out/${nameOrPath}
       ''}
-    '';
+    '');
 
-  # Writes the content to text.
-  #
-  # Example:
-  #   writeText "filename.txt" "file content"
-  writeText = makeDataWriter {
-    input = toString;
-    output = "cp $inputPath $out";
-  };
+  inherit (pkgs) writeText;
 
   # Writes the content to a JSON file.
   #
   # Example:
   #   writeJSON "data.json" { hello = "world"; }
-  writeJSON = makeDataWriter {
-    input = builtins.toJSON;
-    output = "${daselBin} -f $inputPath -r json -w json > $out";
-  };
+  writeJSON = (pkgs.formats.json {}).generate;
 
   # Writes the content to a TOML file.
   #
   # Example:
   #   writeTOML "data.toml" { hello = "world"; }
-  writeTOML = makeDataWriter {
-    input = builtins.toJSON;
-    output = "${daselBin} -f $inputPath -r json -w toml > $out";
-  };
+  writeTOML = (pkgs.formats.toml {}).generate;
 
   # Writes the content to a YAML file.
   #
   # Example:
   #   writeYAML "data.yaml" { hello = "world"; }
-  writeYAML = makeDataWriter {
-    input = builtins.toJSON;
-    output = "${daselBin} -f $inputPath -r json -w yaml > $out";
-  };
+  writeYAML = (pkgs.formats.yaml {}).generate;
 }

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -7,6 +7,7 @@
 , python3Packages
 , pypy3Packages
 , runCommand
+, testers
 , writers
 , writeText
 }:
@@ -36,14 +37,7 @@ let
     let
       expectedFile = writeText "${file.name}-expected" expected;
     in
-    runCommand "run-${file.name}" {} ''
-      if ! diff -u ${file} ${expectedFile}; then
-        echo 'test ${file.name} failed'
-        exit 1
-      fi
-
-      touch $out
-    '';
+    testers.testEqualContents { expected = expectedFile; actual = file; assertion = "${file.name} matches"; };
 in
 lib.recurseIntoAttrs {
   bin = lib.recurseIntoAttrs {

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -261,7 +261,9 @@ lib.recurseIntoAttrs {
 
     toml = expectDataEqual {
       file = writeTOML "data.toml" { hello = "world"; };
-      expected = "hello = 'world'\n";
+      expected = ''
+        hello = "world"
+      '';
     };
 
     yaml = expectDataEqual {


### PR DESCRIPTION
## Description of changes

These functions appear to have been added by mistake.

This change is the bare minimum to reduce maintenance.

Whether to further deprecate or document the aliases is still to be decided.

See https://github.com/NixOS/nixpkgs/pull/244835#pullrequestreview-1679294477 and subsequent comments.

- Remove duplicate implementations
- Deprecate `makeDataWriter`; not used in Nixpkgs and neither specific enough nor general enough
- Improve test, assuming we keep the aliases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
