### PR TITLE
breakpad: unstable-3b3469e -> 2023.01.27

### DIFF
--- a/pkgs/development/misc/breakpad/default.nix
+++ b/pkgs/development/misc/breakpad/default.nix
@@ -1,28 +1,25 @@
-{ lib, stdenv, fetchgit }:
+{ lib, stdenv, fetchgit, zlib }:
 let
   lss = fetchgit {
     url = "https://chromium.googlesource.com/linux-syscall-support";
-    rev = "d9ad2969b369a9f1c455fef92d04c7628f7f9eb8";
-    sha256 = "952dv+ZE1ge/WF5RyHmEqht+AofoRHKAeFmGasVF9BA=";
+    rev = "v2022.10.12";
+    hash = "sha256-rF10v5oH4u9i9vnmFCVVl2Ew3h+QTiOsW64HeB0nRQU=";
   };
-in stdenv.mkDerivation {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "breakpad";
 
-  version = "unstable-3b3469e";
+  version = "2023.01.27";
 
   src = fetchgit {
     url = "https://chromium.googlesource.com/breakpad/breakpad";
-    rev = "3b3469e9ed0de3d02e4450b9b95014a4266cf2ff";
-    sha256 = "bRGOBrGPK+Zxp+KK+E5MFkYlDUNVhVeInVSwq+eCAF0=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-8msKz0K10r13TwM3oS6GCIlMdf8k8HBKfKJkPmrUrIs=";
   };
+
+  buildInputs = [ zlib ];
 
   postUnpack = ''
     ln -s ${lss} $sourceRoot/src/third_party/lss
-  '';
-
-  postPatch = ''
-    substituteInPlace src/client/linux/handler/exception_handler.cc \
-      --replace "max(16384" "max(static_cast<long>(16384)"
   '';
 
   meta = with lib; {
@@ -32,4 +29,4 @@ in stdenv.mkDerivation {
     maintainers = with maintainers; [ berberman ];
     platforms = platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Update [breakpad](https://chromium.googlesource.com/breakpad/breakpad/) from `unstable-3b3469e` to `2023.01.27`.

The old version fails to build, and it's required for `fictx5-mozc`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
