### PR TITLE
azure-cli: fix build failure

### DIFF
--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -1,7 +1,5 @@
 { lib
-, stdenv
-, python3
-, fetchPypi
+, callPackage
 , fetchFromGitHub
 , installShellFiles
 }:
@@ -18,9 +16,7 @@ let
   };
 
   # put packages that needs to be overridden in the py package scope
-  py = import ./python-packages.nix {
-    inherit stdenv src version python3 fetchPypi;
-  };
+  py = callPackage ./python-packages.nix { inherit src version; };
 in
 
 py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -1,6 +1,7 @@
 { stdenv
 , python3
 , fetchPypi
+, fetchpatch
 , src
 , version
 }:
@@ -27,6 +28,20 @@ let
       azure-cli-core = buildAzureCliPackage {
         pname = "azure-cli-core";
         inherit version src;
+
+        patches = [
+          (fetchpatch {
+            name = "fix-python311.patch";
+            url = "https://github.com/Azure/azure-cli/commit/a5198b578b17de934e15b1c92e369e45323e9658.patch";
+            hash = "sha256-qbyKF6Vvtz8QwY78sG7ptTVcbM2IR+phntOKqsrWetE=";
+            stripLen = 2;
+            includes = [
+              "azure/cli/core/tests/test_command_registration.py"
+              "azure/cli/core/tests/test_help.py"
+              "azure/cli/core/tests/test_parser.py"
+            ];
+          })
+        ];
 
         sourceRoot = "${src.name}/src/azure-cli-core";
 


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/263510
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
