### PR TITLE
fishPlugins.bobthefish: unstable-2022-08-02 -> unstable-2023-06-16

### DIFF
--- a/pkgs/shells/fish/plugins/bobthefish.nix
+++ b/pkgs/shells/fish/plugins/bobthefish.nix
@@ -3,15 +3,15 @@
 , fetchFromGitHub
 ,
 }:
-buildFishPlugin rec {
+buildFishPlugin {
   pname = "bobthefish";
-  version = "unstable-2022-08-02";
+  version = "unstable-2023-06-16";
 
   src = fetchFromGitHub {
     owner = "oh-my-fish";
     repo = "theme-bobthefish";
-    rev = "2dcfcab653ae69ae95ab57217fe64c97ae05d8de";
-    sha256 = "sha256-jBbm0wTNZ7jSoGFxRkTz96QHpc5ViAw9RGsRBkCQEIU=";
+    rev = "c2c47dc964a257131b3df2a127c2631b4760f3ec";
+    sha256 = "sha256-LB4g+EA3C7OxTuHfcxfgl8IVBe5NufFc+5z9VcS0Bt0=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Fixes [k8s prompt prefix error from empty namespace value](https://github.com/oh-my-fish/theme-bobthefish/pull/343) and [pwd calculation when using git worktrees](https://github.com/oh-my-fish/theme-bobthefish/commit/c2c47dc964a257131b3df2a127c2631b4760f3ec).

https://github.com/oh-my-fish/theme-bobthefish/compare/2dcfcab653ae69ae95ab57217fe64c97ae05d8de...c2c47dc964a257131b3df2a127c2631b4760f3ec

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
