### PR TITLE
sops: Set `meta.mainProgram`

### DIFF
--- a/pkgs/tools/security/sops/default.nix
+++ b/pkgs/tools/security/sops/default.nix
@@ -21,6 +21,7 @@ buildGoModule rec {
     homepage = "https://github.com/getsops/sops";
     description = "Simple and flexible tool for managing secrets";
     changelog = "https://github.com/getsops/sops/blob/v${version}/CHANGELOG.rst";
+    mainProgram = "sops";
     maintainers = [ maintainers.marsam ];
     license = licenses.mpl20;
   };


### PR DESCRIPTION
## Description of changes

Set `sops.meta.mainProgram`, allowing things like using `lib.getExe sops` to gets the path to the `sops` executable.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
