### PR TITLE
nginxModules.vod: 1.31 -> 1.32 and patch MAX_CLIPS

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -986,7 +986,11 @@ let self = {
       owner = "kaltura";
       repo = "nginx-vod-module";
       rev = "1.32";
-      hash = "sha256-uBZtzh+IvBFNU/9oQ3KmX65Eog2CrI5LYN8sKaqjJhE=";
+      hash = "sha256-ZpG0oj60D3o7/7uyE8AybCiOtncVe1Jnjaz22sIFypk=";
+      postFetch = ''
+        substituteInPlace $out/vod/media_set.h \
+          --replace "MAX_CLIPS (128)" "MAX_CLIPS (1024)"
+      '';
     };
 
     inputs = [ ffmpeg fdk_aac openssl libxml2 libiconv ];

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -985,8 +985,8 @@ let self = {
       name = "vod";
       owner = "kaltura";
       repo = "nginx-vod-module";
-      rev = "1.31";
-      hash = "sha256-ZpeO8QWQ+fGkz08u/zFOq7vj4aHcodzSHNrc1SgGUyc=";
+      rev = "1.32";
+      hash = "sha256-uBZtzh+IvBFNU/9oQ3KmX65Eog2CrI5LYN8sKaqjJhE=";
     };
 
     inputs = [ ffmpeg fdk_aac openssl libxml2 libiconv ];


### PR DESCRIPTION
## Description of changes

[Changelog 1.31 -> 1.32](https://github.com/kaltura/nginx-vod-module/compare/1.31...1.32)

The change with MAX_CLIPS is necessary because the default limit is quite small and breaks some applications. For example Frigate also patches the file before compiling their own nginx: [build_nginx.sh#L31](https://github.com/blakeblackshear/frigate/blob/e0e8a6fcc915a5d12e76e33342fa634880cf0a16/docker/main/build_nginx.sh#L31)

And according to the upstream of nginx-vod, one should just patch this themself when a bigger value is needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
