### PR TITLE
nixos/sudo: fix `security.sudo.package`

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.security.sudo;
 
-  inherit (pkgs) sudo;
-
   toUserString = user: if (isInt user) then "#${toString user}" else "${user}";
   toGroupString = group: if (isInt group) then "%#${toString group}" else "%${group}";
 
@@ -247,7 +245,7 @@ in
       };
     };
 
-    environment.systemPackages = [ sudo ];
+    environment.systemPackages = [ cfg.package ];
 
     security.pam.services.sudo = { sshAgentAuth = true; usshAuth = true; };
 


### PR DESCRIPTION
## Description of changes

Fix buggy handling of `security.sudo.package`, where the specified package would be used for
the suid wrappers (`sudo` and `sudoedit`) but not for `systemPackages`, causing pkgs' `sudo`
to be used instead for many executables (incl. `visudo`), the manpages, etc.

This bug has been present since the introduction of that option in d2dc0ae2033d1655a2011fc932bca5cd9c7bfe5b (Oct 2020)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - NixOS test `sudo`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
