### PR TITLE
electrs-esplora: init at adedee15f1fe460398a7045b292604df2161adc0

### DIFF
--- a/pkgs/applications/blockchains/electrs-esplora/default.nix
+++ b/pkgs/applications/blockchains/electrs-esplora/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, rocksdb_6_23
+, Security
+}:
+let
+  rocksdb = rocksdb_6_23;
+in
+rustPlatform.buildRustPackage {
+  pname = "electrs-esplora";
+  # last tagged versoin is far behind master
+  version = "20230218";
+
+  src = fetchFromGitHub {
+    owner = "Blockstream";
+    repo = "electrs";
+    rev = "adedee15f1fe460398a7045b292604df2161adc0";
+    hash = "sha256-KnN5C7wFtDF10yxf+1dqIMUb8Q+UuCz4CMQrUFAChuA=";
+  };
+
+  cargoHash = "sha256-tM5IFiIYX2SlAp6Q5uccVjW6TgOf5MfoFrLXz3GlZ90=";
+
+  # needed for librocksdb-sys
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+
+  # link rocksdb dynamically
+  ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
+  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  # rename to avoid a name conflict with other electrs package
+  postInstall = ''
+    mv $out/bin/electrs $out/bin/electrs-esplora
+  '';
+
+  meta = with lib; {
+    description = "Blockstream's re-implementation of Electrum Server for Esplora";
+    homepage = "https://github.com/Blockstream/electrs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dpc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37088,6 +37088,10 @@ with pkgs;
 
   erigon = callPackage ../applications/blockchains/erigon { };
 
+  electrs-esplora = callPackage ../applications/blockchains/electrs-esplora {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   exodus = callPackage ../applications/blockchains/exodus { };
 
   faraday = callPackage ../applications/blockchains/faraday { };


### PR DESCRIPTION
## Description of changes

[Esplora's electrs](https://github.com/Blockstream/electrs) is a fork of `electrs` (a Bitcoin indexer implementing Electrum protocol), improving the performance for heavy duty use over the original `electrs` (at the cost of heavy storage requirements).

It's used as a backend of https://blockstream.info and a popular element of integration/e2e testing in Bitcoin community.

Unfortunately they don't really make public releases. The project is very stable, and implements a well osified API.

[I have made an issue informing the developers](https://github.com/Blockstream/esplora/issues/468) that would be great if they could make a proper release, but I don't want to be blocked on it.

I have took a liberty of renaming the liberty so it is different from the original project it forked from.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
