### PR TITLE
cadzinho: init at 0.4.1

### DIFF
--- a/pkgs/by-name/ca/cadzinho/package.nix
+++ b/pkgs/by-name/ca/cadzinho/package.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, SDL2, glew, lua5_4, desktopToDarwinBundle }:
+
+stdenv.mkDerivation rec {
+  pname = "cadzinho";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "zecruel";
+    repo = "CadZinho";
+    rev = version;
+    hash = "sha256-6/sBNxQb52FFO2fWLVs6YDOmJLEbSOA5mwdMdJDjEDM=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/gui_config.c --replace "/usr/share/cadzinho" "$out/share/cadzinho"
+  '';
+
+  nativeBuildInputs = lib.optional stdenv.isDarwin desktopToDarwinBundle;
+
+  buildInputs = [ SDL2 glew lua5_4 ];
+
+  makeFlags = [ "CC:=$(CC)" ];
+
+  # https://github.com/llvm/llvm-project/issues/62254
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-fno-builtin-strrchr";
+
+  hardeningDisable = [ "format" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 cadzinho -t $out/bin
+    install -Dm644 lang/*.lua -t $out/share/cadzinho/lang
+    cp -r linux/CadZinho/share/* $out/share
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Minimalist computer aided design (CAD) software";
+    homepage = "https://github.com/zecruel/CadZinho";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+    mainProgram = "cadzinho";
+  };
+}


### PR DESCRIPTION
## Description of changes
[**CadZinho**](https://github.com/zecruel/CadZinho) - Minimalist computer aided design (CAD) software.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
