### PR TITLE
vcsi: 7.0.13 -> 7.0.16

### DIFF
--- a/pkgs/tools/video/vcsi/default.nix
+++ b/pkgs/tools/video/vcsi/default.nix
@@ -1,13 +1,19 @@
-{ lib, python3Packages, fetchPypi, ffmpeg }:
+{ lib, python3Packages, fetchFromGitHub, ffmpeg }:
 
 python3Packages.buildPythonApplication rec {
   pname = "vcsi";
-  version = "7.0.13";
+  version = "7.0.16";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "01qwbb2l8gwf622zzhh0kzdzw3njvsdwmndwn01i9bn4qm5cas8r";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "amietn";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-I0o6GX/TNMfU+rQtSqReblRplXPynPF6m2zg0YokmtI=";
   };
+
+  nativeBuildInputs = [ python3Packages.poetry-core ];
 
   propagatedBuildInputs = with python3Packages; [
     numpy
@@ -26,6 +32,6 @@ python3Packages.buildPythonApplication rec {
     description = "Create video contact sheets";
     homepage = "https://github.com/amietn/vcsi";
     license = licenses.mit;
-    maintainers = with maintainers; [ dandellion ];
+    maintainers = with maintainers; [ dandellion zopieux ];
   };
 }


### PR DESCRIPTION
## Description of changes

vcsi 7.0.13 (currently in master) fails to run because of a [breaking change](https://github.com/amietn/vcsi/issues/119) in Pillow 10.x (PIL) FreeType API.
The project [switched to pyproject](https://github.com/amietn/vcsi/commit/5de3a14c31c60b9a460a9012de42a50b137489ef) in the meantime. This PR reflects that change.

I've tested that the binary correctly produces a JPEG file from a sample video.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
