### PR TITLE
nixos/sudo{,-rs}: De-duplicate common code

### DIFF
--- a/nixos/lib/sudo-common.nix
+++ b/nixos/lib/sudo-common.nix
@@ -1,0 +1,249 @@
+{ lib
+, pkgs
+, config
+, defaultOptions ? []
+, pname
+, ... }:
+
+with lib;
+let
+  cfg = config.security.${pname};
+
+  toUserString = user: if (isInt user) then "#${toString user}" else "${user}";
+  toGroupString = group: if (isInt group) then "%#${toString group}" else "%${group}";
+
+  toCommandOptionsString = options:
+    "${concatStringsSep ":" options}${optionalString (length options != 0) ":"} ";
+
+  toCommandsString = commands:
+    concatStringsSep ", " (
+      map (command:
+        if (isString command) then
+          command
+        else
+          "${toCommandOptionsString command.options}${command.command}"
+      ) commands
+    );
+in
+{
+  options = {
+    package = mkPackageOption pkgs pname { };
+
+    defaultOptions = mkOption {
+      type = with types; listOf str;
+      default = defaultOptions;
+      description = mdDoc ''
+        Options used for the default rules, granting `root` and the
+        `wheel` group permission to run any command as any user.
+      '';
+    };
+
+    wheelNeedsPassword = mkOption {
+      type = types.bool;
+      default = true;
+      description = mdDoc ''
+        Whether users of the `wheel` group must
+        provide a password to run commands as super user via {command}`sudo`.
+      '';
+      };
+
+    execWheelOnly = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Only allow members of the `wheel` group to execute sudo by
+        setting the executable's permissions accordingly.
+        This prevents users that are not members of `wheel` from
+        exploiting vulnerabilities in sudo such as CVE-2021-3156.
+      '';
+    };
+
+    configFile = mkOption {
+      type = types.lines;
+      # Note: if syntax errors are detected in this file, the NixOS
+      # configuration will fail to build.
+      description = mdDoc ''
+        This string contains the contents of the
+        {file}`sudoers` file.
+      '';
+    };
+
+    extraRules = mkOption {
+      description = mdDoc ''
+        Define specific rules to be in the {file}`sudoers` file.
+        More specific rules should come after more general ones in order to
+        yield the expected behavior. You can use mkBefore/mkAfter to ensure
+        this is the case when configuration options are merged.
+      '';
+      default = [];
+      example = literalExpression ''
+        [
+          # Allow execution of any command by all users in group sudo,
+          # requiring a password.
+          { groups = [ "sudo" ]; commands = [ "ALL" ]; }
+
+          # Allow execution of "/home/root/secret.sh" by user `backup`, `database`
+          # and the group with GID `1006` without a password.
+          { users = [ "backup" "database" ]; groups = [ 1006 ];
+            commands = [ { command = "/home/root/secret.sh"; options = [ "SETENV" "NOPASSWD" ]; } ]; }
+
+          # Allow all users of group `bar` to run two executables as user `foo`
+          # with arguments being pre-set.
+          { groups = [ "bar" ]; runAs = "foo";
+            commands =
+              [ "/home/baz/cmd1.sh hello-sudo"
+                  { command = '''/home/baz/cmd2.sh ""'''; options = [ "SETENV" ]; } ]; }
+        ]
+      '';
+      type = with types; listOf (submodule {
+        options = {
+          users = mkOption {
+            type = with types; listOf (either str int);
+            description = mdDoc ''
+              The usernames / UIDs this rule should apply for.
+            '';
+            default = [];
+          };
+
+          groups = mkOption {
+            type = with types; listOf (either str int);
+            description = mdDoc ''
+              The groups / GIDs this rule should apply for.
+            '';
+            default = [];
+          };
+
+          host = mkOption {
+            type = types.str;
+            default = "ALL";
+            description = mdDoc ''
+              For what host this rule should apply.
+            '';
+          };
+
+          runAs = mkOption {
+            type = with types; str;
+            default = "ALL:ALL";
+            description = mdDoc ''
+              Under which user/group the specified command is allowed to run.
+
+              A user can be specified using just the username: `"foo"`.
+              It is also possible to specify a user/group combination using `"foo:bar"`
+              or to only allow running as a specific group with `":bar"`.
+            '';
+          };
+
+          commands = mkOption {
+            description = mdDoc ''
+              The commands for which the rule should apply.
+            '';
+            type = with types; listOf (either str (submodule {
+
+              options = {
+                command = mkOption {
+                  type = with types; str;
+                  description = mdDoc ''
+                    A command being either just a path to a binary to allow any arguments,
+                    the full command with arguments pre-set or with `""` used as the argument,
+                    not allowing arguments to the command at all.
+                  '';
+                };
+
+                options = mkOption {
+                  type = with types; listOf (enum [ "NOPASSWD" "PASSWD" "NOEXEC" "EXEC" "SETENV" "NOSETENV" "LOG_INPUT" "NOLOG_INPUT" "LOG_OUTPUT" "NOLOG_OUTPUT" ]);
+                  description = mdDoc ''
+                    Options for running the command. Refer to the [sudo manual](https://www.sudo.ws/man/1.7.10/sudoers.man.html).
+                  '';
+                  default = [];
+                };
+              };
+
+            }));
+          };
+        };
+      });
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = mdDoc ''
+        Extra configuration text appended to {file}`sudoers`.
+      '';
+    };
+  };
+
+  config = {
+    environment.systemPackages = [ cfg.package ];
+    environment.etc.sudoers =
+      { source =
+          pkgs.runCommand "sudoers"
+          {
+            src = pkgs.writeText "sudoers-in" cfg.configFile;
+            preferLocalBuild = true;
+          }
+          # Make sure that the sudoers file is syntactically valid.
+          "${pkgs.buildPackages.${pname}}/bin/visudo -f $src -c && cp $src $out";
+        mode = "0440";
+      };
+
+    security.${pname} = {
+      extraRules =
+        let
+          defaultRule = { users ? [], groups ? [], opts ? [] }: [ {
+            inherit users groups;
+            commands = [ {
+              command = "ALL";
+              options = opts ++ cfg.defaultOptions;
+            } ];
+          } ];
+        in mkMerge [
+          # This is ordered before users' `mkBefore` rules,
+          # so as not to introduce unexpected changes.
+          (mkOrder 400 (defaultRule { users = [ "root" ]; }))
+
+          # This is ordered to show before (most) other rules, but
+          # late-enough for a user to `mkBefore` it.
+          (mkOrder 600 (defaultRule {
+            groups = [ "wheel" ];
+            opts = (optional (!cfg.wheelNeedsPassword) "NOPASSWD");
+          }))
+        ];
+
+      configFile = concatStringsSep "\n" (filter (s: s != "") [
+        ''
+          # Don't edit this file. Set the NixOS options ‘security.${pname}.configFile’
+          # or ‘security.${pname}.extraRules’ instead.
+        ''
+        (pipe cfg.extraRules [
+          (filter (rule: length rule.commands != 0))
+          (map (rule: [
+            (map (user: "${toUserString user}     ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.users)
+            (map (group: "${toGroupString group}  ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.groups)
+          ]))
+          flatten
+          (concatStringsSep "\n")
+        ])
+        "\n"
+        (optionalString (cfg.extraConfig != "") ''
+          # extraConfig
+          ${cfg.extraConfig}
+        '')
+      ]);
+    };
+
+    security.pam.services.sudo = { sshAgentAuth = true; usshAuth = true; };
+
+    security.wrappers = let
+      owner = "root";
+      group = if cfg.execWheelOnly then "wheel" else "root";
+      setuid = true;
+      permissions = if cfg.execWheelOnly then "u+rx,g+x" else "u+rx,g+x,o+x";
+    in {
+      sudo = {
+        source = "${cfg.package.out}/bin/sudo";
+        inherit owner group setuid permissions;
+      };
+    };
+  };
+}

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -3,267 +3,31 @@
 with lib;
 
 let
-
   cfg = config.security.sudo-rs;
-
-  toUserString = user: if (isInt user) then "#${toString user}" else "${user}";
-  toGroupString = group: if (isInt group) then "%#${toString group}" else "%${group}";
-
-  toCommandOptionsString = options:
-    "${concatStringsSep ":" options}${optionalString (length options != 0) ":"} ";
-
-  toCommandsString = commands:
-    concatStringsSep ", " (
-      map (command:
-        if (isString command) then
-          command
-        else
-          "${toCommandOptionsString command.options}${command.command}"
-      ) commands
-    );
-
+  common = import ../../lib/sudo-common.nix {
+    inherit config lib pkgs;
+    pname = "sudo-rs";
+  };
 in
-
 {
-
-  ###### interface
-
-  options.security.sudo-rs = {
-
-    defaultOptions = mkOption {
-      type = with types; listOf str;
-      default = [];
-      description = mdDoc ''
-        Options used for the default rules, granting `root` and the
-        `wheel` group permission to run any command as any user.
-      '';
-    };
-
+  options.security.sudo-rs = attrsets.unionOfDisjoint common.options {
     enable = mkEnableOption (mdDoc ''
       a memory-safe implementation of the {command}`sudo` command,
       which allows non-root users to execute commands as root.
     '');
-
-    package = mkPackageOption pkgs "sudo-rs" { };
-
-    wheelNeedsPassword = mkOption {
-      type = types.bool;
-      default = true;
-      description = mdDoc ''
-        Whether users of the `wheel` group must
-        provide a password to run commands as super user via {command}`sudo`.
-      '';
-      };
-
-    execWheelOnly = mkOption {
-      type = types.bool;
-      default = false;
-      description = mdDoc ''
-        Only allow members of the `wheel` group to execute sudo by
-        setting the executable's permissions accordingly.
-        This prevents users that are not members of `wheel` from
-        exploiting vulnerabilities in sudo such as CVE-2021-3156.
-      '';
-    };
-
-    configFile = mkOption {
-      type = types.lines;
-      # Note: if syntax errors are detected in this file, the NixOS
-      # configuration will fail to build.
-      description = mdDoc ''
-        This string contains the contents of the
-        {file}`sudoers` file.
-      '';
-    };
-
-    extraRules = mkOption {
-      description = mdDoc ''
-        Define specific rules to be in the {file}`sudoers` file.
-        More specific rules should come after more general ones in order to
-        yield the expected behavior. You can use mkBefore/mkAfter to ensure
-        this is the case when configuration options are merged.
-      '';
-      default = [];
-      example = literalExpression ''
-        [
-          # Allow execution of any command by all users in group sudo,
-          # requiring a password.
-          { groups = [ "sudo" ]; commands = [ "ALL" ]; }
-
-          # Allow execution of "/home/root/secret.sh" by user `backup`, `database`
-          # and the group with GID `1006` without a password.
-          { users = [ "backup" "database" ]; groups = [ 1006 ];
-            commands = [ { command = "/home/root/secret.sh"; options = [ "SETENV" "NOPASSWD" ]; } ]; }
-
-          # Allow all users of group `bar` to run two executables as user `foo`
-          # with arguments being pre-set.
-          { groups = [ "bar" ]; runAs = "foo";
-            commands =
-              [ "/home/baz/cmd1.sh hello-sudo"
-                  { command = '''/home/baz/cmd2.sh ""'''; options = [ "SETENV" ]; } ]; }
-        ]
-      '';
-      type = with types; listOf (submodule {
-        options = {
-          users = mkOption {
-            type = with types; listOf (either str int);
-            description = mdDoc ''
-              The usernames / UIDs this rule should apply for.
-            '';
-            default = [];
-          };
-
-          groups = mkOption {
-            type = with types; listOf (either str int);
-            description = mdDoc ''
-              The groups / GIDs this rule should apply for.
-            '';
-            default = [];
-          };
-
-          host = mkOption {
-            type = types.str;
-            default = "ALL";
-            description = mdDoc ''
-              For what host this rule should apply.
-            '';
-          };
-
-          runAs = mkOption {
-            type = with types; str;
-            default = "ALL:ALL";
-            description = mdDoc ''
-              Under which user/group the specified command is allowed to run.
-
-              A user can be specified using just the username: `"foo"`.
-              It is also possible to specify a user/group combination using `"foo:bar"`
-              or to only allow running as a specific group with `":bar"`.
-            '';
-          };
-
-          commands = mkOption {
-            description = mdDoc ''
-              The commands for which the rule should apply.
-            '';
-            type = with types; listOf (either str (submodule {
-
-              options = {
-                command = mkOption {
-                  type = with types; str;
-                  description = mdDoc ''
-                    A command being either just a path to a binary to allow any arguments,
-                    the full command with arguments pre-set or with `""` used as the argument,
-                    not allowing arguments to the command at all.
-                  '';
-                };
-
-                options = mkOption {
-                  type = with types; listOf (enum [ "NOPASSWD" "PASSWD" "NOEXEC" "EXEC" "SETENV" "NOSETENV" "LOG_INPUT" "NOLOG_INPUT" "LOG_OUTPUT" "NOLOG_OUTPUT" ]);
-                  description = mdDoc ''
-                    Options for running the command. Refer to the [sudo manual](https://www.sudo.ws/man/1.7.10/sudoers.man.html).
-                  '';
-                  default = [];
-                };
-              };
-
-            }));
-          };
-        };
-      });
-    };
-
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
-      description = mdDoc ''
-        Extra configuration text appended to {file}`sudoers`.
-      '';
-    };
   };
 
-
-  ###### implementation
-
-  config = mkIf cfg.enable {
-    assertions = [ {
-      assertion = ! config.security.sudo.enable;
-      message = "`security.sudo` and `security.sudo-rs` cannot both be enabled";
-    }];
-    security.sudo.enable = mkDefault false;
-
-    security.sudo-rs.extraRules =
-      let
-        defaultRule = { users ? [], groups ? [], opts ? [] }: [ {
-          inherit users groups;
-          commands = [ {
-            command = "ALL";
-            options = opts ++ cfg.defaultOptions;
-          } ];
-        } ];
-      in mkMerge [
-        # This is ordered before users' `mkBefore` rules,
-        # so as not to introduce unexpected changes.
-        (mkOrder 400 (defaultRule { users = [ "root" ]; }))
-
-        # This is ordered to show before (most) other rules, but
-        # late-enough for a user to `mkBefore` it.
-        (mkOrder 600 (defaultRule {
-          groups = [ "wheel" ];
-          opts = (optional (!cfg.wheelNeedsPassword) "NOPASSWD");
-        }))
-      ];
-
-    security.sudo-rs.configFile = concatStringsSep "\n" (filter (s: s != "") [
-      ''
-        # Don't edit this file. Set the NixOS options ‘security.sudo-rs.configFile’
-        # or ‘security.sudo-rs.extraRules’ instead.
-      ''
-      (pipe cfg.extraRules [
-        (filter (rule: length rule.commands != 0))
-        (map (rule: [
-          (map (user: "${toUserString user}     ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.users)
-          (map (group: "${toGroupString group}  ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.groups)
-        ]))
-        flatten
-        (concatStringsSep "\n")
-      ])
-      "\n"
-      (optionalString (cfg.extraConfig != "") ''
-        # extraConfig
-        ${cfg.extraConfig}
-      '')
-    ]);
-
-    security.wrappers = let
-      owner = "root";
-      group = if cfg.execWheelOnly then "wheel" else "root";
-      setuid = true;
-      permissions = if cfg.execWheelOnly then "u+rx,g+x" else "u+rx,g+x,o+x";
-    in {
-      sudo = {
-        source = "${cfg.package.out}/bin/sudo";
-        inherit owner group setuid permissions;
-      };
-    };
-
-    environment.systemPackages = [ cfg.package ];
-
-    security.pam.services.sudo = { sshAgentAuth = true; usshAuth = true; };
-    security.pam.services.sudo-i = { sshAgentAuth = true; usshAuth = true; };
-
-    environment.etc.sudoers =
-      { source =
-          pkgs.runCommand "sudoers"
-          {
-            src = pkgs.writeText "sudoers-in" cfg.configFile;
-            preferLocalBuild = true;
-          }
-          "${pkgs.buildPackages.sudo-rs}/bin/visudo -f $src -c && cp $src $out";
-        mode = "0440";
-      };
-
-  };
+  config = mkIf cfg.enable (mkMerge [
+    common.config
+    {
+      assertions = [ {
+        assertion = ! config.security.sudo.enable;
+        message = "`security.sudo` and `security.sudo-rs` cannot both be enabled";
+      }];
+      security.sudo.enable = mkDefault false;
+      security.pam.services.sudo-i = { sshAgentAuth = true; usshAuth = true; };
+    }
+  ]);
 
   meta.maintainers = [ lib.maintainers.nicoo ];
-
 }

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -3,44 +3,15 @@
 with lib;
 
 let
-
   cfg = config.security.sudo;
-
-  inherit (config.security.pam) enableSSHAgentAuth;
-
-  toUserString = user: if (isInt user) then "#${toString user}" else "${user}";
-  toGroupString = group: if (isInt group) then "%#${toString group}" else "%${group}";
-
-  toCommandOptionsString = options:
-    "${concatStringsSep ":" options}${optionalString (length options != 0) ":"} ";
-
-  toCommandsString = commands:
-    concatStringsSep ", " (
-      map (command:
-        if (isString command) then
-          command
-        else
-          "${toCommandOptionsString command.options}${command.command}"
-      ) commands
-    );
-
+  common = import ../../lib/sudo-common.nix {
+    inherit config lib pkgs;
+    defaultOptions = [ "SETENV" ];
+    pname = "sudo";
+  };
 in
-
 {
-
-  ###### interface
-
-  options.security.sudo = {
-
-    defaultOptions = mkOption {
-      type = with types; listOf str;
-      default = [ "SETENV" ];
-      description = mdDoc ''
-        Options used for the default rules, granting `root` and the
-        `wheel` group permission to run any command as any user.
-      '';
-    };
-
+  options.security.sudo = attrsets.unionOfDisjoint common.options {
     enable = mkOption {
       type = types.bool;
       default = true;
@@ -50,231 +21,29 @@ in
           allows non-root users to execute commands as root.
         '';
     };
+  };
 
-    package = mkPackageOption pkgs "sudo" { };
+  config = mkIf cfg.enable (mkMerge [
+    common.config
+    {
+      assertions = [ {
+        assertion = cfg.package.pname != "sudo-rs";
+        message = ''
+          NixOS' `sudo` module does not support `sudo-rs`; see `security.sudo-rs` instead.
+        '';
+      } ];
 
-    wheelNeedsPassword = mkOption {
-      type = types.bool;
-      default = true;
-      description = mdDoc ''
-        Whether users of the `wheel` group must
-        provide a password to run commands as super user via {command}`sudo`.
-      '';
-      };
-
-    execWheelOnly = mkOption {
-      type = types.bool;
-      default = false;
-      description = mdDoc ''
-        Only allow members of the `wheel` group to execute sudo by
-        setting the executable's permissions accordingly.
-        This prevents users that are not members of `wheel` from
-        exploiting vulnerabilities in sudo such as CVE-2021-3156.
-      '';
-    };
-
-    configFile = mkOption {
-      type = types.lines;
-      # Note: if syntax errors are detected in this file, the NixOS
-      # configuration will fail to build.
-      description = mdDoc ''
-        This string contains the contents of the
-        {file}`sudoers` file.
-      '';
-    };
-
-    extraRules = mkOption {
-      description = mdDoc ''
-        Define specific rules to be in the {file}`sudoers` file.
-        More specific rules should come after more general ones in order to
-        yield the expected behavior. You can use mkBefore/mkAfter to ensure
-        this is the case when configuration options are merged.
-      '';
-      default = [];
-      example = literalExpression ''
-        [
-          # Allow execution of any command by all users in group sudo,
-          # requiring a password.
-          { groups = [ "sudo" ]; commands = [ "ALL" ]; }
-
-          # Allow execution of "/home/root/secret.sh" by user `backup`, `database`
-          # and the group with GID `1006` without a password.
-          { users = [ "backup" "database" ]; groups = [ 1006 ];
-            commands = [ { command = "/home/root/secret.sh"; options = [ "SETENV" "NOPASSWD" ]; } ]; }
-
-          # Allow all users of group `bar` to run two executables as user `foo`
-          # with arguments being pre-set.
-          { groups = [ "bar" ]; runAs = "foo";
-            commands =
-              [ "/home/baz/cmd1.sh hello-sudo"
-                  { command = '''/home/baz/cmd2.sh ""'''; options = [ "SETENV" ]; } ]; }
-        ]
-      '';
-      type = with types; listOf (submodule {
-        options = {
-          users = mkOption {
-            type = with types; listOf (either str int);
-            description = mdDoc ''
-              The usernames / UIDs this rule should apply for.
-            '';
-            default = [];
-          };
-
-          groups = mkOption {
-            type = with types; listOf (either str int);
-            description = mdDoc ''
-              The groups / GIDs this rule should apply for.
-            '';
-            default = [];
-          };
-
-          host = mkOption {
-            type = types.str;
-            default = "ALL";
-            description = mdDoc ''
-              For what host this rule should apply.
-            '';
-          };
-
-          runAs = mkOption {
-            type = with types; str;
-            default = "ALL:ALL";
-            description = mdDoc ''
-              Under which user/group the specified command is allowed to run.
-
-              A user can be specified using just the username: `"foo"`.
-              It is also possible to specify a user/group combination using `"foo:bar"`
-              or to only allow running as a specific group with `":bar"`.
-            '';
-          };
-
-          commands = mkOption {
-            description = mdDoc ''
-              The commands for which the rule should apply.
-            '';
-            type = with types; listOf (either str (submodule {
-
-              options = {
-                command = mkOption {
-                  type = with types; str;
-                  description = mdDoc ''
-                    A command being either just a path to a binary to allow any arguments,
-                    the full command with arguments pre-set or with `""` used as the argument,
-                    not allowing arguments to the command at all.
-                  '';
-                };
-
-                options = mkOption {
-                  type = with types; listOf (enum [ "NOPASSWD" "PASSWD" "NOEXEC" "EXEC" "SETENV" "NOSETENV" "LOG_INPUT" "NOLOG_INPUT" "LOG_OUTPUT" "NOLOG_OUTPUT" ]);
-                  description = mdDoc ''
-                    Options for running the command. Refer to the [sudo manual](https://www.sudo.ws/man/1.7.10/sudoers.man.html).
-                  '';
-                  default = [];
-                };
-              };
-
-            }));
-          };
+      security.wrappers = let
+        owner = "root";
+        group = if cfg.execWheelOnly then "wheel" else "root";
+        setuid = true;
+        permissions = if cfg.execWheelOnly then "u+rx,g+x" else "u+rx,g+x,o+x";
+      in {
+        sudoedit = {
+          source = "${cfg.package.out}/bin/sudoedit";
+          inherit owner group setuid permissions;
         };
-      });
-    };
-
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
-      description = mdDoc ''
-        Extra configuration text appended to {file}`sudoers`.
-      '';
-    };
-  };
-
-
-  ###### implementation
-
-  config = mkIf cfg.enable {
-    assertions = [ {
-      assertion = cfg.package.pname != "sudo-rs";
-      message = ''
-        NixOS' `sudo` module does not support `sudo-rs`; see `security.sudo-rs` instead.
-      '';
-    } ];
-
-    security.sudo.extraRules =
-      let
-        defaultRule = { users ? [], groups ? [], opts ? [] }: [ {
-          inherit users groups;
-          commands = [ {
-            command = "ALL";
-            options = opts ++ cfg.defaultOptions;
-          } ];
-        } ];
-      in mkMerge [
-        # This is ordered before users' `mkBefore` rules,
-        # so as not to introduce unexpected changes.
-        (mkOrder 400 (defaultRule { users = [ "root" ]; }))
-
-        # This is ordered to show before (most) other rules, but
-        # late-enough for a user to `mkBefore` it.
-        (mkOrder 600 (defaultRule {
-          groups = [ "wheel" ];
-          opts = (optional (!cfg.wheelNeedsPassword) "NOPASSWD");
-        }))
-      ];
-
-    security.sudo.configFile = concatStringsSep "\n" (filter (s: s != "") [
-      ''
-        # Don't edit this file. Set the NixOS options ‘security.sudo.configFile’
-        # or ‘security.sudo.extraRules’ instead.
-      ''
-      (pipe cfg.extraRules [
-        (filter (rule: length rule.commands != 0))
-        (map (rule: [
-          (map (user: "${toUserString user}     ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.users)
-          (map (group: "${toGroupString group}  ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.groups)
-        ]))
-        flatten
-        (concatStringsSep "\n")
-      ])
-      "\n"
-      (optionalString (cfg.extraConfig != "") ''
-        # extraConfig
-        ${cfg.extraConfig}
-      '')
-    ]);
-
-    security.wrappers = let
-      owner = "root";
-      group = if cfg.execWheelOnly then "wheel" else "root";
-      setuid = true;
-      permissions = if cfg.execWheelOnly then "u+rx,g+x" else "u+rx,g+x,o+x";
-    in {
-      sudo = {
-        source = "${cfg.package.out}/bin/sudo";
-        inherit owner group setuid permissions;
       };
-      sudoedit = {
-        source = "${cfg.package.out}/bin/sudoedit";
-        inherit owner group setuid permissions;
-      };
-    };
-
-    environment.systemPackages = [ cfg.package ];
-
-    security.pam.services.sudo = { sshAgentAuth = true; usshAuth = true; };
-
-    environment.etc.sudoers =
-      { source =
-          pkgs.runCommand "sudoers"
-          {
-            src = pkgs.writeText "sudoers-in" cfg.configFile;
-            preferLocalBuild = true;
-          }
-          # Make sure that the sudoers file is syntactically valid.
-          # (currently disabled - NIXOS-66)
-          "${pkgs.buildPackages.sudo}/sbin/visudo -f $src -c && cp $src $out";
-        mode = "0440";
-      };
-
-  };
-
+    }
+  ]);
 }


### PR DESCRIPTION
## Description of changes

Move option definitions and configuration shared by the `sudo` and `sudo-rs` modules
into a `nixos/lib/sudo-common.nix`.

This is a follow-up on #262790, #263471, and #263475, which includes their history.
It should only move out of draft status once those are merged.

Fixes #267054

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
