### PR TITLE
coqPackages.iris-named-props: new expression

### DIFF
--- a/pkgs/development/coq-modules/iris-named-props/default.nix
+++ b/pkgs/development/coq-modules/iris-named-props/default.nix
@@ -1,0 +1,20 @@
+{ lib, mkCoqDerivation, coq, version ? null, iris }:
+
+mkCoqDerivation rec {
+  pname = "iris-named-props";
+  owner = "tchajed";
+  inherit version;
+  defaultVersion = with lib.versions; lib.switch coq.version [
+    { case = range "8.16" "8.18";  out = "2023-08-14"; }
+  ] null;
+  release."2023-08-14".sha256 = "sha256-gu9qOdHO0qJ2B9Y9Vf66q08iNJcfuECJO66fizFB08g=";
+  releaseRev = v: lib.switch v [
+    { case = "2023-08-14";
+      out  = "ca1871dd33649f27257a0fbf94076acc80ecffbc"; }
+  ] null;
+  propagatedBuildInputs = [ iris ];
+  meta = {
+    description = "Named props for Iris";
+    maintainers = with lib.maintainers; [ ineol ];
+  };
+}

--- a/pkgs/development/coq-modules/iris-named-props/default.nix
+++ b/pkgs/development/coq-modules/iris-named-props/default.nix
@@ -8,10 +8,7 @@ mkCoqDerivation rec {
     { case = range "8.16" "8.18";  out = "2023-08-14"; }
   ] null;
   release."2023-08-14".sha256 = "sha256-gu9qOdHO0qJ2B9Y9Vf66q08iNJcfuECJO66fizFB08g=";
-  releaseRev = v: lib.switch v [
-    { case = "2023-08-14";
-      out  = "ca1871dd33649f27257a0fbf94076acc80ecffbc"; }
-  ] null;
+  release."2023-08-14".rev = "ca1871dd33649f27257a0fbf94076acc80ecffbc";
   propagatedBuildInputs = [ iris ];
   meta = {
     description = "Named props for Iris";

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -70,6 +70,7 @@ let
       interval = callPackage ../development/coq-modules/interval {};
       InfSeqExt = callPackage ../development/coq-modules/InfSeqExt {};
       iris = callPackage ../development/coq-modules/iris {};
+      iris-named-props = callPackage ../development/coq-modules/iris-named-props {};
       itauto = callPackage ../development/coq-modules/itauto { };
       ITree = callPackage ../development/coq-modules/ITree { };
       LibHyps = callPackage ../development/coq-modules/LibHyps {};


### PR DESCRIPTION
## Description of changes

Add the coq package iris-named-props. Ir's used in a lot of newer Iris papers.

There does not seem to be an official release yet, but looking at the commits it looks quite stable.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
