### PR TITLE
python311Packages.img2pdf: 0.4.4 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/img2pdf/default-icc-profile.patch
+++ b/pkgs/development/python-modules/img2pdf/default-icc-profile.patch
@@ -1,0 +1,20 @@
+diff --git a/src/img2pdf.py b/src/img2pdf.py
+index 036232b..d2e7829 100755
+--- a/src/img2pdf.py
++++ b/src/img2pdf.py
+@@ -3815,14 +3815,7 @@ def gui():
+ 
+ 
+ def get_default_icc_profile():
+-    for profile in [
+-        "/usr/share/color/icc/sRGB.icc",
+-        "/usr/share/color/icc/OpenICC/sRGB.icc",
+-        "/usr/share/color/icc/colord/sRGB.icc",
+-    ]:
+-        if os.path.exists(profile):
+-            return profile
+-    return "/usr/share/color/icc/sRGB.icc"
++    return "@colord@/share/color/icc/colord/sRGB.icc"
+ 
+ 
+ def get_main_parser():

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -1,8 +1,11 @@
 { lib
 , buildPythonPackage
 , isPy27
-, fetchPypi
+, fetchFromGitea
+, substituteAll
 , fetchpatch
+, colord
+, setuptools
 , pikepdf
 , pillow
 , stdenv
@@ -19,29 +22,40 @@
 
 buildPythonPackage rec {
   pname = "img2pdf";
-  version = "0.4.4";
+  version = "0.5.0";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "8ec898a9646523fd3862b154f3f47cd52609c24cc3e2dc1fb5f0168f0cbe793c";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "gitlab.mister-muffin.de";
+    owner = "josch";
+    repo = "img2pdf";
+    rev = version;
+    hash = "sha256-k0GqBTS8PvYDmjzyLCSdQB7oBakrEQYJcQykDNrzgcA=";
   };
 
   patches = [
-    (fetchpatch {
-      # https://gitlab.mister-muffin.de/josch/img2pdf/issues/148
-      url = "https://gitlab.mister-muffin.de/josch/img2pdf/commit/57d7e07e6badb252c12015388b58fcb5285d3158.patch";
-      hash = "sha256-H/g55spe/oVJRxO2Vh+F+ZgR6aLoRUrNeu5WnuU7k/k=";
+    (substituteAll {
+      src = ./default-icc-profile.patch;
+      inherit colord;
     })
+    (fetchpatch {
+      # https://gitlab.mister-muffin.de/josch/img2pdf/issues/178
+      url = "https://salsa.debian.org/debian/img2pdf/-/raw/4a7dbda0f473f7c5ffcaaf68ea4ad3f435e0920d/debian/patches/fix_tests.patch";
+      hash = "sha256-A1zK6yINhS+dvyckZjqoSO1XJRTaf4OXFdq5ufUrBs8=";
+    })
+
+  ];
+
+  nativeBuildInputs = [
+    setuptools
   ];
 
   propagatedBuildInputs = [
     pikepdf
     pillow
   ];
-
-  # https://gitlab.mister-muffin.de/josch/img2pdf/issues/128
-  doCheck = !stdenv.isAarch64;
 
   nativeCheckInputs = [
     exiftool
@@ -60,16 +74,18 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    "test_tiff_rgb"
-    "test_png_gray1"  # https://gitlab.mister-muffin.de/josch/img2pdf/issues/154
+    # https://gitlab.mister-muffin.de/josch/img2pdf/issues/178
+    "test_miff_cmyk16"
   ];
 
   pythonImportsCheck = [ "img2pdf" ];
 
   meta = with lib; {
+    changelog = "https://gitlab.mister-muffin.de/josch/img2pdf/src/tag/${src.rev}/CHANGES.rst";
     description = "Convert images to PDF via direct JPEG inclusion";
     homepage = "https://gitlab.mister-muffin.de/josch/img2pdf";
-    license = licenses.lgpl2;
+    license = licenses.lgpl3Plus;
+    mainProgram = "img2pdf";
     maintainers = with maintainers; [ veprbl dotlambda ];
   };
 }


### PR DESCRIPTION
<details>
<summary>Any idea why four tests are failing?</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.2.0
rootdir: /build/img2pdf-0.5.0
collected 351 items / 18 deselected / 333 selected

src/img2pdf_test.py ......ssssss..........................ss............ [ 15%]
......................................FFFF.............................. [ 37%]
........................................................................ [ 58%]
........................................................................ [ 80%]
.........ssssssss................................................        [100%]

=================================== FAILURES ===================================
__________________________ test_miff_cmyk8[internal] ___________________________

tmp_path_factory = TempPathFactory(_given_basetemp=None, _trace=<pluggy._tracing.TagTracerSub object at 0x7ffff685e0d0>, _basetemp=PosixPath('/build/pytest-of-nixbld/pytest-0'), _retention_count=3, _retention_policy='all')
miff_cmyk8_img = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk80/in.miff')
tiff_cmyk8_img = PosixPath('/build/pytest-of-nixbld/pytest-0/tiff_cmyk80/in.tiff')
miff_cmyk8_pdf = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk8_pdf0/out.pdf')

    @pytest.mark.skipif(
        sys.platform in ["win32"],
        reason="test utilities not available on Windows and MacOS",
    )
    def test_miff_cmyk8(tmp_path_factory, miff_cmyk8_img, tiff_cmyk8_img, miff_cmyk8_pdf):
        tmpdir = tmp_path_factory.mktemp("miff_cmyk8")
>       compare_ghostscript(
            tmpdir, tiff_cmyk8_img, miff_cmyk8_pdf, gsdevice="tiff32nc", exact=False
        )

src/img2pdf_test.py:6406:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/img2pdf_test.py:418: in compare_ghostscript
    compare(str(img), str(tmpdir / "gs-1.") + ext, exact, icc, False)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

im1 = '/build/pytest-of-nixbld/pytest-0/tiff_cmyk80/in.tiff'
im2 = '/build/pytest-of-nixbld/pytest-0/miff_cmyk81/gs-1.tiff', exact = False
icc = False, cmyk = False

    def compare(im1, im2, exact, icc, cmyk):
        if exact:
            if cmyk and not HAVE_EXACT_CMYK8:
                raise Exception("cmyk cannot be exact before ImageMagick 7.1.0-48")
            elif icc:
                raise Exception("icc cannot be exact")
            else:
                subprocess.check_call(
                    COMPARE
                    + [
                        "-metric",
                        "AE",
                        "-alpha",
                        "off",
                        im1,
                        im2,
                        "null:",
                    ]
                )
        else:
            iccargs = []
            if icc:
                if ICC_PROFILE is None:
                    pytest.skip("Could not locate an ICC profile")
                iccargs = ["-profile", ICC_PROFILE]
            psnr = subprocess.run(
                COMPARE
                + iccargs
                + [
                    "-metric",
                    "PSNR",
                    im1,
                    im2,
                    "null:",
                ],
                check=False,
                stderr=subprocess.PIPE,
            ).stderr
            assert psnr != b"0"
>           assert psnr != b"0 (0)"
E           AssertionError: assert b'0 (0)' != b'0 (0)'

src/img2pdf_test.py:391: AssertionError
___________________________ test_miff_cmyk8[pikepdf] ___________________________

tmp_path_factory = TempPathFactory(_given_basetemp=None, _trace=<pluggy._tracing.TagTracerSub object at 0x7ffff685e0d0>, _basetemp=PosixPath('/build/pytest-of-nixbld/pytest-0'), _retention_count=3, _retention_policy='all')
miff_cmyk8_img = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk80/in.miff')
tiff_cmyk8_img = PosixPath('/build/pytest-of-nixbld/pytest-0/tiff_cmyk80/in.tiff')
miff_cmyk8_pdf = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk8_pdf1/out.pdf')

    @pytest.mark.skipif(
        sys.platform in ["win32"],
        reason="test utilities not available on Windows and MacOS",
    )
    def test_miff_cmyk8(tmp_path_factory, miff_cmyk8_img, tiff_cmyk8_img, miff_cmyk8_pdf):
        tmpdir = tmp_path_factory.mktemp("miff_cmyk8")
>       compare_ghostscript(
            tmpdir, tiff_cmyk8_img, miff_cmyk8_pdf, gsdevice="tiff32nc", exact=False
        )

src/img2pdf_test.py:6406:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/img2pdf_test.py:418: in compare_ghostscript
    compare(str(img), str(tmpdir / "gs-1.") + ext, exact, icc, False)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

im1 = '/build/pytest-of-nixbld/pytest-0/tiff_cmyk80/in.tiff'
im2 = '/build/pytest-of-nixbld/pytest-0/miff_cmyk82/gs-1.tiff', exact = False
icc = False, cmyk = False

    def compare(im1, im2, exact, icc, cmyk):
        if exact:
            if cmyk and not HAVE_EXACT_CMYK8:
                raise Exception("cmyk cannot be exact before ImageMagick 7.1.0-48")
            elif icc:
                raise Exception("icc cannot be exact")
            else:
                subprocess.check_call(
                    COMPARE
                    + [
                        "-metric",
                        "AE",
                        "-alpha",
                        "off",
                        im1,
                        im2,
                        "null:",
                    ]
                )
        else:
            iccargs = []
            if icc:
                if ICC_PROFILE is None:
                    pytest.skip("Could not locate an ICC profile")
                iccargs = ["-profile", ICC_PROFILE]
            psnr = subprocess.run(
                COMPARE
                + iccargs
                + [
                    "-metric",
                    "PSNR",
                    im1,
                    im2,
                    "null:",
                ],
                check=False,
                stderr=subprocess.PIPE,
            ).stderr
            assert psnr != b"0"
>           assert psnr != b"0 (0)"
E           AssertionError: assert b'0 (0)' != b'0 (0)'

src/img2pdf_test.py:391: AssertionError
__________________________ test_miff_cmyk16[internal] __________________________

tmp_path_factory = TempPathFactory(_given_basetemp=None, _trace=<pluggy._tracing.TagTracerSub object at 0x7ffff685e0d0>, _basetemp=PosixPath('/build/pytest-of-nixbld/pytest-0'), _retention_count=3, _retention_policy='all')
miff_cmyk16_img = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk160/in.miff')
tiff_cmyk16_img = PosixPath('/build/pytest-of-nixbld/pytest-0/tiff_cmyk160/in.tiff')
miff_cmyk16_pdf = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk16_pdf0/out.pdf')

    @pytest.mark.skipif(
        sys.platform in ["win32"],
        reason="test utilities not available on Windows and MacOS",
    )
    def test_miff_cmyk16(
        tmp_path_factory, miff_cmyk16_img, tiff_cmyk16_img, miff_cmyk16_pdf
    ):
        tmpdir = tmp_path_factory.mktemp("miff_cmyk16")
>       compare_ghostscript(
            tmpdir, tiff_cmyk16_img, miff_cmyk16_pdf, gsdevice="tiff32nc", exact=False
        )

src/img2pdf_test.py:6422:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/img2pdf_test.py:418: in compare_ghostscript
    compare(str(img), str(tmpdir / "gs-1.") + ext, exact, icc, False)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

im1 = '/build/pytest-of-nixbld/pytest-0/tiff_cmyk160/in.tiff'
im2 = '/build/pytest-of-nixbld/pytest-0/miff_cmyk161/gs-1.tiff', exact = False
icc = False, cmyk = False

    def compare(im1, im2, exact, icc, cmyk):
        if exact:
            if cmyk and not HAVE_EXACT_CMYK8:
                raise Exception("cmyk cannot be exact before ImageMagick 7.1.0-48")
            elif icc:
                raise Exception("icc cannot be exact")
            else:
                subprocess.check_call(
                    COMPARE
                    + [
                        "-metric",
                        "AE",
                        "-alpha",
                        "off",
                        im1,
                        im2,
                        "null:",
                    ]
                )
        else:
            iccargs = []
            if icc:
                if ICC_PROFILE is None:
                    pytest.skip("Could not locate an ICC profile")
                iccargs = ["-profile", ICC_PROFILE]
            psnr = subprocess.run(
                COMPARE
                + iccargs
                + [
                    "-metric",
                    "PSNR",
                    im1,
                    im2,
                    "null:",
                ],
                check=False,
                stderr=subprocess.PIPE,
            ).stderr
            assert psnr != b"0"
            assert psnr != b"0 (0)"
            assert psnr_re.fullmatch(psnr) is not None, psnr
            psnr = psnr_re.fullmatch(psnr).group(1)
            psnr = float(psnr)
            assert psnr != 0  # or otherwise we would use the exact variant
>           assert psnr > 50
E           assert 6.35075 > 50

src/img2pdf_test.py:396: AssertionError
__________________________ test_miff_cmyk16[pikepdf] ___________________________

tmp_path_factory = TempPathFactory(_given_basetemp=None, _trace=<pluggy._tracing.TagTracerSub object at 0x7ffff685e0d0>, _basetemp=PosixPath('/build/pytest-of-nixbld/pytest-0'), _retention_count=3, _retention_policy='all')
miff_cmyk16_img = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk160/in.miff')
tiff_cmyk16_img = PosixPath('/build/pytest-of-nixbld/pytest-0/tiff_cmyk160/in.tiff')
miff_cmyk16_pdf = PosixPath('/build/pytest-of-nixbld/pytest-0/miff_cmyk16_pdf1/out.pdf')

    @pytest.mark.skipif(
        sys.platform in ["win32"],
        reason="test utilities not available on Windows and MacOS",
    )
    def test_miff_cmyk16(
        tmp_path_factory, miff_cmyk16_img, tiff_cmyk16_img, miff_cmyk16_pdf
    ):
        tmpdir = tmp_path_factory.mktemp("miff_cmyk16")
>       compare_ghostscript(
            tmpdir, tiff_cmyk16_img, miff_cmyk16_pdf, gsdevice="tiff32nc", exact=False
        )

src/img2pdf_test.py:6422:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/img2pdf_test.py:418: in compare_ghostscript
    compare(str(img), str(tmpdir / "gs-1.") + ext, exact, icc, False)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

im1 = '/build/pytest-of-nixbld/pytest-0/tiff_cmyk160/in.tiff'
im2 = '/build/pytest-of-nixbld/pytest-0/miff_cmyk162/gs-1.tiff', exact = False
icc = False, cmyk = False

    def compare(im1, im2, exact, icc, cmyk):
        if exact:
            if cmyk and not HAVE_EXACT_CMYK8:
                raise Exception("cmyk cannot be exact before ImageMagick 7.1.0-48")
            elif icc:
                raise Exception("icc cannot be exact")
            else:
                subprocess.check_call(
                    COMPARE
                    + [
                        "-metric",
                        "AE",
                        "-alpha",
                        "off",
                        im1,
                        im2,
                        "null:",
                    ]
                )
        else:
            iccargs = []
            if icc:
                if ICC_PROFILE is None:
                    pytest.skip("Could not locate an ICC profile")
                iccargs = ["-profile", ICC_PROFILE]
            psnr = subprocess.run(
                COMPARE
                + iccargs
                + [
                    "-metric",
                    "PSNR",
                    im1,
                    im2,
                    "null:",
                ],
                check=False,
                stderr=subprocess.PIPE,
            ).stderr
            assert psnr != b"0"
            assert psnr != b"0 (0)"
            assert psnr_re.fullmatch(psnr) is not None, psnr
            psnr = psnr_re.fullmatch(psnr).group(1)
            psnr = float(psnr)
            assert psnr != 0  # or otherwise we would use the exact variant
>           assert psnr > 50
E           assert 6.35075 > 50

src/img2pdf_test.py:396: AssertionError
=============================== warnings summary ===============================
src/img2pdf_test.py:130
  /build/img2pdf-0.5.0/src/img2pdf_test.py:130: UserWarning: imagemagick has no jpeg 2000 support, skipping certain checks...
    warnings.warn("imagemagick has no jpeg 2000 support, skipping certain checks...")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED src/img2pdf_test.py::test_miff_cmyk8[internal] - AssertionError: assert b'0 (0)' != b'0 (0)'
FAILED src/img2pdf_test.py::test_miff_cmyk8[pikepdf] - AssertionError: assert b'0 (0)' != b'0 (0)'
FAILED src/img2pdf_test.py::test_miff_cmyk16[internal] - assert 6.35075 > 50
FAILED src/img2pdf_test.py::test_miff_cmyk16[pikepdf] - assert 6.35075 > 50
===== 4 failed, 313 passed, 16 skipped, 18 deselected, 1 warning in 36.74s =====
```
</details>


## Description of changes
Changelog: https://gitlab.mister-muffin.de/josch/img2pdf/src/tag/0.5.0/CHANGES.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
