### PR TITLE
nixos/luksroot: add fido2luks options

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17595,6 +17595,17 @@
     githubId = 74413170;
     name = "Johannes Klein";
   };
+  sivizius = {
+    name = "Sebastian Walz";
+    email = "nixpkgs@sivizius.eu";
+    matrix = "@sivizius:matrix.org";
+    github = "sivizius";
+    githubId = 1690450;
+    keys = [
+      { fingerprint = "6A6A 9F7C 47BA 4CBE DCD5  CB74 7BB4 21C6 84E8 21D8"; }
+      { fingerprint = "CC18 62DD 3726 0C5E F4DA  26C7 9CB0 27E3 30D3 1FB0"; }
+    ];
+  };
   sivteck = {
     email = "sivaram1992@gmail.com";
     github = "sivteck";


### PR DESCRIPTION
## Description of changes

`fido2luks` requires the flag `--pin` if the authenticator requires a PIN for FIDO2 operations. 
The current setup only allowed authenticators without a PIN which is insecure with `passwordLess` set to `true`. 
With this PR, the following options will be added:

* `requiresPIN` to add the flag `--pin` to `fido2luks`.
* `salt` to specify a static salt. This could replace the option `passwordLess` some day.
* `slot` to specify the slot of the authenticator.
* `maxRetries` to allow multiple tries to unlock before falling back to the usual passphrase prompt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).