### PR TITLE
eclipses.plugins: Replace SHA-1 hashes

### DIFF
--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -671,12 +671,12 @@ rec {
 
     srcFeature = fetchurl {
       url = "https://downloads.apache.org/ant/ivyde/updatesite/ivyde-${version}/features/org.apache.ivyde.feature_${version}.jar";
-      sha1 = "c8fb6c4aab32db13db0bd81c1a148032667fff31";
+      hash = "sha256-iKe7oOPjy6th0HmKt6NXexOHN60EDpQe1r+n6K+uoyw=";
     };
 
     srcPlugin = fetchurl {
       url = "https://downloads.apache.org/ant/ivyde/updatesite/ivyde-${version}/plugins/org.apache.ivyde.eclipse_${version}.jar";
-      sha1 = "0c80c2e228a07f18efab1c56ea026448eda70c06";
+      hash = "sha256-lhwFwdMDwCIUrQjdWfe5ZSutCIsKtZSBT6FWthUipdk=";
     };
 
     meta = with lib; {
@@ -695,12 +695,12 @@ rec {
 
     srcFeature = fetchurl {
       url = "https://downloads.apache.org/ant/ivyde/updatesite/ivyde-${version}/features/org.apache.ivyde.eclipse.resolvevisualizer.feature_${version}.jar";
-      sha1 = "fb1941eaa2c0de54259de01b0da6d5a6b4a2cab1";
+      hash = "sha256-PSH5NtE7hN2hHoHUhVK1CLkHN7YSDdTTqBP7711X4rU=";
     };
 
     srcPlugin = fetchurl {
       url = "https://downloads.apache.org/ant/ivyde/updatesite/ivyde-${version}/plugins/org.apache.ivyde.eclipse.resolvevisualizer_${version}.jar";
-      sha1 = "225e0c8ccb010d622c159560638578c2fc51a67e";
+      hash = "sha256-qjTvn1j7viSfzLkWnYjyS9Pj2ExqsiFGLzot3+oB0Tw=";
     };
 
     meta = with lib; {


### PR DESCRIPTION
## Description of changes

Replace `eclipses.plugins.ivyde{,rv}.src{Feature, Plugin}.sha1` with a `hash`
attribute, containing a SHA-256 hash in SRI format.

cc @r3dl3g

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
