### PR TITLE
kodiPackages.somafm: init at 2.0.1

### DIFF
--- a/pkgs/applications/video/kodi/addons/somafm/default.nix
+++ b/pkgs/applications/video/kodi/addons/somafm/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+
+buildKodiAddon rec {
+  pname = "somafm";
+  namespace = "plugin.audio.somafm";
+  version = "2.0.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/nexus/plugin.audio.somafm/plugin.audio.somafm-${version}.zip";
+    sha256 = "sha256-auPLm7QFabU4tXJPjTl17KpE+lqWM2Edbd2HrXPRx40=";
+  };
+
+  passthru = {
+    pythonPath = "resources/lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.somafm";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/Soma-FM-Kodi-Add-On/plugin.audio.somafm";
+    description = "SomaFM addon for Kodi";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -92,6 +92,8 @@ let self = rec {
 
   steam-library = callPackage ../applications/video/kodi/addons/steam-library { };
 
+  somafm = callPackage ../applications/video/kodi/addons/somafm { };
+
   pdfreader = callPackage ../applications/video/kodi/addons/pdfreader { };
 
   pvr-hts = callPackage ../applications/video/kodi/addons/pvr-hts { };


### PR DESCRIPTION
## Description of changes

Inits [the SomaFM  addon for Kodi](https://kodi.tv/addons/nexus/plugin.audio.somafm/) at 2.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
