### PR TITLE
python311Packages.pydbus: patch python311 compat

### DIFF
--- a/pkgs/development/python-modules/py3status/default.nix
+++ b/pkgs/development/python-modules/py3status/default.nix
@@ -6,6 +6,7 @@
 , dbus-python
 , fetchPypi
 , file
+, hatchling
 , i3
 , i3ipc
 , libnotify
@@ -24,11 +25,16 @@
 buildPythonPackage rec {
   pname = "py3status";
   version = "3.53";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-vZrzHERjAg9J004A2dAbq8hKmAUslCTaRdwEAe9JRqU=";
   };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
 
   propagatedBuildInputs = [
     pytz

--- a/pkgs/development/python-modules/pydbus/default.nix
+++ b/pkgs/development/python-modules/pydbus/default.nix
@@ -1,21 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi, pygobject3, pythonAtLeast }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pygobject3
+}:
 
 buildPythonPackage rec {
   pname = "pydbus";
   version = "0.6.0";
+  pyproejct = true;
 
-  # Python 3.11 changed the API of the `inspect` module and pydbus was never
-  # updated to adapt; last commit was in 2018.
-  disabled = pythonAtLeast "3.11";
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0b0gipvz7vcfa9ddmwq2jrx16d4apb0hdnl5q4i3h8jlzwp1c1s2";
+  src = fetchFromGitHub {
+    owner = "LEW21";
+    repo = "pydbus";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-F1KKXG+7dWlEbToqtF3G7wU0Sco7zH5NqzlL58jyDGw=";
   };
 
-  propagatedBuildInputs = [ pygobject3 ];
+  postPatch = ''
+    substituteInPlace pydbus/_inspect3.py \
+      --replace "getargspec" "getfullargspec"
+  '';
 
-  pythonImportsCheck = [ "pydbus" ];
+  propagatedBuildInputs = [
+    pygobject3
+  ];
+
+  pythonImportsCheck = [
+    "pydbus"
+    "pydbus.generic"
+  ];
+
+  doCheck = false; # requires a working dbus setup
 
   meta = {
     homepage = "https://github.com/LEW21/pydbus";


### PR DESCRIPTION
The package has not been updated since 2018 and has been running into removals on python311.

Fortunately getfullargspec is a drop-in replacement for getargspec, so a simple substitution restore life support for now.

cc #263657

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
