### PR TITLE
pythonPackages.adafruit-nrfutil: fix tests for 0.5.3.post17

### DIFF
--- a/pkgs/by-name/ad/adafruit-nrfutil/package.nix
+++ b/pkgs/by-name/ad/adafruit-nrfutil/package.nix
@@ -1,6 +1,7 @@
 { lib
 , python3Packages
 , fetchFromGitHub
+, fetchpatch
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -15,6 +16,16 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-mHHKOQE9AGBX8RAyaPOy+JS3fTs98+AFdq9qsVy7go4=";
   };
 
+  patches = [
+    # Pull a patch which fixes the tests, but is not yet released in a new version:
+    # https://github.com/adafruit/Adafruit_nRF52_nrfutil/pull/38
+    (fetchpatch {
+      name = "fix-tests.patch";
+      url = "https://github.com/adafruit/Adafruit_nRF52_nrfutil/commit/e5fbcc8ee5958041db38c04139ba686bf7d1b845.patch";
+      sha256 = "sha256-0tbJldGtYcDdUzA3wZRv0lenXVn6dqV016U9nMpQ6/w=";
+    })
+  ];
+
   nativeBuildInputs = with python3Packages; [
     setuptools
   ];
@@ -28,6 +39,7 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = with python3Packages; [
     behave
     nose
+    pytestCheckHook
   ];
 
   preCheck = ''


### PR DESCRIPTION
## Description of changes

This PR fixes the build and tests for the Python package `adafruit-nrfutil`. The PR #251878 broke this package by resetting its source to some ancient version (see https://github.com/NixOS/nixpkgs/commit/6597fe2a5e0efc963a403eb339e85ee93b3c6bcc , the tag [appveyor-test-release-1](https://github.com/adafruit/Adafruit_nRF52_nrfutil/tree/appveyor-test-release-1) is a lot older than the newest [0.5.3.post17 ](https://github.com/adafruit/Adafruit_nRF52_nrfutil/tree/0.5.3.post17) release which should be used).

My PR https://github.com/adafruit/Adafruit_nRF52_nrfutil/pull/38 in the package repo to fix its tests for Python 3 has since been merged into master, so I use that as source instead of manually applying the patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
