### PR TITLE
ocamlPackages.yuujinchou: 4.0.0 → 5.1.0; cooltt: 2022-04-28 → 2023-10-03

### DIFF
--- a/pkgs/development/ocaml-modules/cooltt/default.nix
+++ b/pkgs/development/ocaml-modules/cooltt/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , fetchurl
 , buildDunePackage
+, bos
 , bwd
 , cmdliner
 , containers
@@ -16,22 +17,21 @@
 , yuujinchou
 , ounit2
 , qcheck
+, qcheck-core
 }:
 
 let
   bantorra = buildDunePackage rec {
     pname = "bantorra";
-    version = "unstable-2022-04-20";
+    version = "unstable-2022-05-08";
     src = fetchFromGitHub {
       owner = "RedPRL";
       repo = "bantorra";
-      rev = "1e78633d9a2ef7104552a24585bb8bea36d4117b";
-      sha256 = "sha256:15v1cggm7awp11iwl3lzpaar91jzivhdxggp5mr48gd28kfipzk2";
+      rev = "d05c34295727dd06d0ac4416dc2e258732e8593d";
+      hash = "sha256-s6lUTs3VRl6YhLAn3PO4aniANhFp8ytoTsFAgcOlee4=";
     };
 
-    duneVersion = "3";
-
-    propagatedBuildInputs = [ ezjsonm findlib ];
+    propagatedBuildInputs = [ bos ezjsonm findlib ];
 
     meta = {
       description = "Extensible Library Management and Path Resolution";
@@ -41,19 +41,18 @@ let
   };
   kado = buildDunePackage rec {
     pname = "kado";
-    version = "unstable-2022-04-30";
+    version = "unstable-2023-10-03";
     src = fetchFromGitHub {
       owner = "RedPRL";
       repo = "kado";
-      rev = "8dce50e7d759d482b82565090e550d3860d64729";
-      sha256 = "sha256:1xb754fha4s0bgjfqjxzqljvalmkfdwdn5y4ycsp51wiah235bsy";
+      rev = "6b2e9ba2095e294e6e0fc6febc280d80c5799c2b";
+      hash = "sha256-fP6Ade3mJeyOMjuDIvrW88m6E3jfb2z3L8ufgloz4Tc=";
     };
-
-    duneVersion = "3";
 
     propagatedBuildInputs = [ bwd ];
 
     doCheck = true;
+    checkInputs = [ qcheck-core ];
 
     meta = {
       description = "Cofibrations in Cartecian Cubical Type Theory";
@@ -65,16 +64,15 @@ in
 
 buildDunePackage {
   pname = "cooltt";
-  version = "unstable-2022-04-28";
+  version = "unstable-2023-10-03";
 
-  minimalOCamlVersion = "4.13";
-  duneVersion = "3";
+  minimalOCamlVersion = "5.0";
 
   src = fetchFromGitHub {
     owner = "RedPRL";
     repo = "cooltt";
-    rev = "88511e10cb9e17286f585882dee334f3d8ace47c";
-    sha256 = "sha256:1n9bh86r2n9s3mm7ayfzwjbnjqcphpsf8yqnf4whd3yi930sqisw";
+    rev = "a5eaf4db195b5166a7102d47d42724f59cf3de19";
+    hash = "sha256-48bEf59rtPRrCRjab7+GxppjfR2c87HjQ+uKY2Bag0I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/yuujinchou/default.nix
+++ b/pkgs/development/ocaml-modules/yuujinchou/default.nix
@@ -4,8 +4,8 @@
 }:
 
 let params = if lib.versionAtLeast ocaml.version "5.0" then {
-    version = "4.0.0";
-    hash = "sha256-yNLN5bBe4aft9Rl5VHmlOYTlnCdR2NgDWsc3uJHaZy4=";
+    version = "5.1.0";
+    hash = "sha256-J3qkytgJkk2gT83KJ47nNM4cXqVHbx4iTPK+fLwR7Wk=";
     propagatedBuildInputs = [ algaeff bwd ];
   } else {
     version = "2.0.0";
@@ -18,7 +18,6 @@ buildDunePackage rec {
   inherit (params) version;
 
   minimalOCamlVersion = "4.12";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "RedPRL";


### PR DESCRIPTION
## Description of changes

Fix build with OCaml ≥ 5.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
