### PR TITLE
paumr: add maintainer, archi: add paumr as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13595,6 +13595,11 @@
     githubId = 15645854;
     name = "Brad Christensen";
   };
+  paumr = {
+    github = "paumr";
+    name = "Michael Bergmeister";
+    githubId = 53442728;
+  };
   paveloom = {
     email = "paveloom@riseup.net";
     github = "paveloom";

--- a/pkgs/tools/misc/archi/default.nix
+++ b/pkgs/tools/misc/archi/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.mit;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ earldouglas ];
+    maintainers = with maintainers; [ earldouglas paumr ];
   };
 }


### PR DESCRIPTION
## Description of changes

Adds this account as a maintainer to nixpkgs.

## Things done

- All checks mentioned in `maintainers/maintainer-list.nix` were run