### PR TITLE
python311Packages.cffi: 1.15.1 -> 1.16.0

### DIFF
--- a/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
+++ b/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
@@ -1,7 +1,8 @@
-diff -r bac92fcfe4d7 c/_cffi_backend.c
---- a/c/_cffi_backend.c	Mon Jul 18 15:58:34 2022 +0200
-+++ b/c/_cffi_backend.c	Sat Aug 20 12:38:31 2022 -0700
-@@ -96,7 +96,7 @@
+diff --git a/src/c/_cffi_backend.c b/src/c/_cffi_backend.c
+index 537271f..9c3bf94 100644
+--- a/src/c/_cffi_backend.c
++++ b/src/c/_cffi_backend.c
+@@ -103,7 +103,7 @@
  # define CFFI_CHECK_FFI_PREP_CIF_VAR 0
  # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 0
  
@@ -10,7 +11,7 @@ diff -r bac92fcfe4d7 c/_cffi_backend.c
  
  # define CFFI_CHECK_FFI_CLOSURE_ALLOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
  # define CFFI_CHECK_FFI_CLOSURE_ALLOC_MAYBE 1
-@@ -6413,7 +6413,7 @@
+@@ -6422,7 +6422,7 @@ static PyObject *b_callback(PyObject *self, PyObject *args)
      else
  #endif
      {

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , isPyPy
 , fetchPypi
-, fetchpatch
+, setuptools
 , pytestCheckHook
 , libffi
 , pkg-config
@@ -13,11 +13,12 @@
 
 if isPyPy then null else buildPythonPackage rec {
   pname = "cffi";
-  version = "1.15.1";
+  version = "1.16.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-1AC/uaN7E1ElPLQCZxzqfom97MKU6AFqcH9tHYrJNPk=";
+    hash = "sha256-vLPvQ+WGZbvaL7GYaY/K5ndkg+DEpjGqVkeAbCXgLMA=";
   };
 
   patches = [
@@ -32,38 +33,12 @@ if isPyPy then null else buildPythonPackage rec {
     # deemed safe to trust in cffi.
     #
     ./darwin-use-libffi-closures.diff
-    (fetchpatch {
-      # Drop py.code usage from tests, no longer depend on the deprecated py package
-      url = "https://foss.heptapod.net/pypy/cffi/-/commit/9c7d865e17ec16a847090a3e0d1498b698b99756.patch";
-      excludes = [
-        "README.md"
-        "requirements.txt"
-      ];
-      hash = "sha256-HSuLLIYXXGGCPccMNLV7o1G3ppn2P0FGCrPjqDv2e7k=";
-    })
-    (fetchpatch {
-      #  Replace py.test usage with pytest
-      url = "https://foss.heptapod.net/pypy/cffi/-/commit/bd02e1b122612baa74a126e428bacebc7889e897.patch";
-      excludes = [
-        "README.md"
-        "requirements.txt"
-      ];
-      hash = "sha256-+2daRTvxtyrCPimOEAmVbiVm1Bso9hxGbaAbd03E+ws=";
-    })
   ] ++ lib.optionals (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc) "13") [
     # -Wnull-pointer-subtraction is enabled with -Wextra. Suppress it to allow the following tests
     # to run and pass when cffi is built with newer versions of clang:
     # - testing/cffi1/test_verify1.py::test_enum_usage
     # - testing/cffi1/test_verify1.py::test_named_pointer_as_argument
     ./clang-pointer-substraction-warning.diff
-  ] ++  lib.optionals (pythonAtLeast "3.11") [
-    # Fix test that failed because python seems to have changed the exception format in the
-    # final release. This patch should be included in the next version and can be removed when
-    # it is released.
-    (fetchpatch {
-      url = "https://foss.heptapod.net/pypy/cffi/-/commit/8a3c2c816d789639b49d3ae867213393ed7abdff.diff";
-      hash = "sha256-3wpZeBqN4D8IP+47QDGK7qh/9Z0Ag4lAe+H0R5xCb1E=";
-    })
   ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
@@ -74,11 +49,18 @@ if isPyPy then null else buildPythonPackage rec {
       --replace '/usr/include/libffi' '${lib.getDev libffi}/include'
   '';
 
-  buildInputs = [ libffi ];
+  nativeBuildInputs = [
+    pkg-config
+    setuptools
+  ];
 
-  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    libffi
+  ];
 
-  propagatedBuildInputs = [ pycparser ];
+  propagatedBuildInputs = [
+    pycparser
+  ];
 
   # The tests use -Werror but with python3.6 clang detects some unreachable code.
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang
@@ -86,18 +68,16 @@ if isPyPy then null else buildPythonPackage rec {
 
   doCheck = !stdenv.hostPlatform.isMusl;
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = lib.optionals stdenv.isDarwin [
-    # AssertionError: cannot seem to get an int[10] not completely cleared
-    # https://foss.heptapod.net/pypy/cffi/-/issues/556
-    "test_ffi_new_allocator_1"
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   meta = with lib; {
-    maintainers = with maintainers; [ domenkozar lnl7 ];
+    changelog = "https://github.com/python-cffi/cffi/releases/tag/v${version}";
+    description = "Foreign Function Interface for Python calling C code";
+    downloadPage = "https://github.com/python-cffi/cffi";
     homepage = "https://cffi.readthedocs.org/";
     license = licenses.mit;
-    description = "Foreign Function Interface for Python calling C code";
+    maintainers = teams.python.members;
   };
 }


### PR DESCRIPTION
https://github.com/python-cffi/cffi/releases/tag/v1.16.0

Unblocks cffi on Python 3.12. Migrates maintainership to the Python Team.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (3.10, 3.11, 3.12)
  - [x] aarch64-linux (3.10, 3.11, 3.12)
  - [x] x86_64-darwin (3.11)
  - [x] aarch64-darwin (3.11)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
