### PR TITLE
rust-analyzer-unwrapped: optional proc-macro-srv-cli

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -7,6 +7,7 @@
 , cmake
 , libiconv
 , useMimalloc ? false
+, enableProcMacroSrvCli ? false
 , doCheck ? true
 , nix-update-script
 }:
@@ -23,8 +24,11 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-9ScvChrqG35GXwO6cFzZOgsq/5PdrUZDCTBRgkhoShk=";
   };
 
-  cargoBuildFlags = [ "--bin" "rust-analyzer" "--bin" "rust-analyzer-proc-macro-srv" ];
-  cargoTestFlags = [ "--package" "rust-analyzer" "--package" "proc-macro-srv-cli" ];
+  cargoBuildFlags = [ "--bin" "rust-analyzer" ]
+    ++ lib.optionals enableProcMacroSrvCli [ "--bin" "rust-analyzer-proc-macro-srv" ];
+  cargoTestFlags = [ "--package" "rust-analyzer" ]
+    ++ lib.optionals enableProcMacroSrvCli [ "--package" "proc-macro-srv-cli" ];
+  RUSTC_BOOTSTRAP = enableProcMacroSrvCli;
 
   # Code format check requires more dependencies but don't really matter for packaging.
   # So just ignore it.
@@ -37,7 +41,8 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  buildFeatures = lib.optional useMimalloc "mimalloc";
+  buildFeatures = lib.optional useMimalloc "mimalloc"
+    ++ lib.optional enableProcMacroSrvCli "sysroot-abi";
 
   CFG_RELEASE = version;
 
@@ -47,11 +52,17 @@ rustPlatform.buildRustPackage rec {
   '';
 
   doInstallCheck = true;
-  installCheckPhase = ''
+  installCheckPhase = let
+    checkProcMacroSrvCli = ''
+      RUST_ANALYZER_INTERNALS_DO_NOT_USE='this is unstable' \
+        $out/bin/rust-analyzer-proc-macro-srv < /dev/null
+    '';
+  in ''
     runHook preInstallCheck
     versionOutput="$($out/bin/rust-analyzer --version)"
     echo "'rust-analyzer --version' returns: $versionOutput"
     [[ "$versionOutput" == "rust-analyzer ${version}" ]]
+    ${lib.optionalString enableProcMacroSrvCli checkProcMacroSrvCli}
     runHook postInstallCheck
   '';
 


### PR DESCRIPTION
## Description of changes

Resolves a crash related to https://github.com/rust-lang/rust-analyzer/issues/14991

```bash
:; export RUST_ANALYZER_INTERNALS_DO_NOT_USE='this is unstable'
:; nix shell .#rust-analyzer-unwrapped -c rust-analyzer-proc-macro-srv < /dev/null

thread 'main' panicked at 'proc-macro-srv-cli requires the `sysroot-abi` feature to be enabled', crates/proc-macro-srv-cli/src/main.rs:23:5
```

Unfortunately, the server isn't able to compile without unstable rust so I've chosen to disable it by default since it's currently broken - though I don't personally have a preference on whether to enable or disable it by default? Another approach is to pull the macro server out into an entirely seperate package, though that may be inefficient since both binaries share common dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
