### PR TITLE
python311Packages.keyutils: fix build

### DIFF
--- a/pkgs/development/python-modules/keyutils/default.nix
+++ b/pkgs/development/python-modules/keyutils/default.nix
@@ -1,4 +1,10 @@
-{ lib, buildPythonPackage, fetchFromGitHub, keyutils, pytest-runner, pytest }:
+{ lib
+, buildPythonPackage
+, cython
+, fetchFromGitHub
+, keyutils
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "keyutils";
@@ -16,8 +22,19 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace '"pytest-runner"' ""
   '';
 
+  preBuild = ''
+    cython keyutils/_keyutils.pyx
+  '';
+
+  preCheck = ''
+    rm -rf keyutils
+  '';
+
   buildInputs = [ keyutils ];
-  nativeCheckInputs = [ pytest pytest-runner ];
+  nativeBuildInputs = [ cython ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = {
     description = "A set of python bindings for keyutils";


### PR DESCRIPTION
## Description of changes

This fixes the build for keyutils on Python 3.11 and higher.

It appears this package is affected by changes that were made to CPython that were causing code generated by certain earlier versions of Cython to fail.

This update simply re-generates the relevant code with the up-to-date Cython 0.29.x series during the pre-build phase, allowing the build to succeed.

Fixes #263482. fixes https://github.com/NixOS/nixpkgs/issues/263506

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
