### PR TITLE
Python 3.12 enablement

### DIFF
--- a/pkgs/development/python-modules/nose3/default.nix
+++ b/pkgs/development/python-modules/nose3/default.nix
@@ -5,12 +5,16 @@
 , isPyPy
 , isPy311
 , python
+, pythonAtLeast
 , stdenv
 }:
 
 buildPythonPackage rec {
   pname = "nose3";
   version = "1.3.8";
+
+  # https://github.com/jayvdb/nose3/issues/5
+  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -28,9 +28,9 @@ let
 in buildPythonPackage rec {
   # Using an untagged version, with numpy 1.25 support, when it's released
   # also drop the versioneer patch in postPatch
-  version = "0.58.0rc2";
+  version = "0.58.1";
   pname = "numba";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8" || pythonAtLeast "3.12";
 
@@ -50,7 +50,7 @@ in buildPythonPackage rec {
     # use `forceFetchGit = true;`.` If in the future we'll observe the hash
     # changes too often, we can always use forceFetchGit, and inject the
     # relevant strings ourselves, using `sed` commands, in extraPostFetch.
-    hash = "sha256-ktFBjzd2vEahdr86lhVLVFEadCIhPP3hRF/EuZhHCC4=";
+    hash = "sha256-1Tj2GFoUwRRCWBFxhreF+0Mr+Tjyb7+X4peO+T0qGNs=";
   };
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
 

--- a/pkgs/development/python-modules/pkgconfig/default.nix
+++ b/pkgs/development/python-modules/pkgconfig/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , poetry-core
 , pkg-config
 , pytestCheckHook
@@ -36,6 +37,10 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [ poetry-core ];
+
+  # ModuleNotFoundError: No module named 'distutils'
+  # https://github.com/matze/pkgconfig/issues/64
+  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Various package bumps to unblock Python 3.12 usage. <del>Based on top of staging-next, so they're cheap to build, while they have the latest package versions.</del>

## numpy

https://github.com/numpy/numpy/releases/tag/v1.26.0
https://github.com/numpy/numpy/releases/tag/v1.26.1

Migrates the build system to meson-python, obsoleting all NPY_* environment variables used in the build process.

Adds support for Python 3.12.

## numba

https://github.com/numba/numba/compare/refs/tags/0.58.0rc2...0.58.1

Update to allow building it with numpy 1.26. Does not yet support Python 3.12

Executed the full test suite on x86_64-linux.

## greenlet

https://github.com/python-greenlet/greenlet/blob/3.0.1/CHANGES.rst

Updates to 3.0 for Python 3.12 support. Running the tests in passthru.tests.pytest, since an infinite recursion via objgraph/graphviz causes problems otherwise.

## nose3

Disabled on Python 3.12, since it relies on the `imp` module, which was deprecated since 3.4 and removed in 3.12 in favor of `importlib`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
