### PR TITLE
python311Packages.compressai: init at 1.2.4

### DIFF
--- a/pkgs/development/python-modules/compressai/default.nix
+++ b/pkgs/development/python-modules/compressai/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pybind11
+, setuptools
+, wheel
+, numpy
+, matplotlib
+, pytorch-msssim
+, scipy
+, torch
+, torchvision
+, ipywidgets
+, jupyter
+, plotly
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "compressai";
+  version = "1.2.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "InterDigitalInc";
+    repo = "CompressAI";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-nT2vd7t67agIWobJalORbRuns0UJGRGGbTX2/8vbTiY=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pybind11
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    matplotlib
+    pytorch-msssim
+    scipy
+    torch
+    torchvision
+  ];
+
+  passthru.optional-dependencies = {
+    tutorials = [
+      ipywidgets
+      jupyter
+    ];
+  };
+
+  pythonImportsCheck = [
+    "compressai"
+    "compressai._CXX"
+  ];
+
+  preCheck = ''
+    # We have to delete the source because otherwise it is used intead the installed package.
+    rm -rf compressai
+
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    plotly
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Those tests require internet access to download some weights
+    "test_image_codec"
+    "test_update"
+    "test_eval_model_pretrained"
+    "test_cheng2020_anchor"
+    "test_pretrained"
+  ];
+
+  meta = with lib; {
+    description = "A PyTorch library and evaluation platform for end-to-end compression research";
+    homepage = "https://github.com/InterDigitalInc/CompressAI";
+    license = licenses.bsd3Clear;
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pytorch-msssim/default.nix
+++ b/pkgs/development/python-modules/pytorch-msssim/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "pytorch-msssim";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "VainF";
+    repo = "pytorch-msssim";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-bghglwQhgByC7BqbDvImSvt6edKF55NLYEPjqmmSFH8=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    torch
+  ];
+
+  pythonImportsCheck = [ "pytorch_msssim" ];
+
+  # This test doesn't have (automatic) tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Fast and differentiable MS-SSIM and SSIM for pytorch";
+    homepage = "https://github.com/VainF/pytorch-msssim";
+    license = licenses.mit;
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11642,6 +11642,8 @@ self: super: with self; {
 
   pytorch-metric-learning = callPackage ../development/python-modules/pytorch-metric-learning { };
 
+  pytorch-msssim = callPackage ../development/python-modules/pytorch-msssim { };
+
   pytorch-pfn-extras = callPackage ../development/python-modules/pytorch-pfn-extras { };
 
   pytraccar = callPackage ../development/python-modules/pytraccar { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2242,6 +2242,8 @@ self: super: with self; {
 
   compreffor = callPackage ../development/python-modules/compreffor { };
 
+  compressai = callPackage ../development/python-modules/compressai { };
+
   concurrent-log-handler = callPackage ../development/python-modules/concurrent-log-handler { };
 
   conda = callPackage ../development/python-modules/conda { };


### PR DESCRIPTION
## Description of changes

Add [compressai](https://github.com/InterDigitalInc/CompressAI), a PyTorch library and evaluation platform for end-to-end compression research.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
