### PR TITLE
netdata: don't use absolute path for `echo`

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -118,6 +118,10 @@ stdenv.mkDerivation rec {
   ];
 
   postFixup = ''
+    # remove once https://github.com/netdata/netdata/pull/16300 merged
+    substituteInPlace $out/bin/netdata-claim.sh \
+      --replace /bin/echo echo
+
     wrapProgram $out/bin/netdata-claim.sh --prefix PATH : ${lib.makeBinPath [ openssl ]}
     wrapProgram $out/libexec/netdata/plugins.d/cgroup-network-helper.sh --prefix PATH : ${lib.makeBinPath [ bash ]}
     wrapProgram $out/bin/netdatacli --set NETDATA_PIPENAME /run/netdata/ipc


### PR DESCRIPTION
## Description of changes

`netdata` includes [a script, `netdata-claim.sh`](https://github.com/netdata/netdata/blob/master/claim/netdata-claim.sh.in) used to connect a server/node to the centralized Netdata monitoring service. However, the script uses a hard-coded path, `/bin/echo` to write a UUID to a file while setting up - [line 178](https://github.com/netdata/netdata/blob/072cd3cbcfef32ebe890508cebcc0943390cf434/claim/netdata-claim.sh.in#L178). This causes a problem when running the script for the first time - a UUID is generated but the `echo` command is not found. 

The offending code in `netdata-claim.sh`: 

```bash
# get the MACHINE_GUID by default
if [ -r "${MACHINE_GUID_FILE}" ]; then
        ID="$(cat "${MACHINE_GUID_FILE}")"
        MGUID=$ID
elif [ -f "${MACHINE_GUID_FILE}" ]; then
        echo >&2 "netdata.public.unique.id is not readable. Please make sure you have rights to read it (Filename: ${MACHINE_GUID_FILE})."
        exit 18
else
        if mkdir -p "${MACHINE_GUID_FILE%/*}" && /bin/echo -n "$(gen_id)" > "${MACHINE_GUID_FILE}"; then
                ID="$(cat "${MACHINE_GUID_FILE}")"
                MGUID=$ID
        else
                echo >&2 "Failed to write new machine GUID. Please make sure you have rights to write to ${MACHINE_GUID_FILE}."
                exit 18
        fi
fi
```

Bash has a footgun here, as the `echo` command fails but the `>` operator still creates an empty file at `$MACHINE_GUID_FILE`, typically `/var/lib/netdata/netdata.api.key`. The first invocation of the script fails with the `Failed to write new machine...` error; subsequent invocations of the script (usually runs 4 more times, as systemd sees a failed script and retries it) then read and empty file and set `ID` to an empty string, which causes the remainder of the script to fail. 

Easy enough fix once I found the problem - let the script use the `echo` that's on `$PATH` rather than a hard-coded path to it. 

In more detail - all scripts for systemd have [`coreutils` included on the $PATH for the script](https://github.com/NixOS/nixpkgs/blob/fac16fbfae144461f41accc3455682e052e6ce49/nixos/lib/systemd-lib.nix#L324) but the script is looking for the `echo` binary at `/bin/echo` rather than relying on searching through $PATH. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
