### PR TITLE
aba: init at 0.7.0

### DIFF
--- a/pkgs/by-name/ab/aba/package.nix
+++ b/pkgs/by-name/ab/aba/package.nix
@@ -1,0 +1,53 @@
+{ fetchFromSourcehut
+, just
+, lib
+, nix-update-script
+, rustPlatform
+, scdoc
+}:
+let
+  version = "0.7.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "aba";
+  inherit version;
+
+  src = fetchFromSourcehut {
+    owner = "~onemoresuza";
+    repo = "aba";
+    rev = version;
+    hash = "sha256-YPE5HYa90BcNy5jdYbzkT81KavJcbSeGrsWRILnIiEE=";
+    domain = "sr.ht";
+  };
+
+  cargoSha256 = "sha256-wzI+UMcVeFQNFlWDkyxk8tjpU7beNRKoPYbid8b15/Q=";
+
+  nativeBuildInputs = [
+    just
+    scdoc
+  ];
+
+  # There are no tests
+  doCheck = false;
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+  dontUseJustInstall = true;
+
+  postInstall = ''
+    just --set PREFIX $out install-doc
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An address book for aerc";
+    homepage = "https://sr.ht/~onemoresuza/aba/";
+    changelog = "https://git.sr.ht/~onemoresuza/aba/tree/main/item/CHANGELOG.md";
+    downloadPage = "https://git.sr.ht/~onemoresuza/aba/refs/${version}";
+    maintainers = with lib.maintainers; [ onemoresuza ];
+    license = lib.licenses.isc;
+    platforms = lib.platforms.unix;
+    mainProgram = "aba";
+  };
+}


### PR DESCRIPTION
## Description of changes

Initialize [aba](https://sr.ht/~onemoresuza/aba/), an address book for the aerc mail client, at 0.7.0.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
