### PR TITLE
corretto{11,17,19}: init at 11.0.20.9.1/17.0.8.8.1/19.0.2.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14462,6 +14462,12 @@
     githubId = 69053978;
     name = "rogarb";
   };
+  rollf = {
+    email = "rolf.schroeder@limbus-medtec.com";
+    github = "rollf";
+    githubId = 58295931;
+    name = "Rolf Schröder";
+  };
   roman = {
     email = "open-source@roman-gonzalez.info";
     github = "roman";

--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -1,0 +1,37 @@
+{ corretto11
+, fetchFromGitHub
+, gradle_7
+, jdk11
+, lib
+, stdenv
+, rsync
+, runCommand
+, testers
+}:
+
+let
+  corretto = import ./mk-corretto.nix {
+    inherit lib stdenv rsync runCommand testers;
+    jdk = jdk11;
+    gradle = gradle_7;
+    version = "11.0.20.9.1";
+    src = fetchFromGitHub {
+      owner = "corretto";
+      repo = "corretto-11";
+      rev = "b880bdc8397ec3dd6b7cd4b837ce846c9e902783";
+      sha256 = "sha256-IomJHQn0ZgqsBZ5BrRqVrEOhTq7wjLiIKMQlz53JxsU=";
+    };
+  };
+in
+corretto.overrideAttrs (oldAttrs: {
+  # jdk11 is built with --disable-warnings-as-errors (see openjdk/11.nix)
+  # because of several compile errors. We need to include this parameter for
+  # Corretto, too. Since the build is invoked via `gradle` build.gradle has to
+  # be adapted.
+  postPatch = oldAttrs.postPatch + ''
+    for file in $(find installers -name "build.gradle"); do
+      substituteInPlace $file --replace "command += archSpecificFlags" "command += archSpecificFlags + ['--disable-warnings-as-errors']"
+    done
+  '';
+
+})

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -1,0 +1,26 @@
+{ corretto17
+, fetchFromGitHub
+, gradle_7
+, jdk17
+, lib
+, stdenv
+, rsync
+, runCommand
+, testers
+}:
+
+let
+  corretto = import ./mk-corretto.nix {
+    inherit lib stdenv rsync runCommand testers;
+    jdk = jdk17;
+    gradle = gradle_7;
+    version = "17.0.8.8.1";
+    src = fetchFromGitHub {
+      owner = "corretto";
+      repo = "corretto-17";
+      rev = "9a3cc984f76cb5f90598bdb43215bad20e0f7319";
+      sha256 = "sha256-/VuB3ocD5VvDqCU7BoTG+fQ0aKvK1TejegRYmswInqQ=";
+    };
+  };
+in
+corretto

--- a/pkgs/development/compilers/corretto/19.nix
+++ b/pkgs/development/compilers/corretto/19.nix
@@ -1,0 +1,26 @@
+{ corretto19
+, fetchFromGitHub
+, gradle_7
+, jdk19
+, lib
+, stdenv
+, rsync
+, runCommand
+, testers
+}:
+
+let
+  corretto = import ./mk-corretto.nix {
+    inherit lib stdenv rsync runCommand testers;
+    jdk = jdk19;
+    gradle = gradle_7;
+    version = "19.0.2.7.1";
+    src = fetchFromGitHub {
+      owner = "corretto";
+      repo = "corretto-19";
+      rev = "72f064a1d716272bd17d4e425d4a264b2c2c7d36";
+      sha256 = "sha256-mEj/MIbdXU0+fF5RhqjPuSeyclstesGaXB0e48YlKuw=";
+    };
+  };
+in
+corretto

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -1,0 +1,115 @@
+{ jdk
+, version
+, src
+, lib
+, stdenv
+, gradle
+, rsync
+, runCommand
+, testers
+}:
+
+# Each Corretto version is based on a corresponding OpenJDK version. So
+# building Corretto is more or less the same as building OpenJDK. Hence, the
+# Corretto derivation overrides the corresponding OpenJDK derivation in order
+# to have access to all the version-specific fixes for the various OpenJDK
+# builds. However, Corretto uses `gradle` as build tool (which in turn will
+# invoke `make`). The configure/build phases are adapted as needed.
+
+let
+  pname = "corretto";
+  # The version scheme is different between OpenJDK & Corretto.
+  # See https://github.com/corretto/corretto-17/blob/release-17.0.8.8.1/build.gradle#L40
+  # "major.minor.security.build.revision"
+in
+jdk.overrideAttrs (finalAttrs: oldAttrs: {
+  inherit pname version src;
+  name = "${pname}-${version}";
+
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ jdk gradle rsync ];
+
+  dontConfigure = true;
+
+  postPatch = ''
+    # The rpm/deb task definitions require a Gradle plugin which we don't
+    # have and so the build fails. We'll simply remove them here because
+    # they are not needed anyways.
+    rm -rf installers/linux/universal/{rpm,deb}
+
+    # `/usr/bin/rsync` is invoked to copy the source tree. We don't have that.
+    for file in $(find installers -name "build.gradle"); do
+      substituteInPlace $file --replace "workingDir '/usr/bin'" "workingDir '.'"
+    done
+  '';
+
+
+  buildPhase =
+    let
+      # The Linux installer is placed at linux/universal/tar whereas the MacOS
+      # one is at mac/tar.
+      task =
+        if stdenv.isDarwin then
+          ":installers:mac:tar:packageBuildResults"
+        else ":installers:linux:universal:tar:packageBuildResults";
+    in
+    ''
+      runHook preBuild
+
+      # Corretto's actual built is triggered via `gradle`.
+      gradle --console=plain --no-daemon ${task}
+
+      # Prepare for the installPhase so that it looks like if a normal
+      # OpenJDK had been built.
+      dir=build/jdkImageName/images
+      mkdir -p $dir
+      file=$(find ./installers -name 'amazon-corretto-${version}*.tar.gz')
+      tar -xzf $file -C $dir
+      mv $dir/amazon-corretto-* $dir/jdk
+
+      runHook postBuild
+    '';
+
+  installPhase = oldAttrs.installPhase + ''
+    # The installPhase will place everything in $out/lib/openjdk and
+    # reference through symlinks. We don't rewrite the installPhase but at
+    # least move the folder to convey that this is not OpenJDK anymore.
+    mv $out/lib/openjdk $out/lib/corretto
+    ln -s $out/lib/corretto $out/lib/openjdk
+  '';
+
+  passthru =
+    let
+      pkg = finalAttrs.finalPackage;
+    in
+    oldAttrs.passthru // {
+      tests = {
+        version = testers.testVersion {
+          package = pkg;
+        };
+        vendor = runCommand "${pname}-vendor" { nativeBuildInputs = [ pkg ]; } ''
+          output=$(${pkg.meta.mainProgram} -XshowSettings:properties -version 2>&1 | grep vendor)
+          grep -Fq "java.vendor = Amazon.com Inc." - <<< "$output" && touch $out
+        '';
+        compiler = runCommand "${pname}-compiler" { nativeBuildInputs = [ pkg ]; } ''
+          cat << EOF  > Main.java
+          class Main {
+              public static void main(String[] args) {
+                  System.out.println("Hello, World!");
+              }
+          }
+          EOF
+          ${pkg}/bin/javac Main.java
+          ${pkg}/bin/java Main | grep -q "Hello, World!" && touch $out
+        '';
+      };
+    };
+
+  meta = with lib; {
+    homepage = "https://aws.amazon.com/corretto";
+    license = licenses.gpl2Only;
+    description = "Amazon's distribution of OpenJDK";
+    platforms = jdk.meta.platforms;
+    mainProgram = "java";
+    maintainers = with maintainers; [ rollf ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15416,6 +15416,10 @@ with pkgs;
 
   copper = callPackage ../development/compilers/copper { };
 
+  corretto11 = javaPackages.compiler.corretto11;
+  corretto17 = javaPackages.compiler.corretto17;
+  corretto19 = javaPackages.compiler.corretto19;
+
   cotton = callPackage ../development/tools/cotton {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -93,6 +93,10 @@ in {
       ../development/compilers/adoptopenjdk-bin/jdk17-linux.nix
       ../development/compilers/adoptopenjdk-bin/jdk17-darwin.nix;
 
+    corretto11 = callPackage ../development/compilers/corretto/11.nix { };
+    corretto17 = callPackage ../development/compilers/corretto/17.nix { };
+    corretto19 = callPackage ../development/compilers/corretto/19.nix { };
+
     openjdk8-bootstrap = mkBootstrap adoptopenjdk-8
       ../development/compilers/openjdk/bootstrap.nix
       { version = "8"; };


### PR DESCRIPTION
## Description of changes

This PR adds several versions of [Amazon Corretto](https://aws.amazon.com/corretto/). Corretto is basically OpenJDK with patches provided by Amazon. The Corretto derivations (in this PR) are based on the OpenJDK derivations (`overrideAttr`). I believe this is justified as a rebuild from scratch (`stdenv.mkDerivation`) would have to include all nixpkgs-specific fixes for OpenJDK, too.

There has been a [previous attempt](https://github.com/NixOS/nixpkgs/pull/55156) to include Corretto which was declined. I assume because it was stale? This PR would close https://github.com/NixOS/nixpkgs/issues/244456. Furthermore, this issue https://github.com/NixOS/nixpkgs/issues/114795 raises some concerns:
* I think the trademark is not a problem. The derivations make it clear, that this is *not* OpenJDK.
* Also, here, the distribution is built from source. No binary is patched. I therefore assume the running-modified-binaries argument is invalid.
* My personal use case for using Corretto is because my employer happens to use it. Our build environment even [enforces](https://docs.gradle.org/current/userguide/toolchains.html#sec:vendors) the vendor. I currently use OpenJDK on my NixOs machine and can't run an unmodified version of the build pipeline.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md); although I have some open questions:
  - See PR comments for details.
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
