### PR TITLE
citra: nightly 1963 -> 2043, canary 2573 -> 2695

### DIFF
--- a/pkgs/applications/emulators/citra/default.nix
+++ b/pkgs/applications/emulators/citra/default.nix
@@ -9,19 +9,19 @@ let
   # Please make sure to update this when updating citra!
   compat-list = fetchurl {
     name = "citra-compat-list";
-    url = "https://web.archive.org/web/20230807103651/https://api.citra-emu.org/gamedb/";
+    url = "https://web.archive.org/web/20231111133415/https://api.citra-emu.org/gamedb";
     hash = "sha256-J+zqtWde5NgK2QROvGewtXGRAWUTNSKHNMG6iu9m1fU=";
   };
 in {
   nightly = qt6Packages.callPackage ./generic.nix rec {
     pname = "citra-nightly";
-    version = "1963";
+    version = "2043";
 
     src = fetchFromGitHub {
       owner = "citra-emu";
       repo = "citra-nightly";
       rev = "nightly-${version}";
-      sha256 = "0ggi1l8327s43xaxs616g0s9vmal6q7vsv69bn07gp71gchhcmyi";
+      sha256 = "sha256-26M3uzqp4rUMOhr619UooupZT11B03IJfamUPNkceQk=";
       fetchSubmodules = true;
     };
 
@@ -30,13 +30,13 @@ in {
 
   canary = qt6Packages.callPackage ./generic.nix rec {
     pname = "citra-canary";
-    version = "2573";
+    version = "2695";
 
     src = fetchFromGitHub {
       owner = "citra-emu";
       repo = "citra-canary";
       rev = "canary-${version}";
-      sha256 = "sha256-tQJ3WcqGcnW9dOiwDrBgL0n3UNp1DGQ/FjCR28Xjdpc=";
+      sha256 = "sha256-090er4aUGze8bk3DIFZoa+/6EcJhr4bim3nWgZHs1mo=";
       fetchSubmodules = true;
     };
 

--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -6,70 +6,93 @@
 
 , lib
 , stdenv
-, fetchFromGitHub
 , cmake
 , boost
 , pkg-config
-, libusb1
+, catch2_3
+, cpp-jwt
+, cryptopp
+, enet
+, ffmpeg
+, fmt
 , glslang
+, httplib
+, inih
+, libusb1
+, nlohmann_json
+, openal
+, openssl
+, SDL2
+, soundtouch
+, spirv-tools
 , zstd
-, libressl
-, enableSdl2 ? true, SDL2
-, enableQt ? true, qtbase, qtmultimedia, wrapQtAppsHook
+, vulkan-headers
+, vulkan-loader
+, enableSdl2Frontend ? true
+, enableQt ? true, qtbase, qtmultimedia, qtwayland, wrapQtAppsHook
 , enableQtTranslation ? enableQt, qttools
 , enableWebService ? true
 , enableCubeb ? true, cubeb
-, enableFfmpegAudioDecoder ? true
-, enableFfmpegVideoDumper ? true
-, ffmpeg_4
 , useDiscordRichPresence ? true, rapidjson
-, enableFdk ? false, fdk_aac
 }:
-assert lib.assertMsg (!enableFfmpegAudioDecoder || !enableFdk) "Can't enable both enableFfmpegAudioDecoder and enableFdk";
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   inherit pname version src;
 
   nativeBuildInputs = [
     cmake
-    glslang
     pkg-config
+    ffmpeg
+    glslang
   ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
 
   buildInputs = [
     boost
+    catch2_3
+    cpp-jwt
+    cryptopp
+    # intentionally omitted: dynarmic - prefer vendored version for compatibility
+    enet
+    fmt
+    httplib
+    inih
     libusb1
-  ] ++ lib.optionals enableQt [ qtbase qtmultimedia ]
-    ++ lib.optional enableSdl2 SDL2
+    nlohmann_json
+    openal
+    openssl
+    SDL2
+    soundtouch
+    spirv-tools
+    vulkan-headers
+    # intentionally omitted: xbyak - prefer vendored version for compatibility
+    zstd
+  ] ++ lib.optionals enableQt [ qtbase qtmultimedia qtwayland ]
     ++ lib.optional enableQtTranslation qttools
-    ++ lib.optionals enableCubeb cubeb.passthru.backendLibs
-    ++ lib.optional (enableFfmpegAudioDecoder || enableFfmpegVideoDumper) ffmpeg_4
-    ++ lib.optional useDiscordRichPresence rapidjson
-    ++ lib.optional enableFdk fdk_aac;
+    ++ lib.optional enableCubeb cubeb
+    ++ lib.optional useDiscordRichPresence rapidjson;
 
   cmakeFlags = [
-    "-DUSE_SYSTEM_BOOST=ON"
-    "-DCITRA_WARNINGS_AS_ERRORS=OFF"
-    "-DCITRA_USE_BUNDLED_FFMPEG=OFF"
-    "-DCITRA_USE_BUNDLED_QT=OFF"
-    "-DUSE_SYSTEM_SDL2=ON"
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DUSE_SYSTEM_LIBS=ON"
 
-    # We dont want to bother upstream with potentially outdated compat reports
+    "-DDISABLE_SYSTEM_DYNARMIC=ON"
+    "-DDISABLE_SYSTEM_GLSLANG=ON" # The following imported targets are referenced, but are missing: SPIRV-Tools-opt
+    "-DDISABLE_SYSTEM_LODEPNG=ON" # Not packaged in nixpkgs
+    "-DDISABLE_SYSTEM_VMA=ON"
+    "-DDISABLE_SYSTEM_XBYAK=ON"
+
+    # We don't want to bother upstream with potentially outdated compat reports
     "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON"
     "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=OFF" # We provide this deterministically
-  ] ++ lib.optional (!enableSdl2) "-DENABLE_SDL2=OFF"
+  ] ++ lib.optional (!enableSdl2Frontend) "-DENABLE_SDL2_FRONTEND=OFF"
     ++ lib.optional (!enableQt) "-DENABLE_QT=OFF"
     ++ lib.optional enableQtTranslation "-DENABLE_QT_TRANSLATION=ON"
     ++ lib.optional (!enableWebService) "-DENABLE_WEB_SERVICE=OFF"
     ++ lib.optional (!enableCubeb) "-DENABLE_CUBEB=OFF"
-    ++ lib.optional enableFfmpegAudioDecoder "-DENABLE_FFMPEG_AUDIO_DECODER=ON"
-    ++ lib.optional enableFfmpegVideoDumper "-DENABLE_FFMPEG_VIDEO_DUMPER=ON"
-    ++ lib.optional useDiscordRichPresence "-DUSE_DISCORD_PRESENCE=ON"
-    ++ lib.optional enableFdk "-DENABLE_FDK=ON";
+    ++ lib.optional useDiscordRichPresence "-DUSE_DISCORD_PRESENCE=ON";
 
-  postPatch = with lib; let
+  # causes redefinition of _FORTIFY_SOURCE
+  hardeningDisable = [ "fortify3" ];
+
+  postPatch = let
     branchCaptialized = (lib.toUpper (lib.substring 0 1 branch) + lib.substring 1 (-1) branch);
   in ''
     # Fix file not found when looking in var/empty instead of opt
@@ -85,19 +108,17 @@ stdenv.mkDerivation rec {
 
     # Add versions
     echo 'set(BUILD_FULLNAME "${branchCaptialized} ${version}")' >> CMakeModules/GenerateBuildInfo.cmake
-
-    # Devendoring
-    rm -rf externals/zstd externals/libressl
-    cp -r ${zstd.src} externals/zstd
-    tar xf ${libressl.src} -C externals/
-    mv externals/${libressl.name} externals/libressl
-    chmod -R a+w externals/zstd
   '';
 
-  # Fixes https://github.com/NixOS/nixpkgs/issues/171173
-  postInstall = lib.optionalString (enableCubeb && enableSdl2) ''
+  postInstall = let
+    libs = lib.makeLibraryPath [ vulkan-loader ];
+  in lib.optionalString enableSdl2Frontend ''
     wrapProgram "$out/bin/citra" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath cubeb.passthru.backendLibs}
+      --prefix LD_LIBRARY_PATH : ${libs}
+  '' + lib.optionalString enableQt ''
+    qtWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${libs}
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Vulkan's here!
~One problem, though: the SDL frontend segfaults.~ That's an upstream issue, and not a regression here.

Another thing: upstream switched to Clang for performance reasons. However, if I try that here, LTO doesn't work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
