### PR TITLE
thunderbird*: 115.3.x -> 115.4.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "115.3.2";
+  version = "115.4.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/af/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/af/thunderbird-115.4.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "abbdac387f40f5479e40b5818d646982330e9e71cfd97230aa7c1f1d4c015177";
+      sha256 = "984a5d9cd2f6ae70548c8b0453b7a3e0b50c18723215c158d20694d89027c85b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ar/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ar/thunderbird-115.4.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "fc9231f1439f205569d82b7ffa772f7812c0534382e2526a15d0cd66b46f101f";
+      sha256 = "9faa60b0ac4fbf396f4124113832024324a927bd1ad01275b8b11df27c75d29e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ast/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ast/thunderbird-115.4.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "18cb631b00f887fcd35efbb0b13d0db02ab2c0b35c51c53469f8cd9ab9909eb3";
+      sha256 = "aa855f0d40993560f643c22d7781ce2587788e7e7f6aca1612180fe54dbdc11d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/be/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/be/thunderbird-115.4.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f10b82632a1ef6413872a0a8d11f3d7f6372f25650bca53048cc278b73eb64aa";
+      sha256 = "654ddfb82edbfedd07a83947fe1d0c9d08456841cbaefc6abc042203bc25cd24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/bg/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/bg/thunderbird-115.4.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "75806d7a3e10b2677b3cdcabebded26158ed0e4656cee589c50d228074c3cf3b";
+      sha256 = "59904cc762ff431031a9de37267bd1610a0adbc8adb2300b98636d7c2fb1e7fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/br/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/br/thunderbird-115.4.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "f9826b6f79fe891a59dcd49c5e2831a4849c702408e2e166e6f6f4834b7e10d3";
+      sha256 = "6fd568603e1672f415a3c96cb81491281156c4ab3c1c49a1b8798a1a7c3d92b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ca/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ca/thunderbird-115.4.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "a3963a851f236189dfad601b00b06fd711aa4d618bf6f1e5ca8553237f462d4a";
+      sha256 = "c1387f5c9b51c4a30269f72a65b6bb525e9c61db9c78bfd02e09ee8a3d94f250";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/cak/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/cak/thunderbird-115.4.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "34e678c45635c0125e672a8db7d80aca50d5f8348c1967a0f785f30d7da419c2";
+      sha256 = "bfc5c46c935df1c6fe5c407b0b92adf35b00b31e3689ecefaefac59a0f7f9903";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/cs/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/cs/thunderbird-115.4.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "00b06a314f6df6f692531e1084ac57efe59ce0a8baec282c1424f8557cf10e76";
+      sha256 = "3eeb5619ec3804fabe40c6a8c68df9a28f41dc40f250fb4ca0e825595825bb34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/cy/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/cy/thunderbird-115.4.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "c22f9e68c37d15953efa2e7e971a1fe46701dab6eb8e57b4cd1399a4a76f239f";
+      sha256 = "71e11762188bd2f4476b722e8ac8302792ef6d1b4c07eb54affbc1e161376fd3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/da/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/da/thunderbird-115.4.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "8f06b3e7a6b91dafc05451a5967785650b6c8f71eff9e5fe73470b99943f6729";
+      sha256 = "108dd7e1910fe0773ba08250b7d6e09a63ae805b596da9ecdeb23c93cd25f4c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/de/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/de/thunderbird-115.4.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c4360ec6034747b17c26e892700a4665f46438d0fea312fc703a73e5135b5e33";
+      sha256 = "8632aaec06d4f41403631c7d8a777c151aa2ca78c6342e49bbda1551316812c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/dsb/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/dsb/thunderbird-115.4.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "350a83d144fb2e0fee431ffda69a7724c0843797e741e65533f71e51362b29ba";
+      sha256 = "20334b09cbdcf1ce0c9a7a3545283d69952976adc363856394209e34fd0802c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/el/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/el/thunderbird-115.4.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "c13254b14a504002b04a84485494c34b1351c8a338b0d5116ec0b1d6283b6bfb";
+      sha256 = "c519b753f81f92f437cfd4bb9d11423c69195ca4de6dfce227af4408f26d09f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/en-CA/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/en-CA/thunderbird-115.4.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "db9edc64ef4c3bd7b98267c1c29b442d59ceb3ba175f9fc204f6265014a79e5b";
+      sha256 = "1a899fd1bbf89adc9e149cb16fccf46c1881ee1f36b75f62fd70f9af1db5faaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/en-GB/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/en-GB/thunderbird-115.4.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e5e3c2a6333e9407587c6dd5e24d9a6c3a47a7151673842f250c5fd2a6e7ab1b";
+      sha256 = "156d6dcac9653b69875c751cad090d77adc35118df051ca5ce1cb384f28ff7a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/en-US/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/en-US/thunderbird-115.4.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "96d661adf9a4118e1b42cdbca9eedef180264140ebc0628d740132c231c15350";
+      sha256 = "80f9534e18ab00956410374b800db21e7a79eab4f9e452b2a908b4e29d708f1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/es-AR/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/es-AR/thunderbird-115.4.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e5d6b055e1e1025a255bf772ac91db8bef8e3a73bb8e4eb666747b96a2ec1d08";
+      sha256 = "606ce30a8f0005953791ba1a3c612809e1d875ebe1cc257afd4d6a0447ce557d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/es-ES/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/es-ES/thunderbird-115.4.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d1aca735e7a50c9e3aa279e750667d4014ceb43c5cb5496ec9ec9bbd04e3df21";
+      sha256 = "fa41210efdd8f7086db9fbebb54730079e555a3a316b3d5fea3fb015ad4696fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/es-MX/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/es-MX/thunderbird-115.4.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "826170d1a2f951fa8373b85b7862a3848126e7eea21dc30a04c1cd16e0c70b2b";
+      sha256 = "d5d8c3e7daed458c0445cfb42d046e3d81f65b84f0510348d42f17651e3e598a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/et/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/et/thunderbird-115.4.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "8d717d09a6e1eb0d73954b1ee407d6605dd9dab99dde9e24ca92dbdc366a88a4";
+      sha256 = "e94ba80c70ad4a6dd11257b2a456226c96df4f8da7908618b0460625932e3276";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/eu/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/eu/thunderbird-115.4.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "888cc390d5d91fa6df418bb7a71cef558d647479eb1b9ca13641c83b6af21b7f";
+      sha256 = "2055513d9741fcef221308ce61354df4d22276e088ccd9ae6430ccf82368252a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/fi/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/fi/thunderbird-115.4.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "f8c27d320690cc30586786924d70994488ae124db046a6ec656c80e7862ad6d4";
+      sha256 = "c916c8dc7a3d064cb7d6036722e3f2a010dc12e6564608cdad329628691c3e83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/fr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/fr/thunderbird-115.4.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "4805bff97f9b5706666f252670069dd0775056f610697f0ed553962791deed10";
+      sha256 = "2b6e1711762e8c00b87f37461df628e0d45d15f1ac1b19ffdd94ef6c470c9caa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/fy-NL/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/fy-NL/thunderbird-115.4.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "02271686a1873b33362209348d5b725da5035f9fa2ad0877a8c05586bc406a71";
+      sha256 = "1a44264af2d0bedfe930ee09b1036f76fc7f6612f3852ef9b2cfd7ac0dc66fff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ga-IE/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ga-IE/thunderbird-115.4.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "272ab8568be7355843b87ffd977d0601029a8da9595a43637a3be7db262f24a6";
+      sha256 = "fbb59c517f4e24e18da62eecb5f4bb9312d6987fbba472b3d7c095b42f5658ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/gd/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/gd/thunderbird-115.4.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "9fc41912b342a608fb5b3ea91c044d74fc7fef77016670313f1723a726a251a3";
+      sha256 = "220f166ef4b1cc5d2e36e4a8cf5ae0ee4ad529e97442e9f41c3efac7a09f486c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/gl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/gl/thunderbird-115.4.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9c57de323a569314333d6fed1f1debe802d37e973d14ba01f240a210eb3258bd";
+      sha256 = "b73e8ae380b8f659d6a96afde2d9c63b280c0741201311abe9b3ba244700a46f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/he/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/he/thunderbird-115.4.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "faac72eede3fe4d599a6df7a1047a9e66aa2ae4ddd8b755fa2c48e30d843fd95";
+      sha256 = "4a286adf9815f199e9cf0d10f3ba5e1fcb55e44a7e7b7945baa4196458968c3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/hr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/hr/thunderbird-115.4.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "bf826da99307813c1dd5d5c4fc5ae8e19b238401605e184ca303acf37c5333b3";
+      sha256 = "a362008a5e567e2f17f1236c661356ff9a366d014e7449b5fd4dab68f69dfaa6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/hsb/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/hsb/thunderbird-115.4.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "ecc94128403635d05e90702d27654682d16a70dde830964053161a5d2e7bf3c2";
+      sha256 = "e2cfa6ea00d866ea019184f97ae4aa2c390849a135924852aa03dc0feb980c2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/hu/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/hu/thunderbird-115.4.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "04108be734eb77bd114ab1321b951f7ffa12065e894fd08c98a4edcf77821546";
+      sha256 = "ddb3f51aa4c597a0162ff3f84cde69b885fed79ba641bba29e18016d8f2214e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/hy-AM/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/hy-AM/thunderbird-115.4.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "c87caa6de393dec305a3108590c26aafa97543626d6a764c7a9ab1fbfa372339";
+      sha256 = "f08d5845354b7fc90aabfe363b4b4f4b4c7f07c9f5d982942647677f78be0fa6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/id/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/id/thunderbird-115.4.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "6e0c3ca52134b52ef4997a7a5a12ff07329047af904078ccfa908a3e0da311a5";
+      sha256 = "61ae2261379a7e31c0ee9c6a949a03bb4853bcf813eb647eb2f30239516085d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/is/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/is/thunderbird-115.4.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "cc6da6574f3f9fe8b201b414d3dee455ef6da1ccbffa8da9bc82021dc31d9327";
+      sha256 = "ffb985a0f75c9bd56ae7e344791e86fd2a9f17007050b62fda2886547cd56334";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/it/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/it/thunderbird-115.4.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "067c1647f97cb4a63dd45c6e54202ab2296cdfd4f935705bd271ec1c54a85b3d";
+      sha256 = "e8dc54db11815ae9e891f2c79c5e5218147d6694bc7055e933a0397c1619fd61";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ja/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ja/thunderbird-115.4.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "76e157919fb061fdbf7c5a9aec301de41804dcf5b3f1418707a6015bac2e76f0";
+      sha256 = "a510a719215362a33ada3a29641a3999656fa73c5f2ea1cdc2c5c3b2b539f9ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ka/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ka/thunderbird-115.4.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "be1ddb3f71ac0176f3cd4d82e4ecc96f6ba201a08b2920aebcadf4a0636048ae";
+      sha256 = "6b4d0240dc65f3544f2b3c32876720783f179298fa575f8445b4d45449485742";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/kab/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/kab/thunderbird-115.4.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "478efa8b58d79247d1a1669e55806f84c806fc19cfb43d471075736273520e27";
+      sha256 = "fa672dbdf6aa3ab56f1ec4ca741d01a0a0fa7ddbf0f1195824775a8990a65d33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/kk/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/kk/thunderbird-115.4.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "caa3242c6095d603dc017fe0043c1771c3fb2490a173c26da0d8a050cad825ae";
+      sha256 = "f7cbf9147a4a7bed00e9dc52a6bba898b49aabe9e4daf0154a28662b4d16683b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ko/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ko/thunderbird-115.4.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "48f7f992d8d158129935aa404aa6d10b9a1a6cf9d0941b869c10f063332b2737";
+      sha256 = "d95727839f9d348d67371c01dec0eb2ee874d36631fb1fcf5441774fdc2bcd9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/lt/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/lt/thunderbird-115.4.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2f94410bfa04893bf08c6a87aee365f72339839a682d43eb979cf39649854201";
+      sha256 = "cf87612f4d8ddddd0c1ce141c0edcec1bdd15ab73d51d5e83855694bc76e1a8c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/lv/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/lv/thunderbird-115.4.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "0d39a48597467d586bd6d22acfb2c0cbd64c5ddd91a73e23b7e1224238eaaddb";
+      sha256 = "228523902e069aef7c50a2a72fc5d7cdd987e896b263f91583ee8b5dfed36c49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ms/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ms/thunderbird-115.4.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "9ce0df4ba35f72d31982af5a4eeb2aec6060effd0def6ee9bc81754c22b0226e";
+      sha256 = "ab13e157ffcf8949e23c704726ebcc656debb259deebe3897b7d9d4ad8b45464";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/nb-NO/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/nb-NO/thunderbird-115.4.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "0a55fffe830c57c4514560746704b917fa2d0644933e87b94cc9ddb8000b5c41";
+      sha256 = "d64a6286e3ce5a3dd28e43bfd7ba483587d42bfe9037e478a286af704b7cfb88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/nl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/nl/thunderbird-115.4.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "54386b45ba025981bfc87ecaab278524115a08958699f667871471a24bc6313c";
+      sha256 = "3fa698cc239ae0bb0bd5d0984600f8b274e83528c42a62f20815245990fbdf4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/nn-NO/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/nn-NO/thunderbird-115.4.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "ef987a6e5c6dc8b024bfbf56133a8b61ce40de2982628e9c1918b9988e74c2ee";
+      sha256 = "a811b1113f8490c7cf92bca1df2895d7253a07c7f59e3f70d26b3929b7c9b8a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/pa-IN/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/pa-IN/thunderbird-115.4.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "95fc00c7a58db674086910245ac387196b443a9a5cd13be969474fc4628f0fc3";
+      sha256 = "766e77b7a863d6db6b8da29d351650a921bc34742a6a1e389101ed74b41d7e45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/pl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/pl/thunderbird-115.4.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "aabe34619384cd8fdcaf39f1d552300e595bb2a72f34f5340182115673f5e751";
+      sha256 = "7dff7fb5255688e75cdde4189de8c8b2e0c0c9f94e6928819282669b35f4b2fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/pt-BR/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/pt-BR/thunderbird-115.4.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "de1e210275cd1b40c222459b61455e9930573472529e4c2addb20824983874c8";
+      sha256 = "5c55931aad41a8a801805b9b59d6698ede34cf4613205cac7591e112051e29d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/pt-PT/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/pt-PT/thunderbird-115.4.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "3ba07b58308d410486abe20f60b8748b9d2347c57232ff9eb366205f7dc6cfb7";
+      sha256 = "ea4cc3fd7cffa2d18e66dc1137da283157ebfda7fe4289059bc2fa0506385582";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/rm/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/rm/thunderbird-115.4.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "a5318ceea1711a4fdea1cf4236f314caf115e41ddb18793001d33887cfbc5384";
+      sha256 = "aa04eb51601d0d777ae785acac0a6e573fb92d2f3d0fed0d2c4bcc7b54384f9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ro/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ro/thunderbird-115.4.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "c1c001218d4037be09db4f77f7eb03ecb3a0fd701eb342e8d60daab6c0dfb5ae";
+      sha256 = "478109fd6564c4dd08629fdae951331c0c1e49f245a3ee9fd875ae4bfeba39eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/ru/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/ru/thunderbird-115.4.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "47221f5bb04731fd81e2bea8dc986304cbe92861e748aebc56b283af8c215cc0";
+      sha256 = "708f01aa9736c21bc261054b4b71114752621ddabfc6b373c76411fa777cdc46";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/sk/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/sk/thunderbird-115.4.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "127415be4ef276d6b0601ec2dcb534a6178e2d3b84db9d191135491a7c76597a";
+      sha256 = "bdeee131a254dded4975e613d66f3c127736c4fd982a63d5c2de1fd3ab08c14e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/sl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/sl/thunderbird-115.4.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f51172080bdb26aa30366ccb0132183bb8e4b670ae4eab586dcbb03ffb2fa06c";
+      sha256 = "38e9e1b964a599d46143a2255ef7d01e97f1e519b333e578cb5c6f8f1b48e7cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/sq/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/sq/thunderbird-115.4.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "504bbafdca219027b3318a9957eaa7c842e92e2276d319522e2905cc94f104d1";
+      sha256 = "1b6c3b84b123655088a49785bb7347ae8b4014677e12aa5e0a591f380962c7a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/sr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/sr/thunderbird-115.4.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "276ce27d338e9f2bc1ecce9f1ddcdfdbda88022aa976eacc8a5b4f7cb18fddad";
+      sha256 = "17bdc9c1bfaa2c320f196c6847606c0085c92fc15c2870b00f15481f1db7f119";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/sv-SE/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/sv-SE/thunderbird-115.4.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "d91cd25880e6d809618b3f3a9354ffb8eef009aeac1940fdb6dd1c7c4c70e072";
+      sha256 = "371b7bb4c3c2870c8cf61fafe42b281e3de960d26c83de3d07b55e68bf2e9ff5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/th/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/th/thunderbird-115.4.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "935e55a2cb94b9ce678ae235d4762fc8783a6f8b4ab3a48e981bf22afe9f00b7";
+      sha256 = "c2e73af892e0e8fe968017e8337980c33ca2e960b607db7e8d2c5c3479e4103f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/tr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/tr/thunderbird-115.4.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "90031892a6f843af09ac2e77e90f26eb65d0f2b2075db505668274a86dad39a4";
+      sha256 = "58fe07598a46b89f88bb6f543c2627cec64a27adf8cf8c067e2c9cd313823529";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/uk/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/uk/thunderbird-115.4.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "63640c61ac2cae9c20ef1f8ba2ec655da599e7bbfebeb41a1abd662545eed876";
+      sha256 = "d9471d2dab40fad2cc860c1c8d61e447a22c896b1e55b2fc6fd9371d0ddbbe2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/uz/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/uz/thunderbird-115.4.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "bccc6cde4779ac9cea16d4b8635af68b70607bfb6b2c4029cf00529cb0ae54cd";
+      sha256 = "7208f963139afb6bdc6a31a5c756876e25b75dd729a759913abfaaa2ffb3c6a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/vi/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/vi/thunderbird-115.4.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "441ab3749d2c04d099eec5bc85117cee45f611e958b0c93b74bdad022f8ee435";
+      sha256 = "3001fb66160dc7a4d919e3ceabaf3e1c1edde6e3adfff69ea258d3e4092ae545";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/zh-CN/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/zh-CN/thunderbird-115.4.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "7becd014b14997eb24487a1895447bab952c2ebe009862c60f1fa8fe44fa00bf";
+      sha256 = "f10c31a9f5516035b40699512205c14fb52be0bb0bbfabc6f2ef36536c1699df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-x86_64/zh-TW/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-x86_64/zh-TW/thunderbird-115.4.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "28343b2ab133287cc63e307e0b54fa6620265ad76a2e1d41ce92f6ddd153b09e";
+      sha256 = "c7554050509eb446a1c0de17f8f2417009ac5185080daf60e40f7cddf48cc08f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/af/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/af/thunderbird-115.4.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f1d24ef4abb84c081faff0339be086c83b788957b86e3a015794e009176d642b";
+      sha256 = "340b2e82108e0d0ab8980b0df0995fb90ef7869ffe54496cc3538699efb54c6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ar/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ar/thunderbird-115.4.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e604ea0f8dee4c12b5b7d0505e0c127f753f9298828cf7245bcc2d38e348b44b";
+      sha256 = "a3577d6224ad9b4f71dbc28e93fe867843804e2c2e506ab83cf9fdb4915fa965";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ast/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ast/thunderbird-115.4.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "1f36d5e02a3d93e2f4ebc4a51afa94861be1a190f48efe798ebba675f485f0fa";
+      sha256 = "1d4bba1671d23e9cb66622b8a1db264bd142c6ba4573be090bad847bae96a99c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/be/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/be/thunderbird-115.4.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "4e0e24c9a43f28f7ccc858a84c8c054431663384bb9d17b4925783f54b0ec92b";
+      sha256 = "9535fcc380a092fcb580f172ae72b4616e5a68005b4e8b72b7bfd0e25d19446f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/bg/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/bg/thunderbird-115.4.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f73f7b7c19c1fd771d662947f3d955f3d5f18d08ed4a6a835f91654eca756cec";
+      sha256 = "7851ef4d8c8ffe3c39b87c75408d5aa2c48dad9bad066308316f9770c75420aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/br/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/br/thunderbird-115.4.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "45e0b45be17f8e4d4163f38490fcddaf19779818783ff85fd0ffbbbe6d09d9b8";
+      sha256 = "d1928d7d1dadeab49cef49efd55df4c652fb55cbf8f1e91dace8d9aec4bbdeb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ca/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ca/thunderbird-115.4.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "02b8272058d6c4d0738cc02cbd4f41866c2044e499968f929aa9e76564307009";
+      sha256 = "3f9cb1b1335686428a2b38bee4de95da2fe45c31e6c5417789611797413f5bd0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/cak/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/cak/thunderbird-115.4.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "535009c94f902c2a87324c7ad30b11605a9199b8237a6c4fb10ec6d53a7bde9c";
+      sha256 = "6d01411ae87372d8f3ff108166c513fc3dc28d7475c32ba9077ada8699da6ac3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/cs/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/cs/thunderbird-115.4.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "1812171fc55af5eb41056d0da27176d8e3dcd38bcab3dd2b7979cf22e181e067";
+      sha256 = "4854ea58c23f3ff702ce55a2f7159e3383beb2a4df468d164e831e999d54d3ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/cy/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/cy/thunderbird-115.4.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "5a76107a8e49d7b154449beff01a6a0d7ecba88806a376aee2cde9c2aee231c3";
+      sha256 = "42255d0c90bc56f3c580f2a195ed4802eecb0a860d8181e31920c5615019baa1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/da/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/da/thunderbird-115.4.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "d5c72cef228c2d1edb0781a76ca33bae061431e8075f04174a1bf94fb118e1f9";
+      sha256 = "21e793bc846402a5633caf336386281bee63b553954a98e52cab85c134d9c9a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/de/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/de/thunderbird-115.4.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f0dbeef62cad6d2e5a74440fed961a85d370f473330f12523e28deb07ff89444";
+      sha256 = "a5b87277e4fb238fe3db244aa75bd77cb20f9c964d7a4eaca92252cef0b1d4b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/dsb/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/dsb/thunderbird-115.4.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "7a41d558403b0f46f2128ae9a1f6b8a93913723740820dc9fbd3767c1b03a3cb";
+      sha256 = "e0c9d4d7e32a677a51dd0211bcb42ab1545b3580dc0f9d9abb6e3be9a750cc31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/el/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/el/thunderbird-115.4.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "824923b59362e4e1d499cabec5fa11ba9514530ec853fa4ab08b81ee32a58bb4";
+      sha256 = "7cc4762d51133a6c9b80a4ece730c98f21e39ce89d8a66a433a503816a5d2e89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/en-CA/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/en-CA/thunderbird-115.4.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "a1167c95b458620fdb5856022eeabb283d25903c2ec650dd63e20723f7a7f8cb";
+      sha256 = "b1eda5622f414ba75c5972d6653dcfed7a54ec3eeab7a1fe0eafb07c0998865c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/en-GB/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/en-GB/thunderbird-115.4.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "471f55152886b240041bb57997d02682d49506b17a611ad0a75869eba0cb9fe6";
+      sha256 = "d97bad986e68254c3f92c00ea6c517bd42bb0b8ac2c0a5e39df88543a329e277";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/en-US/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/en-US/thunderbird-115.4.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ab9da54ca5265f714fe9aee854b1a4200dd770432b6425bc83e00ae21bc109e2";
+      sha256 = "2e5807f8c6610aa871b79ea62fc063c5655bad70d019a9525845396b7f85b3b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/es-AR/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/es-AR/thunderbird-115.4.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "f67f7e478bfe9b6b5a7378e7255c849dae2b8c9b77332d72aa98625dd8c03a3f";
+      sha256 = "ff1def53d0391a96aba158dd9b967c303bedf71b4e78419290c745e0a88496c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/es-ES/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/es-ES/thunderbird-115.4.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "f32e4dc965c92670355173ae2d364de1e0297c179d88c4481ff17043614068fa";
+      sha256 = "bce7dc0d2ac514f1f66f8441a3229920239265c01e3f6a999441c0f0f9806644";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/es-MX/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/es-MX/thunderbird-115.4.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "9523a37dd4c425cbcf8e5326116af101fa1715009b7856380ccb0b3cedf93c39";
+      sha256 = "a0c6da966679f3eaa93eca1d347b0d221fa26d20b6c01a3544ec5a7519020e26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/et/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/et/thunderbird-115.4.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f45f27e599c2a3daa6f96d183856ba53db38e3dd3f1b4d54d02ac067fc2a408e";
+      sha256 = "6d7f2d67053e5479e2f4f6fb1184901a7fe6f0100f8a8675dde0139195e32da2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/eu/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/eu/thunderbird-115.4.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "bea576eb1bf5204932a6d9a64e65e3b9ec83383f606d9ce68301bd3197f2d870";
+      sha256 = "3b4e08d9eccea42976b07b80a9d84a9c2aee4223a83b128c9aa65357cba0d11f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/fi/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/fi/thunderbird-115.4.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "3f93721a0dc124a10346d00760a28d153ce3c39cebb6c01a1cbd36561cdf9085";
+      sha256 = "bad3c5047dc9d4283723a6f24113fa93434fd44cbb139dd9420a69a759606675";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/fr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/fr/thunderbird-115.4.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "f075ed5f4059a7dfade2dd76482e46d0fc3ab2ddf67cd76ba5bd901b7ce63228";
+      sha256 = "e656c0fe050a4e3c772514f60c6452e8de1f7b14b11b814f20044d32e4bae916";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/fy-NL/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/fy-NL/thunderbird-115.4.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "8557f768822b60bca926fbe49b1c61bc5f0258d8981281e2376ed274d70ec8ef";
+      sha256 = "2a93d49f76354071f43f549a04b035dd1eb47c1b7c4f4c87de1ad6b519e989b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ga-IE/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ga-IE/thunderbird-115.4.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "2ed32b67740e8595b0dd7c06c6c726a6d5eacec9cee4d1d37199600b38838f62";
+      sha256 = "c65a11178928b4ddb9febe35e514a8233a7d6560ef3366cf3fd2141ab19735bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/gd/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/gd/thunderbird-115.4.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "bce2db97e057799871485dc7b8133b89ffa30b40886611251f97650791bc4917";
+      sha256 = "36ef04774e588691c7722e460c6ac95db528bbad29dde07b3e1d5a569889aaef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/gl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/gl/thunderbird-115.4.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "40d0873e76a062a43f97461e4df1c684947bf32101515cee8d231571e5d3f72a";
+      sha256 = "84c9327c3bd811ab722371a396064689486b36083d36e89fb6f6364670d3d94a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/he/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/he/thunderbird-115.4.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "eb2e19dd9072b5b4ffddf67f29d2541c8e956bd1c5955d8ecdba8e137081abae";
+      sha256 = "abd1a3650e46ffdee5edd3d8b450644b2169650ffd9d75fa0b47c4c5567ebd2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/hr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/hr/thunderbird-115.4.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "11d88de2c4e21fa774943fd83df559aa1b8764e13e786b418d33675892f179bf";
+      sha256 = "0daf5e121293462df3b86018bab57e658602d4fdcd67faf8d7ea8f21aaf7632b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/hsb/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/hsb/thunderbird-115.4.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "7dcd340876e1e9f247714e5607630db048f5105c99268f61320be946dd76b879";
+      sha256 = "4a4e81cee163c24773f7bc03c218611134e1004222ce3573e551f6293d8efd58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/hu/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/hu/thunderbird-115.4.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "220b4b59b64576b1e20c16d9d75636a1e8371471d86234a77cdd9cec8f140ac2";
+      sha256 = "f7e8e917827e9c3e52ef48879765258b92fead33bc0e2147a1df6728f6764831";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/hy-AM/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/hy-AM/thunderbird-115.4.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "8d12f76230f1b8062cce3189d7060016fda3f7e9a09c87777f9e453fd4b622dd";
+      sha256 = "4c9cbfd06984815fc61ea98e0c17639c8fca7ebe701a407e841966bb05aa09d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/id/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/id/thunderbird-115.4.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "076c0bae1376130bf4e69f3b21f4e523e07c82b035c4b7401b3f62f67fc86bd4";
+      sha256 = "d3d9eedf96670bb449646b17f5a8a9385855b3854b30b6ba05767b309ba381e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/is/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/is/thunderbird-115.4.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4784948831c6ffbaadd343bcc0e738765f7cd21c09a422bb48a84b8b69f2692c";
+      sha256 = "ee64b52c00a78b4bba3ff14277cee29ce098e2aa28440d034c57769faea9351e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/it/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/it/thunderbird-115.4.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "208384c6457024fe9976191ff8f36c4ff1dc0b8fd52f05c5d10a3ef46bc1820a";
+      sha256 = "4c26187f7eb32ee878ca9df24b8416b7f0fa23d739adb9bf4e58bc9d3cb3fe70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ja/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ja/thunderbird-115.4.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "73c4774d1d6763aefb2750032a1b330c9351f1690b0e99c70c19ddb43ff9dfd5";
+      sha256 = "1d65c17a94131fc651ca3b9db0e5968434ec60096758f1f2ab5f4ebf4e845a26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ka/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ka/thunderbird-115.4.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "cd539ebfad4343e7626fc963f12f2591861197398f7dd2dec19cc9b035a32547";
+      sha256 = "da40fa8bc0f1b1dd4f0d3c062cc79e7179d6e9a29a4f80323b9da8b3e5a38727";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/kab/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/kab/thunderbird-115.4.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "e78b4433da1a3fcc7dccae274bf954ec0568134d2ec8631f17c1c5909214bb74";
+      sha256 = "fbdfc11b4cc9cb0c92e32e2ab1eba6bfc010a84c964c63a05b3672095f6be438";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/kk/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/kk/thunderbird-115.4.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "5258f1d16475b23770f1c5a625c051b2e68bdd95c098c675e2856ab5cbbc8630";
+      sha256 = "dd1419aabe279cbf1c182425b8aa57d97d510fd2586a9f63d6619bf52902dc93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ko/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ko/thunderbird-115.4.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "29da7d5b39e6d6196ea4732eb0078040add625d2fda0d4058d17d8751c693a6e";
+      sha256 = "9901570e3cb732036b430493cb1a21fa645d33c1ada119e65b434ff481c1e732";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/lt/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/lt/thunderbird-115.4.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "962f60e1d9c97870e1662ace5ceff36db6c81227449177a50f7d296e613b63c5";
+      sha256 = "0066a94f77ac6c4602137bef783f45c36b5a0f845c0ad48e7b158c0bd282fd2b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/lv/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/lv/thunderbird-115.4.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "b7cc3ec52b6d02285e4632f03bc8a9d740ede08eff9817d3b3cef3757adcb85d";
+      sha256 = "6abf69968fe1d37096c39f083241afd3e5d2389c929d1939bd8dda6473474044";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ms/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ms/thunderbird-115.4.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "0c176ed3c551c7f5e6babddcf0e08ce6b010ec65edefcb729b339d85102f9242";
+      sha256 = "afe39f70b1ba61e4e3260e629dc60adc3430a8478f3508645c4ab1e6353ca6a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/nb-NO/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/nb-NO/thunderbird-115.4.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "54d390ef94481efa7e04ce99c4bb9c2cafabcf6e7e12a066829141687e13dec9";
+      sha256 = "703c9509e2965b5cd9b20204e1e390530896aefc61afada60ceec46657b5c052";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/nl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/nl/thunderbird-115.4.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "dacfa1474f5ae1a7bebc34a40b787003346c220f2399b040bc478ac9d48217ac";
+      sha256 = "f8901735d4ac97a8e64fb22ac98f1e249399023853761f404e06ed5bb557d6af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/nn-NO/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/nn-NO/thunderbird-115.4.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e2444478ce4e06ca442991f41f8648b8abc3caa9b8df51821f5ca564bff0bfe0";
+      sha256 = "74f7767af5fc88adc4e65bc14794d193069572378a9314bcb1224a90e4991d0b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/pa-IN/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/pa-IN/thunderbird-115.4.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "5110317c5227955116f1e6a8f851d1b518e567763e75c34d5ce35c345c039846";
+      sha256 = "d427a7712ed85b24418f95f8dfbf35c2888bc4f774dddd9594895c3eb30fbbe2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/pl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/pl/thunderbird-115.4.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9f099333e148edccdec20fb8c05c094976a3693cb4da600dc6d852c2ea4a7b0f";
+      sha256 = "5dbb18db564a047556eecf848e9c42d39b28dd3b3b4f94be01aba52ed6d09a83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/pt-BR/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/pt-BR/thunderbird-115.4.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "f58d41ad35652ae87a53808bac13c793d1851f5193fcc3ee74119ddb4f13b5fc";
+      sha256 = "44097bbfaa7c70687d0ebdab94a3ec1c8db326c4d333ff7167c93f65122d2717";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/pt-PT/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/pt-PT/thunderbird-115.4.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "347f4a46c08576af832cfba4f96164bc81b5653350299d416fb91f18107f9e03";
+      sha256 = "b4195c7c92d18fcc350925ff867515c2ee619d76ca40d16de18e77a504e7e3a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/rm/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/rm/thunderbird-115.4.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "bab2cd31ff27512ae03720d4baf475ad5e33e82e6bf07e06f3f02cac0c645b3c";
+      sha256 = "b5b1bde8faf2de0e2027b98e2adcaa1cb85b0402c9a4a1fcdebaa2933b5076c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ro/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ro/thunderbird-115.4.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "69763904dffb09d37df2cfd6a6c71c45dba6c9725a4703c56fb7884cd15fa37a";
+      sha256 = "8e0b8e83a86ccde5530604f89ce989d5e701dc2bf07bf57b2637e3a6cbbb28ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/ru/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/ru/thunderbird-115.4.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e68d2ad8c07eb01449fdd0a705a75c7f45d4d367dd990c38322f4e9ee08398f7";
+      sha256 = "347ccd0bdc999131b5ed6cfc3c3c74d522644c918673d19d1b919a07f778bb80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/sk/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/sk/thunderbird-115.4.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "fe8aa6bf3dfd0a14577b1b45f2bb0b35b1f1b3b533a5f9978972aff29c72d01c";
+      sha256 = "3e0bf1d75d822b5646774d36432d861fea1c8daf848ca434357ac05c49a501be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/sl/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/sl/thunderbird-115.4.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "487056a83091d524c56f726cc96066ba7e035e7af3545e7664a859557289e62b";
+      sha256 = "88eaaacd0b1f0d1096acfa6a7c9e79b6b1268da35e299fdbe435386323564275";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/sq/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/sq/thunderbird-115.4.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "5ea91c8599be87b08ff3fe328454f1629ba655ac059baca20aa38cf08990530b";
+      sha256 = "d95fe0d8a6f960809f85507cf22f6283d97177aa57f802f731519d5c8286502b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/sr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/sr/thunderbird-115.4.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "599d44feab73393230ccecd219139e6eda2206771f71b8890f1be09f8176e4ea";
+      sha256 = "85382234c67e5d4756f2c8d1e69a51918391b361e9bbabfd4509755d3e9bbb57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/sv-SE/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/sv-SE/thunderbird-115.4.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "0e7c08a019f5c5eabe38a7e17c4f280c894f71ff1cf2a90b34ac102816f93984";
+      sha256 = "85f536a1a1fea39bada579df14024228b369daff04cb334e5121df26e9dc9abb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/th/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/th/thunderbird-115.4.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "9b2fa7e157567b7ea6dc506dfb9bea32e1e0b1301053801caf2e4cafa1593a7a";
+      sha256 = "16aa164a8a874a5e29490e802d081a0ac0e0cc8308294fb7718b84b2f1907dd3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/tr/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/tr/thunderbird-115.4.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "34884d791dc0d816aff110be2b111ee2c14ba0cc29227b56b8fe782bcd3441f8";
+      sha256 = "33361a2b058ce97605d6cc49bd8d5f98ff906a033d3d6690a9ead68c5c112a80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/uk/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/uk/thunderbird-115.4.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "68e2211308375061f06e8c620a6cef35cc3785d27ad2fb33f90c6e2cbc8cc51b";
+      sha256 = "be242d2c67e1bfa8f0a982fdb468ba895e4c20e4048f4558846ef15b3370d9a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/uz/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/uz/thunderbird-115.4.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "cdae055179025410d371c8023fc99a3689f215fae88f3b3e14ce1217455517b5";
+      sha256 = "a1ce3c9ba4348e87d91b058d9c86d9f069efce0fdcbde74cb301b97de2cbc0db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/vi/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/vi/thunderbird-115.4.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "0306b2f943819cc9a0050fbc9e5bc2c0bd343795eeaa22d4f1e0325fb55cb6de";
+      sha256 = "a7215f92ac980a5dc0d09ecb52185dfd28cb2295cce0f6f443f8820958e6de3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/zh-CN/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/zh-CN/thunderbird-115.4.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "40fabd734552a7af0762fd828de2810d6fdd8b76a26b2f18db22a301d0c631ca";
+      sha256 = "d1c0b04516aed697a4b93c88a60f3cb0b2ce8479818334b29a262d72afb485d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.3.2/linux-i686/zh-TW/thunderbird-115.3.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.4.1/linux-i686/zh-TW/thunderbird-115.4.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0a363a15cce9fc984b9eb49ce9e9be43bded85d68e66a74db89b364040c315ec";
+      sha256 = "f689bd01e5a43475247b61c4fc3d0699c13a2ba5cafa13bb8c8eeaa669c29951";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -44,13 +44,13 @@ rec {
 
   thunderbird-115 = (buildMozillaMach rec {
     pname = "thunderbird";
-    version = "115.3.3";
+    version = "115.4.1";
     application = "comm/mail";
     applicationName = "Mozilla Thunderbird";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "631042a3cdbcbae91d93eb71c0d4f6a1122e8bc7000d75fcc7d3cbdd0e82a4b31abac590c75771e77ab08d5700582b6dedacf62ce8e21a91e9ea81aedf1bbeaa";
+      sha512 = "ccf48a5376027b1e0182d4040a0571e5f34c2378349c0d11cb4e14c75f10247e2522e8d8d2a0a45022ff1a463a49f59b1cf611c70951cf5e1b383051c0573164";
     };
     extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
https://www.thunderbird.net/en-US/thunderbird/115.3.3/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/115.4.1/releasenotes/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
