### PR TITLE
Retire systemdMinimal

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -311,7 +311,7 @@ let format' = format; in let
       config.system.build.nixos-install
       config.system.build.nixos-enter
       nix
-      systemdMinimal
+      systemd
     ]
     ++ lib.optional deterministic gptfdisk
     ++ stdenv.initialPath);

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -90,8 +90,8 @@ in
 
     package = lib.mkPackageOption pkgs "systemd-repart" {
       default = "systemd";
-      example = lib.literalExpression ''
-        pkgs.systemdMinimal.override { withCryptsetup = true; }
+      description = lib.mdDoc ''
+        The systemd package that provides the systemd-repart binary.
       '';
     };
 

--- a/pkgs/applications/misc/eos-installer/default.nix
+++ b/pkgs/applications/misc/eos-installer/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, writeText
 , glib, meson, ninja, pkg-config, python3
-, coreutils, gnome-desktop, gnupg, gtk3, systemdMinimal, udisks
+, coreutils, gnome-desktop, gnupg, gtk3, systemdLibs, udisks
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     glib gnupg meson ninja pkg-config python3
   ];
-  buildInputs = [ gnome-desktop gtk3 systemdMinimal udisks ];
+  buildInputs = [ gnome-desktop gtk3 systemdLibs udisks ];
 
   preConfigure = ''
     patchShebangs tests

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -3,8 +3,8 @@
 , fetchurl
 , pkg-config
 , expat
-, enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal
-, systemdMinimal
+, enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
+, systemd
 , audit
 , libapparmor
 , dbus
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
       libX11
       libICE
       libSM
-    ]) ++ lib.optional enableSystemd systemdMinimal
+    ]) ++ lib.optional enableSystemd systemd
     ++ lib.optionals stdenv.isLinux [ audit libapparmor ];
   # ToDo: optional selinux?
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
   ] ++ lib.optional (!x11Support) "--without-x"
   ++ lib.optionals stdenv.isLinux [ "--enable-apparmor" "--enable-libaudit" ]
-  ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemdMinimal}/bin/systemctl" ];
+  ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemd}/bin/systemctl" ];
 
   NIX_CFLAGS_LINK = lib.optionalString (!stdenv.isDarwin) "-Wl,--as-needed";
 

--- a/pkgs/development/libraries/libusbsio/default.nix
+++ b/pkgs/development/libraries/libusbsio/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, pkg-config, libusb1, systemdMinimal }:
+{ lib, stdenv, fetchzip, pkg-config, libusb1, udev }:
 let
   binDirPrefix = if stdenv.isDarwin then "osx_" else "linux_";
 in
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libusb1
-    systemdMinimal # libudev
+    udev
   ];
 
   installPhase = ''

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -8,7 +8,7 @@
 , libsodium
 , libtool
 , openssl
-, systemdMinimal
+, systemdLibs
 , libxcrypt
 
 # passthru
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     openssl
   ] ++ lib.optionals (stdenv.isLinux) [
     libxcrypt # causes linking issues on *-darwin
-    systemdMinimal
+    systemdLibs
   ];
 
   preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -21,8 +21,8 @@
 , docbook_xml_dtd_412
 , gtk-doc
 , coreutils
-, useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal
-, systemdMinimal
+, useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs
+, systemdLibs
 , elogind
 , buildPackages
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     duktape
   ] ++ lib.optionals stdenv.isLinux [
     # On Linux, fall back to elogind when systemd support is off.
-    (if useSystemd then systemdMinimal else elogind)
+    (if useSystemd then systemdLibs else elogind)
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -6,7 +6,7 @@
 , flatpak
 , fuse3
 , bubblewrap
-, systemdMinimal
+, systemd
 , geoclue2
 , glib
 , gsettings-desktop-schemas
@@ -61,12 +61,15 @@ stdenv.mkDerivation (finalAttrs: {
     flatpak
     fuse3
     bubblewrap
-    systemdMinimal # libsystemd
     glib
     gsettings-desktop-schemas
     json-glib
     libportal
     pipewire
+
+    # For libsystemd. We could use systemdLibs, but systemd is already
+    # in the closure due to dbus.
+    systemd
 
     # For icon validator
     gdk-pixbuf

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -12,7 +12,7 @@
 , pkg-config
 , python3
 , readline
-, systemdMinimal
+, systemd
 , udev
 , withExperimental ? false
 }: let
@@ -60,7 +60,7 @@ in stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace tools/hid2hci.rules \
-      --replace /sbin/udevadm ${systemdMinimal}/bin/udevadm \
+      --replace /sbin/udevadm ${systemd}/bin/udevadm \
       --replace "hid2hci " "$out/lib/udev/hid2hci "
     # Disable some tests:
     # - test-mesh-crypto depends on the following kernel settings:

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -382,6 +382,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tools test src/!(rpm|kernel-install|ukify) src/kernel-install/test-kernel-install.sh
   '';
 
+  # It would be great to add "lib" here as well, but we get dependency loops in the outputs.
   outputs = [ "out" "dev" ] ++ (lib.optional (!buildLibsOnly) "man");
 
   nativeBuildInputs =

--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -16,7 +16,7 @@
 , judy
 , pam
 , spdlog
-, systemdMinimal
+, systemdLibs
 , zlib # optional
 }:
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     db fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
-    zlib boost judy pam spdlog python3 systemdMinimal
+    zlib boost judy pam spdlog python3 systemdLibs
   ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/opentelemetry-collector/contrib.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/contrib.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , lib
 , stdenv
-, systemdMinimal
+, systemd
 , withSystemd ? false
 }:
 
@@ -30,14 +30,14 @@ buildGoModule rec {
   CGO_ENABLED = 0;
 
   # journalctl is required in-$PATH for the journald receiver tests.
-  nativeCheckInputs = lib.optionals stdenv.isLinux [ systemdMinimal ];
+  nativeCheckInputs = lib.optionals stdenv.isLinux [ systemd ];
 
   # We don't inject the package into propagatedBuildInputs unless
   # asked to avoid hard-requiring a large package. For the journald
   # receiver to work, journalctl will need to be available in-$PATH,
   # so expose this as an option for those who want more control over
   # it instead of trusting the global $PATH.
-  propagatedBuildInputs = lib.optionals withSystemd [ systemdMinimal ];
+  propagatedBuildInputs = lib.optionals withSystemd [ systemd ];
 
   preCheck = "export CGO_ENABLED=1";
 

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -13,7 +13,7 @@
 , lvm2
 , mdadm
 , smartmontools
-, systemdMinimal
+, systemd
 , util-linux
 , btrfs-progs
 , dosfstools
@@ -42,7 +42,7 @@ let
     lvm2
     mdadm
     smartmontools
-    systemdMinimal
+    systemd
     util-linux
 
     btrfs-progs

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -865,6 +865,7 @@ mapAliases ({
   swift-im = throw "swift-im has been removed as it is unmaintained and depends on deprecated Python 2 / Qt WebKit"; # Added 2023-01-06
   swtpm-tpm2 = swtpm; # Added 2021-02-26
   syncthing-cli = syncthing; # Added 2021-04-06
+  systemdMinimal = systemd;  # Added 2023-10-19
 
   ### T ###
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41929,8 +41929,6 @@ with pkgs;
 
   jami = qt6Packages.callPackage ../applications/networking/instant-messengers/jami {
     fmt = fmt_9;
-    # TODO: remove once `udev` is `systemdMinimal` everywhere.
-    udev = systemdMinimal;
     jack = libjack2;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28756,8 +28756,14 @@ with pkgs;
       guiSupport = false;
     };
   };
-  systemdMinimal = systemd.override {
-    pname = "systemd-minimal";
+
+  # This derivation only contains libudev and libsystemd built with
+  # minimal dependencies. This is useful for breaking dependency loops
+  # with pkgs.systemd.
+  systemdLibs = systemd.override {
+    pname = "systemd-minimal-libs";
+    buildLibsOnly = true;
+
     withAcl = false;
     withAnalyze = false;
     withApparmor = false;
@@ -28795,10 +28801,6 @@ with pkgs;
     withUserDb = false;
     withUkify = false;
     withBootloader = false;
-  };
-  systemdLibs = systemdMinimal.override {
-    pname = "systemd-minimal-libs";
-    buildLibsOnly = true;
   };
 
   udev =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26567,7 +26567,7 @@ with pkgs;
 
   knot-dns = callPackage ../servers/dns/knot-dns { };
   knot-resolver = callPackage ../servers/dns/knot-resolver {
-    systemd = systemdMinimal; # in closure already anyway
+    systemd = systemdLibs; # in closure already anyway
   };
 
   rdkafka = callPackage ../development/libraries/rdkafka { };


### PR DESCRIPTION
## Description of changes

This PR retires `systemdMinimal`. It's a follow-up to #261798. The goal is to avoid having multiple sets of systemd binaries in a typical system closure and save everyone some disk space. This is especially relevant for smaller image-based systems (see #263462).

 We replace `systemdMinimal` with:

- `systemd`, if systemd commands or `udevadm` is needed (`bluez`) _or_ when `systemd` is already in the closure (`dbus`)
- `systemdLibs`
  - for dependencies of `systemd` itself to break dependencies
  - for packages that just need `libudev` or `libsystemd` that don't already have `systemd` in their closure. 

Some of the uses of `systemdLibs` could just be `systemd`, if we manage to give `pkgs.systemd` a `lib` output that doesn't drag in lots of unneeded binaries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
