### PR TITLE
Fix FreeCAD with Python 3.11

### DIFF
--- a/pkgs/applications/graphics/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+++ b/pkgs/applications/graphics/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -1,0 +1,60 @@
+From c4f452ef6ae083ed21095313582f6d1bd775cbf3 Mon Sep 17 00:00:00 2001
+From: Andreas Rammhold <andreas@rammhold.de>
+Date: Thu, 2 Nov 2023 17:32:07 +0100
+Subject: [PATCH] NIXOS: don't ignore PYTHONPATH
+
+On NixOS or rather within nixpkgs we provide the runtime Python
+packages via the PYTHONPATH environment variable. FreeCAD tries its
+best to ignore Python environment variables that are being inherited
+from the environment. For Python versions >=3.11 it also tries to
+initialize the interpreter config without any environmental data. We
+have to initialize the configuration *with* the information from the
+environment for our packaging to work.
+
+Upstream has purposely isolated the environments AFAIK and thus
+shouldn't accept this patch (as is). What they might accept (once
+support for older Python versions has been dropped) is removing the
+PYTHONPATH specific putenv calls.
+---
+ src/Base/Interpreter.cpp | 2 +-
+ src/Main/MainGui.cpp     | 3 ---
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/Base/Interpreter.cpp b/src/Base/Interpreter.cpp
+index 52c47168af..9966bd0013 100644
+--- a/src/Base/Interpreter.cpp
++++ b/src/Base/Interpreter.cpp
+@@ -554,7 +554,7 @@ void initInterpreter(int argc,char *argv[])
+ {
+     PyStatus status;
+     PyConfig config;
+-    PyConfig_InitIsolatedConfig(&config);
++    PyConfig_InitPythonConfig(&config);
+ 
+     status = PyConfig_SetBytesArgv(&config, argc, argv);
+     if (PyStatus_Exception(status)) {
+diff --git a/src/Main/MainGui.cpp b/src/Main/MainGui.cpp
+index 48ae847ef4..28813df383 100644
+--- a/src/Main/MainGui.cpp
++++ b/src/Main/MainGui.cpp
+@@ -112,17 +112,14 @@ int main( int argc, char ** argv )
+     // See https://forum.freecad.org/viewtopic.php?f=18&t=20600
+     // See Gui::Application::runApplication()
+     putenv("LC_NUMERIC=C");
+-    putenv("PYTHONPATH=");
+ #elif defined(FC_OS_MACOSX)
+     (void)QLocale::system();
+-    putenv("PYTHONPATH=");
+ #elif defined(__MINGW32__)
+     const char* mingw_prefix = getenv("MINGW_PREFIX");
+     const char* py_home = getenv("PYTHONHOME");
+     if (!py_home && mingw_prefix)
+         _putenv_s("PYTHONHOME", mingw_prefix);
+ #else
+-    _putenv("PYTHONPATH=");
+     // https://forum.freecad.org/viewtopic.php?f=4&t=18288
+     // https://forum.freecad.org/viewtopic.php?f=3&t=20515
+     const char* fc_py_home = getenv("FC_PYTHONHOME");
+-- 
+2.42.0
+

--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -108,6 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
     qtx11extras
   ];
 
+  patches = [
+    ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+  ];
+
   cmakeFlags = [
     "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
     "-DBUILD_FLAT_MESH:BOOL=ON"
@@ -127,10 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     export NIX_LDFLAGS="-L${gfortran.cc}/lib64 -L${gfortran.cc}/lib $NIX_LDFLAGS";
   '';
 
-  # Their main() removes PYTHONPATH=, and we rely on it.
   preConfigure = ''
-    sed '/putenv("PYTHONPATH/d' -i src/Main/MainGui.cpp
-
     qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
   '';
 

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -10,11 +10,6 @@
 , qt5
 , shiboken2
 }:
-
-# Only build when Python<=3.10
-# See https://bugreports.qt.io/browse/PYSIDE-1864
-# "There are no plans to support Python versions > 3.10 in the 5.15 branch."
-disabledIf (pythonAtLeast "3.11") (
 stdenv.mkDerivation rec {
   pname = "pyside2";
   version = "5.15.11";
@@ -80,4 +75,4 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.qt.io/Qt_for_Python";
     maintainers = with maintainers; [ gebner ];
   };
-})
+}


### PR DESCRIPTION
## Description of changes

FreeCAD is pedantic about the source of its python packages. It has been unsetting the PYTHONPATH environment variable for some time. With the recent support for Python 3.11 they are initializing the Python environment using an "isolated" configuration. That means our previous
    approach of removing the `putenv` line from the MainGui doesn't cut it
    anymore. In this commit I'm replacing the isolated configuration with
    a regular configuration. This means that FreeCAD will again pickup our
    PYTHONPATH.
    
An alternative approach would have been to pass each of our (runtime)
    python dependencies with the `-P` argument to the FreeCAD binary
    using (yet another) wrapper.
    
Perhaps the best approach, one that I might explore, is to figure out
    where FreeCAD usually expects the python dependencies to be. It might
    be that we can just symlink them into the package itself. One escape
    hatch that has been there for a while but hasn't been used (by us at
    least) is the `VIRTUAL_ENV` environment variable. We could provide an
    environment to the binary and get away without patching the source
    code. This requires some (new) machinery to produce virtualenv-alike
    folders.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
