### PR TITLE
python3Packages.bip32: init at 3.4

### DIFF
--- a/pkgs/development/python-modules/bip32/default.nix
+++ b/pkgs/development/python-modules/bip32/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+, pythonOlder
+, setuptools
+, base58
+, coincurve
+}:
+
+buildPythonPackage rec {
+  pname = "bip32";
+  version = "3.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  # the PyPi source distribution ships a broken setup.py, so use github instead
+  src = fetchFromGitHub {
+    owner = "darosior";
+    repo = "python-bip32";
+    rev = version;
+    hash = "sha256-o8UKR17XDWp1wTWYeDL0DJY+D11YI4mg0UuGEAPkHxE=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    base58
+    coincurve
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "bip32"
+  ];
+
+  meta = with lib; {
+    description = "Minimalistic implementation of the BIP32 key derivation scheme";
+    homepage = "https://github.com/darosior/python-bip32";
+    changelog = "https://github.com/darosior/python-bip32/blob/${version}/CHANGELOG.md";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ arcnmx ];
+  };
+}

--- a/pkgs/development/python-modules/ledger-bitcoin/default.nix
+++ b/pkgs/development/python-modules/ledger-bitcoin/default.nix
@@ -4,6 +4,8 @@
 , setuptools
 , ledgercomm
 , packaging
+, bip32
+, coincurve
 , typing-extensions
  }:
 
@@ -25,6 +27,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     ledgercomm
     packaging
+    bip32
+    coincurve
     typing-extensions
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1440,6 +1440,8 @@ self: super: with self; {
 
   bip-utils = callPackage ../development/python-modules/bip-utils { };
 
+  bip32 = callPackage ../development/python-modules/bip32 { };
+
   bitarray = callPackage ../development/python-modules/bitarray { };
 
   bitbox02 = callPackage ../development/python-modules/bitbox02 { };


### PR DESCRIPTION
[bip32](https://github.com/darosior/python-bip32) is a required dependency of ledger-bitcoin 0.2.2, which was [updated from 0.2.1](https://github.com/NixOS/nixpkgs/commit/bccd14d7c855a1499f6ae198cbaf87ef47803db0) as part of #251878. It's currently failing to build.
This fixes the currently failing build as well `pkgs.electrum` which depends on it.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
