### PR TITLE
kodiPackages.radioparadise: init at 1.0.5

### DIFF
--- a/pkgs/applications/video/kodi/addons/radioparadise/default.nix
+++ b/pkgs/applications/video/kodi/addons/radioparadise/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, requests }:
+
+buildKodiAddon rec {
+  pname = "radioparadise";
+  namespace = "script.radioparadise";
+  version = "1.0.5";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/nexus/script.radioparadise/script.radioparadise-${version}.zip";
+    sha256 = "sha256-/X/8Q741piNHue5i/kgV+UYpBECyGzkFuN+PUzdeQnA=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  passthru = {
+    pythonPath = "resources/lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.radioparadise";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/alxndr42/script.radioparadise";
+    description = "Radio Paradise addon for Kodi";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -84,6 +84,8 @@ let self = rec {
 
   orftvthek = callPackage ../applications/video/kodi/addons/orftvthek { };
 
+  radioparadise = callPackage ../applications/video/kodi/addons/radioparadise { };
+
   svtplay = callPackage ../applications/video/kodi/addons/svtplay { };
 
   steam-controller = callPackage ../applications/video/kodi/addons/steam-controller { };


### PR DESCRIPTION
## Description of changes

inits [the Radio Paradise Kodi Addon](https://kodi.tv/addons/nexus/script.radioparadise/) at 1.0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
