### PR TITLE
Revert NetworkManager to 1.42.8

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -57,11 +57,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.44.0";
+  version = "1.42.8";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "sha256-7coJY30YL4BrOxLYxWI9e629c8zKGuY74g0vKYd5+58=";
+    sha256 = "sha256-AzfnWD0uxa3iui6MYl0vCe7M2h0ig27imqcpJdOZw1M=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -80,7 +80,6 @@ stdenv.mkDerivation rec {
     "-Dkernel_firmware_dir=/run/current-system/firmware"
 
     # Platform
-    "-Dmodprobe=${kmod}/bin/modprobe"
     "-Dsession_tracking=systemd"
     "-Dlibaudit=yes-disabled-by-default"
     "-Dpolkit_agent_helper_1=/run/wrappers/bin/polkit-agent-helper-1"
@@ -119,7 +118,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit iputils openconnect ethtool gnused systemd;
+      inherit iputils kmod openconnect ethtool gnused systemd;
       inherit runtimeShell;
     })
 

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -57,11 +57,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.44.2";
+  version = "1.44.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "sha256-S1i/OsV+LO+1ZS79CUXrC0vDamPZKmGrRx2LssmkIOE=";
+    sha256 = "sha256-7coJY30YL4BrOxLYxWI9e629c8zKGuY74g0vKYd5+58=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/networkmanager/fix-install-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-install-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index f71c9fd4aa..deddf28816 100644
+index 6813e52ac1..ecdb78ca54 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1022,9 +1022,9 @@ meson.add_install_script(
+@@ -999,9 +999,9 @@ meson.add_install_script(
    join_paths('tools', 'meson-post-install.sh'),
    nm_datadir,
    nm_bindir,

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -11,10 +11,10 @@ index 148acade5c..6395fbfbe5 100644
  
  LABEL="nm_drivers_end"
 diff --git a/data/NetworkManager.service.in b/data/NetworkManager.service.in
-index f09ae86ceb..b2ecb405ef 100644
+index e23b3a5282..c7246a3b61 100644
 --- a/data/NetworkManager.service.in
 +++ b/data/NetworkManager.service.in
-@@ -9,7 +9,7 @@ BindsTo=dbus.service
+@@ -8,7 +8,7 @@ Before=network.target @DISTRO_NETWORK_SERVICE@
  [Service]
  Type=dbus
  BusName=org.freedesktop.NetworkManager
@@ -24,10 +24,10 @@ index f09ae86ceb..b2ecb405ef 100644
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
 diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index 2038e2f205..90bf9fa28b 100644
+index 3565c04d59..52c58fec24 100644
 --- a/src/core/devices/nm-device.c
 +++ b/src/core/devices/nm-device.c
-@@ -14275,14 +14275,14 @@ nm_device_start_ip_check(NMDevice *self)
+@@ -14005,14 +14005,14 @@ nm_device_start_ip_check(NMDevice *self)
              gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET);
              if (gw) {
                  nm_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
@@ -45,10 +45,10 @@ index 2038e2f205..90bf9fa28b 100644
              }
          }
 diff --git a/src/libnm-client-impl/meson.build b/src/libnm-client-impl/meson.build
-index fb879dca47..13cc2867e1 100644
+index 143126c51a..a7143443ec 100644
 --- a/src/libnm-client-impl/meson.build
 +++ b/src/libnm-client-impl/meson.build
-@@ -173,7 +173,6 @@ if enable_introspection
+@@ -172,7 +172,6 @@ if enable_introspection
        input: libnm_core_settings_sources,
        output: 'nm-propery-infos-' + info + '.xml',
        command: [
@@ -56,7 +56,7 @@ index fb879dca47..13cc2867e1 100644
          join_paths(meson.source_root(), 'tools', 'generate-docs-nm-property-infos.py'),
          info,
          '@OUTPUT@',
-@@ -230,7 +229,6 @@ if enable_introspection
+@@ -229,7 +228,6 @@ if enable_introspection
        'env',
        'GI_TYPELIB_PATH=' + gi_typelib_path,
        'LD_LIBRARY_PATH=' + ld_library_path,
@@ -64,14 +64,27 @@ index fb879dca47..13cc2867e1 100644
        join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-gir.py'),
        '--lib-path', meson.current_build_dir(),
        '--gir', '@INPUT@',
+diff --git a/src/libnm-platform/nm-platform-utils.c b/src/libnm-platform/nm-platform-utils.c
+index bebc53a851..93710455d5 100644
+--- a/src/libnm-platform/nm-platform-utils.c
++++ b/src/libnm-platform/nm-platform-utils.c
+@@ -2209,7 +2209,7 @@ nmp_utils_modprobe(GError **error, gboolean suppress_error_logging, const char *
+ 
+     /* construct the argument list */
+     argv = g_ptr_array_sized_new(4);
+-    g_ptr_array_add(argv, "/sbin/modprobe");
++    g_ptr_array_add(argv, "@kmod@/bin/modprobe");
+     g_ptr_array_add(argv, "--use-blacklist");
+     g_ptr_array_add(argv, (char *) arg1);
+ 
 diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
-index cbe76f5f1c..8515f94994 100644
+index 476fbe518e..2641dbf637 100644
 --- a/src/libnmc-base/nm-vpn-helpers.c
 +++ b/src/libnmc-base/nm-vpn-helpers.c
-@@ -284,15 +284,6 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
+@@ -198,25 +198,8 @@ nm_vpn_openconnect_authenticate_helper(const char *host,
+     gs_free const char **output_v = NULL;
      const char *const   *iter;
      const char          *path;
-     const char          *opt;
 -    const char *const    DEFAULT_PATHS[] = {
 -        "/sbin/",
 -        "/usr/sbin/",
@@ -81,12 +94,6 @@ index cbe76f5f1c..8515f94994 100644
 -        "/usr/local/bin/",
 -        NULL,
 -    };
-     const char *oc_argv[(12 + 2 * G_N_ELEMENTS(oc_property_args))];
-     const char *gw;
-     int         port;
-@@ -311,15 +302,7 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
- 
-     port = extract_url_port(gw);
  
 -    path = nm_utils_file_search_in_paths("openconnect",
 -                                         "/usr/sbin/openconnect",
@@ -99,10 +106,10 @@ index cbe76f5f1c..8515f94994 100644
 -        return FALSE;
 +    path = "@openconnect@/bin/openconnect";
  
-     oc_argv[oc_argc++] = path;
-     oc_argv[oc_argc++] = "--authenticate";
+     if (!g_spawn_sync(NULL,
+                       (char **) NM_MAKE_STRV(path, "--authenticate", host),
 diff --git a/src/libnmc-setting/meson.build b/src/libnmc-setting/meson.build
-index cf8a21fc80..61d8e140e2 100644
+index cf8a21fc80..61b992a50e 100644
 --- a/src/libnmc-setting/meson.build
 +++ b/src/libnmc-setting/meson.build
 @@ -7,7 +7,6 @@ if enable_docs
@@ -113,16 +120,8 @@ index cf8a21fc80..61d8e140e2 100644
        join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-merge.py'),
        '@OUTPUT@',
        nm_property_infos_xml['nmcli'],
-@@ -20,7 +19,6 @@ if enable_docs
-     input: settings_docs_input_xml,
-     output: 'settings-docs.h',
-     command: [
--      python.path(),
-       join_paths(meson.source_root(), 'tools', 'generate-docs-settings-docs.py'),
-       '--output', '@OUTPUT@',
-       '--xml', '@INPUT@'
 diff --git a/src/tests/client/meson.build b/src/tests/client/meson.build
-index 8c36e40559..cfb6649a21 100644
+index 6dc0f2a2c8..0a32977a59 100644
 --- a/src/tests/client/meson.build
 +++ b/src/tests/client/meson.build
 @@ -6,7 +6,6 @@ test(
@@ -131,13 +130,5 @@ index 8c36e40559..cfb6649a21 100644
      source_root,
 -    python.path(),
      '--',
-     'TestNmcli',
    ],
-@@ -23,7 +22,6 @@ if enable_nm_cloud_setup
-     args: [
-       build_root,
-       source_root,
--      python.path(),
-       '--',
-       'TestNmCloudSetup',
-     ],
+   env: [


### PR DESCRIPTION
## Description of changes

NetworkManager 1.44.0 does not work with the current Plasma after a restart of the NetworkManager service. It can be sometimes worked around by unloading and loading the iwlwifi kernel module but things like wpa_supplicant continue to behave buggy.

Tested this on my plasma system and after this revert things worked again.
I am open for alternatives and testing things but I couldn't figure out a better way yesterday.

see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1053707

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
