### PR TITLE
k3s: build with go_1_20

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -1,16 +1,23 @@
-{ lib, stdenv, callPackage }:
+{ lib, callPackage, ... }@args:
 
 let
   k3s_builder = import ./builder.nix lib;
   common = opts: callPackage (k3s_builder opts);
+  # extraArgs is the extra arguments passed in by the caller to propogate downward.
+  # This is to allow all-packages.nix to do:
+  #
+  #     let k3s_1_23 = (callPackage ./path/to/k3s {
+  #       commonK3sArg = ....
+  #     }).k3s_1_23;
+  extraArgs = builtins.removeAttrs args [ "callPackage" ];
 in
 {
   k3s_1_26 = common ((import ./1_26/versions.nix) // {
     updateScript = [ ./update-script.sh "26" ];
-  }) { };
+  }) extraArgs;
 
   # 1_27 can be built with the same builder as 1_26
   k3s_1_27 = common ((import ./1_27/versions.nix) // {
     updateScript = [ ./update-script.sh "27" ];
-  }) { };
+  }) extraArgs;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32999,12 +32999,15 @@ with pkgs;
 
   jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };
 
-  k3s_1_24 = callPackage ../applications/networking/cluster/k3s/1_24 { };
-  k3s_1_25 = callPackage ../applications/networking/cluster/k3s/1_25 { };
-  inherit (callPackage ../applications/networking/cluster/k3s { })
-    k3s_1_26
-    k3s_1_27
-  ;
+  k3s_1_24 = callPackage ../applications/networking/cluster/k3s/1_24 {
+    buildGoModule = buildGo120Module;
+  };
+  k3s_1_25 = callPackage ../applications/networking/cluster/k3s/1_25 {
+    buildGoModule = buildGo120Module;
+  };
+  inherit (callPackage ../applications/networking/cluster/k3s {
+    buildGoModule = buildGo120Module;
+  }) k3s_1_26 k3s_1_27;
   k3s = k3s_1_27;
 
   k3sup = callPackage ../applications/networking/cluster/k3sup { };


### PR DESCRIPTION
## Description of changes

k3s upstream does not support go 1.21, so we're stuck on 1.20 for now.
See the linked issue below for more info on that!

Fixes #263580

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
      ```
    $ nix build '.#k3s.passthru.tests.single-node' 
    $ nix build '.#k3s_1_26.passthru.tests.single-node' 
    $ nix build '.#k3s_1_25.passthru.tests.single-node' 
      ```
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
