### PR TITLE
curl: fix build failures due to needing to propagate frameworks

### DIFF
--- a/pkgs/development/misc/juce/default.nix
+++ b/pkgs/development/misc/juce/default.nix
@@ -53,9 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     libglvnd # libGL.so
     webkitgtk # webkit2gtk-4.0
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk_11_0.frameworks.Cocoa
-    darwin.apple_sdk_11_0.frameworks.MetalKit
-    darwin.apple_sdk_11_0.frameworks.WebKit
+    darwin.apple_sdk.frameworks.Cocoa
+    darwin.apple_sdk.frameworks.MetalKit
+    darwin.apple_sdk.frameworks.WebKit
   ];
 
   meta = with lib; {

--- a/pkgs/development/php-packages/datadog_trace/default.nix
+++ b/pkgs/development/php-packages/datadog_trace/default.nix
@@ -47,9 +47,8 @@ buildPecl rec {
     curl
     pcre2
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk_11_0.frameworks.CoreFoundation
-    darwin.apple_sdk_11_0.frameworks.Security
-    darwin.apple_sdk_11_0.Libsystem
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Security
     libiconv
   ];
 

--- a/pkgs/development/tools/rust/cargo-codspeed/default.nix
+++ b/pkgs/development/tools/rust/cargo-codspeed/default.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     openssl
     zlib
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk_11_0.frameworks.Security
+    darwin.apple_sdk.frameworks.Security
   ];
 
   cargoBuildFlags = [ "-p=cargo-codspeed" ];

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -246,4 +246,103 @@ rec {
         env = (args.env or {}) // { NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}"; };
       });
     });
+
+  # Overriding the SDK changes the Darwin SDK used to build the package, which:
+  # * Ensures that the compiler and bintools have the correct Libsystem version; and
+  # * Replaces any SDK references with those in the SDK corresponding to the requested SDK version.
+  #
+  # `sdkVersion` can be any of the following:
+  # * A version string indicating the requested SDK version; or
+  # * An attrset consisting of either or both of the following fields: darwinSdkVersion and darwinMinVersion.
+  overrideSDK = stdenv: sdkVersion:
+    let
+      inherit (
+        { inherit (stdenv.hostPlatform) darwinMinVersion darwinSdkVersion; }
+        // (if lib.isAttrs sdkVersion then sdkVersion else { darwinSdkVersion = sdkVersion; })
+      ) darwinMinVersion darwinSdkVersion;
+
+      sdk = pkgs.darwin."apple_sdk_${lib.replaceStrings [ "." ] [ "_" ] darwinSdkVersion}";
+
+      isSDKFramework = pkg: lib.hasPrefix "apple-framework-" (lib.getName pkg);
+
+      replacePropagatedFrameworks = pkg:
+        let
+          propagatedFrameworks = lib.filter isSDKFramework pkg.propagatedBuildInputs;
+          env = {
+            inherit (pkg) outputs;
+            # Map the old frameworks to new and the package’s outputs to their original outPaths.
+            # The mappings are rendered into tab-separated files to be read back with `read`.
+            frameworks = lib.concatMapStrings (pkg: "${pkg}\t${mapPackageToSDK pkg}\n") propagatedFrameworks;
+            pkgOutputs = lib.concatMapStrings (output: "${output}\t${(lib.getOutput output pkg).outPath}\n") pkg.outputs;
+            passAsFile = [ "frameworks" "pkgOutputs" ];
+          };
+        in
+        if lib.length propagatedFrameworks > 0
+          then pkgs.runCommand pkg.name env ''
+            # Iterate over the outputs in the package being replaced to make sure the proxy is
+            # a fully functional replacement. This is like `symlinkJoin` except for outputs and
+            # the contents of `nix-support`, which will be customized for the requested SDK.
+            while IFS=$'\t\n' read -r outputName pkgOutputPath; do
+              mkdir -p "''${!outputName}"
+
+              for targetPath in "$pkgOutputPath"/*; do
+                targetName=$(basename "$targetPath")
+
+                # `nix-support` is special-cased because any propagated inputs need their SDK
+                # frameworks replaced with those from the requested SDK.
+                if [ "$targetName" == "nix-support" ]; then
+                  mkdir "''${!outputName}/nix-support"
+
+                  for file in "$targetPath"/*; do
+                    fileName=$(basename "$file")
+
+                    if [ "$fileName" == "propagated-build-inputs" ]; then
+                      cp "$file" "''${!outputName}/nix-support/$fileName"
+
+                      while IFS=$'\t\n' read -r oldFramework newFramework; do
+                        substituteInPlace "''${!outputName}/nix-support/$fileName" \
+                          --replace "$oldFramework" "$newFramework"
+                      done < "$frameworksPath"
+                    fi
+                  done
+                else
+                  ln -s "$targetPath" "''${!outputName}/$targetName"
+                fi
+              done
+            done < "$pkgOutputsPath"
+          ''
+        else pkg;
+
+      # Remap a framework from one SDK version to another.
+      mapPackageToSDK = pkg:
+        let
+          name = lib.getName pkg;
+          framework = lib.removePrefix "apple-framework-" name;
+        in
+        if isSDKFramework pkg
+          then sdk.frameworks."${framework}"
+          else replacePropagatedFrameworks pkg;
+
+      mapInputsToSDK = inputs: args:
+        lib.genAttrs inputs (input: map mapPackageToSDK (args."${input}" or [ ]));
+
+      mkCC = cc: cc.override {
+        bintools = cc.bintools.override { libc = sdk.Libsystem; };
+        libc = sdk.Libsystem;
+      };
+    in
+    # TODO: make this work across all input types and not just propagatedBuildInputs
+    stdenv.override (old: {
+      buildPlatform = old.buildPlatform // { inherit darwinMinVersion darwinSdkVersion; };
+      hostPlatform = old.hostPlatform // { inherit darwinMinVersion darwinSdkVersion; };
+      targetPlatform = old.targetPlatform // { inherit darwinMinVersion darwinSdkVersion; };
+
+      allowedRequisites = null;
+      cc = mkCC old.cc;
+
+      extraBuildInputs = [sdk.frameworks.CoreFoundation ];
+      mkDerivationFromStdenv = extendMkDerivationArgs old (mapInputsToSDK [
+        "buildInputs"
+      ]);
+    });
 }

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -64,11 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    CoreFoundation
-    CoreServices
-    SystemConfiguration
-  ]);
   nativeBuildInputs = [ pkg-config perl ];
 
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains
@@ -91,7 +86,12 @@ stdenv.mkDerivation (finalAttrs: {
     optional wolfsslSupport wolfssl ++
     optional rustlsSupport rustls-ffi ++
     optional zlibSupport zlib ++
-    optional zstdSupport zstd;
+    optional zstdSupport zstd ++
+    optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      CoreFoundation
+      CoreServices
+      SystemConfiguration
+    ]);
 
   # for the second line see https://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5755,7 +5755,9 @@ with pkgs;
 
   joystickwake = callPackage ../tools/games/joystickwake { };
 
-  juce = darwin.apple_sdk_11_0.callPackage ../development/misc/juce { };
+  juce = callPackage ../development/misc/juce {
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
 
   jumppad = callPackage ../tools/virtualization/jumppad { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17033,7 +17033,12 @@ with pkgs;
   cargo-clone = callPackage ../development/tools/rust/cargo-clone {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
-  cargo-codspeed = callPackage ../development/tools/rust/cargo-codspeed { };
+  cargo-codspeed = callPackage ../development/tools/rust/cargo-codspeed {
+    rustPlatform = makeRustPlatform {
+      stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+      inherit rustc cargo;
+    };
+  };
   cargo-component = callPackage ../development/tools/rust/cargo-component { };
   cargo-cranky = callPackage ../development/tools/rust/cargo-cranky { };
   cargo-criterion = callPackage ../development/tools/rust/cargo-criterion { };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -30,6 +30,7 @@
 , openldap
 , openssl_1_1
 , openssl
+, overrideSDK
 , pam
 , pcre2
 , postgresql
@@ -239,6 +240,9 @@ lib.makeScope pkgs.newScope (self: with self; {
     couchbase = callPackage ../development/php-packages/couchbase { };
 
     datadog_trace = callPackage ../development/php-packages/datadog_trace {
+      buildPecl = buildPecl.override {
+        stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+      };
       inherit (pkgs) darwin;
     };
 


### PR DESCRIPTION
## Description of changes

curl expects to propagate any libraries and frameworks it links against, which was missed in #260963. This results in Nix and other packages that have curl as a dependency to fail to build. Since propagating frameworks is not compatible with the current mechanism for overriding the SDK used, a new mechanism has been introduced that handles propagated build inputs. This mechanism will likely replace the existing one in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
