### PR TITLE
lib.systems.inspect: isEfi → hasEfi rename

### DIFF
--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -1,5 +1,19 @@
 # Platform Notes {#chap-platform-notes}
 
+## UEFI {#sec-uefi}
+
+Some common issues when packaging software for UEFI environments:
+
+- Not all compilers know about UEFI as a proper target.
+
+  Most software will offer ways to compile UEFI software as it was compiled for the host system (not the UEFI host system) which will either confuse nixpkgs, you, or will be a hack.
+
+  Examples of such software are GNU GRUB (GNU-EFI), systemd-boot (elf2efi) and EDK2 firmware (bespoke build scripts)
+
+- Nixpkgs cannot know if you have UEFI firmware support or not on your platform beyond what is declared to be supported.
+
+  Use `pkgs.stdenv.hostPlatform.hasEfi` to know if it potentially have any form of UEFI support.
+
 ## Darwin (macOS) {#sec-darwin}
 
 Some common issues when packaging software for Darwin:

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -91,13 +91,19 @@ rec {
     isMusl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf muslabin32 muslabi64 ];
     isUClibc       = with abis; map (a: { abi = a; }) [ uclibc uclibceabi uclibceabihf ];
 
-    isEfi = [
+    # This is the list of platforms which can potentially have a UEFI firmware
+    # This is helpful to know when to emit UEFI binaries along your software, e.g. for boot or more.
+    hasEfi = [
       { cpu = { family = "arm"; version = "6"; }; }
       { cpu = { family = "arm"; version = "7"; }; }
       { cpu = { family = "arm"; version = "8"; }; }
       { cpu = { family = "riscv"; }; }
       { cpu = { family = "x86"; }; }
     ];
+
+    # This name will soon be used for detection of the UEFI target itself.
+    # Start deprecation of this in NixOS 24.05
+    isEfi = hasEfi;
   };
 
   matchAnyAttrs = patterns:

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -94,7 +94,7 @@
 , withCryptsetup ? true
 , withRepart ? true
 , withDocumentation ? true
-, withEfi ? stdenv.hostPlatform.isEfi
+, withEfi ? stdenv.hostPlatform.hasEfi
 , withFido2 ? true
 , withFirstboot ? false # conflicts with the NixOS /etc management
 , withHomed ? !stdenv.hostPlatform.isMusl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21796,7 +21796,7 @@ with pkgs;
 
   gnu-config = callPackage ../development/libraries/gnu-config { };
 
-  gnu-efi = if stdenv.hostPlatform.isEfi
+  gnu-efi = if stdenv.hostPlatform.hasEfi
               then callPackage ../development/libraries/gnu-efi { }
             else null;
 


### PR DESCRIPTION
This PR offers one change related to EFI improvements required for #231951.

Move away from `isEfi` meaning "does it have an EFI platform" and onto `isEfi` (is this EFI system, doesn't exist in this PR yet.) and `hasEfi` (does it have an EFI platform).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
