### PR TITLE
Revert "[Backport release-23.05] electron_{22,24}-bin: Mark EOL"

### DIFF
--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -32,7 +32,7 @@ let
       ++ optionals (versionAtLeast version "11.0.0") [ "aarch64-darwin" ]
       ++ optionals (versionOlder version "19.0.0") [ "i686-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    knownVulnerabilities = optional (versionOlder version "25.0.0") "Electron version ${version} is EOL";
+    knownVulnerabilities = optional (versionOlder version "22.0.0" || versions.major version == "23") "Electron version ${version} is EOL";
   };
 
   fetcher = vers: tag: hash: fetchurl {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#262556

I don't see the value in marking Electron < 25 as EOL when release-23.05 is going to be EOL in less than two months anyways. With #262556 merged packages that are still using an older Electron are now broken and require work to make them build again. I attempted to blindly cherry-pick all the changes to Bitwarden on the master branch to the release-23.05 branch and the build failed leading me to believe that this was just not worth it as it requires extra work for little gain.