### PR TITLE
nixos/hostapd: remove managementFrameProtection in favour of clearer default

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -161,7 +161,6 @@ in {
                   mode = "wpa2-sha256";
                   wpaPassword = "a flakey password"; # Use wpaPasswordFile if possible.
                 };
-                managementFrameProtection = "optional";
               };
             };
           }
@@ -900,25 +899,6 @@ in {
                       '';
                     };
                   };
-
-                  managementFrameProtection = mkOption {
-                    default = "required";
-                    type = types.enum ["disabled" "optional" "required"];
-                    apply = x:
-                      getAttr x {
-                        "disabled" = 0;
-                        "optional" = 1;
-                        "required" = 2;
-                      };
-                    description = mdDoc ''
-                      Management frame protection (MFP) authenticates management frames
-                      to prevent deauthentication (or related) attacks.
-
-                      - {var}`"disabled"`: No management frame protection
-                      - {var}`"optional"`: Use MFP if a connection allows it
-                      - {var}`"required"`: Force MFP for all clients
-                    '';
-                  };
                 };
 
                 config = let
@@ -944,7 +924,8 @@ in {
 
                     # IEEE 802.11i (authentication) related configuration
                     # Encrypt management frames to protect against deauthentication and similar attacks
-                    ieee80211w = bssCfg.managementFrameProtection;
+                    ieee80211w = mkDefault 1;
+                    sae_require_mfp = mkDefault 1;
 
                     # Only allow WPA by default and disable insecure WEP
                     auth_algs = mkDefault 1;
@@ -1184,14 +1165,6 @@ in {
                 {
                   assertion = (length (attrNames radioCfg.networks) > 1) -> (bssCfg.bssid != null);
                   message = ''hostapd radio ${radio} bss ${bss}: bssid must be specified manually (for now) since this radio uses multiple BSS.'';
-                }
-                {
-                  assertion = auth.mode == "wpa3-sae" -> bssCfg.managementFrameProtection == 2;
-                  message = ''hostapd radio ${radio} bss ${bss}: uses WPA3-SAE which requires managementFrameProtection="required"'';
-                }
-                {
-                  assertion = auth.mode == "wpa3-sae-transition" -> bssCfg.managementFrameProtection != 0;
-                  message = ''hostapd radio ${radio} bss ${bss}: uses WPA3-SAE in transition mode with WPA2-SHA256, which requires managementFrameProtection="optional" or ="required"'';
                 }
                 {
                   assertion = countWpaPasswordDefinitions <= 1;

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -161,6 +161,7 @@ in {
                   mode = "wpa2-sha256";
                   wpaPassword = "a flakey password"; # Use wpaPasswordFile if possible.
                 };
+                managementFrameProtection = "optional";
               };
             };
           }


### PR DESCRIPTION
## Description of changes

This PR removes the option `services.hostapd.radios.<name>.networks.<name>.managementFrameProtection` (MFP), and instead unconditionally sets `ieee80211w=1` (optional) and [`sae_require_mfp=1`](https://w1.fi/cgit/hostap/tree/hostapd/hostapd.conf?id=2d4be0019d9236923d5fe9eac1f7e69c484d5d27#n2060), which requires MFP if SAE is used, and makes MFP optional if WPA2-SHA256 is used.

Motivation for this PR:
* My initial motivation with this PR is that I noticed that even with the [documented legacy profile](https://github.com/NixOS/nixpkgs/blob/8b1ce3a5716fd761f6f1d1f9c647a28fd619732b/nixos/modules/services/networking/hostapd.nix#L155-L164), my Lenovo Thinkpad x230 was unable to connect to the wifi. Setting `managementFrameProtection` to optional allowed my Thinkpad x230 to connect, but it took a lot of debugging to discover that.
* This module has many options, which reflects the complexity of 802.11 and hostapd, but for the sake of simplicity, if we spot an option that we can reasonably remove before 23.11 is released, we should take that. It's much easier to remove this now, and add later if needed, rather than remove it once 23.11 has been released. *When in doubt, leave it out*, [as Joshua Bloch says about API design](https://www.youtube.com/watch?v=aAb7hSCtvGw&t=1476s). :)

Overall, I think this preserves the "secure out-the-box" profile, and offers an easy "legacy" profile, all while exposing a simpler API, with escape hatches (`settings`) for unusual cases if needed.

It's entirely possible I'm missing some subtlety?

@oddlama , thoughts? :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
