### PR TITLE
wslay: init at 1.1.1

### DIFF
--- a/pkgs/by-name/ws/wslay/package.nix
+++ b/pkgs/by-name/ws/wslay/package.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, cmake, cunit }:
+
+stdenv.mkDerivation rec {
+  pname = "wslay";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "tatsuhiro-t";
+    repo = "wslay";
+    rev = "release-${version}";
+    hash = "sha256-xKQGZO5hNzMg+JYKeqOBsu73YO+ucBEOcNhG8iSNYvA=";
+  };
+
+  checkInputs = [ cunit ];
+  doCheck = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://tatsuhiro-t.github.io/wslay/";
+    description = "The WebSocket library in C";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ pingiun ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/ws/wslay/package.nix
+++ b/pkgs/by-name/ws/wslay/package.nix
@@ -11,10 +11,17 @@ stdenv.mkDerivation rec {
     hash = "sha256-xKQGZO5hNzMg+JYKeqOBsu73YO+ucBEOcNhG8iSNYvA=";
   };
 
-  checkInputs = [ cunit ];
-  doCheck = true;
+  strictDeps = true;
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "WSLAY_TESTS" true)
+  ];
+
+  doCheck = true;
+
+  checkInputs = [ cunit ];
 
   meta = with lib; {
     homepage = "https://tatsuhiro-t.github.io/wslay/";


### PR DESCRIPTION
Grabbed from #170919

## Description of changes

Wslay is a WebSocket library written in C.
https://tatsuhiro-t.github.io/wslay/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Built internal software with this library successfully