### PR TITLE
doc: update r-b issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/unreproducible_package.md
+++ b/.github/ISSUE_TEMPLATE/unreproducible_package.md
@@ -7,25 +7,81 @@ assignees: ''
 
 ---
 
-Building this package twice does not produce the bit-by-bit identical result each time, making it harder to detect CI breaches. You can read more about this at https://reproducible-builds.org/ .
+<!--
+Hello dear reporter,
 
-Fixing bit-by-bit reproducibility also has additional advantages, such as avoiding hard-to-reproduce bugs, making content-addressed storage more effective and reducing rebuilds in such systems.
+Thank you for bringing attention to this issue. Your insights are valuable to
+us, and we appreciate the time you took to document the problem.
+
+I wanted to kindly point out that in this issue template, it would be beneficial
+to replace the placeholder `<package>` with the actual, canonical name of the
+package you're reporting the issue for. Doing so will provide better context and
+facilitate quicker troubleshooting for anyone who reads this issue in the
+future.
+
+Best regards
+-->
+
+Building this package multiple times does not yield bit-by-bit identical
+results, complicating the detection of Continuous Integration (CI) breaches. For
+more information on this issue, visit
+[reproducible-builds.org](https://reproducible-builds.org/).
+
+Fixing bit-by-bit reproducibility also has additional advantages, such as
+avoiding hard-to-reproduce bugs, making content-addressed storage more effective
+and reducing rebuilds in such systems.
 
 ### Steps To Reproduce
 
+In the following steps, replace `<package>` with the canonical name of the
+package.
+
+#### 1. Build the package
+
+This step will build the package. Specific arguments are passed to the command
+to keep the build artifacts so we can compare them in case of differences.
+
+Execute the following command:
+
 ```
-nix-build '<nixpkgs>' -A ... && nix-build '<nixpkgs>' -A ... --check --keep-failed
+nix-build '<nixpkgs>' -A <package> && nix-build '<nixpkgs>' -A <package> --check --keep-failed
 ```
 
-If this command completes successfully, no differences where found. However, when it ends in `error: derivation '<X>' may not be deterministic: output '<Y>' differs from '<Z>'`, you can use `diffoscope <Y> <Z>` to analyze the differences in the output of the two builds.
-
-To view the build log of the build that produced the artifact in the binary cache:
+Or using the new command line style:
 
 ```
-nix-store --read-log $(nix-instantiate '<nixpkgs>' -A ...)
+nix build nixpkgs#<package> && nix build nixpkgs#<package> --rebuild --keep-failed
+```
+
+#### 2. Compare the build artifacts
+
+If the previous command completes successfully, no differences were found and
+there's nothing to do, builds are reproducible.
+If it terminates with the error message `error: derivation '<X>' may not be
+deterministic: output '<Y>' differs from '<Z>'`, use `diffoscope` to investigate
+the discrepancies between the two build outputs. You may need to add the
+`--exclude-directory-metadata recursive` option to ignore files and directories
+metadata (*e.g. timestamp*) differences.
+
+```
+nix run nixpkgs#diffoscopeMinimal -- --exclude-directory-metadata recursive <Y> <Z>
+```
+
+#### 3. Examine the build log
+
+To examine the build log, use:
+
+```
+nix-store --read-log $(nix-instantiate '<nixpkgs>' -A <package>)
+```
+
+Or with the new command line style:
+
+```
+nix log $(nix path-info --derivation nixpkgs#<package>)
 ```
 
 ### Additional context
 
-(please share the relevant fragment of the diffoscope output here,
-and any additional analysis you may have done)
+(please share the relevant fragment of the diffoscope output here, and any
+additional analysis you may have done)


### PR DESCRIPTION
Hello,

While working on https://github.com/NixOS/nixpkgs/issues/230288, I identified an area for improvement in the `r-b` issue template.

Specifically, the following command fails when executed:

```
[pol@x13:~/Code/NixOS/nixpkgs]$ nix-store --read-log $(nix-instantiate '<nixpkgs>' -A wireplumber.doc)
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
error: store path '7wrbjsivcy8z2zq9kvmv9v1glzn1gxn0-wireplumber-0.4.15.drv!doc' contains illegal character '!'
```

However, the command works as expected when using the new CLI style introduced in this PR.

Improving this aspect of the issue template can be an important step in emphasizing the need for reproducibility and facilitating efficient contributions from the community.

This PR:

- [x] Update the description just a little bit and fix minor typos along the way
- [x] Update the command linue using the new style (both styles are proposed) 
- [x] Show how to use `diffoscope`

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
