### PR TITLE
wayqt: init at 0.2.0

### DIFF
--- a/pkgs/development/libraries/wayqt/default.nix
+++ b/pkgs/development/libraries/wayqt/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, substituteAll
+, meson
+, pkg-config
+, qttools
+, ninja
+, qtbase
+, qtwayland
+, wayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wayqt";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "desktop-frameworks";
+    repo = "wayqt";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-qlRRkqhKlcsd9lzlqfE0V0gjudELyENu4IH1NfO/+pI=";
+  };
+
+  patches = [
+    # qmake get qtbase's path, but wayqt need qtwayland
+    (substituteAll {
+      src = ./fix-qtwayland-header-path.diff;
+      qtWaylandPath = "${qtwayland}/include";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    qttools
+    ninja
+  ];
+
+  buildInputs = [
+    qtbase
+    qtwayland
+    wayland
+  ];
+
+  mesonFlags = [
+    "-Duse_qt_version=qt6"
+  ];
+
+  dontWrapQtApps = true;
+
+  outputs = [ "out" "dev" ];
+
+  meta = {
+    homepage = "https://gitlab.com/desktop-frameworks/wayqt";
+    description = "Qt-based library to handle Wayland and Wlroots protocols to be used with any Qt project";
+    maintainers = with lib.maintainers; [ rewine ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/development/libraries/wayqt/fix-qtwayland-header-path.diff
+++ b/pkgs/development/libraries/wayqt/fix-qtwayland-header-path.diff
@@ -1,0 +1,16 @@
+diff --git a/meson.build b/meson.build
+index 5c09644..fc65d37 100644
+--- a/meson.build
++++ b/meson.build
+@@ -39,9 +39,8 @@ elif get_option('use_qt_version') == 'qt6'
+ 		private_headers: [ 'Gui', 'WaylandClient', 'WaylandGlobalPrivate' ],
+ 	)
+ 
+-	qmake = find_program( [ 'qmake-qt6', 'qmake6' ], required: true )
+-	ret = run_command( qmake, '-query', 'QT_INSTALL_HEADERS', check: true )
+-	QtHeaderPath = ret.stdout().strip()
++	qmake = find_program( [ 'qmake-qt6', 'qmake6' ], required: false )
++	QtHeaderPath = '@qtWaylandPath@'
+ 
+ 	QtGlobal = '@0@/QtWaylandGlobal/@1@'.format( QtHeaderPath, QtDeps.version() )
+ 

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -90,6 +90,8 @@ makeScopeWithSplicing' {
 
   waylib = callPackage ../development/libraries/waylib { };
 
+  wayqt = callPackage ../development/libraries/wayqt { };
+
   } // lib.optionalAttrs pkgs.config.allowAliases {
     # Convert to a throw on 01-01-2023.
     # Warnings show up in various cli tool outputs, throws do not.


### PR DESCRIPTION
## Description of changes

https://gitlab.com/desktop-frameworks/wayqt

dependencies for qtgreet and paper desktop （https://github.com/NixOS/nixpkgs/pull/195371 and https://github.com/NixOS/nixpkgs/pull/218112 ）

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
