### PR TITLE
protobuf: disable tests on 32-bit platforms

### DIFF
--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -83,7 +83,9 @@ stdenv.mkDerivation (finalAttrs: {
   # FIXME: investigate.  24.x and 23.x have different errors.
   # At least some of it is not reproduced on some other machine; example:
   # https://hydra.nixos.org/build/235677717/nixlog/4/tail
-  doCheck = !(stdenv.isDarwin && lib.versionAtLeast version "23");
+  # Also AnyTest.TestPackFromSerializationExceedsSizeLimit fails on 32-bit platforms
+  # https://github.com/protocolbuffers/protobuf/issues/8460
+  doCheck = !(stdenv.isDarwin && lib.versionAtLeast version "23") && !stdenv.targetPlatform.is32bit;
 
   passthru = {
     tests = {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix build on i686-linux and armv7l-linux
```
[       OK ] FileDescriptorSetSource/EncodeDecodeTest.DecodeDeterministicOutput/1 (0 ms)
[----------] 16 tests from FileDescriptorSetSource/EncodeDecodeTest (117 ms total)

[----------] Global test environment tear-down
[==========] 2506 tests from 218 test suites ran. (22904 ms total)
[  PASSED  ] 2499 tests.
[  SKIPPED ] 6 tests, listed below:
[  SKIPPED ] ArenaTest.SpaceReusePoisonsAndUnpoisonsMemory
[  SKIPPED ] Default/ShiftMixParseVarint32Test.AtOrBelowLimit/5
[  SKIPPED ] Default/ShiftMixParseVarint32Test.AtOrBelowLimit/6
[  SKIPPED ] Default/ShiftMixParseVarint32Test.AtOrBelowLimit/7
[  SKIPPED ] Default/ShiftMixParseVarint32Test.AtOrBelowLimit/8
[  SKIPPED ] Default/ShiftMixParseVarint32Test.AtOrBelowLimit/9
[  FAILED  ] 1 test, listed below:
[  FAILED  ] AnyTest.TestPackFromSerializationExceedsSizeLimit

 1 FAILED TEST


50% tests passed, 1 tests failed out of 2

Total Test time (real) =  23.00 sec

The following tests FAILED:
          2 - full-test (Failed)
Errors while running CTest
make: *** [Makefile:71: test] Error 8
error: builder for '/nix/store/yxbcdf1n3zy1xrqj7xbx4mx2ywdi5p98-protobuf-3.24.3.drv' failed with exit code 2;
       last 10 log lines:
       >
       >
       > 50ests passed, 1 tests failed out of 2
       >
       > Total Test time (real) =  23.00 sec
       >
       > The following tests FAILED:
       >    2 - full-test (Failed)
       > Errors while running CTest
       > make: *** [Makefile:71: test] Error 8
       For full logs, run 'nix log /nix/store/yxbcdf1n3zy1xrqj7xbx4mx2ywdi5p98-protobuf-3.24.3.drv'.    
```

Target branch is not master due to a potential merge conflict with staging-next.

Broken since https://github.com/NixOS/nixpkgs/pull/254447/commits/81d8fdb6ab4790adc7d85c70e4c58c2a56b0ac93

Upstream issue: https://github.com/protocolbuffers/protobuf/issues/8460

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] i686-linux
  - [X] armv7l-linux
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
