### PR TITLE
fuse3: 3.11.0 -> 3.16.2

### DIFF
--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -11,7 +11,7 @@ in {
   };
 
   fuse_3 = mkFuse {
-    version = "3.11.0";
-    sha256Hash = "1wx80xxlvjn0wxhmkr1g91vwrgxssyzds1hizzxc2xrd4kjh9dfb";
+    version = "3.16.2";
+    sha256Hash = "sha256-QO9s+IkR0rkqIYNqt2IYST6AVBkCr56jcuuz5nKJuA4=";
   };
 }

--- a/pkgs/os-specific/linux/fuse/fuse3-Do-not-set-FUSERMOUNT_DIR.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-Do-not-set-FUSERMOUNT_DIR.patch
@@ -1,12 +1,14 @@
+diff --git a/lib/meson.build b/lib/meson.build
+index 9044630..3d4af3c 100644
 --- a/lib/meson.build
 +++ b/lib/meson.build
 @@ -37,8 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                    soversion: '3', include_directories: include_dirs,
                    dependencies: deps, install: true,
                    link_depends: 'fuse_versionscript',
--                  c_args: [ '-DFUSE_USE_VERSION=35',
+-                  c_args: [ '-DFUSE_USE_VERSION=312',
 -                            '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
-+                  c_args: [ '-DFUSE_USE_VERSION=35' ],
++                  c_args: [ '-DFUSE_USE_VERSION=312' ],
                    link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                                + '/fuse_versionscript' ])
  

--- a/pkgs/os-specific/linux/fuse/fuse3-install.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-install.patch
@@ -1,20 +1,24 @@
---- a/util/install_helper.sh	2019-07-10 12:00:15.984840142 +0200
-+++ b/util/install_helper.sh	2019-07-10 12:28:56.343011401 +0200
-@@ -37,10 +37,10 @@
- fi
+diff --git a/util/install_helper.sh b/util/install_helper.sh
+index 76f2b47..b45b110 100755
+--- a/util/install_helper.sh
++++ b/util/install_helper.sh
+@@ -39,12 +39,12 @@ fi
  
- install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
+ if [ "${udevrulesdir}" != "" ]; then
+     install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
 -        "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
 +        "${sysconfdir}${udevrulesdir}/99-fuse3.rules"
+ fi
  
- install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
--        "${DESTDIR}/etc/init.d/fuse3"
-+        "${sysconfdir}/init.d/fuse3"
+ if [ "$initscriptdir" != "" ]; then
+     install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
+-            "${DESTDIR}${initscriptdir}/fuse3"
++            "${sysconfdir}${initscriptdir}/fuse3"
  
- 
- if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
+     if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
+         /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true
 diff --git a/util/meson.build b/util/meson.build
-index aa0e734..06d4378 100644
+index 47aac14..50d5cca 100644
 --- a/util/meson.build
 +++ b/util/meson.build
 @@ -1,4 +1,4 @@


### PR DESCRIPTION
## Description of changes

Changes are plenty, due too some versions in between. Please find a small selection below.

3.16.2
- Various minor bugfixes and improvements.

3.16.1
- Readdir kernel cache can be enabled from high-level API.

3.15.0
- Unsupported mount options are no longer silently accepted.
- auto_unmount is now compatible with allow_other.

3.13.0
- A deadlock when resolving paths in the high-level API has been fixed.
- A segfault when loading custom FUSE modules has been fixed.

All: https://github.com/libfuse/libfuse/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
