### PR TITLE
peroxide: add certificate-name as an option

### DIFF
--- a/nixos/modules/services/networking/peroxide.nix
+++ b/nixos/modules/services/networking/peroxide.nix
@@ -23,6 +23,15 @@ in
       description = lib.mdDoc "Only log messages of this priority or higher.";
     };
 
+    certificate-name = mkOption {
+      type = types.str;
+      default = "nixos";
+      description = lib.mdDoc ''
+        The C/N to use when generating the self-signed certificate. It should generally
+        be the hostname of the machine.
+      '';
+    };
+
     settings = mkOption {
       type = types.submodule {
         freeformType = settingsFormat.type;
@@ -103,7 +112,7 @@ in
         if [[ ! -e "${cfg.settings.X509Key}" && ! -e "${cfg.settings.X509Cert}" ]]; then
             ${cfg.package}/bin/peroxide-cfg -action gen-x509 \
               -x509-org 'N/A' \
-              -x509-cn 'nixos' \
+              -x509-cn '${cfg.certificate-name}' \
               -x509-cert "${cfg.settings.X509Cert}" \
               -x509-key "${cfg.settings.X509Key}"
         fi


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a new option to the peroxide service module to allow configuring the C/N for the generated certificate.

Some SSL clients seem to check it (e.g. `mbsync`) and fail if the hostname doesn't match the hardcoded `'nixos'` value.

One can workaround this now by adding an entry to the `hosts` file to match the local server's IP to the hardcoded `'nixos'` hostname:
```nix
networking.hosts = {
  "<host ip>" = [ "nixos , ... ];
};
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Added a new configuration option for `services.peroxide` to allow setting the C/N for the self-signed certificate. Kept the old value as the default, so I don't expect anything breaking.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
