### PR TITLE
bind: support service reload and config in /etc

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -277,6 +277,8 @@ in
         ExecStop = "${bindPkg.out}/sbin/rndc -k '/etc/bind/rndc.key' stop";
       };
 
+      restartTriggers = [ confFile ];
+
       unitConfig.Documentation = "man:named(8)";
     };
   };

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -252,13 +252,14 @@ in
       };
     users.groups.${bindUser} = {};
 
+    environment.etc."bind/named.conf".source = confFile;
+
     systemd.services.bind = {
       description = "BIND Domain Name Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        mkdir -m 0755 -p /etc/bind
         if ! [ -f "/etc/bind/rndc.key" ]; then
           ${bindPkg.out}/sbin/rndc-confgen -c /etc/bind/rndc.key -u ${bindUser} -a -A hmac-sha256 2>/dev/null
         fi
@@ -271,7 +272,7 @@ in
       '';
 
       serviceConfig = {
-        ExecStart = "${bindPkg.out}/sbin/named -u ${bindUser} ${optionalString cfg.ipv4Only "-4"} -c ${cfg.configFile} -f";
+        ExecStart = "${bindPkg.out}/sbin/named -u ${bindUser} ${optionalString cfg.ipv4Only "-4"} -c /etc/bind/named.conf -f";
         ExecReload = "${bindPkg.out}/sbin/rndc -k '/etc/bind/rndc.key' reload";
         ExecStop = "${bindPkg.out}/sbin/rndc -k '/etc/bind/rndc.key' stop";
       };

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -18,6 +18,10 @@ in
 {
   name = "bind";
 
+  meta = with lib.maintainers; {
+    maintainers = [ sarcasticadmin ];
+  };
+
   nodes.machine = { ... }: {
     services.bind.enable = true;
     services.bind.extraOptions = "empty-zones-enable no;";

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -1,28 +1,40 @@
-import ./make-test-python.nix {
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+let
+  zoneTmpl = addr: lib.singleton {
+    name = ".";
+    master = true;
+    file = pkgs.writeText "root.zone" ''
+      $TTL 3600
+      . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+      . IN NS ns.example.org.
+
+      ns.example.org. IN A    192.168.0.${addr}
+      ns.example.org. IN AAAA abcd::${addr}
+
+      ${addr}.0.168.192.in-addr.arpa IN PTR ns.example.org.
+    '';
+  };
+in
+{
   name = "bind";
 
-  nodes.machine = { pkgs, lib, ... }: {
+  nodes.machine = { ... }: {
     services.bind.enable = true;
     services.bind.extraOptions = "empty-zones-enable no;";
-    services.bind.zones = lib.singleton {
-      name = ".";
-      master = true;
-      file = pkgs.writeText "root.zone" ''
-        $TTL 3600
-        . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
-        . IN NS ns.example.org.
+    services.bind.zones = zoneTmpl "1";
 
-        ns.example.org. IN A    192.168.0.1
-        ns.example.org. IN AAAA abcd::1
-
-        1.0.168.192.in-addr.arpa IN PTR ns.example.org.
-      '';
+    specialisation.daemonReload.configuration = {
+      services.bind.zones = lib.mkForce (zoneTmpl "2");
     };
+
   };
 
-  testScript = ''
-    machine.wait_for_unit("bind.service")
-    machine.wait_for_open_port(53)
-    machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
-  '';
-}
+  testScript = { nodes, ... }:
+    ''
+      machine.wait_for_unit("bind.service")
+      machine.wait_for_open_port(53)
+      machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
+      machine.succeed("${nodes.machine.system.build.toplevel}/specialisation/daemonReload/bin/switch-to-configuration test >&2")
+      machine.succeed("host 192.168.0.2 127.0.0.1 | grep -qF ns.example.org")
+    '';
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Bind configuration symlinked from `/nix/store` to `/etc/bind/named.conf` for service unit file
- Bind daemon handles rebuilds correctly by reloading
- Added additional test logic for reload case
- And added myself as a maintainer of the `nixosTests.bind`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
