### PR TITLE
python3.pkgs.pyocr: 0.8.3->0.8.5

### DIFF
--- a/pkgs/development/python-modules/pyocr/default.nix
+++ b/pkgs/development/python-modules/pyocr/default.nix
@@ -7,12 +7,15 @@
 , isPy3k
 , substituteAll
 , pytestCheckHook
+, setuptools
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "pyocr";
-  version = "0.8.3";
+  version = "0.8.5";
   disabled = !isPy3k;
+  format = "pyproject";
 
   # Don't fetch from PYPI because it doesn't contain tests.
   src = fetchFromGitLab {
@@ -21,7 +24,7 @@ buildPythonPackage rec {
     owner = "OpenPaperwork";
     repo = "pyocr";
     rev = version;
-    hash = "sha256-gIn50H9liQcTb7SzoWnBwm5LTvkr+R+5OPvITls1B/w=";
+    hash = "sha256-gE0+qbHCwpDdxXFY+4rjVU2FbUSfSVrvrVMcWUk+9FU=";
   };
 
   patches = [
@@ -31,18 +34,17 @@ buildPythonPackage rec {
     })
   ];
 
-  # see the logic in setup.py
-  ENABLE_SETUPTOOLS_SCM = "0";
-  preConfigure = ''
-    echo 'version = "${version}"' > src/pyocr/_version.py
-  '';
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [ pillow ];
+
+  nativeBuildInputs = [ setuptools setuptools-scm ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     inherit (src.meta) homepage;
+    changelog = "https://gitlab.gnome.org/World/OpenPaperwork/pyocr/-/blob/${version}/ChangeLog";
     description = "A Python wrapper for Tesseract and Cuneiform";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ symphorien ];

--- a/pkgs/development/python-modules/pyocr/paths.patch
+++ b/pkgs/development/python-modules/pyocr/paths.patch
@@ -1,4 +1,4 @@
-commit c4bac00441363fcaeb074682d8226ca523614ea2
+commit cfc05af26b571e9ca09e9c709c0fb8934e9e46dd
 Author: Guillaume Girol <symphorien+git@xlumurb.eu>
 Date:   Sat Aug 20 17:48:01 2022 +0200
 
@@ -25,7 +25,7 @@ index 2e5b717..35647e2 100644
  LANGUAGES_LINE_PREFIX = "Supported languages: "
  LANGUAGES_SPLIT_RE = re.compile("[^a-z]")
 diff --git a/src/pyocr/libtesseract/tesseract_raw.py b/src/pyocr/libtesseract/tesseract_raw.py
-index 2002614..9ebea5c 100644
+index 1edec8c..434a336 100644
 --- a/src/pyocr/libtesseract/tesseract_raw.py
 +++ b/src/pyocr/libtesseract/tesseract_raw.py
 @@ -2,7 +2,6 @@ import ctypes
@@ -51,7 +51,7 @@ index 2002614..9ebea5c 100644
  DPI_DEFAULT = 70
  
 -
--if getattr(sys, 'frozen', False):  # pragma: no cover
+-if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
 -    # Pyinstaller integration
 -    libnames += [os.path.join(sys._MEIPASS, "libtesseract-4.dll")]
 -    libnames += [os.path.join(sys._MEIPASS, "libtesseract-3.dll")]
@@ -125,10 +125,10 @@ index 0fe0d20..c1fdd27 100644
  
  TESSDATA_EXTENSION = ".traineddata"
  
-diff --git a/tests/tests_cuneiform.py b/tests/tests_cuneiform.py
-index 45b7f6a..95f55c6 100644
---- a/tests/tests_cuneiform.py
-+++ b/tests/tests_cuneiform.py
+diff --git a/tests/test_cuneiform.py b/tests/test_cuneiform.py
+index b76e93c..266f6b2 100644
+--- a/tests/test_cuneiform.py
++++ b/tests/test_cuneiform.py
 @@ -21,7 +21,7 @@ class TestCuneiform(BaseTest):
          # XXX is it useful?
          which.return_value = True
@@ -147,7 +147,7 @@ index 45b7f6a..95f55c6 100644
              stdout=subprocess.PIPE, stderr=subprocess.STDOUT
          )
  
-@@ -109,7 +109,7 @@ class TestCuneiformTxt(BaseTest):
+@@ -110,7 +110,7 @@ class TestCuneiformTxt(BaseTest):
          output = cuneiform.image_to_string(self.image)
          self.assertEqual(output, self._get_file_content("text").strip())
          popen.assert_called_once_with(
@@ -156,7 +156,7 @@ index 45b7f6a..95f55c6 100644
              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
              stderr=subprocess.STDOUT
          )
-@@ -125,7 +125,7 @@ class TestCuneiformTxt(BaseTest):
+@@ -126,7 +126,7 @@ class TestCuneiformTxt(BaseTest):
                                             builder=self.builder)
          self.assertEqual(output, self._get_file_content("text").strip())
          popen.assert_called_once_with(
@@ -165,7 +165,7 @@ index 45b7f6a..95f55c6 100644
               "-"],
              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
              stderr=subprocess.STDOUT
-@@ -142,7 +142,7 @@ class TestCuneiformTxt(BaseTest):
+@@ -143,7 +143,7 @@ class TestCuneiformTxt(BaseTest):
                                             builder=self.builder)
          self.assertEqual(output, self._get_file_content("text").strip())
          popen.assert_called_once_with(
@@ -174,7 +174,7 @@ index 45b7f6a..95f55c6 100644
              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
              stderr=subprocess.STDOUT
          )
-@@ -173,7 +173,7 @@ class TestCuneiformTxt(BaseTest):
+@@ -174,7 +174,7 @@ class TestCuneiformTxt(BaseTest):
          output = cuneiform.image_to_string(image, builder=self.builder)
          self.assertEqual(output, self._get_file_content("text").strip())
          popen.assert_called_once_with(
@@ -183,7 +183,7 @@ index 45b7f6a..95f55c6 100644
              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
              stderr=subprocess.STDOUT
          )
-@@ -227,7 +227,7 @@ class TestCuneiformWordBox(BaseTest):
+@@ -230,7 +230,7 @@ class TestCuneiformWordBox(BaseTest):
          output = cuneiform.image_to_string(self.image,
                                             builder=self.builder)
          popen.assert_called_once_with(
@@ -192,7 +192,7 @@ index 45b7f6a..95f55c6 100644
              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
              stderr=subprocess.STDOUT
          )
-@@ -280,7 +280,7 @@ class TestCuneiformLineBox(BaseTest):
+@@ -284,7 +284,7 @@ class TestCuneiformLineBox(BaseTest):
          output = cuneiform.image_to_string(self.image,
                                             builder=self.builder)
          popen.assert_called_once_with(
@@ -201,11 +201,11 @@ index 45b7f6a..95f55c6 100644
              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
              stderr=subprocess.STDOUT
          )
-diff --git a/tests/tests_libtesseract.py b/tests/tests_libtesseract.py
-index a5d46d8..8b9e315 100644
---- a/tests/tests_libtesseract.py
-+++ b/tests/tests_libtesseract.py
-@@ -165,7 +165,8 @@ class TestLibTesseractRaw(BaseTest):
+diff --git a/tests/test_libtesseract.py b/tests/test_libtesseract.py
+index cc31a50..890c02c 100644
+--- a/tests/test_libtesseract.py
++++ b/tests/test_libtesseract.py
+@@ -167,7 +167,8 @@ class TestLibTesseractRaw(BaseTest):
              args = libtess.TessBaseAPIInit3.call_args[0]
              self.assertEqual(len(args), 3)
              self.assertEqual(args[0].value, self.handle)
@@ -215,7 +215,7 @@ index a5d46d8..8b9e315 100644
              self.assertEqual(args[2].value, lang.encode() if lang else None)
  
              self.assertEqual(
-@@ -201,7 +202,8 @@ class TestLibTesseractRaw(BaseTest):
+@@ -203,7 +204,8 @@ class TestLibTesseractRaw(BaseTest):
              args = libtess.TessBaseAPIInit3.call_args[0]
              self.assertEqual(len(args), 3)
              self.assertEqual(args[0].value, self.handle)
@@ -225,11 +225,11 @@ index a5d46d8..8b9e315 100644
              self.assertEqual(args[2].value, lang.encode() if lang else None)
  
              self.assertEqual(
-diff --git a/tests/tests_tesseract.py b/tests/tests_tesseract.py
-index 18d01ef..593cf94 100644
---- a/tests/tests_tesseract.py
-+++ b/tests/tests_tesseract.py
-@@ -36,7 +36,7 @@ class TestTesseract(BaseTest):
+diff --git a/tests/test_tesseract.py b/tests/test_tesseract.py
+index 823818f..2ee5fb4 100644
+--- a/tests/test_tesseract.py
++++ b/tests/test_tesseract.py
+@@ -37,7 +37,7 @@ class TestTesseract(BaseTest):
      def test_available(self, which):
          which.return_value = True
          self.assertTrue(tesseract.is_available())
@@ -238,7 +238,7 @@ index 18d01ef..593cf94 100644
  
      @patch("subprocess.Popen")
      def test_version_error(self, popen):
-@@ -162,7 +162,7 @@ class TestTesseract(BaseTest):
+@@ -163,7 +163,7 @@ class TestTesseract(BaseTest):
          for lang in ("eng", "fra", "jpn", "osd"):
              self.assertIn(lang, langs)
          popen.assert_called_once_with(
@@ -247,7 +247,7 @@ index 18d01ef..593cf94 100644
              startupinfo=None, creationflags=0,
              stdout=subprocess.PIPE, stderr=subprocess.STDOUT
          )
-@@ -177,7 +177,7 @@ class TestTesseract(BaseTest):
+@@ -178,7 +178,7 @@ class TestTesseract(BaseTest):
          self.assertEqual(te.exception.status, 1)
          self.assertEqual("unable to get languages", te.exception.message)
          popen.assert_called_once_with(
@@ -256,7 +256,7 @@ index 18d01ef..593cf94 100644
              startupinfo=None, creationflags=0,
              stdout=subprocess.PIPE, stderr=subprocess.STDOUT
          )
-@@ -254,7 +254,7 @@ class TestTesseract(BaseTest):
+@@ -255,7 +255,7 @@ class TestTesseract(BaseTest):
          self.assertEqual(status, 0)
          self.assertEqual(error, message)
          popen.assert_called_once_with(
@@ -265,7 +265,7 @@ index 18d01ef..593cf94 100644
              cwd=tmpdir,
              startupinfo=None,
              creationflags=0,
-@@ -277,7 +277,7 @@ class TestTesseract(BaseTest):
+@@ -278,7 +278,7 @@ class TestTesseract(BaseTest):
          self.assertEqual(status, 0)
          self.assertEqual(error, message)
          popen.assert_called_with(
@@ -274,7 +274,7 @@ index 18d01ef..593cf94 100644
              cwd=tmpdir,
              startupinfo=None,
              creationflags=0,
-@@ -308,7 +308,7 @@ class TestTesseract(BaseTest):
+@@ -309,7 +309,7 @@ class TestTesseract(BaseTest):
              self.assertEqual(result["angle"], 90)
              self.assertEqual(result["confidence"], 9.30)
              popen.assert_called_once_with(
@@ -283,7 +283,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -344,7 +344,7 @@ class TestTesseract(BaseTest):
+@@ -345,7 +345,7 @@ class TestTesseract(BaseTest):
              self.assertEqual(result["angle"], 90)
              self.assertEqual(result["confidence"], 9.30)
              popen.assert_called_once_with(
@@ -292,7 +292,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -377,7 +377,7 @@ class TestTesseract(BaseTest):
+@@ -378,7 +378,7 @@ class TestTesseract(BaseTest):
              self.assertEqual(result["angle"], 90)
              self.assertEqual(result["confidence"], 9.30)
              popen.assert_called_once_with(
@@ -301,7 +301,7 @@ index 18d01ef..593cf94 100644
                   "--psm", "0", "-l", "osd"],
                  stdin=subprocess.PIPE,
                  shell=False,
-@@ -405,7 +405,7 @@ class TestTesseract(BaseTest):
+@@ -406,7 +406,7 @@ class TestTesseract(BaseTest):
              with self.assertRaises(tesseract.TesseractError) as te:
                  tesseract.detect_orientation(self.image)
              popen.assert_called_once_with(
@@ -310,7 +310,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -439,7 +439,7 @@ class TestTesseract(BaseTest):
+@@ -440,7 +440,7 @@ class TestTesseract(BaseTest):
              with self.assertRaises(tesseract.TesseractError) as te:
                  tesseract.detect_orientation(self.image)
              popen.assert_called_once_with(
@@ -319,7 +319,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -473,7 +473,7 @@ class TestTesseract(BaseTest):
+@@ -474,7 +474,7 @@ class TestTesseract(BaseTest):
              self.assertEqual(result["angle"], 90)
              self.assertEqual(result["confidence"], 9.30)
              popen.assert_called_once_with(
@@ -328,7 +328,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -506,7 +506,7 @@ class TestTesseract(BaseTest):
+@@ -507,7 +507,7 @@ class TestTesseract(BaseTest):
              self.assertEqual(result["angle"], 90)
              self.assertEqual(result["confidence"], 9.30)
              popen.assert_called_once_with(
@@ -337,7 +337,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -533,7 +533,7 @@ class TestTesseract(BaseTest):
+@@ -534,7 +534,7 @@ class TestTesseract(BaseTest):
              with self.assertRaises(tesseract.TesseractError) as te:
                  tesseract.detect_orientation(self.image)
              popen.assert_called_once_with(
@@ -346,7 +346,7 @@ index 18d01ef..593cf94 100644
                  stdin=subprocess.PIPE,
                  shell=False,
                  startupinfo=None,
-@@ -567,7 +567,7 @@ class TestTesseract(BaseTest):
+@@ -568,7 +568,7 @@ class TestTesseract(BaseTest):
              with self.assertRaises(tesseract.TesseractError) as te:
                  tesseract.detect_orientation(self.image)
              popen.assert_called_once_with(


### PR DESCRIPTION
## Description of changes

announcement:
https://forum.openpaper.work/t/pyocr-0-8-4/326

tested by scanning with paperwork and seeing that ocr still works.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
