### PR TITLE
cups-kyodialog: 9.2-20220928 -> 9.3-20230720

### DIFF
--- a/pkgs/misc/cups/drivers/kyodialog/default.nix
+++ b/pkgs/misc/cups/drivers/kyodialog/default.nix
@@ -23,8 +23,8 @@
 assert region == "Global" || region == "EU";
 
 let
-  kyodialog_version = "9.2";
-  date = "20220928";
+  kyodialog_version = "9.3";
+  date = "20230720";
 in
 stdenv.mkDerivation rec {
   pname = "cups-kyodialog";
@@ -33,11 +33,15 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   src = fetchzip {
+    # Steps to find the release download URL:
+    # 1. Go to https://www.kyoceradocumentsolutions.us/en/support/downloads.html
+    # 2. Search for printer model, e.g. "TASKalfa 6053ci"
+    # 3. Locate e.g. "Linux Print Driver (9.3)" in the list
     urls = [
       "https://www.kyoceradocumentsolutions.us/content/download-center-americas/us/drivers/drivers/KyoceraLinuxPackages_${date}_tar_gz.download.gz"
-      "https://web.archive.org/web/20221122230412/https://www.kyoceradocumentsolutions.us/content/download-center-americas/us/drivers/drivers/KyoceraLinuxPackages_${date}_tar_gz.download.gz"
+      "https://web.archive.org/web/20231021143259/https://www.kyoceradocumentsolutions.us/content/download-center-americas/us/drivers/drivers/KyoceraLinuxPackages_${date}_tar_gz.download.gz"
     ];
-    sha256 = "sha256-WCHuAQO2T6S8JtRsI2Yf/ypeCLMH365Ax/qX+Ah2s3k=";
+    hash = "sha256-3h2acOmaQIiqe2Fd9QiqEfre5TrxzRrll6UlUruwj1o=";
     extension = "tar.gz";
     stripRoot = false;
     postFetch = ''


### PR DESCRIPTION
## Description of changes

Steps to find the release download URL:
1. Go to https://www.kyoceradocumentsolutions.us/en/support/downloads.html
2. Search for printer model, e.g. "TASKalfa 6053ci"
3. Locate e.g. "Linux Print Driver (9.3)" in the list

The description says:
> This update supports the MA6000ifx/ PA6000x Series, fixes a Security enhancement vulnerability of OpenSSL and eliminates the data collection feature. 

(I cannot confirm the security and privacy claims. At least the amd64 binaries look to me very similar. OpenSSL 1.0.1f 6 Jan 2014 is statically compiled in, as well as a version of curl and the google analytics string. But since we don't ship the config file at the hard coded location , no reports are sent out to GA)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
