### PR TITLE
scip: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/development/tools/misc/scip/default.nix
+++ b/pkgs/development/tools/misc/scip/default.nix
@@ -1,33 +1,22 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, fetchpatch
 , testers
 , scip
 }:
 
 buildGoModule rec {
   pname = "scip";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "sourcegraph";
     repo = "scip";
     rev = "v${version}";
-    hash = "sha256-tcnBv+dxuLD/ixeOLGrHu2UVfOnrfANjyaRzW5oDC94=";
+    hash = "sha256-8CH5rIWvCXZGspAyF6c8Qs/gntpfdpPrxrvxW3bZ/ww=";
   };
 
-  vendorHash = "sha256-+IR3fc6tvSwPGDZ4DxrE48Ii3azcT0LMmID1LRAu5g8=";
-
-  patches = [
-    # update documentation to fix broken test
-    # https://github.com/sourcegraph/scip/pull/174
-    (fetchpatch {
-      name = "test-fix-out-of-sync-documentation.patch";
-      url = "https://github.com/sourcegraph/scip/commit/7450b7701637956d4ae6669338c808234f7a7bfa.patch";
-      hash = "sha256-Y5nAVHyy430xdN89ohA8XAssNdSSPq4y7QaesN48jVs=";
-    })
-  ];
+  vendorHash = "sha256-3Tq2cexcxHjaH6WIz2hneE1QeBSGoMINBncKbqxODxQ=";
 
   ldflags = [
     "-s"
@@ -35,8 +24,10 @@ buildGoModule rec {
     "-X=main.Reproducible=true"
   ];
 
-  postInstall = ''
-    mv $out/bin/{cmd,scip}
+  # update documentation to fix broken test
+  postPatch = ''
+    substituteInPlace docs/CLI.md \
+      --replace 0.3.0 0.3.1
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Diff: https://github.com/sourcegraph/scip/compare/v0.3.0...v0.3.1

Changelog: https://github.com/sourcegraph/scip/blob/v0.3.1/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
