### PR TITLE
nixos/virtualisation/nixos-containers: add systemCallFilter option, remove null checks

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -173,6 +173,9 @@ let
         ${optionalString (cfg.additionalCapabilities != [])
           ''--capability="${concatStringsSep "," cfg.additionalCapabilities}"''
         } \
+        ${optionalString (cfg.systemCallFilter != [])
+          ''--system-call-filter="${concatStringsSep " " cfg.systemCallFilter}"''
+        } \
         ${optionalString (cfg.tmpfs != [])
           ''--tmpfs=${concatStringsSep " --tmpfs=" cfg.tmpfs}''
         } \
@@ -437,6 +440,7 @@ let
     {
       extraVeths = {};
       additionalCapabilities = [];
+      systemCallFilter = [];
       ephemeral = false;
       timeoutStartSec = "1min";
       allowedDevices = [];
@@ -542,6 +546,16 @@ in
                 Grant additional capabilities to the container. See the
                 capabilities(7) and systemd-nspawn(1) man pages for more
                 information.
+              '';
+            };
+
+            systemCallFilter = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = [ "add_key" "keyctl" "bpf" ];
+              description = lib.mdDoc ''
+                Set the system call filter for the container. See the
+                {manpage}`systemd-nspawn(1)` man page for more information.
               '';
             };
 

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -170,10 +170,10 @@ let
         --setenv HOST_PORT="$HOST_PORT" \
         --setenv PATH="$PATH" \
         ${optionalString cfg.ephemeral "--ephemeral"} \
-        ${optionalString (cfg.additionalCapabilities != null && cfg.additionalCapabilities != [])
+        ${optionalString (cfg.additionalCapabilities != [])
           ''--capability="${concatStringsSep "," cfg.additionalCapabilities}"''
         } \
-        ${optionalString (cfg.tmpfs != null && cfg.tmpfs != [])
+        ${optionalString (cfg.tmpfs != [])
           ''--tmpfs=${concatStringsSep " --tmpfs=" cfg.tmpfs}''
         } \
         ${containerInit cfg} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
@@ -444,7 +444,7 @@ let
       hostAddress6 = null;
       localAddress = null;
       localAddress6 = null;
-      tmpfs = null;
+      tmpfs = [];
     };
 
 in

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -539,7 +539,7 @@ in
               default = [];
               example = [ "CAP_NET_ADMIN" "CAP_MKNOD" ];
               description = lib.mdDoc ''
-                Grant additional capabilities to the container.  See the
+                Grant additional capabilities to the container. See the
                 capabilities(7) and systemd-nspawn(1) man pages for more
                 information.
               '';


### PR DESCRIPTION
Add systemCallFilter to NixOS containers. This is notably required to run docker in nspawn. As far as I know, the only current way to do this is [this very ugly hack](https://discourse.nixos.org/t/podman-docker-in-nixos-container-ideally-in-unprivileged-one/22909/12):
```nix
additionalCapabilities = [
  # This is a very ugly hack to add the system-call-filter flag to
  # nspawn. extraFlags is written to an env file as an env var and
  # does not support spaces in arguments, so I take advantage of
  # the additionalCapabilities generation to inject the command
  # line argument.
  ''CAP_NET_ADMIN" --system-call-filter="add_key keyctl bpf" --capability="CAP_NET_ADMIN''
];
```

This PR allows this to be written as
```nix
systemCallFilter = [ "add_key" "keyctl" "bpf" ]
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
