### PR TITLE
fte: fix build

### DIFF
--- a/pkgs/applications/editors/fte/default.nix
+++ b/pkgs/applications/editors/fte/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   };
   src = [ ftesrc ftecommon ];
 
+  env.NIX_CFLAGS_COMPILE = "-DHAVE_STRLCAT -DHAVE_STRLCPY";
+
   buildFlags = [ "PREFIX=$(out)" ];
 
   installFlags = [ "PREFIX=$(out)" "INSTALL_NONROOT=1" ];


### PR DESCRIPTION
## Description of changes

I stumbled upon an [fte build failure](https://hydra.nixos.org/build/238989728) in zh.fail.

```
/nix/store/x8lqlydsxbrwvf6p7v18gws8kn1xl37f-glibc-2.38-23-dev/include/string.h:506:15: error: conflicting declaration of 'size_t strlcpy(char*, const char*, size_t)' with 'C' linkage
  506 | extern size_t strlcpy (char *__restrict __dest,
      |               ^~~~~~~
In file included from s_string.cpp:1:
s_string.h:10:8: note: previous declaration with 'C++' linkage
   10 | size_t strlcpy(char *dst, const char *src, size_t size);
      |        ^~~~~~~
/nix/store/x8lqlydsxbrwvf6p7v18gws8kn1xl37f-glibc-2.38-23-dev/include/string.h:506:15: error: declaration of 'size_t strlcpy(char*, const char*, size_t) noexcept' has a different exception specifier
  506 | extern size_t strlcpy (char *__restrict __dest,
      |               ^~~~~~~
s_string.h:10:8: note: from previous declaration 'size_t strlcpy(char*, const char*, size_t)'
   10 | size_t strlcpy(char *dst, const char *src, size_t size);
      |        ^~~~~~~
/nix/store/x8lqlydsxbrwvf6p7v18gws8kn1xl37f-glibc-2.38-23-dev/include/string.h:512:15: error: conflicting declaration of 'size_t strlcat(char*, const char*, size_t)' with 'C' linkage
  512 | extern size_t strlcat (char *__restrict __dest,
      |               ^~~~~~~
s_string.h:14:8: note: previous declaration with 'C++' linkage
   14 | size_t strlcat(char *dst, const char *src, size_t size);
      |        ^~~~~~~
/nix/store/x8lqlydsxbrwvf6p7v18gws8kn1xl37f-glibc-2.38-23-dev/include/string.h:512:15: error: declaration of 'size_t strlcat(char*, const char*, size_t) noexcept' has a different exception specifier
  512 | extern size_t strlcat (char *__restrict __dest,
      |               ^~~~~~~
s_string.h:14:8: note: from previous declaration 'size_t strlcat(char*, const char*, size_t)'
   14 | size_t strlcat(char *dst, const char *src, size_t size);
      |        ^~~~~~~
```

The problem is that [glibc-2.38 added the strlcpy and strlcat functions](https://sourceware.org/pipermail/libc-alpha/2023-July/150524.html), but these were also defined in the fte source code.

Luckily, we can turn off the functions in fte by setting the `HAVE_STRLCPY` and `HAVE_STRLCAT` variables.  Upstream hasn't been changed since 2011, so this PR adds the variables in the nix derivation.

I tested by running the resulting binary and it seems to work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
