### PR TITLE
displaylink: Add aarch64 support

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -12,11 +12,11 @@
 }:
 
 let
-  arch =
-    if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
-    else if stdenv.hostPlatform.system == "i686-linux" then "x86"
+  bins =
+    if stdenv.hostPlatform.system == "x86_64-linux" then "x64-ubuntu-1604"
+    else if stdenv.hostPlatform.system == "i686-linux" then "x86-ubuntu-1604"
+    else if stdenv.hostPlatform.system == "aarch64-linux" then "aarch64-linux-gnu"
     else throw "Unsupported architecture";
-  bins = "${arch}-ubuntu-1604";
   libPath = lib.makeLibraryPath [ stdenv.cc.cc util-linux libusb1 evdi ];
 
 in
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.displaylink.com/";
     license = licenses.unfree;
     maintainers = with maintainers; [ abbradar ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
     hydraPlatforms = [];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = with licenses; [ lgpl21Only gpl2Only ];
     homepage = "https://www.displaylink.com/";
-    broken = kernel.kernelOlder "4.19" || stdenv.isAarch64;
+    broken = kernel.kernelOlder "4.19";
   };
 }


### PR DESCRIPTION
Aarch64 support for displaylink and used kernel driver. Verified to work on aarch64 laptop.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

