### PR TITLE
graphene: disable broken NEON support on armv7l-linux

### DIFF
--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -77,6 +77,10 @@ stdenv.mkDerivation rec {
     "-Dintrospection=enabled"
     "-Dinstalled_test_datadir=${placeholder "installedTests"}/share"
     "-Dinstalled_test_bindir=${placeholder "installedTests"}/libexec"
+  ] ++ lib.optionals stdenv.isAarch32 [
+    # the box test is failing with SIGBUS on armv7l-linux
+    # https://github.com/ebassi/graphene/issues/215
+    "-Darm_neon=false"
   ];
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes
Fix build failure on armv7l-linux
```
[78/78] Generating src/Graphene-1.0.typelib with a custom command
running tests
check flags: ''
 1/19 euler                    OK              0.07s   10 subtests passed
 2/19 frustum                  OK              0.05s   21 subtests passed
 3/19 matrix                   OK              0.08s   70 subtests passed
 4/19 plane                    OK              0.07s   13 subtests passed
 5/19 point                    OK              0.10s   24 subtests passed
 6/19 point3d                  OK              0.11s   36 subtests passed
 7/19 quad                     OK              0.14s   12 subtests passed
 8/19 quaternion               OK              0.11s   24 subtests passed
 9/19 ray                      OK              0.10s   26 subtests passed
10/19 box                      ERROR           0.34s   killed by signal 7 SIGBUS
>>> LD_LIBRARY_PATH=/build/source/build/src MALLOC_PERTURB_=136 MUTEST_OUTPUT=tap /build/source/build/tests/box

11/19 rect                     OK              0.14s   69 subtests passed
12/19 simd                     OK              0.15s   25 subtests passed
13/19 size                     OK              0.14s   17 subtests passed
14/19 sphere                   OK              0.11s   17 subtests passed
15/19 triangle                 OK              0.14s   56 subtests passed
16/19 vec2                     OK              0.16s   37 subtests passed
17/19 vec3                     OK              0.13s   51 subtests passed
18/19 vec4                     OK              0.09s   63 subtests passed
19/19 introspection.py         OK              0.21s   1 subtests passed

Ok:                 18  
Expected Fail:      0   
Fail:               1   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /build/source/build/meson-logs/testlog.txt
```

See also:
https://github.com/ebassi/graphene/issues/215
https://github.com/archlinuxarm/PKGBUILDs/pull/1977

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] armv7l-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
