### PR TITLE
pulumiPackages.pulumi-github, python311Packages.pulumi-github: init at 5.21.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/default.nix
+++ b/pkgs/tools/admin/pulumi-packages/default.nix
@@ -7,6 +7,7 @@ in
   pulumi-aws-native = callPackage' ./pulumi-aws-native.nix { };
   pulumi-azure-native = callPackage' ./pulumi-azure-native.nix { };
   pulumi-command = callPackage' ./pulumi-command.nix { };
+  pulumi-github = callPackage' ./pulumi-github.nix { };
   pulumi-language-go = callPackage ./pulumi-language-go.nix { };
   pulumi-language-nodejs = callPackage ./pulumi-language-nodejs.nix { };
   pulumi-language-python = callPackage ./pulumi-language-python.nix { };

--- a/pkgs/tools/admin/pulumi-packages/pulumi-github.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-github.nix
@@ -1,0 +1,25 @@
+{ lib
+, mkPulumiPackage
+}:
+mkPulumiPackage rec {
+  owner = "pulumi";
+  repo = "pulumi-github";
+  version = "5.21.0";
+  rev = "v${version}";
+  hash = "sha256-ZgGyr0bBupcI5Q9Ih4NYhE1axLaTgFiQ+cCZ9lIc0/w=";
+  vendorHash = "sha256-GfLhfgyVJPwjpjvF9mirxhlnjY0QyxSl/AM6dYgu/HA";
+  cmdGen = "pulumi-tfgen-github";
+  cmdRes = "pulumi-resource-github";
+  extraLdflags = [
+    "-X github.com/pulumi/${repo}/provider/v5/pkg/version.Version=v${version}"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "A Pulumi package to facilitate interacting with GitHub";
+    homepage = "https://github.com/pulumi/pulumi-github";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ trundle veehaitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1265,6 +1265,8 @@ self: super: with self; {
 
   pulumi-command = pkgs.pulumiPackages.pulumi-command.sdks.python;
 
+  pulumi-github = pkgs.pulumiPackages.pulumi-github.sdks.python;
+
   pulumi-random = pkgs.pulumiPackages.pulumi-random.sdks.python;
 
   backcall = callPackage ../development/python-modules/backcall { };


### PR DESCRIPTION
## Description of changes

[pulumi-github](https://github.com/pulumi/pulumi-github/) is the GitHub resource provider for [Pulumi](https://www.pulumi.com/). It lets you use GitHub resources in your infrastructure programs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
