### PR TITLE
darwin.diskdev_cmds: fix build with clang 16

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/diskdev_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/diskdev_cmds/default.nix
@@ -5,12 +5,17 @@ let
   xnu-src = if stdenv.isAarch64 then macosPackages_11_0_1.xnu.src else xnu.src;
   arch = if stdenv.isAarch64 then "arm" else "i386";
 in appleDerivation {
+  patches = [
+    # Fixes a build failure with newer versions of clang that make implicit int an error.
+    ./fix-implicit-int.patch
+  ];
+
   nativeBuildInputs = [ xcbuildHook ];
   buildInputs = [ libutil ];
 
   env.NIX_CFLAGS_COMPILE = "-I.";
   NIX_LDFLAGS = "-lutil";
-  patchPhase = ''
+  prePatch = ''
     # ugly hacks for missing headers
     # most are bsd related - probably should make this a drv
     unpackFile ${Libc.src}

--- a/pkgs/os-specific/darwin/apple-source-releases/diskdev_cmds/fix-implicit-int.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/diskdev_cmds/fix-implicit-int.patch
@@ -1,0 +1,11 @@
+diff -ur a/diskdev_cmds.xcodeproj/project.pbxproj b/diskdev_cmds.xcodeproj/project.pbxproj
+--- a/quota.tproj/quota.c	2021-10-06 01:13:40.000000000 -0400
++++ b/quota.tproj/quota.c	2023-10-27 08:24:05.960965958 -0400
+@@ -115,6 +115,7 @@
+ 
+ int
+ main(argc, argv)
++	int argc;
+ 	char *argv[];
+ {
+ 	int ngroups; 


### PR DESCRIPTION
## Description of changes

Fix an implicit `int` on argc, which is an error with newer clangs.

Fixes staging-next failure: https://hydra.nixos.org/build/239459310. #263535

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
