### PR TITLE
lkrg: 0.9.5 -> 0.9.7, switch to finalAttrs

### DIFF
--- a/pkgs/os-specific/linux/lkrg/default.nix
+++ b/pkgs/os-specific/linux/lkrg/default.nix
@@ -1,25 +1,25 @@
-{ lib, stdenv, fetchpatch, fetchFromGitHub, kernel }:
+{ fetchFromGitHub
+, kernel
+, lib
+, stdenv
+, umhLogOnly ? false
+}:
 let
   isKernelRT = (kernel.structuredExtraConfig ? PREEMPT_RT) && (kernel.structuredExtraConfig.PREEMPT_RT == lib.kernel.yes);
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}-${kernel.version}";
   pname = "lkrg";
-  version = "0.9.5";
+  version = "0.9.7";
 
   src = fetchFromGitHub {
     owner = "lkrg-org";
     repo = "lkrg";
     rev = "v${version}";
-    sha256 = "sha256-+yIKkTvfVbLnFBoXSKGebB1A8KqpaRmsLh8SsNuI9Dc=";
+    hash = "sha256-96ubxSc1JcvwYFC273gp9RHlu3+wFbKW3j1vThkNm5w=";
   };
-  patches = [
-    (fetchpatch {
-      name = "fix-aarch64.patch";
-      url = "https://github.com/lkrg-org/lkrg/commit/a4e5c00f13f7081b346bc3736e4c035e3d17d3f7.patch";
-      sha256 = "sha256-DPscqi+DySHwFxGuGe7P2itPkoyb3XGu5Xp2S/ezP4Y=";
-    })
-  ];
+
+  patches = lib.optional umhLogOnly ./umh-enforce-0-by-default.patch;
 
   hardeningDisable = [ "pic" ];
 
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ chivay ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "5.10" || kernel.kernelAtLeast "6.1" || isKernelRT;
+    broken = kernel.kernelOlder "5.10" || kernel.kernelAtLeast "6.6" || isKernelRT;
   };
 }

--- a/pkgs/os-specific/linux/lkrg/default.nix
+++ b/pkgs/os-specific/linux/lkrg/default.nix
@@ -7,15 +7,15 @@
 let
   isKernelRT = (kernel.structuredExtraConfig ? PREEMPT_RT) && (kernel.structuredExtraConfig.PREEMPT_RT == lib.kernel.yes);
 in
-stdenv.mkDerivation rec {
-  name = "${pname}-${version}-${kernel.version}";
+stdenv.mkDerivation (finalAttrs: {
+  name = "${finalAttrs.pname}-${finalAttrs.version}-${kernel.version}";
   pname = "lkrg";
   version = "0.9.7";
 
   src = fetchFromGitHub {
     owner = "lkrg-org";
     repo = "lkrg";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-96ubxSc1JcvwYFC273gp9RHlu3+wFbKW3j1vThkNm5w=";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     broken = kernel.kernelOlder "5.10" || kernel.kernelAtLeast "6.6" || isKernelRT;
   };
-}
+})

--- a/pkgs/os-specific/linux/lkrg/umh-enforce-0-by-default.patch
+++ b/pkgs/os-specific/linux/lkrg/umh-enforce-0-by-default.patch
@@ -1,0 +1,13 @@
+diff --git a/src/p_lkrg_main.c b/src/p_lkrg_main.c
+index 9ed9d37..0fa83ed 100644
+--- a/src/p_lkrg_main.c
++++ b/src/p_lkrg_main.c
+@@ -29,7 +29,7 @@ unsigned int pint_enforce = 1;
+ unsigned int pcfi_validate = 2;
+ unsigned int pcfi_enforce = 1;
+ unsigned int umh_validate = 1;
+-unsigned int umh_enforce = 1;
++unsigned int umh_enforce = 0;
+ #if defined(CONFIG_X86)
+ unsigned int smep_validate = 1;
+ unsigned int smep_enforce = 2;


### PR DESCRIPTION
## Description of changes

Updated lkrg so it's compatible with 6.1+

Also added a patch to set umh_enforce to 0 by default (but the patch itself has to be applied explicitly). Not sure if it'll be useful but I load lkrg in stage 1 before everything and in this case I think it's the best way of making umh log-only.

Switched to finalAttrs instead of rec because why not.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
