### PR TITLE
libdicom: init at 1.0.5

### DIFF
--- a/pkgs/development/libraries/libdicom/default.nix
+++ b/pkgs/development/libraries/libdicom/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, uthash
+, meson
+, ninja
+, pkg-config
+, check
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdicom";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ImagingDataCommons";
+    repo = "libdicom";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-9n0Gp9+fmTM/shgWC8zpwt1pic9BrvDubOt7f+ZDMeE=";
+  };
+
+  buildInputs = [ uthash ];
+
+  nativeBuildInputs = [ meson ninja pkg-config ]
+    ++ lib.optionals (finalAttrs.finalPackage.doCheck) [ check ];
+
+  mesonBuildType = "release";
+
+  mesonFlags = lib.optionals (!finalAttrs.finalPackage.doCheck) [ "-Dtests=false" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "C library for reading DICOM files";
+    homepage = "https://github.com/ImagingDataCommons/libdicom";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lromor ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22668,6 +22668,8 @@ with pkgs;
 
   libdex = callPackage ../development/libraries/libdex { };
 
+  libdicom = callPackage ../development/libraries/libdicom { };
+
   libdigidocpp = callPackage ../development/libraries/libdigidocpp { };
 
   libdiscid = callPackage ../development/libraries/libdiscid { };


### PR DESCRIPTION
## Description of changes

Added latest version of a C library to decode DICOM files.
https://github.com/ImagingDataCommons/libdicom

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).