### PR TITLE
buildFlutterApplication: fix

### DIFF
--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -20,7 +20,6 @@
 
 (buildDartApplication.override {
   dart = flutter;
-  fetchDartDeps = fetchDartDeps.override { dart = flutter; };
 }) (args // {
   sdkSetupScript = ''
     # Pub needs SSL certificates. Dart normally looks in a hardcoded path.
@@ -44,8 +43,8 @@
     ''}/bin/dart"
 
     export HOME="$NIX_BUILD_TOP"
-    flutter config --no-analytics &>/dev/null # mute first-run
-    flutter config --enable-linux-desktop >/dev/null
+    ${flutter}/bin/flutter config --no-analytics &>/dev/null # mute first-run
+    ${flutter}/bin/flutter config --enable-linux-desktop >/dev/null
   '';
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ wrapGAppsHook ];


### PR DESCRIPTION
## Description of changes

The fetchDartDeps in buildFlutterApplication is overrided to use flutter instead of dart. 

https://github.com/NixOS/nixpkgs/blob/d6ada5d880ebdd9ff0a752a4ab4f07231f368fd6/pkgs/build-support/flutter/default.nix#L23

But buildDartApplication overrides fetchDartDeps again.

https://github.com/NixOS/nixpkgs/blob/d6ada5d880ebdd9ff0a752a4ab4f07231f368fd6/pkgs/build-support/dart/build-dart-application/default.nix#L39

So no flutter and the build fails.

https://github.com/NixOS/nixpkgs/blob/d6ada5d880ebdd9ff0a752a4ab4f07231f368fd6/pkgs/build-support/flutter/default.nix#L47

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
