### PR TITLE
nordic: make sddm a separate output

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -80,14 +80,11 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
+  outputs = [ "out" "sddm" ];
+
   nativeBuildInputs = [ jdupes ];
 
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine
-    breeze-icons
-    plasma-framework
-    plasma-workspace
-  ];
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   dontWrapQtApps = true;
 
@@ -119,15 +116,18 @@ stdenv.mkDerivation rec {
     rmdir $out/share/themes/Nordic/extras{/wallpapers,}
 
     # move kde related contents to appropriate directories
-    mkdir -p $out/share/{aurorae/themes,color-schemes,Kvantum,plasma,sddm/themes,icons}
+    mkdir -p $out/share/{aurorae/themes,color-schemes,Kvantum,plasma,icons}
     mv -v $out/share/themes/Nordic/kde/aurorae/* $out/share/aurorae/themes/
     mv -v $out/share/themes/Nordic/kde/colorschemes/* $out/share/color-schemes/
     mv -v $out/share/themes/Nordic/kde/konsole $out/share/
     mv -v $out/share/themes/Nordic/kde/kvantum/* $out/share/Kvantum/
     mv -v $out/share/themes/Nordic/kde/plasma/look-and-feel $out/share/plasma/
-    mv -v $out/share/themes/Nordic/kde/sddm/* $out/share/sddm/themes/
     mv -v $out/share/themes/Nordic/kde/folders/* $out/share/icons/
     mv -v $out/share/themes/Nordic/kde/cursors/*-cursors $out/share/icons/
+
+    mkdir -p $sddm/share/sddm/themes
+    mv -v $out/share/themes/Nordic/kde/sddm/* $sddm/share/sddm/themes/
+
     rm -rf $out/share/themes/Nordic/kde
 
     # Replace duplicate files with symbolic links to the first file in
@@ -135,6 +135,16 @@ stdenv.mkDerivation rec {
     jdupes --quiet --link-soft --recurse $out/share
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    # Propagate sddm theme dependencies to user env otherwise sddm
+    # does find them. Putting them in buildInputs is not enough.
+
+    mkdir -p $sddm/nix-support
+
+    printWords ${breeze-icons} ${plasma-framework} ${plasma-workspace} \
+      >> $sddm/nix-support/propagated-user-env-packages
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

It brings some kde stuff into the environment, and that may not be desirable when one does not need it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
