### PR TITLE
systemd-stage-1: No longer experimental

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -128,10 +128,6 @@ in {
         stage 2 counterparts such as {option}`systemd.services`,
         except that `restartTriggers` and `reloadTriggers` are not
         supported.
-
-        Note: This is experimental. Some of the `boot.initrd` options
-        are not supported when this is enabled, and the options under
-        `boot.initrd.systemd` are subject to change.
       '';
     };
 


### PR DESCRIPTION
I really want systemd initrd to be unmarked as experimental before 23.11. To do that, these need to be merged:

- https://github.com/NixOS/nixpkgs/pull/262583
- https://github.com/NixOS/nixpkgs/pull/262854
- https://github.com/NixOS/nixpkgs/pull/263033
- https://github.com/NixOS/nixpkgs/pull/227633

The only remaining work after those is figuring out why one test fails in [the iscsi/multipath PR](https://github.com/NixOS/nixpkgs/pull/263417), and implementing `extraFiles` (which as far as I can tell is only used by `system/boot/uvesafb.nix`)