### PR TITLE
qt5.qtbase: switch to overrideSDK

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -263,21 +263,24 @@ rec {
 
       sdk = pkgs.darwin."apple_sdk_${lib.replaceStrings [ "." ] [ "_" ] darwinSdkVersion}";
 
-      isSDKFramework = pkg: lib.hasPrefix "apple-framework-" (lib.getName pkg);
-
       replacePropagatedFrameworks = pkg:
         let
-          propagatedFrameworks = lib.filter isSDKFramework pkg.propagatedBuildInputs;
+          propagatedInputs = pkg.propagatedBuildInputs;
+          mappedInputs = map mapPackageToSDK propagatedInputs;
+
           env = {
             inherit (pkg) outputs;
-            # Map the old frameworks to new and the package’s outputs to their original outPaths.
-            # The mappings are rendered into tab-separated files to be read back with `read`.
-            frameworks = lib.concatMapStrings (pkg: "${pkg}\t${mapPackageToSDK pkg}\n") propagatedFrameworks;
+            # Map old frameworks to new ones and the package’s outputs to their original outPaths.
+            # Also map any packages that have propagated frameworks to their proxy packages using
+            # the requested SDK version. These mappings are rendered into tab-separated files to be
+            # parsed and read back with `read`.
+            dependencies = lib.concatMapStrings (pair: "${pair.fst}\t${pair.snd}\n") (lib.zipLists propagatedInputs mappedInputs);
             pkgOutputs = lib.concatMapStrings (output: "${output}\t${(lib.getOutput output pkg).outPath}\n") pkg.outputs;
-            passAsFile = [ "frameworks" "pkgOutputs" ];
+            passAsFile = [ "dependencies" "pkgOutputs" ];
           };
         in
-        if lib.length propagatedFrameworks > 0
+        # Only remap the package’s propagated inputs if there are any and if any of them were themselves remapped.
+        if lib.length propagatedInputs > 0 && propagatedInputs != mappedInputs
           then pkgs.runCommand pkg.name env ''
             # Iterate over the outputs in the package being replaced to make sure the proxy is
             # a fully functional replacement. This is like `symlinkJoin` except for outputs and
@@ -302,7 +305,7 @@ rec {
                       while IFS=$'\t\n' read -r oldFramework newFramework; do
                         substituteInPlace "''${!outputName}/nix-support/$fileName" \
                           --replace "$oldFramework" "$newFramework"
-                      done < "$frameworksPath"
+                      done < "$dependenciesPath"
                     fi
                   done
                 else
@@ -319,9 +322,9 @@ rec {
           name = lib.getName pkg;
           framework = lib.removePrefix "apple-framework-" name;
         in
-        if isSDKFramework pkg
-          then sdk.frameworks."${framework}"
-          else replacePropagatedFrameworks pkg;
+        /**/ if pkg == null then pkg
+        else if name != framework then sdk.frameworks."${framework}"
+        else replacePropagatedFrameworks pkg;
 
       mapRuntimeToSDK = pkg:
         # Only remap xcbuild for now, which exports the SDK used to build it.

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -367,6 +367,7 @@ rec {
         "buildInputs"
         "nativeBuildInputs"
         "propagatedNativeBuildInputs"
+        "propagatedBuildInputs"
       ]);
     });
 }

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -328,7 +328,7 @@ rec {
 
       mapRuntimeToSDK = pkg:
         # Only remap xcbuild for now, which exports the SDK used to build it.
-        if pkg != null && lib.getName pkg == "xcodebuild"
+        if pkg != null && lib.isAttrs pkg && lib.getName pkg == "xcodebuild"
           then pkg.override { stdenv = overrideSDK stdenv { inherit darwinMinVersion darwinSdkVersion; }; }
           else pkg;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24667,7 +24667,7 @@ with pkgs;
         darwin buildPackages;
       inherit (__splicedPackages.gst_all_1) gstreamer gst-plugins-base;
       inherit config;
-      stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+      stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
     });
 
   libsForQt5 = recurseIntoAttrs (import ./qt5-packages.nix {

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -178,7 +178,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   pulseaudio-qt = callPackage ../development/libraries/pulseaudio-qt { };
 
-  qca-qt5 = pkgs.darwin.apple_sdk_11_0.callPackage ../development/libraries/qca-qt5 {
+  qca-qt5 = callPackage ../development/libraries/qca-qt5 {
+    stdenv = if pkgs.stdenv.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
     inherit (libsForQt5) qtbase;
   };
 
@@ -209,8 +210,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
   qtinstaller = callPackage ../development/libraries/qtinstaller { };
 
   qtkeychain = callPackage ../development/libraries/qtkeychain {
-    stdenv = if pkgs.stdenv.isDarwin then pkgs.darwin.apple_sdk_11_0.stdenv else pkgs.stdenv;
-    inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreFoundation Security;
+    stdenv = if pkgs.stdenv.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   qtmpris = callPackage ../development/libraries/qtmpris { };


### PR DESCRIPTION
## Description of changes

Fixes staging-next build failure on x86_64-darwin: https://hydra.nixos.org/build/239500595. #263535

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
