### PR TITLE
nsncd: unstable-2022-11-14 -> unstable-2023-10-26

### DIFF
--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -7,16 +7,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nsncd";
-  version = "unstable-2022-11-14";
+  version = "unstable-2023-10-26";
 
+  # https://github.com/twosigma/nsncd/pull/71 has not been upstreamed
+  # to twosigma/nsncd yet. Using the nix-community fork in the
+  # meantime.
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nsncd";
-    rev = "47e580f1db99603df6e212a2e62f18cc970cef40";
-    hash = "sha256-Nv3MYZcuYgD66BAGs3Tg37s086HAGsaDBFvELqQF3Tk=";
+    rev =  "d6513421f420e407248c6d0aee39ae2f861a7cec";
+    hash = "sha256-PykzwpPxMDHJOr2HubXuw+Krk9Jbi0E3M2lEAOXhx2M=";
   };
 
-  cargoSha256 = "sha256-c1L6nEUBHw1YegmoRrI3WU/bF80Nzbz13hsGlNyBR9o=";
+  cargoSha256 = "sha256-cUM7rYXWpJ0aMiurXBp15IlxAmf/x5uiodxEqBPCQT0=";
 
   meta = with lib; {
     description = "the name service non-caching daemon";


### PR DESCRIPTION
Note: we decided to rewrite the history of the fork who somehow got
out of hand. Feature-wise, this version bump fixes the various host
faulty behaviour. See the
https://github.com/nix-community/nsncd/pull/9 and
https://github.com/nix-community/nsncd/pull/10 PRs for more details.

We're in the process of upstreaming this change to twosigma/nsncd,
however, upstream has been pretty slow to review our PRs so far. Since
the hostname bug surfaces quite regularly in the Nixpkgs issue
tracker, we decided to use the nix-community fork as canon for Nixpkgs
for now.

Fixes: https://github.com/NixOS/nixpkgs/issues/132646
Fixes: https://github.com/NixOS/nixpkgs/issues/261269
Fixes: https://github.com/NixOS/nixpkgs/issues/196934

------------------------------------------------------------------

@wkral, this fixes the `nixos.tests.networking.hostname.explicitDomain` test you mentioned in https://github.com/NixOS/nixpkgs/issues/132646#issuecomment-1552310509

@B4dM4n  @Majiir @RaitoBezarius @thomask77 , this PR should fix the bogus `hostname --fqdn` behavior you experienced. Can you confirm?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
