### PR TITLE
python311Packages.torchinfo: 1.64 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/torchinfo/default.nix
+++ b/pkgs/development/python-modules/torchinfo/default.nix
@@ -1,25 +1,37 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
+, fetchpatch
 , pythonOlder
 , torch
 , torchvision
+, pytestCheckHook
+, transformers
 }:
 
 buildPythonPackage rec {
   pname = "torchinfo";
-  version = "1.64";
+  version = "1.8.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "TylerYep";
-    repo = pname;
+    repo = "torchinfo";
     rev = "refs/tags/v${version}";
-    hash = "sha256-gcl8RxCD017FP4LtB60WVtOh7jg2Otv/vNd9hKneEAU=";
+    hash = "sha256-pPjg498aT8y4b4tqIzNxxKyobZX01u+66ScS/mee51Q=";
   };
+
+  patches = [
+    (fetchpatch {  # Add support for Python 3.11 and pytorch 2.1
+      url = "https://github.com/TylerYep/torchinfo/commit/c74784c71c84e62bcf56664653b7f28d72a2ee0d.patch";
+      hash = "sha256-xSSqs0tuFpdMXUsoVv4sZLCeVnkK6pDDhX/Eobvn5mw=";
+      includes = [
+        "torchinfo/model_statistics.py"
+      ];
+    })
+  ];
 
   propagatedBuildInputs = [
     torch
@@ -28,17 +40,23 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    transformers
   ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   disabledTests = [
     # Skip as it downloads pretrained weights (require network access)
     "test_eval_order_doesnt_matter"
+    "test_flan_t5_small"
     # AssertionError in output
     "test_google"
   ];
 
   disabledTestPaths = [
-    # Wants "compressai", which we don't package (2023-03-23)
+    # Test requires network access
     "tests/torchinfo_xl_test.py"
   ];
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/TylerYep/torchinfo/releases/tag/v1.8.0

cc @storvik 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
