### PR TITLE
mytetra: fix build

### DIFF
--- a/pkgs/applications/office/mytetra/default.nix
+++ b/pkgs/applications/office/mytetra/default.nix
@@ -23,6 +23,10 @@ mkDerivation rec {
 
     substituteInPlace app/src/views/mainWindow/MainWindow.cpp \
       --replace ":/resource/pic/logo.svg" "$out/share/icons/hicolor/48x48/apps/mytetra.png"
+
+    # https://github.com/xintrea/mytetra_dev/issues/164
+    substituteInPlace thirdParty/mimetex/mimetex.c \
+      --replace "const char *strcasestr" "char *strcasestr"
   '';
 
   postFixup = ''


### PR DESCRIPTION
## Description of changes

I stumbled upon a [mytetra build failure](https://hydra.nixos.org/build/238972428) on zh.fail:

```
/nix/store/x8lqlydsxbrwvf6p7v18gws8kn1xl37f-glibc-2.38-23-dev/include/string.h:380:14: error: conflicting types for 'strcasestr'; have 'char *(const char *, const char *)'
  380 | extern char *strcasestr (const char *__haystack, const char *__needle)
      |              ^~~~~~~~~~
mimetex.c:428:13: note: previous declaration of 'strcasestr' with type 'const char *(const char *, const char *)'
  428 | const char *strcasestr(const char *s1, const char *s2);
      |             ^~~~~~~~~~
```

I assume this started failing because of some gcc changes, although I haven't checked.

The upstream repository doesn't look active, so I fixed this here by sed-ing away the const-ness of the function return type (which I think is safe to do).

I tested by running the resulting binary for a bit, but I'm not a user of this program, so there might be some breakage hidden deeper within.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
