### PR TITLE
armagetronad: 0.2.9.1.0 -> 0.2.9.1.1 + refactor

### DIFF
--- a/pkgs/games/armagetronad/default.nix
+++ b/pkgs/games/armagetronad/default.nix
@@ -1,42 +1,153 @@
-{ lib, stdenv, fetchurl
-, pkg-config, SDL, libxml2, SDL_image, libjpeg, libpng, libGLU, libGL, zlib
-, dedicatedServer ? false }:
+{ lib
+, stdenv
+, fetchFromGitLab
+, autoconf
+, automake
+, gnum4
+, pkg-config
+, bison
+, python3
+, which
+, boost
+, ftgl
+, freetype
+, glew
+, SDL
+, SDL_image
+, SDL_mixer
+, SDL2
+, SDL2_image
+, SDL2_mixer
+, libpng
+, libxml2
+, protobuf
+, dedicatedServer ? false
+}:
 
 let
-  versionMajor = "0.2.9";
-  versionMinor = "1.0";
-  version = "${versionMajor}.${versionMinor}";
+  latestVersionMajor = "0.2.9";
+  unstableVersionMajor = "0.4";
+
+  latestCommonBuildInputs = [ SDL SDL_image SDL_mixer libpng ];
+
+  unstableCommonBuildInputs = [ SDL2 SDL2_image SDL2_mixer glew ftgl freetype ];
+  unstableCommonNativeBuildInputs = [ SDL ]; # for sdl-config
+
+  srcs = {
+    ${latestVersionMajor} = rec {
+      version = "${latestVersionMajor}.1.1";
+      src = fetchFromGitLab {
+        owner = "armagetronad";
+        repo = "armagetronad";
+        rev = "v${version}";
+        sha256 = "tvmKGqzH8IYTSeahc8XmN3RV+GdE5GsP8pAlwG8Ph3M=";
+      };
+      extraBuildInputs = latestCommonBuildInputs;
+    };
+
+    ${unstableVersionMajor} =
+      let
+        rev = "4bf6245a668ce181cd464b767ce436a6b7bf8506";
+      in
+      {
+        version = "${unstableVersionMajor}-${builtins.substring 0 8 rev}";
+        src = fetchFromGitLab {
+          owner = "armagetronad";
+          repo = "armagetronad";
+          inherit rev;
+          sha256 = "cpJmQHCS6asGasD7anEgNukG9hRXpsIJZrCr3Q7uU4I=";
+        };
+        extraBuildInputs = [ protobuf boost ] ++ unstableCommonBuildInputs;
+        extraNativeBuildInputs = [ bison ] ++ unstableCommonNativeBuildInputs;
+      };
+
+    "${latestVersionMajor}-sty+ct+ap" =
+      let
+        rev = "fdfd5fb97083aed45467385b96d50d87669e4023";
+      in
+      {
+        version = "${latestVersionMajor}-sty+ct+ap-${builtins.substring 0 8 rev}";
+        src = fetchFromGitLab {
+          owner = "armagetronad";
+          repo = "armagetronad";
+          inherit rev;
+          sha256 = "UDbe7DiMLzNFAs4C6BbnmdEjqSltSbnk/uQfNOLGAfo=";
+        };
+        extraBuildInputs = latestCommonBuildInputs;
+        extraNativeBuildInputs = [ python3 ];
+      };
+  };
+
+  mkArmagetron = { version, src, dedicatedServer ? false, extraBuildInputs ? [ ], extraNativeBuildInputs ? [ ] }@params:
+    stdenv.mkDerivation rec {
+      pname = if dedicatedServer then "armagetronad-dedicated" else "armagetronad";
+      inherit version src;
+
+      # Build works fine; install has a race.
+      enableParallelBuilding = true;
+      enableParallelInstalling = false;
+
+      preConfigure = ''
+        patchShebangs .
+
+        ./bootstrap.sh
+      '';
+
+      configureFlags = [
+        "--enable-automakedefaults"
+        "--enable-authentication"
+        "--disable-memmanager"
+        "--disable-useradd"
+        "--disable-initscripts"
+        "--disable-etc"
+        "--disable-uninstall"
+        "--disable-sysinstall"
+      ] ++ lib.optional dedicatedServer "--enable-dedicated"
+        ++ lib.optional (!dedicatedServer) "--enable-music";
+
+      buildInputs = [ libxml2 ] ++ extraBuildInputs;
+
+      nativeBuildInputs = [ autoconf automake gnum4 pkg-config which python3 ]
+        ++ extraNativeBuildInputs;
+
+      doInstallCheck = true;
+
+      installCheckPhase = ''
+        export XDG_RUNTIME_DIR=/tmp
+        bin="$out/bin/${pname}"
+        prefix="$("$bin" --prefix || true)"
+        rubber="$("$bin" --doc | grep -m1 CYCLE_RUBBER)"
+        if [ "$prefix" != "$out" ] || \
+           [[ ! "$rubber" =~ ^CYCLE_RUBBER[[:space:]]+Niceness[[:space:]]factor ]]; then
+          exit 1
+        fi
+      '';
+
+      passthru =
+        if (dedicatedServer) then {
+          # No passthru, end of the line.
+          # https://www.youtube.com/watch?v=NOMa56y_Was
+        }
+        else if (version != srcs.${latestVersionMajor}.version) then {
+          # Allow a "dedicated" passthru for versions other than the default.
+          dedicated = mkArmagetron (params // {
+            dedicatedServer = true;
+          });
+        }
+        else (lib.mapAttrs (name: value: mkArmagetron value) (lib.filterAttrs (name: value: value.version != srcs.${latestVersionMajor}.version) srcs)) // {
+          # Allow both a "dedicated" passthru and a passthru for all the options other than the latest version, which this is.
+          dedicated = mkArmagetron (params // {
+            dedicatedServer = true;
+          });
+        };
+
+      meta = with lib; {
+        homepage = "http://armagetronad.org";
+        description = "A multiplayer networked arcade racing game in 3D similar to Tron";
+        maintainers = with maintainers; [ numinit ];
+        license = licenses.gpl2Plus;
+        platforms = platforms.linux;
+      };
+    };
 in
-stdenv.mkDerivation {
-  pname = if dedicatedServer then "armagetronad-dedicated" else "armagetronad";
-  inherit version;
-  src = fetchurl {
-    url = "https://launchpad.net/armagetronad/${versionMajor}/${version}/+download/armagetronad-${version}.tbz";
-    sha256 = "sha256-WbbHwBzj+MylQ34z+XSmN1KVQaEapPUsGlwXSZ4m9qE";
-  };
-
-  enableParallelBuilding = true;
-
-  configureFlags = [
-    "--enable-memmanager"
-    "--enable-automakedefaults"
-    "--disable-useradd"
-    "--disable-initscripts"
-    "--disable-etc"
-    "--disable-uninstall"
-    "--disable-sysinstall"
-  ] ++ lib.optional dedicatedServer "--enable-dedicated";
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ libxml2 zlib ]
-    ++ lib.optionals (!dedicatedServer) [ SDL SDL_image libxml2 libjpeg libpng libGLU libGL ];
-
-  meta = with lib; {
-    homepage = "http://armagetronad.org";
-    description = "A multiplayer networked arcade racing game in 3D similar to Tron";
-    maintainers = with maintainers; [ numinit ];
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-  };
-}
+mkArmagetron (srcs.${latestVersionMajor} // { inherit dedicatedServer; })


### PR DESCRIPTION
## Description of changes

Update to latest and fix potential crash due to --enable-memmanager (#263244). Add an installCheckPhase and the following passthrus for obscure types of game servers:

- `pkgs.armagetronad`
- `pkgs.armagetronad.dedicated`
- `pkgs.armagetronad."0.2.9-sty+ct+ap"`
- `pkgs.armagetronad."0.2.9-sty+ct+ap".dedicated`
- `pkgs.armagetronad."0.4"`
- `pkgs.armagetronad."0.4".dedicated`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
