### PR TITLE
quarto: 1.3.450 -> 1.4.550

### DIFF
--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , pandoc
+, typst
 , esbuild
 , deno
 , fetchurl
@@ -18,35 +19,31 @@
 
 stdenv.mkDerivation (final: {
   pname = "quarto";
-  version = "1.3.450";
+  version = "1.4.550";
   src = fetchurl {
     url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${final.version}/quarto-${final.version}-linux-amd64.tar.gz";
-    sha256 = "sha256-bcj7SzEGfQxsw9P8WkcLrKurPupzwpgIGtxoE3KVwAU=";
+    sha256 = "sha256-cWHd7ZWGBdRTaSHYVa8LuTDA5gefJ5baOGERS2g6Vvg=";
   };
 
   nativeBuildInputs = [
     makeWrapper
   ];
 
-  patches = [
-    ./fix-deno-path.patch
-  ];
-
   postPatch = ''
     # Compat for Deno >=1.26
     substituteInPlace bin/quarto.js \
-      --replace 'Deno.setRaw(stdin.rid, ' 'Deno.stdin.setRaw(' \
-      --replace 'Deno.setRaw(Deno.stdin.rid, ' 'Deno.stdin.setRaw('
+      --replace-fail ']))?.trim();' ']))?.trim().split(" ")[0];'
   '';
 
   dontStrip = true;
 
   preFixup = ''
     wrapProgram $out/bin/quarto \
-      --prefix PATH : ${lib.makeBinPath [ deno ]} \
-      --prefix QUARTO_PANDOC : ${pandoc}/bin/pandoc \
-      --prefix QUARTO_ESBUILD : ${esbuild}/bin/esbuild \
-      --prefix QUARTO_DART_SASS : ${dart-sass}/bin/dart-sass \
+      --prefix QUARTO_DENO : ${lib.getExe deno} \
+      --prefix QUARTO_PANDOC : ${lib.getExe pandoc} \
+      --prefix QUARTO_ESBUILD : ${lib.getExe esbuild} \
+      --prefix QUARTO_DART_SASS : ${lib.getExe dart-sass} \
+      --prefix QUARTO_TYPST : ${lib.getExe typst} \
       ${lib.optionalString (rWrapper != null) "--prefix QUARTO_R : ${rWrapper.override { packages = [ rPackages.rmarkdown ] ++ extraRPackages; }}/bin/R"} \
       ${lib.optionalString (python3 != null) "--prefix QUARTO_PYTHON : ${python3.withPackages (ps: with ps; [ jupyter ipython ] ++ (extraPythonPackages ps))}/bin/python3"}
   '';

--- a/pkgs/development/libraries/quarto/fix-deno-path.patch
+++ b/pkgs/development/libraries/quarto/fix-deno-path.patch
@@ -1,8 +1,0 @@
---- a/bin/quarto
-+++ b/bin/quarto
-@@ -125,4 +125,4 @@ fi
- # Be sure to include any already defined QUARTO_DENO_OPTIONS
- QUARTO_DENO_OPTIONS="--unstable --no-config --cached-only --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi ${QUARTO_DENO_OPTIONS}"
- 
--"${QUARTO_DENO}" ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" "${QUARTO_TARGET}" "$@"
-+deno ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" "${QUARTO_TARGET}" "$@"


### PR DESCRIPTION
## Description of changes

Updated to release 1.4.550.
Added support for typst.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
