### PR TITLE
aiger: fix build with clang 16

### DIFF
--- a/pkgs/applications/science/logic/aiger/default.nix
+++ b/pkgs/applications/science/logic/aiger/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "1ish0dw0nf9gyghxsdhpy1jjiy5wp54c993swp85xp7m6vdx6l0y";
   };
 
+  patches = [
+    # Fix implicit declaration of `isatty`, which is an error with newer versions of clang.
+    ./fix-missing-header.patch
+  ];
+
   enableParallelBuilding = true;
 
   configurePhase = ''

--- a/pkgs/applications/science/logic/aiger/fix-missing-header.patch
+++ b/pkgs/applications/science/logic/aiger/fix-missing-header.patch
@@ -1,0 +1,11 @@
+diff -ur a/aigunconstraint.c b/aigunconstraint.c
+--- a/aigunconstraint.c	2013-10-06 09:08:03.000000000 -0400
++++ b/aigunconstraint.c	2023-10-27 08:55:01.678566389 -0400
+@@ -26,6 +26,7 @@
+ #include <stdarg.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ static const char * USAGE =
+ "usage: aigunconstraint [-h][-v] [<input> [<output>]]\n"


### PR DESCRIPTION
## Description of changes

Add missing header to resolve implicit decalaration of `isatty`.

Fixes build failure on staging-next: https://hydra.nixos.org/build/239530124. #263535

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
