### PR TITLE
libretro.mame2015 & libretro.mame2016: fix build

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -582,6 +582,7 @@ in
 
   mame2016 = mkLibretroCore {
     core = "mame2016";
+    patches = [ ./patches/mame2016-python311.patch ];
     extraNativeBuildInputs = [ python3 ];
     extraBuildInputs = [ alsa-lib ];
     makeFlags = [ "PYTHON_EXECUTABLE=python3" ];

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -568,6 +568,7 @@ in
 
   mame2015 = mkLibretroCore {
     core = "mame2015";
+    patches = [ ./patches/mame2015-python311.patch ];
     makeFlags = [ "PYTHON=python3" ];
     extraNativeBuildInputs = [ python3 ];
     extraBuildInputs = [ alsa-lib ];

--- a/pkgs/applications/emulators/retroarch/patches/mame2015-python311.patch
+++ b/pkgs/applications/emulators/retroarch/patches/mame2015-python311.patch
@@ -1,0 +1,61 @@
+diff --git a/src/emu/cpu/m6502/m6502make.py b/src/emu/cpu/m6502/m6502make.py
+index da29fc722a..3de641dd69 100755
+--- a/src/emu/cpu/m6502/m6502make.py
++++ b/src/emu/cpu/m6502/m6502make.py
+@@ -16,7 +16,7 @@ def load_opcodes(fname):
+     opcodes = []
+     logging.info("load_opcodes: %s", fname)
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read opcodes file %s [%s]", fname, err)
+@@ -39,7 +39,7 @@ def load_disp(fname):
+     logging.info("load_disp: %s", fname)
+     states = []
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read display file %s [%s]", fname, err)
+diff --git a/src/emu/cpu/m6809/m6809make.py b/src/emu/cpu/m6809/m6809make.py
+index c3d5b0f66e..79f6f90cdd 100644
+--- a/src/emu/cpu/m6809/m6809make.py
++++ b/src/emu/cpu/m6809/m6809make.py
+@@ -14,7 +14,7 @@ def load_file(fname, lines):
+ 	if path != "":
+ 		path += '/'
+ 	try:
+-		f = open(fname, "rU")
++		f = open(fname, "r")
+ 	except Exception:
+ 		err = sys.exc_info()[1]
+ 		sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/emu/cpu/mcs96/mcs96make.py b/src/emu/cpu/mcs96/mcs96make.py
+index ec5ec37a78..7ab806a653 100644
+--- a/src/emu/cpu/mcs96/mcs96make.py
++++ b/src/emu/cpu/mcs96/mcs96make.py
+@@ -71,7 +71,7 @@ def __init__(self, fname, is_196):
+         self.ea = {}
+         self.macros = {}
+         try:
+-            f = open(fname, "rU")
++            f = open(fname, "r")
+         except Exception:
+             err = sys.exc_info()[1]
+             sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/emu/cpu/tms57002/tmsmake.py b/src/emu/cpu/tms57002/tmsmake.py
+index 62092097d9..78f9fe43cd 100755
+--- a/src/emu/cpu/tms57002/tmsmake.py
++++ b/src/emu/cpu/tms57002/tmsmake.py
+@@ -326,7 +326,7 @@ def ins_cmp_dasm(a, b):
+ def LoadLst(filename):
+     instructions = []
+     ins = None
+-    for n, line in enumerate(open(filename, "rU")):
++    for n, line in enumerate(open(filename, "r")):
+         line = line.rstrip()
+         if not line and ins:
+             # new lines separate intructions

--- a/pkgs/applications/emulators/retroarch/patches/mame2016-python311.patch
+++ b/pkgs/applications/emulators/retroarch/patches/mame2016-python311.patch
@@ -1,0 +1,74 @@
+diff --git a/scripts/build/verinfo.py b/scripts/build/verinfo.py
+index a73d8ad268..82a80c0984 100644
+--- a/scripts/build/verinfo.py
++++ b/scripts/build/verinfo.py
+@@ -63,7 +63,7 @@ def extract_version(input):
+ build, outfmt, srcfile, dstfile = parse_args()
+ 
+ try:
+-    fp = open(srcfile, 'rU')
++    fp = open(srcfile, 'r')
+ except IOError:
+     sys.stderr.write("Unable to open source file '%s'\n" % srcfile)
+     sys.exit(1)
+diff --git a/src/devices/cpu/m6502/m6502make.py b/src/devices/cpu/m6502/m6502make.py
+index 8bcd85f8e2..557b175966 100755
+--- a/src/devices/cpu/m6502/m6502make.py
++++ b/src/devices/cpu/m6502/m6502make.py
+@@ -18,7 +18,7 @@ def load_opcodes(fname):
+     opcodes = []
+     logging.info("load_opcodes: %s", fname)
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read opcodes file %s [%s]", fname, err)
+@@ -41,7 +41,7 @@ def load_disp(fname):
+     logging.info("load_disp: %s", fname)
+     states = []
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read display file %s [%s]", fname, err)
+diff --git a/src/devices/cpu/m6809/m6809make.py b/src/devices/cpu/m6809/m6809make.py
+index 8838b96019..e1ea25db06 100644
+--- a/src/devices/cpu/m6809/m6809make.py
++++ b/src/devices/cpu/m6809/m6809make.py
+@@ -16,7 +16,7 @@ def load_file(fname, lines):
+ 	if path != "":
+ 		path += '/'
+ 	try:
+-		f = open(fname, "rU")
++		f = open(fname, "r")
+ 	except Exception:
+ 		err = sys.exc_info()[1]
+ 		sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/devices/cpu/mcs96/mcs96make.py b/src/devices/cpu/mcs96/mcs96make.py
+index b4844942e3..207208d2b6 100644
+--- a/src/devices/cpu/mcs96/mcs96make.py
++++ b/src/devices/cpu/mcs96/mcs96make.py
+@@ -73,7 +73,7 @@ def __init__(self, fname, is_196):
+         self.ea = {}
+         self.macros = {}
+         try:
+-            f = open(fname, "rU")
++            f = open(fname, "r")
+         except Exception:
+             err = sys.exc_info()[1]
+             sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/devices/cpu/tms57002/tmsmake.py b/src/devices/cpu/tms57002/tmsmake.py
+index e2e12b5a4b..942ec09537 100755
+--- a/src/devices/cpu/tms57002/tmsmake.py
++++ b/src/devices/cpu/tms57002/tmsmake.py
+@@ -323,7 +323,7 @@ def AddInfo(self, line):
+ def LoadLst(filename):
+     instructions = []
+     ins = None
+-    for n, line in enumerate(open(filename, "rU")):
++    for n, line in enumerate(open(filename, "r")):
+         line = line.rstrip()
+         if not line and ins:
+             # new lines separate intructions


### PR DESCRIPTION
## Description of changes

Presumably broken since `python3 = python311`.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
