### PR TITLE
reversal-icon-theme: init at unstable-2023-05-13

### DIFF
--- a/pkgs/data/icons/reversal-icon-theme/default.nix
+++ b/pkgs/data/icons/reversal-icon-theme/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, jdupes
+, adwaita-icon-theme
+, hicolor-icon-theme
+, numix-icon-theme-circle
+, gitUpdater
+, allColorVariants ? false
+, colorVariants ? []
+}:
+
+let
+  pname = "reversal-icon-theme";
+in
+lib.checkListOfEnum "${pname}: color variants" [ "-blue" "-red" "-pink" "-purple" "-green" "-orange" "-brown" "-grey" "-black" "-cyan" ] colorVariants
+
+stdenvNoCC.mkDerivation rec {
+  inherit pname;
+  version = "unstable-2023-05-13";
+
+  src = fetchFromGitHub {
+    owner = "yeyushengfan258";
+    repo = pname;
+    rev = "bdae2ea365731b25a869fc2c8c6a1fb849eaf5b2";
+    hash = "sha256-Cd+1ggyS+Y2Sk8w5zifc4IFOwbFrbjL6S6awES/W0EE=";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+    jdupes
+  ];
+
+  propagatedBuildInputs = [
+    adwaita-icon-theme
+    hicolor-icon-theme
+    numix-icon-theme-circle
+  ];
+
+  dontDropIconThemeCache = true;
+
+  # These fixup steps are slow and unnecessary for this package.
+  # Package may install many small files.
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
+  postPatch = ''
+    patchShebangs install.sh
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons
+
+    name= ./install.sh \
+      ${if allColorVariants then "-a" else builtins.toString colorVariants} \
+      -d $out/share/icons
+
+    rm $out/share/icons/*/{AUTHORS,COPYING}
+
+    jdupes --quiet --link-soft --recurse $out/share
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "A colorful Design Rectangle icon theme";
+    homepage = "https://github.com/yeyushengfan258/Reversal-icon-theme";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29996,6 +29996,10 @@ with pkgs;
 
   recursive = callPackage ../data/fonts/recursive { };
 
+  reversal-icon-theme = callPackage ../data/icons/reversal-icon-theme {
+    inherit (gnome) adwaita-icon-theme;
+  };
+
   rubik = callPackage ../data/fonts/rubik { };
 
   rhodium-libre = callPackage ../data/fonts/rhodium-libre { };


### PR DESCRIPTION
## Description of changes

Add [Reversal Icon Theme](https://github.com/yeyushengfan258/Reversal-icon-theme)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
