### PR TITLE
python3Packages.pyscf: migrate tests from nose to pytest

### DIFF
--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -10,8 +10,7 @@
 , h5py
 , numpy
 , scipy
-, nose
-, nose-exclude
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -47,8 +46,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  nativeCheckInputs = [ nose nose-exclude ];
-
+  nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "pyscf" ];
   preCheck = ''
     # Set config used by tests to ensure reproducibility
@@ -57,53 +55,43 @@ buildPythonPackage rec {
     ulimit -s 20000
     export PYSCF_CONFIG_FILE=$(pwd)/pyscf/pyscf_config.py
   '';
-  # As defined for the PySCF CI at https://github.com/pyscf/pyscf/blob/master/.github/workflows/run_tests.sh
-  # minus some additionally numerically instable tests, that are sensitive to BLAS, FFTW, etc.
-  checkPhase = ''
-    runHook preCheck
 
-    nosetests pyscf/ -v \
-      --exclude-dir=examples --exclude-dir=pyscf/pbc/grad \
-      --exclude-dir=pyscf/x2c \
-      --exclude-dir=pyscf/adc \
-      --exclude-dir=pyscf/pbc/tdscf \
-      -e test_bz \
-      -e h2o_vdz \
-      -e test_mc2step_4o4e \
-      -e test_ks_noimport \
-      -e test_jk_hermi0 \
-      -e test_j_kpts \
-      -e test_k_kpts \
-      -e test_lda \
-      -e high_cost \
-      -e skip \
-      -e call_in_background \
-      -e libxc_cam_beta_bug \
-      -e test_finite_diff_rks_eph \
-      -e test_finite_diff_uks_eph \
-      -e test_finite_diff_roks_grad \
-      -e test_finite_diff_df_roks_grad \
-      -e test_frac_particles \
-      -e test_nosymm_sa4_newton \
-      -e test_pipek \
-      -e test_n3_cis_ewald \
-      -e test_veff \
-      -I test_kuccsd_supercell_vs_kpts\.py \
-      -I test_kccsd_ghf\.py \
-      -I test_h_.*\.py \
-      --exclude-test=pyscf/pbc/gw/test/test_kgw_slow_supercell.DiamondTestSupercell3 \
-      --exclude-test=pyscf/pbc/gw/test/test_kgw_slow_supercell.DiamondKSTestSupercell3 \
-      --exclude-test=pyscf/pbc/gw/test/test_kgw_slow.DiamondTestSupercell3 \
-      --exclude-test=pyscf/pbc/gw/test/test_kgw_slow.DiamondKSTestSupercell3 \
-      --exclude-test=pyscf/pbc/tdscf/test/test_krhf_slow_supercell.DiamondTestSupercell3 \
-      --exclude-test=pyscf/pbc/tdscf/test/test_kproxy_hf.DiamondTestSupercell3 \
-      --exclude-test=pyscf/pbc/tdscf/test/test_kproxy_ks.DiamondTestSupercell3 \
-      --exclude-test=pyscf/pbc/tdscf/test/test_kproxy_supercell_hf.DiamondTestSupercell3 \
-      --exclude-test=pyscf/pbc/tdscf/test/test_kproxy_supercell_ks.DiamondTestSupercell3 \
-      -I .*_slow.*py -I .*_kproxy_.*py -I test_proxy.py tdscf/*_slow.py gw/*_slow.py
+  # Numerically slightly off tests
+  disabledTests = [
+    "test_tdhf_singlet"
+    "test_ab_hf"
+    "test_ea"
+    "test_bz"
+    "h2o_vdz"
+    "test_mc2step_4o4e"
+    "test_ks_noimport"
+    "test_jk_hermi0"
+    "test_j_kpts"
+    "test_k_kpts"
+    "test_lda"
+    "high_cost"
+    "skip"
+    "call_in_background"
+    "libxc_cam_beta_bug"
+    "test_finite_diff_rks_eph"
+    "test_finite_diff_uks_eph"
+    "test_finite_diff_roks_grad"
+    "test_finite_diff_df_roks_grad"
+    "test_frac_particles"
+    "test_nosymm_sa4_newton"
+    "test_pipek"
+    "test_n3_cis_ewald"
+    "test_veff"
+    "test_collinear_kgks_gga"
+  ];
 
-    runHook postCheck
-  '';
+  pytestFlagsArray = [
+    "--ignore=pyscf/pbc/tdscf"
+    "--ignore=pyscf/pbc/gw"
+    "--ignore-glob=*_slow.*py"
+    "--ignore-glob=*_kproxy_.*py"
+    "--ignore-glob=test_proxy.py"
+  ];
 
   meta = with lib; {
     description = "Python-based simulations of chemistry framework";


### PR DESCRIPTION
## Description of changes

Closes #263544

The nose test framework seems to be largely dead and upstream PySCF already migrated to PyTest some time ago, so this is our adaption to these changes.
https://github.com/pyscf/pyscf/pull/1249

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).