### PR TITLE
python3Packages.sqids: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/sqids/default.nix
+++ b/pkgs/development/python-modules/sqids/default.nix
@@ -8,21 +8,19 @@
 
 buildPythonPackage rec {
   pname = "sqids";
-  version = "0.3.0";
-  format = "pyproject";
+  version = "0.4.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-qAY41kOp0m+mua/4bvVwuDW5p0EpwY675Ux3W1JsqbE=";
+    hash = "sha256-U9nVpRc9PIM1ZO+bcL3RGIfAdlUMf+uFw/SpPTAjdnA=";
   };
 
   nativeBuildInputs = [
     setuptools-scm
   ];
-
-  doCheck = true;
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
## Description of changes

Also do minor cleanup e.g. "doCheck" is implicitly set by default for Python packages.

https://github.com/sqids/sqids-python/blob/9159badbcb4e9c141fe73a8264d345b6527e0879/CHANGELOG.md#changelog

> * Use double underscore convention to specify private methods
> * Separate single module into a package for better readability
> *  Add PEP 561 compatible type hints

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python310Packages.sqids</li>
    <li>python310Packages.sqids.dist</li>
    <li>python311Packages.sqids</li>
    <li>python311Packages.sqids.dist</li>
  </ul>
</details>