### PR TITLE
cups-brother-mfcl2710dw: init at 4.0.0-1

### DIFF
--- a/pkgs/misc/cups/drivers/mfcl2710dw/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2710dw/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, perl
+, gnused
+, ghostscript
+, file
+, coreutils
+, gnugrep
+, which
+}:
+
+let
+  arches = [ "x86_64" "i686" "armv7l" ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-mfcl2710dw";
+  version = "4.0.0-1";
+
+  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103526/mfcl2710dwpdrv-${version}.i386.deb";
+    hash = "sha256-OOTvbCuyxw4k01CTMuBqG2boMN13q5xC7LacaweGmyw=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # delete unnecessary files for the current architecture
+  '' + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/MFCL2710DW/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches) + ''
+
+      # bundled scripts don't understand the arch subdirectories for some reason
+      ln -s \
+        "$out/opt/brother/Printers/MFCL2710DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+        "$out/opt/brother/Printers/MFCL2710DW/lpd/"
+
+      # Fix global references and replace auto discovery mechanism with hardcoded values
+      substituteInPlace $out/opt/brother/Printers/MFCL2710DW/lpd/lpdfilter \
+        --replace /opt "$out/opt" \
+        --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/MFCL2710DW\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"MFCL2710DW\"; #"
+
+      # Make sure all executables have the necessary runtime dependencies available
+      find "$out" -executable -and -type f | while read file; do
+        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+      done
+
+      # Symlink filter and ppd into a location where CUPS will discover it
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+
+      ln -s \
+        $out/opt/brother/Printers/MFCL2710DW/lpd/lpdfilter \
+        $out/lib/cups/filter/brother_lpdwrapper_MFCL2710DW
+
+      ln -s \
+        $out/opt/brother/Printers/MFCL2710DW/cupswrapper/brother-MFCL2710DW-cups-en.ppd \
+        $out/share/cups/model/
+
+      # Cleanup empty folders
+      rm -rf $out/{etc,usr,var}
+
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother MFC-L2710DW printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = builtins.map (arch: "${arch}-linux") arches;
+    maintainers = [ maintainers.FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40452,6 +40452,8 @@ with pkgs;
 
   cups-brother-hll2350dw = callPackage  ../misc/cups/drivers/hll2350dw { };
 
+  cups-brother-mfcl2710dw = callPackage  ../misc/cups/drivers/mfcl2710dw { };
+
   cups-brother-mfcl2750dw = callPackage  ../misc/cups/drivers/mfcl2750dw { };
 
   cups-drv-rastertosag-gdi = callPackage ../misc/cups/drivers/cups-drv-rastertosag-gdi { };


### PR DESCRIPTION
## Description of changes

Adds driver for Brother MFC-L2710DW, based on the driver for the MFC-L2750DW.

I assume if we added the MFC-L2730DW as well the three drivers could be all spun into a shared builder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).