### PR TITLE
pantalaimon: fix breaking python 3.11 build

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -1,18 +1,14 @@
-{ lib, stdenv, buildPythonApplication, fetchFromGitHub, pythonOlder,
-  attrs, aiohttp, appdirs, click, keyring, logbook, peewee, janus,
-  prompt-toolkit, matrix-nio, dbus-python, pydbus, notify2, pygobject3,
-  setuptools, installShellFiles, nixosTests,
-
-  pytest, faker, pytest-aiohttp, aioresponses,
-
+{ lib, stdenv, python310Packages, fetchFromGitHub,
+  pythonOlder, pythonAtLeast, installShellFiles, nixosTests,
   enableDbusUi ? true
 }:
 
-buildPythonApplication rec {
+# Broken on Python 3.11 because of pydbus-0.6 (unmaintained)
+python310Packages.buildPythonApplication rec {
   pname = "pantalaimon";
   version = "0.10.5";
 
-  disabled = pythonOlder "3.6";
+  disabled = (pythonAtLeast "3.6") || (pythonOlder "3.11");
 
   # pypi tarball miss tests
   src = fetchFromGitHub {
@@ -22,7 +18,7 @@ buildPythonApplication rec {
     sha256 = "sha256-yMhE3wKRbFHoL0vdFR8gMkNU7Su4FHbAwKQYADaaWpk=";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs =  with python310Packages; [
     aiohttp
     appdirs
     attrs
@@ -43,7 +39,7 @@ buildPythonApplication rec {
       pydbus
   ];
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with python310Packages; [
     pytest
     faker
     pytest-aiohttp


### PR DESCRIPTION
## Description of changes

Current pantalaimon package breaks when attempting to build the package with Python 3.11. Therefore I choose to limit the package build to Python 3.10 for it to continue building as expected.

###### Build Error

```
error: pydbus-0.6.0 not supported for interpreter python3.11
```

The solution I came up with might not be good, therefore I'd welcome any form of packaging suggestions if you have one to share!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
