### PR TITLE
chickenPackages.chickenEggs.sdl2{,-image,-ttf}: fix build on linux

### DIFF
--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -77,7 +77,10 @@ in
     ((addToPropagatedBuildInputsWithPkgConfig pkgs.SDL2_image old) //
       # needed for sdl2-config to be in PATH
       (addToNativeBuildInputs pkgs.SDL2 old));
-  sdl2-ttf = addToBuildInputs pkgs.SDL2_ttf;
+  sdl2-ttf = old:
+    ((addToPropagatedBuildInputsWithPkgConfig pkgs.SDL2_ttf old) //
+      # needed for sdl2-config to be in PATH
+      (addToNativeBuildInputs pkgs.SDL2 old));
   soil = addToPropagatedBuildInputsWithPkgConfig pkgs.libepoxy;
   sqlite3 = addToBuildInputs pkgs.sqlite;
   stemmer = old:

--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -69,7 +69,10 @@ in
     addToNativeBuildInputs (lib.optionals (stdenv.system == "x86_64-darwin") [ pkgs.memorymappingHook ])
       (addPkgConfig old);
   sdl-base = addToBuildInputs pkgs.SDL;
-  sdl2 = addToPropagatedBuildInputsWithPkgConfig pkgs.SDL2;
+  sdl2 = old:
+    ((addToPropagatedBuildInputsWithPkgConfig pkgs.SDL2 old) //
+      # needed for sdl2-config to be in PATH
+      (addToNativeBuildInputs pkgs.SDL2 old));
   sdl2-image = addToBuildInputs pkgs.SDL2_image;
   sdl2-ttf = addToBuildInputs pkgs.SDL2_ttf;
   soil = addToPropagatedBuildInputsWithPkgConfig pkgs.libepoxy;

--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -73,7 +73,10 @@ in
     ((addToPropagatedBuildInputsWithPkgConfig pkgs.SDL2 old) //
       # needed for sdl2-config to be in PATH
       (addToNativeBuildInputs pkgs.SDL2 old));
-  sdl2-image = addToBuildInputs pkgs.SDL2_image;
+  sdl2-image = old:
+    ((addToPropagatedBuildInputsWithPkgConfig pkgs.SDL2_image old) //
+      # needed for sdl2-config to be in PATH
+      (addToNativeBuildInputs pkgs.SDL2 old));
   sdl2-ttf = addToBuildInputs pkgs.SDL2_ttf;
   soil = addToPropagatedBuildInputsWithPkgConfig pkgs.libepoxy;
   sqlite3 = addToBuildInputs pkgs.sqlite;


### PR DESCRIPTION
###### Description of changes

Change needed since the enablement of `strictDeps = true`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).