### PR TITLE
arandr: 0.1.10 -> 0.1.11

### DIFF
--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -13,11 +13,11 @@ let
 in
 buildPythonApplication rec {
   pname = "arandr";
-  version = "0.1.10";
+  version = "0.1.11";
 
   src = fetchurl {
     url = "https://christian.amsuess.com/tools/arandr/files/${pname}-${version}.tar.gz";
-    sha256 = "135q0llvm077jil2fr92ssw3p095m4r8jfj0lc5rr3m71n4srj6v";
+    hash = "sha256-5Mu+Npi7gSs5V3CHAXS+AJS7rrOREFqBH5X0LrGCrgI=";
   };
 
   preBuild = ''
@@ -31,10 +31,10 @@ buildPythonApplication rec {
   nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
   propagatedBuildInputs = [ xrandr pygobject3 ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://christian.amsuess.com/tools/arandr/";
     description = "A simple visual front end for XRandR";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.domenkozar ];
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ domenkozar gepbird ];
   };
 }

--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -35,6 +35,6 @@ buildPythonApplication rec {
     homepage = "https://christian.amsuess.com/tools/arandr/";
     description = "A simple visual front end for XRandR";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ domenkozar gepbird ];
+    maintainers = with maintainers; [ gepbird ];
   };
 }


### PR DESCRIPTION
## Description of changes

Diff: https://gitlab.com/arandr/arandr/-/commit/8348c0b6020a792c1fed5baca923151db98b9397.
A python function got deprecated, making it unable to launch the binary. This was fixed in 0.1.11.
<details><summary>Error message when launching the binary</summary><pre>Traceback (most recent call last):
  File "/nix/store/31fva7xfs324zblzgh3sk392m0dhn8ga-arandr-0.1.10/bin/..arandr-wrapped-wrapped", line 42, in <module>
    from screenlayout.gui import main
  File "/nix/store/31fva7xfs324zblzgh3sk392m0dhn8ga-arandr-0.1.10/lib/python3.11/site-packages/screenlayout/gui.py", line 76, in <module>
    class Application:
  File "/nix/store/31fva7xfs324zblzgh3sk392m0dhn8ga-arandr-0.1.10/lib/python3.11/site-packages/screenlayout/gui.py", line 185, in Application
    @actioncallback
     ^^^^^^^^^^^^^^
  File "/nix/store/31fva7xfs324zblzgh3sk392m0dhn8ga-arandr-0.1.10/lib/python3.11/site-packages/screenlayout/gui.py", line 48, in actioncallback
    argnames = inspect.getargspec(function)[0]
               ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
</pre></details>

Also added myself as a maintainer and cleaned the code up a bit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
