### PR TITLE
borgmatic: 1.8.1 -> 1.8.8

### DIFF
--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -13,14 +13,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "borgmatic";
-  version = "1.8.1";
+  version = "1.8.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-XbihTQJtoiRRfwjMCP+XEPmbt7//zFPx1fIWOvn92Nc=";
+    sha256 = "sha256-dPWp8SH4//HJlCrF6YRaMb32idox1E0/Gd8qc/GmP4c=";
   };
 
-  nativeCheckInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ];
+  nativeCheckInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ] ++ passthru.optional-dependencies.apprise;
 
   # - test_borgmatic_version_matches_news_version
   # The file NEWS not available on the pypi source, and this test is useless
@@ -39,6 +39,10 @@ python3Packages.buildPythonApplication rec {
     requests
     setuptools
   ];
+
+  passthru.optional-dependencies = {
+    apprise = with python3Packages; [ apprise ];
+  };
 
   postInstall = ''
     installShellCompletion --cmd borgmatic \


### PR DESCRIPTION
## Description of changes

Release note:

- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.8
- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.7
- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.6
- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.5
- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.4
- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.3
- https://github.com/borgmatic-collective/borgmatic/releases/tag/1.8.2

There is a new hook using [apprise](https://torsion.org/borgmatic/docs/how-to/monitor-your-backups/#apprise-hook), which is an [optional](https://github.com/borgmatic-collective/borgmatic/blob/1.8.8/setup.py#L39) dependency.

So I add a `passthru.optional-dependencies.apprise` parameter for people who want to use Apprise as a hook.

`apprise` is added to `nativeCheckInputs` because there are [tests](https://github.com/borgmatic-collective/borgmatic/blob/1.8.8/tests/unit/hooks/test_apprise.py) for apprise

The new ./result/bin/borgmatic are tested with my previous config

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
