### PR TITLE
nixos/sudo-rs: cleanup

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -28,9 +28,9 @@
   - `root` and `wheel` are not given the ability to set (or preserve)
     arbitrary environment variables.
 
-- [glibc](https://www.gnu.org/software/libc/) has been updated from version 2.37 to 2.38, see [the release notes](https://sourceware.org/glibc/wiki/Release/2.38) for what was changed.
-
 [`sudo-rs`]: https://github.com/memorysafety/sudo-rs/
+
+- [glibc](https://www.gnu.org/software/libc/) has been updated from version 2.37 to 2.38, see [the release notes](https://sourceware.org/glibc/wiki/Release/2.38) for what was changed.
 
 - `linuxPackages_testing_bcachefs` is now soft-deprecated by `linuxPackages_testing`.
   - Please consider changing your NixOS configuration's `boot.kernelPackages` to `linuxPackages_testing` until a stable kernel with bcachefs support is released.

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -22,7 +22,7 @@
 
 - [`sudo-rs`], a reimplementation of `sudo` in Rust, is now supported.
   An experimental new module `security.sudo-rs` was added.
-  Switching to it (via `security.sudo.enable = false; security.sudo-rs.enable = true;`) introduces
+  Switching to it (via ` security.sudo-rs.enable = true;`) introduces
   slight changes in sudo behaviour, due to `sudo-rs`' current limitations:
   - terminfo-related environment variables aren't preserved for `root` and `wheel`;
   - `root` and `wheel` are not given the ability to set (or preserve)

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -28,6 +28,10 @@
   - `root` and `wheel` are not given the ability to set (or preserve)
     arbitrary environment variables.
 
+  **Note:** The `sudo-rs` module only takes configuration through `security.sudo-rs`,
+  and in particular does not automatically use previously-set rules; this could be
+  achieved with `security.sudo-rs.extraRules = security.sudo.extraRules;` for instance.
+
 [`sudo-rs`]: https://github.com/memorysafety/sudo-rs/
 
 - [glibc](https://www.gnu.org/software/libc/) has been updated from version 2.37 to 2.38, see [the release notes](https://sourceware.org/glibc/wiki/Release/2.38) for what was changed.

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -943,6 +943,11 @@ let
       value.source = pkgs.writeText "${name}.pam" service.text;
     };
 
+  optionalSudoConfigForSSHAgentAuth = optionalString config.security.pam.enableSSHAgentAuth ''
+    # Keep SSH_AUTH_SOCK so that pam_ssh_agent_auth.so can do its magic.
+    Defaults env_keep+=SSH_AUTH_SOCK
+  '';
+
 in
 
 {
@@ -1532,9 +1537,7 @@ in
         concatLines
       ]);
 
-    security.sudo.extraConfig = optionalString config.security.pam.enableSSHAgentAuth ''
-      # Keep SSH_AUTH_SOCK so that pam_ssh_agent_auth.so can do its magic.
-      Defaults env_keep+=SSH_AUTH_SOCK
-    '';
-    };
+    security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;
+    security.sudo-rs.extraConfig = optionalSudoConfigForSSHAgentAuth;
+  };
 }

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -220,10 +220,6 @@ in
         # Don't edit this file. Set the NixOS options ‘security.sudo-rs.configFile’
         # or ‘security.sudo-rs.extraRules’ instead.
       ''
-      (optionalString enableSSHAgentAuth ''
-        # Keep SSH_AUTH_SOCK so that pam_ssh_agent_auth.so can do its magic.
-        Defaults env_keep+=SSH_AUTH_SOCK
-      '')
       (pipe cfg.extraRules [
         (filter (rule: length rule.commands != 0))
         (map (rule: [

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -4,13 +4,10 @@ with lib;
 
 let
 
-  inherit (pkgs) sudo sudo-rs;
-
   cfg = config.security.sudo-rs;
 
-  enableSSHAgentAuth =
-    with config.security;
-    pam.enableSSHAgentAuth && pam.sudo.sshAgentAuth;
+  inherit (config.security.pam) enableSSHAgentAuth;
+  inherit (pkgs) sudo sudo-rs;
 
   usingMillersSudo = cfg.package.pname == sudo.pname;
   usingSudoRs = cfg.package.pname == sudo-rs.pname;

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -42,7 +42,8 @@ in
     };
 
     enable = mkEnableOption (mdDoc ''
-      the {command}`sudo` command, which allows non-root users to execute commands as root.
+      a memory-safe implementation of the {command}`sudo` command,
+      which allows non-root users to execute commands as root.
     '');
 
     package = mkPackageOption pkgs "sudo-rs" { };

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -208,6 +208,12 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
+    assertions = [ {
+      assertion = ! config.security.sudo.enable;
+      message = "`security.sudo` and `security.sudo-rs` cannot both be enabled";
+    }];
+    security.sudo.enable = mkDefault false;
+
     security.sudo-rs.extraRules =
       let
         defaultRule = { users ? [], groups ? [], opts ? [] }: [ {

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -41,23 +41,11 @@ in
       '';
     };
 
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = mdDoc ''
-        Whether to enable the {command}`sudo` command, which
-        allows non-root users to execute commands as root.
-      '';
-    };
+    enable = mkEnableOption (mdDoc ''
+      the {command}`sudo` command, which allows non-root users to execute commands as root.
+    '');
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.sudo-rs;
-      defaultText = literalExpression "pkgs.sudo-rs";
-      description = mdDoc ''
-        Which package to use for `sudo`.
-      '';
-    };
+    package = mkPackageOption pkgs "sudo-rs" { };
 
     wheelNeedsPassword = mkOption {
       type = types.bool;

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -7,7 +7,7 @@ let
   cfg = config.security.sudo-rs;
 
   inherit (config.security.pam) enableSSHAgentAuth;
-  inherit (pkgs) sudo sudo-rs;
+  inherit (pkgs) sudo-rs;
 
   toUserString = user: if (isInt user) then "#${toString user}" else "${user}";
   toGroupString = group: if (isInt group) then "%#${toString group}" else "%${group}";
@@ -264,7 +264,7 @@ in
       };
     };
 
-    environment.systemPackages = [ sudo ];
+    environment.systemPackages = [ cfg.package ];
 
     security.pam.services.sudo = { sshAgentAuth = true; usshAuth = true; };
     security.pam.services.sudo-i = { sshAgentAuth = true; usshAuth = true; };

--- a/nixos/tests/sudo-rs.nix
+++ b/nixos/tests/sudo-rs.nix
@@ -24,7 +24,6 @@ in
 
         security.sudo-rs = {
           enable = true;
-          package = pkgs.sudo-rs;
           wheelNeedsPassword = false;
 
           extraRules = [
@@ -55,7 +54,6 @@ in
       };
 
       security.sudo-rs = {
-        package = pkgs.sudo-rs;
         enable = true;
         wheelNeedsPassword = false;
         execWheelOnly = true;

--- a/nixos/tests/sudo-rs.nix
+++ b/nixos/tests/sudo-rs.nix
@@ -22,8 +22,6 @@ in
           test5 = { isNormalUser = true; };
         };
 
-        security.sudo.enable = false;
-
         security.sudo-rs = {
           enable = true;
           package = pkgs.sudo-rs;
@@ -55,8 +53,6 @@ in
         admin = { isNormalUser = true; extraGroups = [ "wheel" ]; };
         noadmin = { isNormalUser = true; };
       };
-
-      security.sudo.enable = false;
 
       security.sudo-rs = {
         package = pkgs.sudo-rs;


### PR DESCRIPTION
## Description of changes

Cleanup following #256491 partially reverting #253876 and creating a distinct `sudo-rs` module :
- simplify switching to sudo-rs to `security.sudo-rs.enable = true;` ;
- fixed & updated release notes, warned against caveats introduced by #256491 ;
- removed checks, configuration etc. not necessary since the split.

Also fix a bug: after the split, the sudo-rs module was setting
`environment.systemPackages = [ sudo ];`.  (The root cause is a bug in the o.g. sudo module,
but I'll submit a fix separately)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - NixOS test `sudo-rs`
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
