### PR TITLE
system-path: Remove `defaultPackages` option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -120,6 +120,8 @@
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- `environment.defaultPackages` was removed, which means the perl, rsync, and strace packages will no longer be installed by default.
+
 - `services.pid-fan-controller` no longer provides deep configuration rewriting and adheres now fully to RFC42.
 
 - The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -50,23 +50,16 @@ let
     ++ [ pkgs.stdenv.cc.libc ];
   corePackagesText = "[ ${lib.concatMapStringsSep " " (n: "pkgs.${n}") corePackageNames} ]";
 
-  defaultPackageNames = [
-    "perl"
-    "rsync"
-    "strace"
-  ];
-  defaultPackages = map (
-    n:
-    let
-      pkg = pkgs.${n};
-    in
-    lib.setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg
-  ) defaultPackageNames;
-  defaultPackagesText = "[ ${lib.concatMapStringsSep " " (n: "pkgs.${n}") defaultPackageNames} ]";
-
 in
 
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "environment"
+      "defaultPackages"
+    ] "Use environment.systemPackages instead")
+  ];
+
   options = {
 
     environment = {
@@ -99,29 +92,6 @@ in
           Set of core packages for a normal interactive system.
 
           Only change this if you know what you're doing!
-
-          Like with systemPackages, packages are installed to
-          {file}`/run/current-system/sw`. They are
-          automatically available to all users, and are
-          automatically updated every time you rebuild the system
-          configuration.
-        '';
-      };
-
-      defaultPackages = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default = defaultPackages;
-        defaultText = lib.literalMD ''
-          these packages, with their `meta.priority` numerically increased
-          (thus lowering their installation priority):
-
-              ${defaultPackagesText}
-        '';
-        example = [ ];
-        description = ''
-          Set of default packages that aren't strictly necessary
-          for a running system, entries can be removed for a more
-          minimal NixOS installation.
 
           Like with systemPackages, packages are installed to
           {file}`/run/current-system/sw`. They are
@@ -183,7 +153,7 @@ in
     # merging.
     environment.corePackages = corePackages;
 
-    environment.systemPackages = config.environment.corePackages ++ config.environment.defaultPackages;
+    environment.systemPackages = config.environment.corePackages;
 
     environment.pathsToLink = [
       "/bin"

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -47,7 +47,7 @@
     done
   '';
 
-  environment.defaultPackages = with pkgs; [
+  environment.systemPackages = with pkgs; [
     rsync
   ];
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -39,7 +39,7 @@
   # Enable plymouth
   boot.plymouth.enable = true;
 
-  environment.defaultPackages = with pkgs; [
+  environment.systemPackages = with pkgs; [
     # Include gparted for partitioning disks.
     gparted
 

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -17,11 +17,7 @@ in
     nixos.enable = mkDefault false;
   };
 
-  environment = {
-    # Perl is a default package.
-    defaultPackages = mkDefault [ ];
-    stub-ld.enable = mkDefault false;
-  };
+  environment.stub-ld.enable = mkDefault false;
 
   programs = {
     command-not-found.enable = mkDefault false;

--- a/nixos/modules/profiles/perlless.nix
+++ b/nixos/modules/profiles/perlless.nix
@@ -9,7 +9,6 @@
   # Random perl remnants
   system.tools.nixos-generate-config.enable = lib.mkDefault false;
   boot.loader.grub.enable = lib.mkDefault false;
-  environment.defaultPackages = lib.mkDefault [ ];
   documentation.info.enable = lib.mkDefault false;
   documentation.nixos.enable = lib.mkDefault false;
 

--- a/nixos/tests/disable-installer-tools.nix
+++ b/nixos/tests/disable-installer-tools.nix
@@ -11,7 +11,6 @@
     { pkgs, lib, ... }:
     {
       system.disableInstallerTools = true;
-      environment.defaultPackages = [ ];
     };
 
   testScript = ''


### PR DESCRIPTION
## Description of changes

None of these tools are necessary for a minimal system.

Closes #263289.

@ofborg test disable-installer-tools

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) `nix-build --attr nixosTests.disable-installer-tools`
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) ~Added~ Modified a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).