### PR TITLE
cairo: fix cross

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -60,18 +60,18 @@ in {
     (lib.mesonEnable "tests" finalAttrs.doCheck)
     (lib.mesonEnable "xlib" x11Support)
     (lib.mesonEnable "xcb" xcbSupport)
-  # ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-  #   "--cross-file=${builtins.toFile "cross-file.conf" ''
-  #     [properties]
-  #     ipc_rmid_deferred_release = ${
-  #       {
-  #         linux = "true";
-  #         freebsd = "true";
-  #         netbsd = "false";
-  #       }.${stdenv.hostPlatform.parsed.kernel.name} or
-  #         throw "Unknown value for ipc_rmid_deferred_release"
-  #     }
-  #   ''}"
+  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "--cross-file=${builtins.toFile "cross-file.conf" ''
+      [properties]
+      ipc_rmid_deferred_release = ${
+        {
+          linux = "true";
+          freebsd = "true";
+          netbsd = "false";
+        }.${stdenv.hostPlatform.parsed.kernel.name} or
+          (throw "Unknown value for ipc_rmid_deferred_release")
+      }
+    ''}"
   ];
 
   preConfigure = ''


### PR DESCRIPTION
## Description of changes

I accidentally left this commented out when I did the cairo update that switched the build system to Meson.

I don't know what the correct value for Darwin is, but if somebody lets me know, I can add it here.  Otherwise, it can be follow-up for Darwin users.

Fixes: 2c0a4f46b95c ("cairo: 1.16.0 -> 1.18.0")

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [b] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
