### PR TITLE
fsautocomplete: 0.66.1 -> 0.67.0

### DIFF
--- a/pkgs/development/tools/fsautocomplete/default.nix
+++ b/pkgs/development/tools/fsautocomplete/default.nix
@@ -5,13 +5,13 @@ let
 in
 buildDotnetModule rec {
   pname = "fsautocomplete";
-  version = "0.66.1";
+  version = "0.67.0";
 
   src = fetchFromGitHub {
     owner = "fsharp";
     repo = "FsAutoComplete";
     rev = "v${version}";
-    sha256 = "sha256-9kuGteoWbYoqgFA11qH+MEjhLMk/23bXXiGG8Lsr1MA=";
+    sha256 = "sha256-txHkQDLyIejsEZGpfIGqeiJ8EUePZq1btxfd+EZD4aM=";
   };
 
   nugetDeps = ./deps.nix;

--- a/pkgs/development/tools/fsautocomplete/deps.nix
+++ b/pkgs/development/tools/fsautocomplete/deps.nix
@@ -70,7 +70,7 @@
   (fetchNuGet { pname = "IcedTasks"; version = "0.5.4"; sha256 = "0584bbld25f6hzglzsah1n215658d4lwnzwxcazrwzyy25rmansl"; })
   (fetchNuGet { pname = "ICSharpCode.Decompiler"; version = "7.2.1.6856"; sha256 = "19z68rgzl93lh1h8anbgzw119mhvcgr9nh5q2nxk6qihl2mx97ba"; })
   (fetchNuGet { pname = "Ionide.KeepAChangelog.Tasks"; version = "0.1.8"; sha256 = "066zla2rp1sal6by3h3sg6ibpkk52kbhn30bzk58l6ym7q1kqa6b"; })
-  (fetchNuGet { pname = "Ionide.LanguageServerProtocol"; version = "0.4.17"; sha256 = "14h8rkc9q6shh9fqa640bzfs1k1y5nfriwviwjynpjf79xbbcpvs"; })
+  (fetchNuGet { pname = "Ionide.LanguageServerProtocol"; version = "0.4.19"; sha256 = "1n910ipbscr7b3cr873cr5zh40ysn0n9z47dlqlndbq0g3kl6vi5"; })
   (fetchNuGet { pname = "Ionide.ProjInfo"; version = "0.62.0"; sha256 = "1da6hhca9vd6hxbz9jmwxwx2pc7d5ayd41sp6mzzmbk4n3jk32q2"; })
   (fetchNuGet { pname = "Ionide.ProjInfo.FCS"; version = "0.62.0"; sha256 = "1mkw4b1sawv1p0c4a1fidkw02bh9iik7fi80ffgqi0msc3ql8lmg"; })
   (fetchNuGet { pname = "Ionide.ProjInfo.ProjectSystem"; version = "0.62.0"; sha256 = "0kj9h5gvvrl720kg5jylx8w1jjmcci7bdhabr57sbq31vbgav74d"; })


### PR DESCRIPTION
## Description of changes

Update fsautocomplete according to the new release [https://github.com/fsharp/FsAutoComplete/releases/tag/v0.67.0](https://github.com/fsharp/FsAutoComplete/releases/tag/v0.67.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
