### PR TITLE
stdenv and base packages: fix with __structuredAttrs enabled

### DIFF
--- a/pkgs/build-support/add-opengl-runpath/default.nix
+++ b/pkgs/build-support/add-opengl-runpath/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "add-opengl-runpath";
 
-  driverLink = "/run/opengl-driver" + lib.optionalString stdenv.isi686 "-32";
+  env.driverLink = "/run/opengl-driver" + lib.optionalString stdenv.isi686 "-32";
 
   buildCommand = ''
     mkdir -p $out/nix-support

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -51,11 +51,11 @@ let
 in
 
 runCommand name
-  rec {
+  {
     inherit manifest ignoreCollisions checkCollisionContents passthru
             meta pathsToLink extraPrefix postBuild
             nativeBuildInputs buildInputs;
-    pkgs = builtins.toJSON (map (drv: {
+    pkgs = map (drv: {
       paths =
         # First add the usual output(s): respect if user has chosen explicitly,
         # and otherwise use `meta.outputsToInstall`. The attribute is guaranteed
@@ -69,11 +69,10 @@ runCommand name
         ++ lib.filter (p: p!=null)
           (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
       priority = drv.meta.priority or 5;
-    }) paths);
+    }) paths;
     preferLocalBuild = true;
     allowSubstitutes = false;
-    # XXX: The size is somewhat arbitrary
-    passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else [ ];
+    __structuredAttrs = true;
   }
   ''
     ${buildPackages.perl}/bin/perl -w ${builder}

--- a/pkgs/build-support/fetchurl/write-mirror-list.sh
+++ b/pkgs/build-support/fetchurl/write-mirror-list.sh
@@ -1,3 +1,5 @@
+if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+
 source $stdenv/setup
 
 # !!! this is kinda hacky.

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -48,9 +48,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontUnpack = true;
 
-  # Additional flags passed to pkg-config.
-  addFlags = lib.optional stdenv.targetPlatform.isStatic "--static";
-
   installPhase =
     ''
       mkdir -p $out/bin $out/nix-support
@@ -116,6 +113,9 @@ stdenv.mkDerivation {
     shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
     wrapperName = "PKG_CONFIG_WRAPPER";
     inherit targetPrefix suffixSalt baseBinName;
+
+    # Additional flags passed to pkg-config.
+    addFlags = lib.optionalString stdenv.targetPlatform.isStatic "--static";
   };
 
   meta =

--- a/pkgs/build-support/remove-references-to/default.nix
+++ b/pkgs/build-support/remove-references-to/default.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation {
     substituteAll ${./darwin-sign-fixup.sh} $out/nix-support/setup-hooks.sh
   '';
 
-  inherit (builtins) storeDir;
-  shell = lib.getBin shell + (shell.shellPath or "");
-  signingUtils = if darwinCodeSign then signingUtils else null;
+  env = {
+    inherit (builtins) storeDir;
+    shell = lib.getBin shell + (shell.shellPath or "");
+    signingUtils = lib.optionalString darwinCodeSign signingUtils;
+  };
 }

--- a/pkgs/build-support/setup-hooks/autoreconf.sh
+++ b/pkgs/build-support/setup-hooks/autoreconf.sh
@@ -2,6 +2,13 @@ preConfigurePhases="${preConfigurePhases:-} autoreconfPhase"
 
 autoreconfPhase() {
     runHook preAutoreconf
-    autoreconf ${autoreconfFlags:---install --force --verbose}
+
+    if [ -z "$__structuredAttrs" ]; then
+        autoreconfFlags=(${autoreconfFlags[*]})
+    fi
+
+    defaultFlags=(--install --force --verbose)
+    autoreconf "${autoreconfFlags[@]:-"${defaultFlags[@]}"}"
+
     runHook postAutoreconf
 }

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -1,6 +1,6 @@
 { stdenvNoCC }:
 
-args:
+args@{ postInstall ? "", preInstall ? "", meta ? {}, ... }:
 
 # see the substituteAll in the nixpkgs documentation for usage and constaints
 stdenvNoCC.mkDerivation {
@@ -9,5 +9,6 @@ stdenvNoCC.mkDerivation {
   inherit (args) src;
   preferLocalBuild = true;
   allowSubstitutes = false;
-  env = removeAttrs args ["name" "src" "meta"];
+  env = removeAttrs args ["name" "src" "meta" "postInstall" "preInstall"];
+  inherit meta preInstall postInstall;
 }

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -3,10 +3,11 @@
 args:
 
 # see the substituteAll in the nixpkgs documentation for usage and constaints
-stdenvNoCC.mkDerivation ({
+stdenvNoCC.mkDerivation {
   name = if args ? name then args.name else baseNameOf (toString args.src);
   builder = ./substitute-all.sh;
   inherit (args) src;
   preferLocalBuild = true;
   allowSubstitutes = false;
-} // args)
+  env = removeAttrs args ["name" "src"];
+}

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -9,5 +9,5 @@ stdenvNoCC.mkDerivation {
   inherit (args) src;
   preferLocalBuild = true;
   allowSubstitutes = false;
-  env = removeAttrs args ["name" "src"];
+  env = removeAttrs args ["name" "src" "meta"];
 }

--- a/pkgs/build-support/substitute/substitute-all.sh
+++ b/pkgs/build-support/substitute/substitute-all.sh
@@ -1,3 +1,5 @@
+if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+
 source $stdenv/setup
 
 eval "$preInstall"

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -646,11 +646,7 @@ rec {
     }:
     script:
     runCommand name
-      (substitutions // {
-        # TODO(@Artturin:) substitutions should be inside the env attrset
-        # but users are likely passing non-substitution arguments through substitutions
-        # turn off __structuredAttrs to unbreak substituteAll
-        __structuredAttrs = false;
+      ({
         inherit meta;
         inherit depsTargetTargetPropagated;
         propagatedBuildInputs =
@@ -659,6 +655,7 @@ rec {
             (lib.warnIf (deps != [ ]) "'deps' argument to makeSetupHook is deprecated and will be removed in release 23.11., Please use propagatedBuildInputs instead. content of deps: ${toString deps}"
               propagatedBuildInputs ++ (if lib.isList deps then deps else [ deps ]));
         strictDeps = true;
+        env = substitutions;
         # TODO 2023-01, no backport: simplify to inherit passthru;
         passthru = passthru
           // optionalAttrs (substitutions?passthru)

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck, haskell }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck, haskell, jq }:
 
 let
   inherit (lib)
@@ -542,12 +542,13 @@ rec {
       args = removeAttrs args_ [ "name" "postBuild" ]
         // {
           inherit preferLocalBuild allowSubstitutes;
-          passAsFile = [ "paths" ];
+          __structuredAttrs = true;
         }; # pass the defaults
     in runCommand name args
       ''
         mkdir -p $out
-        for i in $(cat $pathsPath); do
+        ${jq}/bin/jq -r ".paths[]" < .attrs.json > paths
+        for i in $(cat paths); do
           ${lndir}/bin/lndir -silent $i $out
         done
         ${postBuild}

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -35,8 +35,12 @@ cmakeConfigurePhase() {
         : ${cmakeDir:=.}
     fi
 
+    if [ -z "$__structuredAttrs" ]; then
+        cmakeFlags=(${cmakeFlags[*]})
+    fi
+
     if [ -z "${dontAddPrefix-}" ]; then
-        cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix $cmakeFlags"
+        cmakeFlags=("-DCMAKE_INSTALL_PREFIX=$prefix" "${cmakeFlags[@]}")
     fi
 
     # We should set the proper `CMAKE_SYSTEM_NAME`.
@@ -45,21 +49,21 @@ cmakeConfigurePhase() {
     # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
     # strip. Otherwise they are taken to be relative to the source root of the
     # package being built.
-    cmakeFlags="-DCMAKE_CXX_COMPILER=$CXX $cmakeFlags"
-    cmakeFlags="-DCMAKE_C_COMPILER=$CC $cmakeFlags"
-    cmakeFlags="-DCMAKE_AR=$(command -v $AR) $cmakeFlags"
-    cmakeFlags="-DCMAKE_RANLIB=$(command -v $RANLIB) $cmakeFlags"
-    cmakeFlags="-DCMAKE_STRIP=$(command -v $STRIP) $cmakeFlags"
+    cmakeFlags=("-DCMAKE_CXX_COMPILER=$CXX" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_C_COMPILER=$CC" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_AR=$(command -v $AR)" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_RANLIB=$(command -v $RANLIB)" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_STRIP=$(command -v $STRIP)" "${cmakeFlags[@]}")
 
     # on macOS we want to prefer Unix-style headers to Frameworks
     # because we usually do not package the framework
-    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=LAST $cmakeFlags"
+    cmakeFlags=("-DCMAKE_FIND_FRAMEWORK=LAST" "${cmakeFlags[@]}")
 
     # we never want to use the global macOS SDK
-    cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
+    cmakeFlags=("-DCMAKE_OSX_SYSROOT=" "${cmakeFlags[@]}")
 
     # correctly detect our clang compiler
-    cmakeFlags="-DCMAKE_POLICY_DEFAULT_CMP0025=NEW $cmakeFlags"
+    cmakeFlags=("-DCMAKE_POLICY_DEFAULT_CMP0025=NEW" "${cmakeFlags[@]}")
 
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
@@ -68,7 +72,7 @@ cmakeConfigurePhase() {
     # libraries are in a system path or in the same directory as the
     # executable. This flag makes the shared library accessible from its
     # nix/store directory.
-    cmakeFlags="-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib $cmakeFlags"
+    cmakeFlags=("-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib" "${cmakeFlags[@]}")
 
     # The docdir flag needs to include PROJECT_NAME as per GNU guidelines,
     # try to extract it from CMakeLists.txt.
@@ -91,39 +95,41 @@ cmakeConfigurePhase() {
     # This ensures correct paths with multiple output derivations
     # It requires the project to use variables from GNUInstallDirs module
     # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-    cmakeFlags="-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName} $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale $cmakeFlags"
+    cmakeFlags=("-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName}" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale" "${cmakeFlags[@]}")
 
     # Don’t build tests when doCheck = false
     if [ -z "${doCheck-}" ]; then
-        cmakeFlags="-DBUILD_TESTING=OFF $cmakeFlags"
+        cmakeFlags=("-DBUILD_TESTING=OFF" "${cmakeFlags[@]}")
     fi
 
     # Always build Release, to ensure optimisation flags
-    cmakeFlags="-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release} $cmakeFlags"
+    cmakeFlags=("-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release}" "${cmakeFlags[@]}")
 
     # Disable user package registry to avoid potential side effects
     # and unecessary attempts to access non-existent home folder
     # https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#disabling-the-package-registry
-    cmakeFlags="-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON $cmakeFlags"
-    cmakeFlags="-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF $cmakeFlags"
-    cmakeFlags="-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF $cmakeFlags"
+    cmakeFlags=("-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF" "${cmakeFlags[@]}")
+    cmakeFlags=("-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF" "${cmakeFlags[@]}")
 
     if [ "${buildPhase-}" = ninjaBuildPhase ]; then
-        cmakeFlags="-GNinja $cmakeFlags"
+        cmakeFlags=("-GNinja" "${cmakeFlags[@]}")
     fi
 
-    echo "cmake flags: $cmakeFlags ${cmakeFlagsArray[@]}"
+    cmakeFlags=("${cmakeFlags[@]}" "${cmakeFlagsArray[@]}")
 
-    cmake "$cmakeDir" $cmakeFlags "${cmakeFlagsArray[@]}"
+    echo "cmake flags: ${cmakeFlags[@]}"
+
+    cmake "$cmakeDir" "${cmakeFlags[@]}"
 
     if ! [[ -v enableParallelBuilding ]]; then
         enableParallelBuilding=1

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -14,8 +14,8 @@ in
       ] ++ lib.optionals (! withoutTargetLibc) [
         "-B${lib.getLib dep}${dep.libdir or "/lib"}"
       ]);
-    in mkFlags libcCross langD
-       ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null) langD)
+    in toString (mkFlags libcCross langD
+       ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null) langD))
     ;
 
   EXTRA_LDFLAGS_FOR_TARGET = let
@@ -27,7 +27,7 @@ in
           "-Wl,-rpath,${lib.getLib dep}${dep.libdir or "/lib"}"
           "-Wl,-rpath-link,${lib.getLib dep}${dep.libdir or "/lib"}"
       ]));
-    in mkFlags libcCross
-       ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null))
+    in toString (mkFlags libcCross
+       ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null)))
     ;
 }

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -387,19 +387,19 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
     # Cross-compiling, we need gcc not to read ./specs in order to build the g++
     # compiler (after the specs for the cross-gcc are created). Having
     # LIBRARY_PATH= makes gcc read the specs from ., and the build breaks.
-    CPATH = optionals (targetPlatform == hostPlatform) (makeSearchPathOutput "dev" "include" ([]
+    CPATH = toString (optionals (targetPlatform == hostPlatform) (makeSearchPathOutput "dev" "include" ([]
       ++ optional (zlib != null) zlib
       ++ optional langJava boehmgc
       ++ optionals javaAwtGtk xlibs
       ++ optionals javaAwtGtk [ gmp mpfr ]
-    ));
+    )));
 
-    LIBRARY_PATH = optionals (targetPlatform == hostPlatform) (makeLibraryPath (
+    LIBRARY_PATH = toString (optionals (targetPlatform == hostPlatform) (makeLibraryPath (
       optional (zlib != null) zlib
       ++ optional langJava boehmgc
       ++ optionals javaAwtGtk xlibs
       ++ optionals javaAwtGtk [ gmp mpfr ]
-    ));
+    )));
 
     inherit (callFile ./common/extra-target-flags.nix { })
       EXTRA_FLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -278,7 +278,6 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
     else [ "out" "lib" "man" "info" ];
 
   setOutputFlags = false;
-  NIX_NO_SELF_RPATH = true;
 
   libc_dev = stdenv.cc.libc_dev;
 
@@ -372,41 +371,50 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   # https://gcc.gnu.org/PR109898
   enableParallelInstalling = false;
 
-  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
-  ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
+  env = {
+    NIX_NO_SELF_RPATH = true;
 
-  # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
-  # library headers and binaries, regarless of the language being compiled.
-  #
-  # Note: When building the Java AWT GTK peer, the build system doesn't honor
-  # `--with-gmp' et al., e.g., when building
-  # `libjava/classpath/native/jni/java-math/gnu_java_math_GMP.c', so we just add
-  # them to $CPATH and $LIBRARY_PATH in this case.
-  #
-  # Likewise, the LTO code doesn't find zlib.
-  #
-  # Cross-compiling, we need gcc not to read ./specs in order to build the g++
-  # compiler (after the specs for the cross-gcc are created). Having
-  # LIBRARY_PATH= makes gcc read the specs from ., and the build breaks.
+    # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
+    # library headers and binaries, regarless of the language being compiled.
+    #
+    # Note: When building the Java AWT GTK peer, the build system doesn't honor
+    # `--with-gmp' et al., e.g., when building
+    # `libjava/classpath/native/jni/java-math/gnu_java_math_GMP.c', so we just add
+    # them to $CPATH and $LIBRARY_PATH in this case.
+    #
+    # Likewise, the LTO code doesn't find zlib.
+    #
+    # Cross-compiling, we need gcc not to read ./specs in order to build the g++
+    # compiler (after the specs for the cross-gcc are created). Having
+    # LIBRARY_PATH= makes gcc read the specs from ., and the build breaks.
+    CPATH = optionals (targetPlatform == hostPlatform) (makeSearchPathOutput "dev" "include" ([]
+      ++ optional (zlib != null) zlib
+      ++ optional langJava boehmgc
+      ++ optionals javaAwtGtk xlibs
+      ++ optionals javaAwtGtk [ gmp mpfr ]
+    ));
 
-  CPATH = optionals (targetPlatform == hostPlatform) (makeSearchPathOutput "dev" "include" ([]
-    ++ optional (zlib != null) zlib
-    ++ optional langJava boehmgc
-    ++ optionals javaAwtGtk xlibs
-    ++ optionals javaAwtGtk [ gmp mpfr ]
-  ));
+    LIBRARY_PATH = optionals (targetPlatform == hostPlatform) (makeLibraryPath (
+      optional (zlib != null) zlib
+      ++ optional langJava boehmgc
+      ++ optionals javaAwtGtk xlibs
+      ++ optionals javaAwtGtk [ gmp mpfr ]
+    ));
 
-  LIBRARY_PATH = optionals (targetPlatform == hostPlatform) (makeLibraryPath (
-    optional (zlib != null) zlib
-    ++ optional langJava boehmgc
-    ++ optionals javaAwtGtk xlibs
-    ++ optionals javaAwtGtk [ gmp mpfr ]
-  ));
-
-  inherit (callFile ./common/extra-target-flags.nix { })
-    EXTRA_FLAGS_FOR_TARGET
-    EXTRA_LDFLAGS_FOR_TARGET
-    ;
+    inherit (callFile ./common/extra-target-flags.nix { })
+      EXTRA_FLAGS_FOR_TARGET
+      EXTRA_LDFLAGS_FOR_TARGET
+      ;
+  } // optionalAttrs (hostPlatform.system == "x86_64-solaris") {
+    # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+    CC = "gcc -m64";
+  } // optionalAttrs is7 {
+    NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument";
+  } // optionalAttrs (!atLeast7) {
+    langJava = langJava;
+  } // optionalAttrs atLeast6 {
+    NIX_LDFLAGS = lib.optionalString hostPlatform.isSunOS "-lm";
+  };
 
   passthru = {
     inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD version;
@@ -430,12 +438,6 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   } // lib.optionalAttrs (!atLeast11) {
     badPlatforms = if !is49 then [ "aarch64-darwin" ] else lib.platforms.darwin;
   };
-} // optionalAttrs is7 {
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument";
-} // optionalAttrs (!atLeast7) {
-  env.langJava = langJava;
-} // optionalAttrs atLeast6 {
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 } // optionalAttrs (!atLeast8) {
   doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv
 } // optionalAttrs enableMultilib {

--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, rustPlatform, rustc, Security, asNightly ? false }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "rustfmt" + lib.optionalString asNightly "-nightly";
   inherit (rustc) version src;
 
@@ -26,13 +26,15 @@ rustPlatform.buildRustPackage rec {
     install_name_tool -add_rpath "${rustc}/lib" "$out/bin/git-rustfmt"
   '';
 
-  # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
-  RUSTC_BOOTSTRAP = 1;
+  env = {
+    # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
+    RUSTC_BOOTSTRAP = 1;
 
-  # As of rustc 1.45.0, these env vars are required to build rustfmt (due to
-  # https://github.com/rust-lang/rust/pull/72001)
-  CFG_RELEASE = rustc.version;
-  CFG_RELEASE_CHANNEL = if asNightly then "nightly" else "stable";
+    # As of rustc 1.45.0, these env vars are required to build rustfmt (due to
+    # https://github.com/rust-lang/rust/pull/72001)
+    CFG_RELEASE = rustc.version;
+    CFG_RELEASE_CHANNEL = if asNightly then "nightly" else "stable";
+  };
 
   meta = with lib; {
     description = "A tool for formatting Rust code according to style guidelines";

--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -11,7 +11,7 @@ pipInstallPhase() {
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
     pushd dist || return 1
-    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags
+    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache "${pipInstallFlags[@]}"
     popd || return 1
 
     runHook postInstall

--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -6,8 +6,10 @@ pythonImportsCheckPhase () {
 
     if [ -n "$pythonImportsCheck" ]; then
         echo "Check whether the following modules can be imported: $pythonImportsCheck"
+        # TODO(globin) use .attrs.json?
+        export pythonImportsCheckStr="${pythonImportsCheck[*]}"
         export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
-        ( cd $out && eval "@pythonCheckInterpreter@ -c 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ[\"pythonImportsCheck\"].split()))'" )
+        ( cd $out && eval "@pythonCheckInterpreter@ -c 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ[\"pythonImportsCheckStr\"].split()))'" )
     fi
 }
 

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -5,7 +5,11 @@ unittestCheckPhase() {
     echo "Executing unittestCheckPhase"
     runHook preCheck
 
-    eval "@pythonCheckInterpreter@ -m unittest discover $unittestFlagsArray"
+    if [ -n "$__structuredAttrs" ]; then
+        @pythonCheckInterpreter@ -m unittest discover "${unittestFlagsArray[@]}"
+    else
+        eval "@pythonCheckInterpreter@ -m unittest discover $unittestFlagsArray"
+    fi
 
     runHook postCheck
     echo "Finished executing unittestCheckPhase"

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -195,7 +195,7 @@ let
   # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
   self = toPythonModule (stdenv.mkDerivation ((builtins.removeAttrs attrs [
     "disabled" "checkPhase" "checkInputs" "nativeCheckInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "pyproject" "format"
-    "disabledTestPaths" "outputs" "stdenv"
+    "outputs" "stdenv"
   ]) // {
 
     name = namePrefix + name_;
@@ -293,8 +293,6 @@ let
     # If given use the specified checkPhase, otherwise use the setup hook.
     # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
     installCheckPhase = attrs.checkPhase;
-  } //  lib.optionalAttrs (disabledTestPaths != []) {
-      disabledTestPaths = lib.escapeShellArgs disabledTestPaths;
   }));
 
   passthru.updateScript = let

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -1,13 +1,18 @@
+if [ -z "$__structuredAttrs" ]; then
+    pythonPath=(${pythonPath[*]})
+fi
+
 # Wrapper around wrapPythonProgramsIn, below. The $pythonPath
 # variable is passed in from the buildPythonPackage function.
 wrapPythonPrograms() {
-    wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
+    local pythonPath=("$out" "${pythonPath[@]}")
+    wrapPythonProgramsIn "$out/bin" "${pythonPath[@]}"
 }
 
 # Builds environment variables like PYTHONPATH and PATH walking through closure
 # of dependencies.
 buildPythonPath() {
-    local pythonPath="$1"
+    local pythonPath=("$@")
     local path
 
     # Create an empty table of python paths (see doc on _addToPythonPath
@@ -18,8 +23,8 @@ buildPythonPath() {
     program_PATH=
     pythonPathsSeen["@pythonHost@"]=1
     addToSearchPath program_PATH @pythonHost@/bin
-    for path in $pythonPath; do
-        _addToPythonPath $path
+    for path in "${pythonPath[@]}"; do
+        _addToPythonPath "$path"
     done
 }
 
@@ -41,10 +46,11 @@ patchPythonScript() {
 # suffix).
 wrapPythonProgramsIn() {
     local dir="$1"
-    local pythonPath="$2"
+    shift
+    local pythonPath=("$@")
     local f
 
-    buildPythonPath "$pythonPath"
+    buildPythonPath "${pythonPath[@]}"
 
     # Find all regular files in the output directory that are executable.
     if [ -d "$dir" ]; then

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -469,7 +469,6 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withModplug "libmodplug")
     (enableFeature withMysofa "libmysofa")
     (enableFeature withOpus "libopus")
-    (optionalString (versionAtLeast version "5.0" && withLibplacebo) "--enable-libplacebo")
     (enableFeature withSvg "librsvg")
     (enableFeature withSrt "libsrt")
     (enableFeature withSsh "libssh")
@@ -526,6 +525,8 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withOptimisations "optimizations")
     (enableFeature withExtraWarnings "extra-warnings")
     (enableFeature withStripping "stripping")
+  ] ++ optionals (versionAtLeast version "5.0" && withLibplacebo) [
+    "--enable-libplacebo"
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--cross-prefix=${stdenv.cc.targetPrefix}"
     "--enable-cross-compile"

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -45,8 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (precision != "double") "--enable-${precision}"
   # https://www.fftw.org/fftw3_doc/SIMD-alignment-and-fftw_005fmalloc.html
   # FFTW will try to detect at runtime whether the CPU supports these extensions
-  ++ lib.optional (stdenv.isx86_64 && (precision == "single" || precision == "double"))
-    "--enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-avx128-fma"
+  ++ lib.optionals (stdenv.isx86_64 && (precision == "single" || precision == "double"))
+    [ "--enable-sse2" "--enable-avx" "--enable-avx2" "--enable-avx512" "--enable-avx128-fma" ]
   ++ lib.optional enableMpi "--enable-mpi"
   # doc generation causes Fortran wrapper generation which hard-codes gcc
   ++ lib.optional (!withDoc) "--disable-doc";

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -206,6 +206,11 @@ stdenv.mkDerivation ({
     inherit sha256;
   };
 
+  makeFlags = lib.optionals (stdenv.cc.libc != null) [
+    "BUILD_LDFLAGS=-Wl,-rpath,${stdenv.cc.libc}/lib"
+    "OBJDUMP=${stdenv.cc.bintools.bintools}/bin/objdump"
+  ];
+
   # Remove absolute paths from `configure' & co.; build out-of-tree.
   preConfigure = ''
     export PWD_P=$(type -tP pwd)
@@ -219,12 +224,6 @@ stdenv.mkDerivation ({
     cd ../build
 
     configureScript="`pwd`/../$sourceRoot/configure"
-
-    ${lib.optionalString (stdenv.cc.libc != null)
-      ''makeFlags="$makeFlags BUILD_LDFLAGS=-Wl,-rpath,${stdenv.cc.libc}/lib OBJDUMP=${stdenv.cc.bintools.bintools}/bin/objdump"''
-    }
-
-
   '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i s/-lgcc_eh//g "../$sourceRoot/Makeconfig"
 

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -27,8 +27,6 @@ in
     # override the patches in `common.nix` -- so instead you should
     # write `patches = (previousAttrs.patches or []) ++ [ ... ]`.
 
-    NIX_NO_SELF_RPATH = true;
-
     postConfigure = ''
       # Hack: get rid of the `-static' flag set by the bootstrap stdenv.
       # This has to be done *after* `configure' because it builds some
@@ -52,6 +50,8 @@ in
     hardeningDisable = [ "fortify" "pie" "stackprotector" ];
 
     env = (previousAttrs.env or { }) // {
+      NIX_NO_SELF_RPATH = true;
+
       NIX_CFLAGS_COMPILE = (previousAttrs.env.NIX_CFLAGS_COMPILE or "") + lib.concatStringsSep " "
         (builtins.concatLists [
           (lib.optionals withGd gdCflags)

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -19,11 +19,9 @@
 
   outputs = [ "out" ];
 
-  LOCALEDEF_FLAGS = [
-    (if stdenv.hostPlatform.isLittleEndian
+  env.LOCALEDEF_FLAGS = if stdenv.hostPlatform.isLittleEndian
     then "--little-endian"
-    else "--big-endian")
-  ];
+    else "--big-endian";
 
   preBuild = (previousAttrs.preBuild or "") + ''
       # Awful hack: `localedef' doesn't allow the path to `locale-archive'

--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     version = "1.1";
   };
 
-  PERL_USE_UNSAFE_INC = "1";
+  env.PERL_USE_UNSAFE_INC = "1";
 
   src = fetchurl {
     url = "${meta.homepage}${name}.tar.gz";

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -63,6 +63,10 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace config/shlib.conf \
         --replace "'ld " "'${stdenv.cc.targetPrefix}ld "
+
+    if [ -z "$__structuredAttrs" ]; then
+      libFolders=(''${libFolders[*]})
+    fi
   '';
 
   libFolders = [ "util" "include" "lib" "build-tools" ];
@@ -71,7 +75,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     MAKE="make -j $NIX_BUILD_CORES"
-    for folder in $libFolders; do
+    for folder in "''${libFolders[@]}"; do
       $MAKE -C $folder
     done
 
@@ -83,7 +87,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p "$out"/{bin,sbin,lib/pkgconfig,share/{et,man/man1}} \
       "$dev"/include/{gssapi,gssrpc,kadm5,krb5}
-    for folder in $libFolders; do
+
+    for folder in "''${libFolders[@]}"; do
       $MAKE -C $folder install
     done
 

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -214,7 +214,7 @@ self = stdenv.mkDerivation {
     "-Dvalgrind=disabled"
   ] ++ lib.optional enablePatentEncumberedCodecs
     "-Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec"
-  ++ lib.optional (vulkanLayers != []) "-D vulkan-layers=${builtins.concatStringsSep "," vulkanLayers}";
+  ++ lib.optional (vulkanLayers != []) "-Dvulkan-layers=${builtins.concatStringsSep "," vulkanLayers}";
 
   buildInputs = with xorg; [
     expat llvmPackages.libllvm libglvnd xorgproto

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation rec {
   # at install time but Meson does not support this
   # so we need to convince it to install all files to a temporary
   # location using DESTDIR and then move it to proper one in postInstall.
-  DESTDIR = "${placeholder "out"}/dest";
+  env.DESTDIR = "${placeholder "out"}/dest";
 
   inherit doCheck;
 
@@ -166,17 +166,17 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # Move stuff from DESTDIR to proper location.
     # We use rsync to merge the directories.
-    rsync --archive "${DESTDIR}/etc" "$out"
-    rm --recursive "${DESTDIR}/etc"
-    rsync --archive "${DESTDIR}${system}"/* "$out"
-    rm --recursive "${DESTDIR}${system}"/*
-    rmdir --parents --ignore-fail-on-non-empty "${DESTDIR}${system}"
+    rsync --archive "''${DESTDIR}/etc" "$out"
+    rm --recursive "''${DESTDIR}/etc"
+    rsync --archive "''${DESTDIR}${system}"/* "$out"
+    rm --recursive "''${DESTDIR}${system}"/*
+    rmdir --parents --ignore-fail-on-non-empty "''${DESTDIR}${system}"
     for o in $(getAllOutputNames); do
-        rsync --archive "${DESTDIR}/''${!o}" "$(dirname "''${!o}")"
-        rm --recursive "${DESTDIR}/''${!o}"
+        rsync --archive "''${DESTDIR}/''${!o}" "$(dirname "''${!o}")"
+        rm --recursive "''${DESTDIR}/''${!o}"
     done
     # Ensure the DESTDIR is removed.
-    destdirContainer="$(dirname "${DESTDIR}")"
+    destdirContainer="$(dirname "''${DESTDIR}")"
     pushd "$destdirContainer"; rmdir --parents "''${DESTDIR##$destdirContainer/}${builtins.storeDir}"; popd
   '';
 

--- a/pkgs/development/libraries/qt-5/hooks/move-qt-dev-tools.sh
+++ b/pkgs/development/libraries/qt-5/hooks/move-qt-dev-tools.sh
@@ -10,25 +10,27 @@ updateToolPath() {
 }
 
 moveQtDevTools() {
-    if [ -n "$devTools" ]; then
-        for tool in $devTools; do
-            moveToOutput "$tool" "${!outputDev}"
+    if [ -z "$__structuredAttrs" ]; then
+        devTools=(${devTools[*]})
+    fi
+
+    for tool in "${devTools[@]}"; do
+        moveToOutput "$tool" "${!outputDev}"
+    done
+
+    if [ -d "${!outputDev}/mkspecs" ]; then
+        find "${!outputDev}/mkspecs" -name '*.pr?' | while read pr_; do
+            for tool in "${devTools[@]}"; do
+                updateToolPath "$tool" "$pr_"
+            done
         done
+    fi
 
-        if [ -d "${!outputDev}/mkspecs" ]; then
-            find "${!outputDev}/mkspecs" -name '*.pr?' | while read pr_; do
-                for tool in $devTools; do
-                    updateToolPath "$tool" "$pr_"
-                done
+    if [ -d "${!outputDev}/lib/cmake" ]; then
+        find "${!outputDev}/lib/cmake" -name '*.cmake' | while read cmake; do
+            for tool in "${devTools[@]}"; do
+                updateToolPath "$tool" "$cmake"
             done
-        fi
-
-        if [ -d "${!outputDev}/lib/cmake" ]; then
-            find "${!outputDev}/lib/cmake" -name '*.cmake' | while read cmake; do
-                for tool in $devTools; do
-                    updateToolPath "$tool" "$cmake"
-                done
-            done
-        fi
+        done
     fi
 }

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -1,6 +1,8 @@
 . @fix_qmake_libtool@
 
-qmakeFlags=( ${qmakeFlags-} )
+if [ -z "$__structuredAttrs" ]; then
+    qmakeFlags=( ${qmakeFlags-} )
+fi
 
 qmakePrePhase() {
     qmakeFlags_orig=( "${qmakeFlags[@]}" )

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -139,10 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
     ''
   );
 
-  qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
-  qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
-  qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
-
   setOutputFlags = false;
   prefixKey = "-prefix ";
 
@@ -207,6 +203,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     fix_qt_builtin_paths = ../hooks/fix-qt-builtin-paths.sh;
     fix_qt_module_paths = ../hooks/fix-qt-module-paths.sh;
+
+    qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
+    qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
+    qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
   };
 
   preHook = ''

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -318,7 +318,7 @@ stdenv.mkDerivation (finalAttrs: {
     ] ++ lib.optionals (mysqlSupport) [
       "-L" "${libmysqlclient}/lib"
       "-I" "${libmysqlclient}/include"
-    ] ++ lib.optional (qttranslations != null) [
+    ] ++ lib.optionals (qttranslations != null) [
       "-translationdir" "${qttranslations}/translations"
     ]
   );

--- a/pkgs/development/libraries/ti-rpc/default.nix
+++ b/pkgs/development/libraries/ti-rpc/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  KRB5_CONFIG = "${libkrb5.dev}/bin/krb5-config";
+  env.KRB5_CONFIG = "${libkrb5.dev}/bin/krb5-config";
   nativeBuildInputs = [ autoreconfHook ];
   propagatedBuildInputs = [ libkrb5 ];
   strictDeps = true;

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -23,7 +23,11 @@ preConfigure() {
         fi
     done
 
-    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    if [ -n "$__structuredAttrs" ]; then
+        perl Makefile.PL PREFIX=$out INSTALLDIRS=site "${makeMakerFlags[@]}" PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    else
+        perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    fi
 }
 
 if test -n "$perlPreHook"; then

--- a/pkgs/development/python-modules/pkgconfig/default.nix
+++ b/pkgs/development/python-modules/pkgconfig/default.nix
@@ -12,12 +12,15 @@ buildPythonPackage rec {
   format = "pyproject";
 
   inherit (pkg-config)
-    setupHooks
-    wrapperName
-    suffixSalt
-    targetPrefix
-    baseBinName
-    ;
+    setupHooks;
+
+  env = {
+    inherit (pkg-config)
+      wrapperName
+      suffixSalt
+      targetPrefix
+      baseBinName;
+  };
 
   src = fetchFromGitHub {
     owner = "matze";

--- a/pkgs/development/python-modules/platformdirs/default.nix
+++ b/pkgs/development/python-modules/platformdirs/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     hash = "sha256-Ytilbs29oxuwLfoKTXNQxlh8qBF39F2ZRK8imd57A1w=";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     hatchling

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   # - the other disabled tests are likely due to sanboxing (missing specific errors)
   pytestFlagsArray = [
     # Note: $out must be referenced as test import paths are relative
-    "$out/${python.sitePackages}/psutil/tests/test_system.py"
+    "${placeholder "out"}/${python.sitePackages}/psutil/tests/test_system.py"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -39,13 +39,11 @@ buildPythonPackage rec {
     export PYSTEMMER_SYSTEM_LIBSTEMMER="${lib.getDev libstemmer}/include"
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${lib.getDev libstemmer}/include"
-  ];
+  env = {
+    NIX_CFLAGS_COMPILE = "-I${lib.getDev libstemmer}/include";
 
-  NIX_CFLAGS_LINK = [
-    "-L${libstemmer}/lib"
-  ];
+    NIX_CFLAGS_LINK = "-L${libstemmer}/lib";
+  };
 
   pythonImportsCheck = [
     "Stemmer"

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     "testout"
   ];
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     setuptools-scm

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -45,10 +45,10 @@ buildPythonPackage rec {
     setproctitle = [ setproctitle ];
   };
 
-  pytestFlagsArray = [
-    # pytest can already use xdist at this point
-    "--numprocesses=$NIX_BUILD_CORES"
-  ];
+  # pytest can already use xdist at this point
+  preCheck = ''
+    pytestFlagsArray+=("--numprocesses=$NIX_BUILD_CORES")
+  '';
 
   # access file system
   disabledTests = [

--- a/pkgs/development/python-modules/python-dbusmock/default.nix
+++ b/pkgs/development/python-modules/python-dbusmock/default.nix
@@ -29,8 +29,6 @@ in buildPythonPackage rec {
     hash = "sha256-sfvVLPTSTXjwyB0a2NyDIONv01FXZ40nHZwwo3oqI90=";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeBuildInputs = [
     setuptools-scm
   ];
@@ -48,28 +46,32 @@ in buildPythonPackage rec {
     nose
   ];
 
-  # TODO: Get the rest of these tests running?
-  NOSE_EXCLUDE = lib.concatStringsSep "," [
-    "test_bluez4" # NixOS ships BlueZ5
-    # These appear to fail because they're expecting to run in an Ubuntu chroot?
-    "test_everything" # BlueZ5 OBEX
-    "test_polkitd"
-    "test_consolekit"
-    "test_api"
-    "test_logind"
-    "test_notification_daemon"
-    "test_ofono"
-    "test_gnome_screensaver"
-    "test_cli"
-    "test_timedated"
-    "test_upower"
-    # needs glib
-    "test_accounts_service"
-    # needs dbus-daemon active
-    "test_systemd"
-    # Very slow, consider disabling?
-    # "test_networkmanager"
-  ];
+  env = {
+    # TODO: Get the rest of these tests running?
+    NOSE_EXCLUDE = lib.concatStringsSep "," [
+      "test_bluez4" # NixOS ships BlueZ5
+      # These appear to fail because they're expecting to run in an Ubuntu chroot?
+      "test_everything" # BlueZ5 OBEX
+      "test_polkitd"
+      "test_consolekit"
+      "test_api"
+      "test_logind"
+      "test_notification_daemon"
+      "test_ofono"
+      "test_gnome_screensaver"
+      "test_cli"
+      "test_timedated"
+      "test_upower"
+      # needs glib
+      "test_accounts_service"
+      # needs dbus-daemon active
+      "test_systemd"
+      # Very slow, consider disabling?
+      # "test_networkmanager"
+    ];
+
+    SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  };
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/tools/build-managers/scons/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/scons/setup-hook.sh
@@ -1,5 +1,12 @@
 # shellcheck shell=bash disable=SC2206
 
+if [ -z "$__structuredAttrs" ]; then
+    buildFlags=(${buildFlags[*]})
+    sconsFlags=(${sconsFlags[*]})
+    installFlags=(${installFlags[*]})
+    installTargets=(${installTargets[*]})
+fi
+
 sconsBuildPhase() {
     runHook preBuild
 
@@ -8,13 +15,13 @@ sconsBuildPhase() {
     fi
 
     if [ -z "${dontAddPrefix:-}" ] && [ -n "$prefix" ]; then
-        buildFlags="${prefixKey:-prefix=}$prefix $buildFlags"
+        buildFlags=("${prefixKey:-prefix=}$prefix" "${buildFlags[@]}")
     fi
 
     local flagsArray=(
       ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}
-      $sconsFlags ${sconsFlagsArray[@]}
-      $buildFlags ${buildFlagsArray[@]}
+      "${sconsFlags[@]}" "${sconsFlagsArray[@]}"
+      "${buildFlags[@]}" "${buildFlagsArray[@]}"
     )
 
     echoCmd 'scons build flags' "${flagsArray[@]}"
@@ -31,14 +38,14 @@ sconsInstallPhase() {
     fi
 
     if [ -z "${dontAddPrefix:-}" ] && [ -n "$prefix" ]; then
-        installFlags="${prefixKey:-prefix=}$prefix $installFlags"
+        installFlags=("${prefixKey:-prefix=}$prefix" "${installFlags[@]}")
     fi
 
     local flagsArray=(
         ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
-        $sconsFlags ${sconsFlagsArray[@]}
-        $installFlags ${installFlagsArray[@]}
-        ${installTargets:-install}
+        "${sconsFlags[@]}" "${sconsFlagsArray[@]}"
+        "${installFlags[@]}" "${installFlagsArray[@]}"
+        "${installTargets[@]:-install}"
     )
 
     echoCmd 'scons install flags' "${flagsArray[@]}"
@@ -63,8 +70,8 @@ sconsCheckPhase() {
     else
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
-            $sconsFlags ${sconsFlagsArray[@]}
-            ${checkFlagsArray[@]}
+            "${sconsFlags[@]}" "${sconsFlagsArray[@]}"
+            "${checkFlagsArray[@]}"
         )
 
         echoCmd 'scons check flags' "${flagsArray[@]}"

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -4,9 +4,11 @@ let
   self = runCommand "rust-bindgen-${rust-bindgen-unwrapped.version}"
     {
       #for substituteAll
-      inherit bash;
-      unwrapped = rust-bindgen-unwrapped;
-      libclang = clang.cc.lib;
+      env = {
+        inherit bash;
+        unwrapped = rust-bindgen-unwrapped;
+        libclang = clang.cc.lib;
+      };
       meta = rust-bindgen-unwrapped.meta // {
         longDescription = rust-bindgen-unwrapped.meta.longDescription + ''
           This version of bindgen is wrapped with the required compiler flags

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -26,7 +26,7 @@ in rustPlatform.buildRustPackage rec {
   doCheck = true;
   nativeCheckInputs = [ clang ];
 
-  RUSTFMT = "${rustfmt-nightly}/bin/rustfmt";
+  env.RUSTFMT = "${rustfmt-nightly}/bin/rustfmt";
 
   preCheck = ''
     # for the ci folder, notably

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -74,18 +74,19 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ check pam ];
-  NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isStatic "-laudit";
   nativeBuildInputs = [ autoreconfHook pkg-config flex ];
 
-  passthru.tests = {
-    inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
-  };
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isStatic "-laudit";
+
   passthru = {
     gzip = gzip;
     updateScript = gitUpdater {
        # No nicer place to find latest release.
        url = "https://github.com/legionus/kbd.git";
        rev-prefix = "v";
+    };
+    tests = {
+      inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
     };
   };
 

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ elfutils zlib ];
 
   enableParallelBuilding = true;
-  makeFlags = [ "PREFIX=$(out)" "-C src" ];
+  makeFlags = [ "PREFIX=$(out)" "-C" "src" ];
 
   passthru.tests = {
     bpf = nixosTests.bpf;

--- a/pkgs/servers/x11/xorg/builder.sh
+++ b/pkgs/servers/x11/xorg/builder.sh
@@ -28,7 +28,7 @@ postInstall() {
 }
 
 
-installFlags="appdefaultdir=$out/share/X11/app-defaults $installFlags"
+installFlags=("appdefaultdir=$out/share/X11/app-defaults" "${installFlags[@]}")
 
 
 if test -n "$x11BuildHook"; then

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -498,8 +498,8 @@ else let
     assert lib.assertMsg (overlappingNames == [ ])
       "The ‘env’ attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping: ${lib.concatStringsSep ", " overlappingNames}";
     lib.mapAttrs
-      (n: v: assert lib.assertMsg (lib.isString v || lib.isBool v || lib.isInt v || lib.isDerivation v)
-        "The ‘env’ attribute set can only contain derivation, string, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; v)
+      (n: v: assert lib.assertMsg (lib.isString v || lib.isPath v || lib.isBool v || lib.isInt v || lib.isDerivation v)
+        "The ‘env’ attribute set can only contain derivation, string, path, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; v)
       env;
 
 in

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -145,7 +145,11 @@ stdenv.mkDerivation rec {
     # Build libunbound again, but only against nettle instead of openssl.
     # This avoids gnutls.out -> unbound.lib -> lib.getLib openssl.
     ''
-      configureFlags="$configureFlags --with-nettle=${nettle.dev} --with-libunbound-only"
+      if [ -n "$__structuredAttrs" ]; then
+        configureFlags=("''${configureFlags[@]}" "--with-nettle=${nettle.dev}" "--with-libunbound-only")
+      else
+        configureFlags="$configureFlags --with-nettle=${nettle.dev} --with-libunbound-only"
+      fi
       configurePhase
       buildPhase
       if [ -n "$doCheck" ]; then

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1275,7 +1275,7 @@ with self; {
     };
     buildInputs = [ pkgs.zlib TestWarn ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.zlib.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
     meta = {
       description = "Fast C metadata and tag reader for all common audio file formats";
       license = with lib.licenses; [ gpl2Plus ];
@@ -1694,7 +1694,7 @@ with self; {
       hash = "sha256-o/LKnSuu/BqqQJCLL5y5KS/aPn15fji7146rudna62s=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.db4.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.db4.out}/lib -ldb";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.db4.out}/lib -ldb";
     buildInputs = [ pkgs.db4 ];
     propagatedBuildInputs = [ commonsense ];
     meta = {
@@ -4968,7 +4968,7 @@ with self; {
     };
     buildInputs = [ pkgs.gmp DevelChecklib TestRequires ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     meta = {
       description = "Crypt::DH Using GMP Directly";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -5352,7 +5352,7 @@ with self; {
       hash = "sha256-kHxzoQVs6gV9qYGa6kipKreG5qqq858c3ZZHsj8RbHg=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.libsodium.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.libsodium.out}/lib -lsodium";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.libsodium.out}/lib -lsodium";
     meta = {
       description = "Perl bindings for libsodium (NaCL)";
       homepage = "https://metacpan.org/release/Crypt-Sodium";
@@ -5413,7 +5413,7 @@ with self; {
     };
     buildInputs = [ CryptOpenSSLGuess FileWhich pkgs.openssl ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     meta = {
       description = "Perl wrapper around OpenSSL's AES library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -5428,7 +5428,7 @@ with self; {
       hash = "sha256-I05y+4OW1FUn5v1F5DdZxcPzogjPjynmoiFhqZb9Qtw=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     meta = {
       description = "OpenSSL's multiprecision integer arithmetic";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -5457,7 +5457,7 @@ with self; {
       hash = "sha256-8IdvqhujER45uGqnMMYDIR7/KQXkYMcqV7YejPR1zvQ=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     OPENSSL_PREFIX = pkgs.openssl;
     buildInputs = [ CryptOpenSSLGuess ];
     meta = {
@@ -5475,7 +5475,7 @@ with self; {
     };
     propagatedBuildInputs = [ CryptOpenSSLRandom ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     OPENSSL_PREFIX = pkgs.openssl;
     buildInputs = [ CryptOpenSSLGuess ];
     meta = {
@@ -5492,7 +5492,7 @@ with self; {
       hash = "sha256-xNvBbE/CloV4I3v8MkWH/9eSSacQFQJlLbnjjUSJUX8=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     OPENSSL_PREFIX = pkgs.openssl;
     buildInputs = [ CryptOpenSSLGuess ];
     propagatedBuildInputs = [ ConvertASN1 ];
@@ -5646,7 +5646,7 @@ with self; {
         --replace '#! /usr/bin/perl' '#!${perl}/bin/perl'
     '';
     propagatedBuildInputs = [ pkgs.ncurses ];
-    NIX_CFLAGS_LINK = "-L${pkgs.ncurses.out}/lib -lncurses";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.ncurses.out}/lib -lncurses";
     meta = {
       description = "Perl bindings to ncurses";
       license = with lib.licenses; [ artistic1 ];
@@ -13871,7 +13871,7 @@ with self; {
       hash = "sha256-MSlAwfYPR8T8k/oKnSpiZCX6qDcEDIwvGtWO4J9i83E=";
     };
     buildInputs = [ pkgs.acl ];
-    NIX_CFLAGS_LINK = "-L${pkgs.acl.out}/lib -lacl";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.acl.out}/lib -lacl";
     meta = {
       description = "Perl extension for reading and setting Access Control Lists for files by libacl linux library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -15098,7 +15098,7 @@ with self; {
     buildInputs = [ pkgs.gmp ];
     doCheck = false;
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     propagatedBuildInputs = [ MathBigInt ];
     meta = {
       description = "Backend library for Math::BigInt etc. based on GMP";
@@ -15170,7 +15170,7 @@ with self; {
     };
     buildInputs = [ pkgs.gmp AlienGMP ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     meta = {
       description = "High speed arbitrary size integer math";
       license = with lib.licenses; [ lgpl21Plus ];
@@ -15185,7 +15185,7 @@ with self; {
       hash = "sha256-mmrN45G0Ff5f7HwUyCTVUf/j+W81rycYRWuJ3jpkEaQ=";
     };
     buildInputs = [ TestWarn pkgs.gmp ];
-    NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     meta = {
       description = "Perl interface to the GMP integer functions";
       homepage = "https://github.com/sisyphus/math-gmpz";
@@ -15304,7 +15304,7 @@ with self; {
     };
     buildInputs = [ pkgs.gmp ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     meta = {
       description = "Utilities related to prime numbers, using GMP";
       homepage = "https://github.com/danaj/Math-Prime-Util-GMP";
@@ -19492,7 +19492,7 @@ with self; {
     hardeningDisable = [ "format" ];
     # Make the async API accessible
     env.NIX_CFLAGS_COMPILE = "-DTHREADED";
-    NIX_CFLAGS_LINK = "-L${pkgs.zookeeper_mt.out}/lib -lzookeeper_mt";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.zookeeper_mt.out}/lib -lzookeeper_mt";
     # Most tests are skipped as no server is available in the sandbox.
     # `t/35_log.t` seems to suffer from a race condition; remove it.  See
     # https://github.com/NixOS/nixpkgs/pull/104889#issuecomment-737144513
@@ -20038,7 +20038,7 @@ with self; {
     };
     buildInputs = [ pkgs.pcsclite ];
     nativeBuildInputs = [ pkgs.pkg-config ];
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.pcsclite}/lib -lpcsclite";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.pcsclite}/lib -lpcsclite";
     # tests fail; look unfinished
     doCheck = false;
     meta = {
@@ -20301,7 +20301,7 @@ with self; {
       hash = "sha256-SEhnmj8gHj87DF9vlSbmAq9Skj/6RxoqNlfbeGvTvcU=";
     };
     buildInputs = [ pkgs.zlib ];
-    NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
     meta = {
       description = "Perl extension to provide a PerlIO layer to gzip/gunzip";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -24073,7 +24073,7 @@ with self; {
       hash = "sha256-sTgyEy5QNmw0/qwSzoKDfAqds0ylMK5dJ9uXz5yWTHs=";
     };
     buildInputs = [ pkgs.readline pkgs.ncurses ];
-    NIX_CFLAGS_LINK = "-lreadline -lncursesw";
+    env.NIX_CFLAGS_LINK = "-lreadline -lncursesw";
 
     # For some crazy reason Makefile.PL doesn't generate a Makefile if
     # AUTOMATED_TESTING is set.
@@ -26097,7 +26097,7 @@ with self; {
     propagatedBuildInputs = [ pkgs.aspell ];
     ASPELL_CONF = "dict-dir ${pkgs.aspellDicts.en}/lib/aspell";
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.aspell}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.aspell}/lib -laspell";
+    env.NIX_CFLAGS_LINK = "-L${pkgs.aspell}/lib -laspell";
     meta = {
       description = "Perl interface to the GNU Aspell library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -28173,7 +28173,7 @@ with self; {
       hash = "sha256-3O7eU3AGEP/xQtydXE5M0DcMiKTysTcfnL9NjYzm9ks=";
     };
     buildInputs = [ pkgs.xorg.libX11 pkgs.xorg.libXi pkgs.xorg.libXt pkgs.xorg.libXtst ];
-    NIX_CFLAGS_LINK = "-lX11";
+    env.NIX_CFLAGS_LINK = "-lX11";
     doCheck = false; # requires an X server
     meta = {
       description = "Provides GUI testing/interaction routines";
@@ -28192,7 +28192,7 @@ with self; {
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ pkgs.xorg.libxcb pkgs.xorg.xcbproto pkgs.xorg.xcbutil pkgs.xorg.xcbutilwm ExtUtilsDepends ExtUtilsPkgConfig TestDeep TestException XSObjectMagic ];
     propagatedBuildInputs = [ DataDump MouseXNativeTraits XMLDescent XMLSimple ];
-    NIX_CFLAGS_LINK = "-lxcb -lxcb-util -lxcb-xinerama -lxcb-icccm";
+    env.NIX_CFLAGS_LINK = "-lxcb -lxcb-util -lxcb-xinerama -lxcb-icccm";
     doCheck = false; # requires an X server
     meta = {
       description = "Perl bindings for libxcb";
@@ -28998,7 +28998,7 @@ with self; {
       hash = "sha256-BpsWQRcpX6gtJSlAocqLMIrYsfPocjvk6CaqqX9wbWw=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include -I${pkgs.libidn2}.dev}/include";
-    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.libidn2}/lib -lcrypto -lidn2";
+    env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.libidn2}/lib -lcrypto -lidn2";
 
     makeMakerFlags = [ "--prefix-openssl=${pkgs.openssl.dev}" ];
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -111,7 +111,7 @@ let
     import ../build-support/trivial-builders {
       inherit lib;
       inherit (self) runtimeShell stdenv stdenvNoCC haskell;
-      inherit (self.pkgsBuildHost) shellcheck;
+      inherit (self.pkgsBuildHost) shellcheck jq;
       inherit (self.pkgsBuildHost.xorg) lndir;
     };
 


### PR DESCRIPTION
## Description of changes

This fixes stdenv with `__structuredAttrs` enabled.

Test build:
```
nix-build -E 'with import ./. { config.structuredAttrsByDefault = true; }; hello'
```

* `makeFlags` is a bash array and cannot be appended to as done in glibc's `preConfigure`.
* env vars may only be strings and have to be in `env` to be exported
* substituteAll only reads and substitutes exported variables

This is the first part of a number of PRs that intend to make nixpkgs forward-compatible with `__structuredAttrs` enabled globally.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
