### PR TITLE
fcitx5-nord: init at unstable-2021-07-27, fcitx5-material-color: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3674,6 +3674,15 @@
       fingerprint = "2017 E152 BB81 5C16 955C  E612 45BC C1E2 709B 1788";
     }];
   };
+  Cryolitia = {
+    name = "Beiyan Cryolitia";
+    email = "Cryolitia@gmail.com";
+    github = "Cryolitia";
+    githubId = 23723294;
+    keys = [{
+      fingerprint = "1C3C 6547 538D 7152 310C 0EEA 84DD 0C01 30A5 4DF7";
+    }];
+  };
   cryptix = {
     email = "cryptix@riseup.net";
     github = "cryptix";

--- a/pkgs/by-name/fc/fcitx5-material-color/package.nix
+++ b/pkgs/by-name/fc/fcitx5-material-color/package.nix
@@ -1,0 +1,41 @@
+{ stdenvNoCC
+, fetchFromGitHub
+, lib
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fcitx5-material-color";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "hosxy";
+    repo = "Fcitx5-Material-Color";
+    rev = finalAttrs.version;
+    hash = "sha256-i9JHIJ+cHLTBZUNzj9Ujl3LIdkCllTWpO1Ta4OT1LTc=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/fcitx5-material-color/-/blob/main/PKGBUILD?ref_type=heads#L16
+    install -Dm644 arrow.png radio.png -t $out/share/${finalAttrs.pname}/
+    for _variant in black blue brown deepPurple indigo orange pink red sakuraPink teal; do
+      _variant_name=Material-Color-$_variant
+      install -dm755 $_variant_name $out/share/fcitx5/themes/$_variant_name
+      ln -sv ../../../$pname/arrow.png $out/share/fcitx5/themes/$_variant_name/
+      ln -sv ../../../$pname/radio.png $out/share/fcitx5/themes/$_variant_name/
+      install -Dm644 theme-$_variant.conf $out/share/fcitx5/themes/$_variant_name/theme.conf
+      sed -i "s/^Name=.*/Name=$_variant_name/" $out/share/fcitx5/themes/$_variant_name/theme.conf
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fcitx5 themes based on Material color";
+    homepage = "https://github.com/hosxy/Fcitx5-Material-Color";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Cryolitia h7x4 ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/by-name/fc/fcitx5-nord/package.nix
+++ b/pkgs/by-name/fc/fcitx5-nord/package.nix
@@ -1,0 +1,33 @@
+{ stdenvNoCC
+, fetchFromGitHub
+, lib
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "fcitx5-nord";
+  version = "unstable-2021-07-27";
+
+  src = fetchFromGitHub {
+    owner = "tonyfettes";
+    repo = "fcitx5-nord";
+    rev = "bdaa8fb723b8d0b22f237c9a60195c5f9c9d74d1";
+    hash = "sha256-qVo/0ivZ5gfUP17G29CAW0MrRFUO0KN1ADl1I/rvchE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out/share/fcitx5/themes/
+    cp -rv Nord* $out/share/fcitx5/themes/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fcitx5 theme based on Nord color";
+    homepage = "https://github.com/tonyfettes/fcitx5-nord";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Cryolitia ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add two fcitx theme, both of them are already in archlinux extra repo, so I hope that it could help some people ^_^.

https://github.com/hosxy/Fcitx5-Material-Color

https://github.com/tonyfettes/fcitx5-nord

- [x] To confirm `fcitx5-material-color` working

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
