### PR TITLE
zsnes: fix build against zlib-1.3

### DIFF
--- a/pkgs/applications/emulators/zsnes/default.nix
+++ b/pkgs/applications/emulators/zsnes/default.nix
@@ -23,7 +23,10 @@ in stdenv.mkDerivation {
     sha256 = "1gy79d5wdaacph0cc1amw7mqm7i0716n6mvav16p1svi26iz193v";
   };
 
-  patches = [ ./zlib-1.3.patch ];
+  patches = [
+    ./zlib-1.3.patch
+    ./fortify3.patch
+  ];
 
   buildInputs = [ nasm SDL zlib libpng ncurses libGLU libGL ];
 

--- a/pkgs/applications/emulators/zsnes/default.nix
+++ b/pkgs/applications/emulators/zsnes/default.nix
@@ -23,6 +23,8 @@ in stdenv.mkDerivation {
     sha256 = "1gy79d5wdaacph0cc1amw7mqm7i0716n6mvav16p1svi26iz193v";
   };
 
+  patches = [ ./zlib-1.3.patch ];
+
   buildInputs = [ nasm SDL zlib libpng ncurses libGLU libGL ];
 
   prePatch = ''

--- a/pkgs/applications/emulators/zsnes/fortify3.patch
+++ b/pkgs/applications/emulators/zsnes/fortify3.patch
@@ -1,0 +1,29 @@
+pal16bxcl is an array of 256 dwords, not bytes:
+    src/endmem.asm:NEWSYM pal16bxcl, resd 256
+
+While at it fixes off-by-4 out of bounds exit.
+
+Detected by _FORTIFY_SOURCE=3:
+    *** buffer overflow detected ***: terminated
+    #7  0x08057c14 in memset (__len=2, __ch=255, __dest=<optimized out>) at ...-glibc-2.38-23-dev/include/bits/string_fortified.h:59
+#8  clearmem () at initc.c:1461
+--- a/src/initc.c
++++ b/src/initc.c
+@@ -1389,7 +1389,7 @@ extern unsigned char vidmemch8[4096];
+ extern unsigned char pal16b[1024];
+ extern unsigned char pal16bcl[1024];
+ extern unsigned char pal16bclha[1024];
+-extern unsigned char pal16bxcl[256];
++extern unsigned char pal16bxcl[1024];
+ extern unsigned char SPCRAM[65472];
+ unsigned char *SPCState = SPCRAM;
+ 
+@@ -1456,7 +1456,7 @@ void clearmem()
+   memset(pal16b, 0, 1024);
+   memset(pal16bcl, 0, 1024);
+   memset(pal16bclha, 0, 1024);
+-  for (i=0 ; i<1024 ; i+=4)
++  for (i=0 ; i<1024-4 ; i+=4)
+   {
+     memset(pal16bxcl+i, 255, 2);
+     memset(pal16bxcl+i+2, 0, 2);

--- a/pkgs/applications/emulators/zsnes/zlib-1.3.patch
+++ b/pkgs/applications/emulators/zsnes/zlib-1.3.patch
@@ -1,0 +1,41 @@
+Add support for 2-digit zlib version like "1.3".
+--- a/src/acinclude.m4
++++ b/src/acinclude.m4
+@@ -67,7 +67,7 @@ char* my_strdup (char *str)
+ 
+ int main (int argc, char *argv[])
+ {
+-  int major, minor, micro, zlib_major_version, zlib_minor_version, zlib_micro_version;
++  int major, minor, micro, zlib_major_version, zlib_minor_version, zlib_micro_version = 0;
+ 
+   char *zlibver, *tmp_version;
+ 
+@@ -85,7 +85,7 @@ int main (int argc, char *argv[])
+     printf("%s, bad version string for\n\tmin_zlib_version... ", "$min_zlib_version");
+     exit(1);
+   }
+-  if (sscanf(zlibver, "%d.%d.%d", &zlib_major_version, &zlib_minor_version, &zlib_micro_version) != 3) {
++  if (sscanf(zlibver, "%d.%d.%d", &zlib_major_version, &zlib_minor_version, &zlib_micro_version) != 3 && sscanf(zlibver, "%d.%d", &zlib_major_version, &zlib_minor_version) != 2) {
+     printf("%s, bad version string given\n", zlibver);
+     puts("\tby zlib, sometimes due to very old zlibs that didnt correctly");
+     printf("\tdefine their version. Please upgrade if you are running an\n\told zlib... ");
+--- a/src/configure
++++ b/src/configure
+@@ -3817,7 +3817,7 @@ char* my_strdup (char *str)
+ 
+ int main (int argc, char *argv[])
+ {
+-  int major, minor, micro, zlib_major_version, zlib_minor_version, zlib_micro_version;
++  int major, minor, micro, zlib_major_version, zlib_minor_version, zlib_micro_version = 0;
+ 
+   char *zlibver, *tmp_version;
+ 
+@@ -3835,7 +3835,7 @@ int main (int argc, char *argv[])
+     printf("%s, bad version string for\n\tmin_zlib_version... ", "$min_zlib_version");
+     exit(1);
+   }
+-  if (sscanf(zlibver, "%d.%d.%d", &zlib_major_version, &zlib_minor_version, &zlib_micro_version) != 3) {
++  if (sscanf(zlibver, "%d.%d.%d", &zlib_major_version, &zlib_minor_version, &zlib_micro_version) != 3 && sscanf(zlibver, "%d.%d", &zlib_major_version, &zlib_minor_version) != 2) {
+     printf("%s, bad version string given\n", zlibver);
+     puts("\tby zlib, sometimes due to very old zlibs that didnt correctly");
+     printf("\tdefine their version. Please upgrade if you are running an\n\told zlib... ");


### PR DESCRIPTION
Without the change builda fails on `master` as
https://hydra.nixos.org/build/238481288/nixlog/3:

    checking for zlib - version >= 1.2.3... 1.3, bad version string given
        by zlib, sometimes due to very old zlibs that didnt correctly
        define their version. Please upgrade if you are running an
        old zlib... no

The failure happens due to 2-digit zlib version string. Add a trivial change to allow 2-digit support in addition to existing 3-digit ones..

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
