### PR TITLE
direwolf: 1.6 -> 1.7

### DIFF
--- a/pkgs/applications/radio/direwolf/default.nix
+++ b/pkgs/applications/radio/direwolf/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "direwolf";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "wb2osz";
     repo = "direwolf";
     rev = version;
-    sha256 = "0xmz64m02knbrpasfij4rrq53ksxna5idxwgabcw4n2b1ig7pyx5";
+    hash = "sha256-Vbxc6a6CK+wrBfs15dtjfRa1LJDKKyHMrg8tqsF7EX4=";
   };
 
   patches = [ ./fix-strlcpy-usage.patch ];

--- a/pkgs/applications/radio/direwolf/fix-strlcpy-usage.patch
+++ b/pkgs/applications/radio/direwolf/fix-strlcpy-usage.patch
@@ -75,15 +75,15 @@ index ff18800..b1cb443 100644
 -}
 -
 diff --git a/src/direwolf.h b/src/direwolf.h
-index efc329b..22eb748 100644
+index 69b0952..6f9ec1a 100644
 --- a/src/direwolf.h
 +++ b/src/direwolf.h
-@@ -294,7 +294,7 @@ char *strcasestr(const char *S, const char *FIND);
- #define HAVE_STRLCPY 1
+@@ -328,7 +328,7 @@ char *strcasestr(const char *S, const char *FIND);
+ #endif
+ #endif
  
+-#define DEBUG_STRL 1	// Extra Debug version when using our own strlcpy, strlcat.
++#define DEBUG_STRL 0	// Extra Debug version when using our own strlcpy, strlcat.
+ 			// Should be ignored if not supplying our own.
  
--#define DEBUG_STRL 1
-+#define DEBUG_STRL 0
- 
- #if DEBUG_STRL
- 
+ #ifndef HAVE_STRLCPY	// Need to supply our own.


### PR DESCRIPTION
## Description of changes

Update direwolf to latest tag v1.7.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>direwolf</li>
    <li>openwebrx</li>
    <li>openwebrx.dist</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).