### PR TITLE
ocamlPackages.hacl-star: 0.7.0 → 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/hacl-star/default.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/default.nix
@@ -4,9 +4,9 @@
 buildDunePackage {
   pname = "hacl-star";
 
-  inherit (hacl-star-raw) version src meta doCheck minimalOCamlVersion;
+  inherit (hacl-star-raw) version src meta doCheck;
 
-  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     hacl-star-raw

--- a/pkgs/development/ocaml-modules/hacl-star/raw.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/raw.nix
@@ -12,19 +12,17 @@
 }:
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-hacl-star-raw";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchzip {
     url = "https://github.com/cryspen/hacl-packages/releases/download/ocaml-v${version}/hacl-star.${version}.tar.gz";
-    sha256 = "sha256-jJtxVYhQgP8ItfLhQ2wcF8RKNRnYhB2j0nR7/YH1NfY=";
+    hash = "sha256-TcAEaJou4BOVXSz5DYewzKfvIpjXmhLAlgF0hlq3ToQ=";
     stripRoot = false;
   };
 
   patches = [
     ./aligned-alloc.patch
   ];
-
-  minimalOCamlVersion = "4.08";
 
   # strictoverflow is disabled because it breaks aarch64-darwin
   hardeningDisable = [ "strictoverflow" ];


### PR DESCRIPTION
## Description of changes

https://github.com/cryspen/hacl-packages/blob/ocaml-v0.7.1/ocaml/hacl-star/CHANGES.md#071

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
