### PR TITLE
Systemd stage 1 iscsi and multipathd

### DIFF
--- a/nixos/modules/services/networking/multipath.nix
+++ b/nixos/modules/services/networking/multipath.nix
@@ -548,6 +548,8 @@ in {
     # to display the multipath mappings in the output of `journalctl -b`.
     boot.initrd.kernelModules = [ "dm-multipath" "dm-service-time" ];
     boot.initrd.postDeviceCommands = ''
+      mkdir -p ${builtins.storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${cfg.package.name}/lib/
+      ln -s $extraUtils/lib/multipath ${builtins.storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${cfg.package.name}/lib/multipath
       modprobe -a dm-multipath dm-service-time
       multipathd -s
       (set -x && sleep 1 && multipath -ll)

--- a/nixos/modules/services/networking/multipath.nix
+++ b/nixos/modules/services/networking/multipath.nix
@@ -552,5 +552,16 @@ in {
       multipathd -s
       (set -x && sleep 1 && multipath -ll)
     '';
+
+    boot.initrd.systemd = {
+      packages = [ cfg.package ];
+      extraBin.multipath = "${cfg.package}/bin/multipath";
+      extraBin.multipathd = "${cfg.package}/bin/multipathd";
+      storePaths = [ "${cfg.package}/lib/multipath" ];
+      contents."/etc/multipath.conf".source = config.environment.etc."multipath.conf".source;
+      services.multipathd.wantedBy = [ "sysinit.target" ];
+      services.multipathd.after = [ "systemd-modules-load.service" ];
+      sockets.multipathd.wantedBy = [ "sockets.target" ];
+    };
   };
 }

--- a/nixos/tests/iscsi-multipath-root.nix
+++ b/nixos/tests/iscsi-multipath-root.nix
@@ -82,6 +82,8 @@ import ./make-test-python.nix (
       };
 
       initiatorAuto = { nodes, config, pkgs, ... }: {
+        boot.initrd.systemd.enable = true;
+
         virtualisation.vlans = [ 1 2 ];
 
         services.multipath = {
@@ -119,6 +121,8 @@ import ./make-test-python.nix (
       };
 
       initiatorRootDisk = { config, pkgs, modulesPath, lib, ... }: {
+        boot.initrd.systemd.enable = true;
+
         boot.initrd.network.enable = true;
         boot.loader.grub.enable = false;
 

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -82,6 +82,8 @@ import ./make-test-python.nix (
           };
 
           initiatorAuto = { nodes, config, pkgs, ... }: {
+            boot.initrd.systemd.enable = true;
+
             services.openiscsi = {
               enable = true;
               enableAutoLoginOut = true;
@@ -103,6 +105,8 @@ import ./make-test-python.nix (
           };
 
           initiatorRootDisk = { config, pkgs, modulesPath, lib, ... }: {
+            boot.initrd.systemd.enable = true;
+
             boot.loader.grub.enable = false;
             boot.kernelParams = lib.mkOverride 5 (
               [

--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -63,6 +63,10 @@ stdenv.mkDerivation rec {
     util-linuxMinimal # for libmount
   ];
 
+  # Explicitly link against libgcc_s, to work around the infamous
+  # "libgcc_s.so.1 must be installed for pthread_cancel to work".
+  LDFLAGS = lib.optionalString stdenv.isLinux "-lgcc_s";
+
   makeFlags = [
     "LIB=lib"
     "prefix=$(out)"


### PR DESCRIPTION
## Description of changes

This enables iscsi and multipath with systemd stage 1. It also includes a fix for the `iscsi-multipath-root` test, which has been broken since #199710.

This is currently marked as a draft because the multipath test doesn't work for unknown reasons.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
