### PR TITLE
liquidprompt: 2.1.2 -> 2.2.0

### DIFF
--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   installPhase = ''
+    runHook preInstall
+
     install -D -m 0444 liquidprompt $out/bin/liquidprompt
     install -D -m 0444 liquidpromptrc-dist $out/share/doc/liquidprompt/liquidpromptrc-dist
     install -D -m 0444 liquid.theme $out/share/doc/liquidprompt/liquid.theme
@@ -21,6 +23,8 @@ stdenv.mkDerivation rec {
       $out/share/zsh/plugins/liquidprompt/liquidprompt.plugin.zsh
     install -D -m 0444 liquidprompt \
       $out/share/zsh/plugins/liquidprompt/liquidprompt
+
+    runHook postInstall
   '';
 
   passthru.updateScript = gitUpdater { };

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.1.2";
 
   src = fetchFromGitHub {
-    owner = "nojhan";
+    owner = "liquidprompt";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-7mnrXLqnCdOuS2aRs4tVLfO8SRFrqZHNM40gWE/CVFI=";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A full-featured & carefully designed adaptive prompt for Bash & Zsh";
-    homepage = "https://github.com/nojhan/liquidprompt";
+    homepage = "https://github.com/liquidprompt/liquidprompt";
     license = licenses.agpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ gerschtli ];

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -2,27 +2,40 @@
 
 stdenv.mkDerivation rec {
   pname = "liquidprompt";
-  version = "2.1.2";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "liquidprompt";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7mnrXLqnCdOuS2aRs4tVLfO8SRFrqZHNM40gWE/CVFI=";
+    hash = "sha256-ra+uJg9E2Cr1k0Ni1+xG9yKFF9iMInJFB5oAFnc52lc=";
   };
 
   strictDeps = true;
+
+  postPatch = ''
+    patchShebangs tools/*.sh
+  '';
+
   installPhase = ''
     runHook preInstall
 
     install -D -m 0444 liquidprompt $out/bin/liquidprompt
-    install -D -m 0444 liquidpromptrc-dist $out/share/doc/liquidprompt/liquidpromptrc-dist
-    install -D -m 0444 liquid.theme $out/share/doc/liquidprompt/liquid.theme
 
     install -D -m 0444 liquidprompt.plugin.zsh \
       $out/share/zsh/plugins/liquidprompt/liquidprompt.plugin.zsh
     install -D -m 0444 liquidprompt \
       $out/share/zsh/plugins/liquidprompt/liquidprompt
+
+    # generate default config file
+    mkdir -p $out/share/doc/liquidprompt
+    tools/config-from-doc.sh --verbose > $out/share/doc/liquidprompt/liquidpromptrc-dist
+
+    mkdir -p $out/share/liquidprompt
+    cp -a themes $out/share/liquidprompt/
+
+    mkdir -p $out/share/liquidprompt/contrib
+    cp -a contrib/presets $out/share/liquidprompt/contrib/
 
     runHook postInstall
   '';

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "liquidprompt";
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     install -D -m 0444 liquidprompt \
       $out/share/zsh/plugins/liquidprompt/liquidprompt
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     description = "A full-featured & carefully designed adaptive prompt for Bash & Zsh";


### PR DESCRIPTION
## Description of changes

- liquidprompt: add update script
- liquidprompt: run `preInstall` and `postInstall` hooks
- liquidprompt: update homepage and git repository
- liquidprompt: 2.1.2 -> [2.2.0](https://github.com/liquidprompt/liquidprompt/releases/tag/v2.2.0)
  - `liquidpromptrc-dist` and `liquid.theme` are not available anymore
  - generate `liquidpromptrc-dist` from the docs
  - install themes and contributed presets

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
