### PR TITLE
pulseaudio: refactor meson flags

### DIFF
--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config
+{ lib, stdenv, fetchurl, pkg-config
 , libsndfile, libtool, makeWrapper, perlPackages
 , xorg, libcap, alsa-lib, glib, dconf
 , avahi, libjack2, libasyncns, lirc, dbus
@@ -88,45 +88,47 @@ stdenv.mkDerivation rec {
   );
 
   mesonFlags = [
-    "-Dalsa=${if !libOnly && alsaSupport then "enabled" else "disabled"}"
-    "-Dasyncns=${if !libOnly then "enabled" else "disabled"}"
-    "-Davahi=${if zeroconfSupport then "enabled" else "disabled"}"
-    "-Dbluez5=${if !libOnly && bluetoothSupport then "enabled" else "disabled"}"
+    (lib.mesonEnable "alsa" (!libOnly && alsaSupport))
+    (lib.mesonEnable "asyncns" (!libOnly))
+    (lib.mesonEnable "avahi" zeroconfSupport)
+    (lib.mesonEnable "bluez5" (!libOnly && bluetoothSupport))
     # advanced bluetooth audio codecs are provided by gstreamer
-    "-Dbluez5-gstreamer=${if (!libOnly && bluetoothSupport && advancedBluetoothCodecs) then "enabled" else "disabled"}"
-    "-Ddatabase=simple"
-    "-Ddoxygen=false"
-    "-Delogind=disabled"
+    (lib.mesonEnable "bluez5-gstreamer" (!libOnly && bluetoothSupport && advancedBluetoothCodecs))
+    (lib.mesonOption "database" "simple")
+    (lib.mesonBool "doxygen" false)
+    (lib.mesonEnable "elogind" false)
     # gsettings does not support cross-compilation
-    "-Dgsettings=${if stdenv.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
-    "-Dgstreamer=disabled"
-    "-Dgtk=disabled"
-    "-Djack=${if jackaudioSupport && !libOnly then "enabled" else "disabled"}"
-    "-Dlirc=${if remoteControlSupport then "enabled" else "disabled"}"
-    "-Dopenssl=${if airtunesSupport then "enabled" else "disabled"}"
-    "-Dorc=disabled"
-    "-Dsystemd=${if useSystemd && !libOnly then "enabled" else "disabled"}"
-    "-Dtcpwrap=disabled"
-    "-Dudev=${if !libOnly && udevSupport then "enabled" else "disabled"}"
-    "-Dvalgrind=disabled"
-    "-Dwebrtc-aec=${if !libOnly then "enabled" else "disabled"}"
-    "-Dx11=${if x11Support then "enabled" else "disabled"}"
+    (lib.mesonEnable "gsettings" (stdenv.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform)))
+    (lib.mesonEnable "gstreamer" false)
+    (lib.mesonEnable "gtk" false)
+    (lib.mesonEnable "jack" (jackaudioSupport && !libOnly))
+    (lib.mesonEnable "lirc" remoteControlSupport)
+    (lib.mesonEnable "openssl" airtunesSupport)
+    (lib.mesonEnable "orc" false)
+    (lib.mesonEnable "systemd" (useSystemd && !libOnly))
+    (lib.mesonEnable "tcpwrap" false)
+    (lib.mesonEnable "udev" (!libOnly && udevSupport))
+    (lib.mesonEnable "valgrind" false)
+    (lib.mesonEnable "webrtc-aec" (!libOnly))
+    (lib.mesonEnable "x11" x11Support)
 
-    "-Dlocalstatedir=/var"
-    "-Dsysconfdir=/etc"
-    "-Dsysconfdir_install=${placeholder "out"}/etc"
-    "-Dudevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+    (lib.mesonOption "localstatedir" "/var")
+    (lib.mesonOption "sysconfdir" "/etc")
+    (lib.mesonOption "sysconfdir_install" "${placeholder "out"}/etc")
+    (lib.mesonOption "udevrulesdir" "${placeholder "out"}/lib/udev/rules.d")
 
     # pulseaudio complains if its binary is moved after installation;
     # this is needed so that wrapGApp can operate *without*
     # renaming the unwrapped binaries (see below)
     "--bindir=${placeholder "out"}/.bin-unwrapped"
   ]
-  ++ lib.optional (stdenv.isLinux && useSystemd) "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
+  ++ lib.optionals (stdenv.isLinux && useSystemd) [
+    (lib.mesonOption "systemduserunitdir" "${placeholder "out"}/lib/systemd/user")
+  ]
   ++ lib.optionals stdenv.isDarwin [
-    "-Ddbus=disabled"
-    "-Dglib=disabled"
-    "-Doss-output=disabled"
+    (lib.mesonEnable "dbus" false)
+    (lib.mesonEnable "glib" false)
+    (lib.mesonEnable "oss-output" false)
   ];
 
   # tests fail on Darwin because of timeouts


### PR DESCRIPTION
## Description of changes

... using `lib.meson*`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
