### PR TITLE
Remove netali from WDZ maintainer team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -931,7 +931,6 @@ with lib.maintainers; {
   wdz = {
     members = [
       n0emis
-      netali
       vidister
       johannwagner
       yuka

--- a/pkgs/development/python-modules/coredis/default.nix
+++ b/pkgs/development/python-modules/coredis/default.nix
@@ -60,6 +60,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/alisaifee/coredis";
     changelog = "https://github.com/alisaifee/coredis/blob/${src.rev}/HISTORY.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ netali ];
+    maintainers = teams.wdz.members;
   };
 }

--- a/pkgs/development/python-modules/py-radix-sr/default.nix
+++ b/pkgs/development/python-modules/py-radix-sr/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "Python radix tree for IPv4 and IPv6 prefix matching";
     homepage = "https://github.com/SEKOIA-IO/py-radix";
     license = with licenses; [ isc bsdOriginal ];
-    maintainers = with maintainers; [ netali ];
+    maintainers = teams.wdz.members;
   };
 }

--- a/pkgs/tools/admin/oxidized/default.nix
+++ b/pkgs/tools/admin/oxidized/default.nix
@@ -14,7 +14,7 @@ bundlerApp {
     description = "A network device configuration backup tool. It's a RANCID replacement!";
     homepage    = "https://github.com/ytti/oxidized";
     license     = licenses.asl20;
-    maintainers = with maintainers; [ nicknovitski netali ];
+    maintainers = with maintainers; [ nicknovitski ] ++ teams.wdz.members;
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/iperf3d/default.nix
+++ b/pkgs/tools/networking/iperf3d/default.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     description = "A iperf3 client and server wrapper for dynamic server ports";
     homepage = "https://github.com/wobcom/iperf3d";
     license = licenses.mit;
-    maintainers = [ maintainers.netali ];
+    maintainers = with maintainers; [ netali ] ++ teams.wdz.members;
   };
 }


### PR DESCRIPTION
## Description of changes

My time at WDZ ends this month, so this PR adds some packages I have maintained for WDZ to the WDZ team and removes myself from the team.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
