### PR TITLE
nixos/systemd-boot: Avoid remote mypy executions

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -10,7 +10,9 @@ let
   # We check the source code in a derivation that does not depend on the
   # system configuration so that most users don't have to redo the check and require
   # the necessary dependencies.
-  checkedSource = pkgs.runCommand "systemd-boot" { } ''
+  checkedSource = pkgs.runCommand "systemd-boot" {
+    preferLocalBuild = true;
+  } ''
     install -m755 -D ${./systemd-boot-builder.py} $out
     ${lib.getExe pkgs.buildPackages.mypy} \
       --no-implicit-optional \


### PR DESCRIPTION
## Description of changes

In the systemd-boot NixOS module, set `preferLocalBuilds` when type-checking `systemd-boot-builder.py`, to avoid the overhead of remote builds.

This is a second go at this, #261640 wrongly used `runCommandLocal` instead, breaking a NixOS test and blocking the nixos-unstable channel.

Many thanks to @vcunat for pointing out `runCommandLocal` also sets `allowSubstitutes = false;`


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - NixOS test `installer.simpleUefiSystemdBoot`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
