### PR TITLE
python311Packages.mocket: 3.11.1 -> 3.12.0

### DIFF
--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -1,36 +1,50 @@
 { lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, stdenv
+
+# build-system
+, hatchling
+
+# dependencies
+, decorator
+, httptools
+, python-magic
+, urllib3
+
+# optional-dependencies
+, xxhash
+, pook
+
+# tests
 , aiohttp
 , asgiref
-, buildPythonPackage
-, decorator
 , fastapi
-, fetchPypi
 , gevent
-, httptools
 , httpx
-, isPy3k
-, pook
-, pytest-mock
+, pytest-asyncio
 , pytestCheckHook
-, python-magic
-, pythonOlder
 , redis
+, redis-server
 , requests
 , sure
-, urllib3
+
 }:
 
 buildPythonPackage rec {
   pname = "mocket";
-  version = "3.11.1";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  version = "3.12.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-sEPLUN9nod4AKYcoCNQZ4FBblUCLCPV1dFOrNC6xDWo=";
+    hash = "sha256-brvBWwTWT2F/usVBRr7wz9L0kct4X1Fddl4mu5LUENA=";
   };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
 
   propagatedBuildInputs = [
     decorator
@@ -43,42 +57,48 @@ buildPythonPackage rec {
     pook = [
       pook
     ];
+    speedups = [
+      xxhash
+    ];
   };
 
   nativeCheckInputs = [
-    aiohttp
     asgiref
     fastapi
     gevent
     httpx
-    pytest-mock
+    pytest-asyncio
     pytestCheckHook
     redis
     requests
     sure
-  ] ++ passthru.optional-dependencies.pook;
+  ] ++ lib.optionals (pythonOlder "3.12") [
+    aiohttp
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
-  # Skip http tests
-  SKIP_TRUE_HTTP = true;
+  preCheck = lib.optionalString stdenv.isLinux ''
+    ${redis-server}/bin/redis-server &
+    REDIS_PID=$!
+  '';
 
-  disabledTestPaths = [
-    # Requires a live Redis instance
-    "tests/main/test_redis.py"
-  ];
+  postCheck = lib.optionalString stdenv.isLinux ''
+    kill $REDIS_PID
+  '';
+
+  # Skip http tests, they require network access
+  env.SKIP_TRUE_HTTP = true;
+
+  _darwinAllowLocalNetworking = true;
 
   disabledTests = [
     # tests that require network access (like DNS lookups)
-    "test_truesendall"
-    "test_truesendall_with_chunk_recording"
-    "test_truesendall_with_gzip_recording"
-    "test_truesendall_with_recording"
-    "test_wrongpath_truesendall"
     "test_truesendall_with_dump_from_recording"
-    "test_truesendall_with_recording_https"
-    "test_truesendall_after_mocket_session"
-    "test_real_request_session"
     "test_asyncio_record_replay"
     "test_gethostbyname"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    "tests/main/test_redis.py"
   ];
 
   pythonImportsCheck = [
@@ -86,9 +106,9 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/mindflayer/python-mocket/releases/tag/${version}";
     description = "A socket mock framework for all kinds of sockets including web-clients";
     homepage = "https://github.com/mindflayer/python-mocket";
-    changelog = "https://github.com/mindflayer/python-mocket/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ hexa ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6930,7 +6930,9 @@ self: super: with self; {
 
   mobly = callPackage ../development/python-modules/mobly { };
 
-  mocket = callPackage ../development/python-modules/mocket { };
+  mocket = callPackage ../development/python-modules/mocket {
+    redis-server = pkgs.redis;
+  };
 
   mock = callPackage ../development/python-modules/mock { };
 


### PR DESCRIPTION
https://github.com/mindflayer/python-mocket/releases/tag/3.12.0

Test with redis-server on Linux, reorganize dependencies

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
