### PR TITLE
buildRustCrate: fix cross

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -17,6 +17,9 @@
 }:
 
 let
+  # Rust environment variables for cross-compilation guidance
+  # for `cc-rs` and Cargo.
+  RUST_ENV = rust.envVars.setEnv;
   # Create rustc arguments to link against the given list of dependencies
   # and renames.
   #
@@ -338,6 +341,8 @@ crate_: lib.makeOverridable
         lib.optionals (crate ? extraRustcOptsForBuildRs) crate.extraRustcOptsForBuildRs
         ++ extraRustcOptsForBuildRs_
         ++ (lib.optional (edition != null) "--edition ${edition}");
+      # Required to set up properly cross-compilation with the `cc-rs` crate.
+      env = { inherit RUST_ENV; };
 
 
       configurePhase = configureCrate {

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -10,7 +10,7 @@ build_lib() {
   lib_src=$1
   echo_build_heading $lib_src ${libName}
 
-  noisily rustc \
+  noisily $RUST_ENV rustc \
     --crate-name $CRATE_NAME \
     $lib_src \
     --out-dir target/lib \
@@ -41,7 +41,7 @@ build_bin() {
     main_file=$2
   fi
   echo_build_heading $@
-  noisily rustc \
+  noisily $RUST_ENV rustc \
     --crate-name $crate_name_ \
     $main_file \
     --crate-type bin \
@@ -159,7 +159,7 @@ matching_cargo_toml_path() {
   # But to make it more general, we search for a matching
   # crate in all packages and use the manifest path that
   # is referenced there.
-  cargo metadata --no-deps --format-version 1 \
+  $RUST_ENV cargo metadata --no-deps --format-version 1 \
     --manifest-path "$manifest_path" \
     | jq -r '.packages[]
             | select( .name == "'$expected_crate_name'")


### PR DESCRIPTION
Previously, `cargo` / `rustc` were run while letting `cc-rs` guess what should be the linker, the cc, etc.

In general, this works almost well, except when `cc-rs` is confused and does not.

As we already do in many places in the Rust cross compilation ecosystem, we set certain environment variables which wraps any rustc or cargo invocation to help `cc-rs` or `cargo` understand what is the linker, etc.

We proceed to do the same here.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
