### PR TITLE
nginxModules.videothumb-extractor: unstable -> 1.0.0 and switch to ffmpeg-headless

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -15,6 +15,7 @@
 , geoip
 , libbsd
 , libiconv
+, libjpeg
 , libkrb5
 , libmaxminddb
 , libmodsecurity
@@ -959,17 +960,18 @@ let self = {
     };
   };
 
-  video-thumbextractor = {
+  video-thumbextractor = rec {
     name = "video-thumbextractor";
+    version = "1.0.0";
     src = fetchFromGitHub {
       name = "video-thumbextractor";
       owner = "wandenberg";
       repo = "nginx-video-thumbextractor-module";
-      rev = "92b80642538eec4cfc98114dec5917b8d820e912";
-      sha256 = "0a8d9ifryhhnll7k7jcsf9frshk5yhpsgz7zgxdmw81wbz5hxklc";
+      rev = "refs/tags/${version}";
+      hash = "sha256-F2cuzCbJdGYX0Zmz9MSXTB7x8+FBR6pPpXtLlDRCcj8=";
     };
 
-    inputs = [ ffmpeg ];
+    inputs = [ ffmpeg libjpeg ];
 
     meta = with lib; {
       description = "Extract thumbs from a video file";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -11,7 +11,7 @@
 , curl
 , expat
 , fdk_aac
-, ffmpeg
+, ffmpeg-headless
 , geoip
 , libbsd
 , libiconv
@@ -971,7 +971,7 @@ let self = {
       hash = "sha256-F2cuzCbJdGYX0Zmz9MSXTB7x8+FBR6pPpXtLlDRCcj8=";
     };
 
-    inputs = [ ffmpeg libjpeg ];
+    inputs = [ ffmpeg-headless libjpeg ];
 
     meta = with lib; {
       description = "Extract thumbs from a video file";
@@ -991,7 +991,7 @@ let self = {
       hash = "sha256-ZpeO8QWQ+fGkz08u/zFOq7vj4aHcodzSHNrc1SgGUyc=";
     };
 
-    inputs = [ ffmpeg fdk_aac openssl libxml2 libiconv ];
+    inputs = [ ffmpeg-headless fdk_aac openssl libxml2 libiconv ];
 
     meta = with lib; {
       description = "VOD packager";


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/wandenberg/nginx-video-thumbextractor-module/compare/92b8064...e81f850

Switched from full ffmpeg to ffmpeg-headless for the videothumb-extractor as well as the vod module to reduce the size. Both still compile and the vod plugin has been tested successfully on one of my webservers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
