### PR TITLE
ocsinventory-agent: init at 2.10.1

### DIFF
--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -1,0 +1,102 @@
+{ lib
+, stdenv
+, perlPackages
+, fetchFromGitHub
+, makeWrapper
+, shortenPerlShebang
+, coreutils
+, dmidecode
+, findutils
+, inetutils
+, ipmitool
+, iproute2
+, lvm2
+, nmap
+, pciutils
+, usbutils
+, util-linux
+, testers
+, ocsinventory-agent
+, nix-update-script
+}:
+
+perlPackages.buildPerlPackage rec {
+  version = "2.10.1";
+  pname = "ocsinventory-agent";
+
+  src = fetchFromGitHub {
+    owner = "OCSInventory-NG";
+    repo = "UnixAgent";
+    rev = "refs/tags/v${version}-MAC";
+    hash = "sha256-aFzBrUsVttUhpYGEYd/yYuXmE90PGCiBmBsVjtHcHLg=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isDarwin shortenPerlShebang;
+
+  buildInputs = with perlPackages; [
+    perl
+    DataUUID
+    IOCompress
+    IOSocketSSL
+    LWP
+    LWPProtocolHttps
+    NetIP
+    NetNetmask
+    NetSNMP
+    ParseEDID
+    ProcDaemon
+    ProcPIDFile
+    XMLSimple
+  ] ++ lib.optionals stdenv.isLinux (with perlPackages; [
+    NetCUPS # cups-filters is broken on darwin
+  ]) ++ lib.optionals stdenv.isDarwin (with perlPackages; [
+    MacSysProfile
+  ]);
+
+  postInstall = let
+    runtimeDependencies = [
+      coreutils # uname, cut, df, stat, uptime
+      findutils # find
+      inetutils # ifconfig
+      ipmitool # ipmitool
+      nmap # nmap
+      pciutils # lspci
+    ] ++ lib.optionals stdenv.isLinux [
+      dmidecode # dmidecode
+      iproute2 # ip
+      lvm2 # pvs
+      usbutils # lsusb
+      util-linux # last, lsblk, mount
+    ];
+  in lib.optionalString stdenv.isDarwin ''
+    shortenPerlShebang $out/bin/ocsinventory-agent
+  '' + ''
+    wrapProgram $out/bin/ocsinventory-agent --prefix PATH : ${lib.makeBinPath runtimeDependencies}
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = ocsinventory-agent;
+      command = "ocsinventory-agent --version";
+      # upstream has not updated version in lib/Ocsinventory/Agent/Config.pm
+      version = "2.10.0";
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "OCS Inventory unified agent for Unix operating systems";
+    longDescription = ''
+      Open Computers and Software Inventory (OCS) is an application designed
+      to help a network or system administrator to keep track of the hardware and
+      software configurations of computers that are installed on the network.
+    '';
+    homepage = "https://ocsinventory-ng.org";
+    changelog = "https://github.com/OCSInventory-NG/UnixAgent/releases/tag/v${version}";
+    downloadPage = "https://github.com/OCSInventory-NG/UnixAgent/releases";
+    license = licenses.gpl2Only;
+    mainProgram = "ocsinventory-agent";
+    maintainers = with maintainers; [ totoroot anthonyroussel ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18303,6 +18303,22 @@ with self; {
     };
   };
 
+  NetCUPS = buildPerlPackage {
+    pname = "Net-CUPS";
+    version = "0.64";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/N/NI/NINE/Net-CUPS-0.64.tar.gz";
+      hash = "sha256-17x3/w9iv4dMhDxZDrEqgLvUR0mi+3Tb7URcNdDoWoU=";
+    };
+    buildInputs = [ pkgs.cups pkgs.cups-filters ];
+    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.cups}/lib -lcups";
+    meta = {
+      description = "Common Unix Printing System Interface";
+      homepage = "https://github.com/niner/perl-Net-CUPS";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   NetDBus = buildPerlPackage {
     pname = "Net-DBus";
     version = "1.2.0";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19665,6 +19665,20 @@ with self; {
     };
   };
 
+  ParseEDID = buildPerlPackage {
+    pname = "Parse-Edid";
+    version = "1.0.7";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/G/GR/GROUSSE/Parse-EDID-1.0.7.tar.gz";
+      hash = "sha256-GtwPEFoyGYoqK02lsOD5hfBe/tmc42YZCnkOFl1nW/E=";
+    };
+    buildInputs = [ TestWarn ];
+    meta = {
+      description = "Extended display identification data (EDID) parser";
+      license = lib.licenses.gpl3Plus;
+    };
+  };
+
   ParseDebControl = buildPerlPackage {
     pname = "Parse-DebControl";
     version = "2.005";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20734,6 +20734,21 @@ with self; {
     };
   };
 
+  ProcDaemon = buildPerlPackage {
+    pname = "Proc-Daemon";
+    version = "0.23";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AK/AKREAL/Proc-Daemon-0.23.tar.gz";
+      hash = "sha256-NMC4W3lItDHLq8l87lgINeUVzPQ7rb2DOesQlHQIm2k=";
+    };
+    buildInputs = [ ProcProcessTable ];
+    meta = {
+      description = "Run Perl program(s) as a daemon process";
+      homepage = "https://github.com/akreal/Proc-Daemon";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ProcFind = buildPerlPackage {
     pname = "Proc-Find";
     version = "0.051";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28093,6 +28093,24 @@ with self; {
     };
   };
 
+  XMLEntities = buildPerlPackage {
+    pname = "XML-Entities";
+    version = "1.0002";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SI/SIXTEASE/XML-Entities-1.0002.tar.gz";
+      hash = "sha256-wyqk8wlXPXZIqy5Bb2K2sgZS8q2c/T7sgv1REB/nMQ0=";
+    };
+    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+    propagatedBuildInputs = [ LWP ];
+    postInstall = lib.optionalString stdenv.isDarwin ''
+      shortenPerlShebang $out/bin/download-entities.pl
+    '';
+    meta = {
+      description = "Mapping of XML entities to Unicode";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   XMLDOM = buildPerlPackage {
     pname = "XML-DOM";
     version = "1.46";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14657,6 +14657,21 @@ with self; {
     };
   };
 
+  MacSysProfile = buildPerlPackage {
+    pname = "Mac-SysProfile";
+    version = "0.05";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/Mac-SysProfile-0.05.tar.gz";
+      hash = "sha256-QDOXa3dbOcwqaTtyoC1l71p7oDveTU2w3/RuEmx9n2w=";
+    };
+    propagatedBuildInputs = [ MacPropertyList ];
+    meta = {
+      description = "Perl extension for OS X system_profiler";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      platforms = lib.platforms.darwin;
+    };
+  };
+
   MailAuthenticationResults = buildPerlPackage {
     pname = "Mail-AuthenticationResults";
     version = "1.20200824.1";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14657,6 +14657,21 @@ with self; {
     };
   };
 
+  MacPropertyList = buildPerlPackage {
+    pname = "Mac-PropertyList";
+    version = "1.504";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Mac-PropertyList-1.504.tar.gz";
+      hash = "sha256-aIl96Yw2j76c22iF1H3qADxG7Ho3MmNSPvZkVwc7eq4=";
+    };
+    propagatedBuildInputs = [ XMLEntities ];
+    meta = {
+      description = "Work with Mac plists at a low level";
+      homepage = "https://github.com/briandfoy/mac-propertylist";
+      license = lib.licenses.artistic2;
+    };
+  };
+
   MacSysProfile = buildPerlPackage {
     pname = "Mac-SysProfile";
     version = "0.05";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20749,6 +20749,20 @@ with self; {
     };
   };
 
+  ProcPIDFile = buildPerlPackage {
+    pname = "Proc-PID-File";
+    version = "1.29";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMITRI/Proc-PID-File-1.29.tar.gz";
+      hash = "sha256-O87aSd8YLT2BaLcMKlGyBW8v1FlQptBCipmS/TVc1KQ=";
+    };
+    meta = {
+      description = "Manage process id files";
+      homepage = "https://github.com/dtikhonov/Proc-PID-File";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ProcFind = buildPerlPackage {
     pname = "Proc-Find";
     version = "0.051";


### PR DESCRIPTION
## Description of changes

The purpose of this PR is to continue the work started by @totoroot on PR https://github.com/NixOS/nixpkgs/pull/242659, to make the OCS Inventory agent work on NixOS environment.

I have seen this tool several times in work environments in French companies. This tool was each time a prerequisite for developers to be able to install a Linux OS on their workstation, since IT and system administrators need to trace and inventory the hardware/software.  I think it might be a good idea to add support for this package on NixOS.

I'll continue after this PR on the development of the NixOS module.

See https://github.com/OCSInventory-NG/UnixAgent

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
