### PR TITLE
vpd: init at R117-15572.B

### DIFF
--- a/pkgs/by-name/vp/vpd/package.nix
+++ b/pkgs/by-name/vp/vpd/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitiles
+, libuuid
+, makeWrapper
+, flashrom
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vpd";
+  version = "R117-15572.B";
+
+  src = fetchFromGitiles {
+    url = "https://chromium.googlesource.com/chromiumos/platform/vpd/";
+    rev = "0827891b4ea45375ca3d9fd395d3161bbd65144e";
+    hash = "sha256-7840GSQU7g0Mtq96avpJ2QM60xF9QyYmSLgRhDTfjk8=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ libuuid ];
+
+  buildFlags = [ "VERSION=release-${finalAttrs.version}" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 --target-directory=$out/bin vpd
+    wrapProgram $out/bin/vpd --prefix PATH : ${lib.makeBinPath [ flashrom ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "ChromiumOS Vital Product Data tooling for firmware images";
+    homepage = "https://chromium.googlesource.com/chromiumos/platform/vpd/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jmbaur ];
+    mainProgram = "vpd";
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

`vpd` is tool from the ChromiumOS project for reading product data/configuration from firmware files. In addition to ChromiumOS devices, this tool is generally useful for devices using coreboot.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
