### PR TITLE
python3Packages.tblite: fix toml-f 0.4 compatibility

### DIFF
--- a/pkgs/development/libraries/science/chemistry/tblite/python.nix
+++ b/pkgs/development/libraries/science/chemistry/tblite/python.nix
@@ -1,4 +1,5 @@
 { buildPythonPackage
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -42,8 +43,17 @@ buildPythonPackage {
 
   propagatedBuildInputs = [ tblite simple-dftd3 cffi numpy ];
 
-  # Add multicharge to the meson deps; otherwise we get missing mod_multicharge errors
-  patches = [ ./0001-fix-multicharge-dep-needed-for-static-compilation.patch ];
+
+  patches = [
+    # Add multicharge to the meson deps; otherwise we get missing mod_multicharge errors
+    ./0001-fix-multicharge-dep-needed-for-static-compilation.patch
+
+    # Toml-f 0.4.0 compatibility https://github.com/tblite/tblite/pull/108
+    (fetchpatch {
+      url = "https://github.com/tblite/tblite/commit/e4255519b58a5198a5fa8f3073bef1c78a4bbdbe.diff";
+      hash = "sha256-BMwYsdWfK+vG3BFgzusLYfwo0WXrYSPxJoEJIyOvbPg=";
+    })
+  ];
 
   format = "other";
   pythonImportsCheck = [ "tblite" "tblite.interface" ];


### PR DESCRIPTION
## Description of changes

Closes #263541

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
