### PR TITLE
treewide: remove references to qtquick1

### DIFF
--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, qmake, qtbase, qtxmlpatterns, qtsvg, qtscxml
-, qtquick1, libGLU }:
+, libGLU }:
 
 stdenv.mkDerivation rec {
   pname = "qxmledit";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake ];
 
-  buildInputs = [ qtbase qtxmlpatterns qtsvg qtscxml qtquick1 libGLU ];
+  buildInputs = [ qtbase qtxmlpatterns qtsvg qtscxml libGLU ];
 
   qmakeFlags = [ "CONFIG+=release" ];
 

--- a/pkgs/applications/networking/instant-messengers/ricochet/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ricochet/default.nix
@@ -6,7 +6,6 @@
 , qtbase
 , qttools
 , qtmultimedia
-, qtquick1
 , qtquickcontrols
 , openssl
 , protobuf
@@ -38,7 +37,6 @@ mkDerivation rec {
     qtbase
     qttools
     qtmultimedia
-    qtquick1
     qtquickcontrols
     openssl
     protobuf

--- a/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
+++ b/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , mkDerivation
 , qtbase
-, qtquick1
 , qmltermwidget
 , qtquickcontrols2
 , qtgraphicaleffects
@@ -28,7 +27,6 @@ mkDerivation rec {
 
   buildInputs = [
     qtbase
-    qtquick1
     qmltermwidget
     qtquickcontrols2
     qtgraphicaleffects

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -4,7 +4,6 @@
 , extra-cmake-modules
 , qtbase
 , qtmultimedia
-, qtquick1
 , qttools
 , libGL
 , libX11
@@ -25,7 +24,6 @@ mkDerivation rec {
   buildInputs = [
     qtbase
     qtmultimedia
-    qtquick1
     libGL
     libX11
     libass

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , qtbase
-, qtquick1
 , qmake
 , qtmultimedia
 , utmp
@@ -23,7 +22,6 @@ stdenv.mkDerivation {
 
   buildInputs = [
     qtbase
-    qtquick1
     qtmultimedia
   ] ++ lib.optional stdenv.isDarwin utmp;
 


### PR DESCRIPTION
## Description of changes

... since `qt5.qtquick1` evaluates to `null`, which currently breaks `overrideSDK` in these packages on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
