### PR TITLE
rojo: 7.2.1 -> 7.4.0

### DIFF
--- a/pkgs/development/tools/rojo/default.nix
+++ b/pkgs/development/tools/rojo/default.nix
@@ -12,17 +12,17 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "rojo";
-  version = "7.2.1";
+  version = "7.4.0";
 
   src = fetchFromGitHub {
     owner = "rojo-rbx";
     repo = "rojo";
     rev = "v${version}";
-    sha256 = "sha256-Kmq/lBwayYkFU4mbjExj7M9wpg59OkIiTc+2ZrwpuBc=";
+    sha256 = "sha256-Eh1G0jX9KXVlMZLl8whxULywadblWml232qvcq4JLJ4=";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "sha256-qx6Ja0DMe4cEmDSpovtY9T3+0nJS9XivR92K3UKgacE=";
+  cargoSha256 = "sha256-aKfgylY9aspL1JpdYa6hOy/6lQoqO54OhZWqSlMPZ8o=";
 
   nativeBuildInputs = [
     pkg-config
@@ -33,6 +33,9 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     CoreServices
   ];
+
+  # reqwest's native-tls-vendored feature flag uses vendored openssl. this disables that
+  OPENSSL_NO_VENDOR = "1";
 
   # tests flaky on darwin on hydra
   doCheck = !stdenv.isDarwin;

--- a/pkgs/development/tools/rojo/default.nix
+++ b/pkgs/development/tools/rojo/default.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  inherit (darwin.apple_sdk.frameworks) CoreServices;
+  inherit (darwin.apple_sdk.frameworks) CoreServices SystemConfiguration;
 in
 rustPlatform.buildRustPackage rec {
   pname = "rojo";
@@ -32,6 +32,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ] ++ lib.optionals stdenv.isDarwin [
     CoreServices
+    SystemConfiguration
   ];
 
   # reqwest's native-tls-vendored feature flag uses vendored openssl. this disables that


### PR DESCRIPTION
## Description of changes

[Changelog](https://github.com/rojo-rbx/rojo/releases)

I enabled the `OPENSSL_NO_VENDOR` environment variable so that reqwest builds without vendoring OpenSSL.

~~I will keep this PR a draft until 7.4.0 releases (it is currently in the release candidate stage).~~

Edit: 7.4.0 has released and the PR is ready.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
