### PR TITLE
diffoci: Add version literal and shell completions

### DIFF
--- a/pkgs/tools/misc/diffoci/default.nix
+++ b/pkgs/tools/misc/diffoci/default.nix
@@ -16,7 +16,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-4C35LBxSm6EkcOznQY1hT2vX9bwFfps/q76VqqPKBfI=";
 
-  ldflags = [ "-s" "-w" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/reproducible-containers/diffoci/cmd/diffoci/version.Version=v${version}"
+  ];
 
   meta = with lib; {
     description = "Diff for Docker and OCI container images";

--- a/pkgs/tools/misc/diffoci/default.nix
+++ b/pkgs/tools/misc/diffoci/default.nix
@@ -1,6 +1,9 @@
 { lib
+, stdenv
+, buildPackages
 , buildGoModule
 , fetchFromGitHub
+, installShellFiles
 }:
 
 buildGoModule rec {
@@ -21,6 +24,19 @@ buildGoModule rec {
     "-w"
     "-X=github.com/reproducible-containers/diffoci/cmd/diffoci/version.Version=v${version}"
   ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    let
+      diffoci = if stdenv.buildPlatform.canExecute stdenv.hostPlatform then placeholder "out" else buildPackages.diffoci;
+    in
+    ''
+      installShellCompletion --cmd trivy \
+        --bash <(${diffoci}/bin/diffoci completion bash) \
+        --fish <(${diffoci}/bin/diffoci completion fish) \
+        --zsh <(${diffoci}/bin/diffoci completion zsh)
+    '';
 
   meta = with lib; {
     description = "Diff for Docker and OCI container images";


### PR DESCRIPTION
## Description of changes

* Add version literal to ldflags
* Add shell completions

## Things done

```console
$ nix-build -A diffoci
/nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4

$ find /nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4 -type f
/nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4/bin/diffoci
/nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4/share/bash-completion/completions/trivy.bash
/nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4/share/fish/vendor_completions.d/trivy.fish
/nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4/share/zsh/site-functions/_trivy

$ /nix/store/9c26msfzqj8wrzzjkciywy3gd5xm0l77-diffoci-0.1.4/bin/diffoci --version
diffoci version v0.1.4

$ nix-build --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' -A diffoci
/nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4

$ find /nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4 -type f
/nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4/bin/diffoci
/nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4/share/bash-completion/completions/trivy.bash
/nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4/share/fish/vendor_completions.d/trivy.fish
/nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4/share/zsh/site-functions/_trivy

$ file /nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4/bin/diffoci
/nix/store/p9m0zicy3yiw7d6q16fjfp5cx0ha49yr-diffoci-aarch64-unknown-linux-gnu-0.1.4/bin/diffoci: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/dmdjg1r6120l6xgyclvpwk1l9bs0k268-glibc-aarch64-unknown-linux-gnu-2.38-27/lib/ld-linux-aarch64.so.1, Go BuildID=DZcH3b1zklYIX3eswd7O/Zq5HaYRSz6VaZBGtb-0R/KImNwl0fkY_63WVRsrP8/_0NgnLDrtYeHgRhFjH5K, stripped
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).