### PR TITLE
qbittorrent: 4.5.5 -> 4.6.0 + other changes

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,58 +1,92 @@
-{ mkDerivation, lib, stdenv, fetchFromGitHub, pkg-config
-, boost, libtorrent-rasterbar, qtbase, qttools, qtsvg
-, debugSupport ? false
-, guiSupport ? true, dbus ? null # GUI (disable to run headless)
-, webuiSupport ? true # WebUI
-, trackerSearch ? true, python3 ? null
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, boost
+, cmake
+, Cocoa
+, libtorrent-rasterbar
+, ninja
+, qtbase
+, qtsvg
+, qttools
+, wrapQtAppsHook
+
+, guiSupport ? true
+, dbus
+, qtwayland
+
+, trackerSearch ? true
+, python3
+
+, webuiSupport ? true
 }:
 
-assert guiSupport -> (dbus != null);
-assert trackerSearch -> (python3 != null);
-
-mkDerivation rec {
-  pname = "qbittorrent" + lib.optionalString (!guiSupport) "-nox";
-  version = "4.5.5";
+let
+  qtVersion = lib.versions.major qtbase.version;
+in
+stdenv.mkDerivation rec {
+  pname = "qbittorrent"
+    + lib.optionalString (guiSupport && qtVersion == "5") "-qt5"
+    + lib.optionalString (!guiSupport) "-nox";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "qbittorrent";
     repo = "qBittorrent";
     rev = "release-${version}";
-    hash = "sha256-rWv+KGw+3385GOKK4MvoSP0CepotUZELiDVFpyDf+9k=";
+    hash = "sha256-o9zMGjVCXLqdRdXzRs1kFPDMFJXQWBEtWwIfeIyFxJw=";
   };
 
-  enableParallelBuilding = true;
+  nativeBuildInputs = [
+    cmake
+    ninja
+    wrapQtAppsHook
+  ];
 
-  # NOTE: 2018-05-31: CMake is working but it is not officially supported
-  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    boost
+    libtorrent-rasterbar
+    qtbase
+    qtsvg
+    qttools
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+  ] ++ lib.optionals guiSupport [
+    dbus
+  ] ++ lib.optionals (guiSupport && stdenv.isLinux) [
+    qtwayland
+  ] ++ lib.optionals trackerSearch [
+    python3
+  ];
 
-  buildInputs = [ boost libtorrent-rasterbar qtbase qttools qtsvg ]
-    ++ lib.optional guiSupport dbus # D(esktop)-Bus depends on GUI support
-    ++ lib.optional trackerSearch python3;
+  cmakeFlags = lib.optionals (qtVersion == "6") [
+    "-DQT6=ON"
+  ] ++ lib.optionals (!guiSupport) [
+    "-DGUI=OFF"
+    "-DSYSTEMD=ON"
+    "-DSYSTEMD_SERVICES_INSTALL_DIR=${placeholder "out"}/lib/systemd/system"
+  ] ++ lib.optionals (!webuiSupport) [
+    "-DWEBUI=OFF"
+  ];
 
-  # Otherwise qm_gen.pri assumes lrelease-qt5, which does not exist.
-  QMAKE_LRELEASE = "lrelease";
-
-  configureFlags = [
-    "--with-boost-libdir=${boost.out}/lib"
-    "--with-boost=${boost.dev}" ]
-    ++ lib.optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
-    ++ lib.optional (!webuiSupport) "--disable-webui"
-    ++ lib.optional debugSupport "--enable-debug";
-
-  qtWrapperArgs = lib.optional trackerSearch "--prefix PATH : ${lib.makeBinPath [ python3 ]}";
+  qtWrapperArgs = lib.optionals trackerSearch [
+    "--prefix PATH : ${lib.makeBinPath [ python3 ]}"
+  ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
+    APP_NAME=qbittorrent${lib.optionalString (!guiSupport) "-nox"}
     mkdir -p $out/{Applications,bin}
-    cp -R src/${pname}.app $out/Applications
-    makeWrapper $out/{Applications/${pname}.app/Contents/MacOS,bin}/${pname}
+    cp -R $APP_NAME.app $out/Applications
+    makeWrapper $out/{Applications/$APP_NAME.app/Contents/MacOS,bin}/$APP_NAME
   '';
 
   meta = with lib; {
     description = "Featureful free software BitTorrent client";
-    homepage    = "https://www.qbittorrent.org/";
-    changelog   = "https://github.com/qbittorrent/qBittorrent/blob/release-${version}/Changelog";
-    license     = licenses.gpl2Plus;
-    platforms   = platforms.unix;
-    maintainers = with maintainers; [ Anton-Latukha kashw2 ];
+    homepage = "https://www.qbittorrent.org";
+    changelog = "https://github.com/qbittorrent/qBittorrent/blob/release-${version}/Changelog";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ Anton-Latukha kashw2 paveloom ];
   };
 }

--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -42,6 +42,11 @@ in stdenv.mkDerivation {
     moveToOutput "lib/${python.libPrefix}" "$python"
   '';
 
+  postFixup = ''
+    substituteInPlace "$dev/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib" "$out/lib"
+  '';
+
   outputs = [ "out" "dev" "python" ];
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34877,9 +34877,12 @@ with pkgs;
 
   pyrosimple = callPackage ../applications/networking/p2p/pyrosimple { };
 
-  qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent { };
-  qbittorrent-nox = qbittorrent.override {
-    guiSupport = false;
+  qbittorrent = qt6Packages.callPackage ../applications/networking/p2p/qbittorrent {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+  qbittorrent-nox = qbittorrent.override { guiSupport = false; };
+  qbittorrent-qt5 = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
   qcad = libsForQt5.callPackage ../applications/misc/qcad { };


### PR DESCRIPTION
## Description of changes

- https://github.com/qbittorrent/qBittorrent/blob/release-4.6.0/Changelog
- Switched to CMake and Qt6
- Fixed the path to the library in the CMake module of `libtorrent-rasterbar`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
