### PR TITLE
hylafaxplus: fix with new `libtiff_4_5`

### DIFF
--- a/pkgs/development/libraries/libtiff/headers-4.5.patch
+++ b/pkgs/development/libraries/libtiff/headers-4.5.patch
@@ -1,0 +1,16 @@
+export private headers for freeimage
+--- i/libtiff/Makefile.am
++++ w/libtiff/Makefile.am
+@@ -36,8 +36,12 @@ EXTRA_DIST = \
+ 	tiffconf.h.cmake.in
+
+ libtiffinclude_HEADERS = \
++	tif_config.h \
++	tif_dir.h \
++	tif_hash_set.h \
+ 	tiff.h \
+ 	tiffio.h \
++	tiffiop.h \
+ 	tiffvers.h
+
+ if HAVE_CXX

--- a/pkgs/development/libraries/libtiff/rename-version-4.5.patch
+++ b/pkgs/development/libraries/libtiff/rename-version-4.5.patch
@@ -1,0 +1,21 @@
+fix case-insensitive build
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -34,7 +34,7 @@ docfiles = \
+ 	README.md \
+ 	RELEASE-DATE \
+ 	TODO \
+-	VERSION
++	VERSION.txt
+
+ EXTRA_DIST = \
+ 	cmake \
+@@ -61,7 +61,7 @@ SUBDIRS = port libtiff tools build contrib test doc
+
+ release:
+	(rm -f $(top_srcdir)/RELEASE-DATE && echo $(LIBTIFF_RELEASE_DATE) > $(top_srcdir)/RELEASE-DATE)
+-	(rm -f $(top_srcdir)/VERSION && echo $(LIBTIFF_VERSION) > $(top_srcdir)/VERSION)
++	(rm -f $(top_srcdir)/VERSION.txt && echo $(LIBTIFF_VERSION) > $(top_srcdir)/VERSION.txt)
+	(rm -f $(top_srcdir)/libtiff/tiffvers.h && sed 's,LIBTIFF_VERSION,$(LIBTIFF_VERSION),;s,LIBTIFF_RELEASE_DATE,$(LIBTIFF_RELEASE_DATE),;s,LIBTIFF_MAJOR_VERSION,$(LIBTIFF_MAJOR_VERSION),;s,LIBTIFF_MINOR_VERSION,$(LIBTIFF_MINOR_VERSION),;s,LIBTIFF_MICRO_VERSION,$(LIBTIFF_MICRO_VERSION),' $(top_srcdir)/libtiff/tiffvers.h.in > $(top_srcdir)/libtiff/tiffvers.h)
+
+ pkgconfigdir = $(libdir)/pkgconfig

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9296,7 +9296,10 @@ with pkgs;
     stdenv = gcc8Stdenv;
   };
 
-  hylafaxplus = callPackage ../servers/hylafaxplus { };
+  hylafaxplus = callPackage ../servers/hylafaxplus {
+    # libtiff >= 4.6 dropped many executables needed by hylafaxplus
+    libtiff = libtiff_4_5;
+  };
 
   hyphen = callPackage ../development/libraries/hyphen { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23537,6 +23537,7 @@ with pkgs;
   libtifiles2 = callPackage ../development/libraries/libtifiles2 { };
 
   libtiff = callPackage ../development/libraries/libtiff { };
+  libtiff_4_5 = callPackage ../development/libraries/libtiff/4.5.nix { };
 
   libtiger = callPackage ../development/libraries/libtiger { };
 


### PR DESCRIPTION
## Description of changes

With the [update to libtiff 4.6.0](https://github.com/NixOS/nixpkgs/pull/261791), the library [dropped many tiff processing utility executables](https://github.com/NixOS/nixpkgs/pull/261791#issuecomment-1771689841), like `tiff2ps` and `fax2ps`.  These executables are needed at least by `hylafaxplus` (possibly also by other packages).

The pull request at hand introduces `libtiff_4_5` to nixpkgs in order to ~~avoid breaking the `hylafaxplus` package when https://github.com/NixOS/nixpkgs/pull/263535 gets merged~~ fix `hylafaxplus`.

libtiff 4.6.0 also [fixed two CVEs](https://github.com/NixOS/nixpkgs/pull/261791#issuecomment-1768177356).  `libtiff_4_5` includes the corresponding patches from the libtiff development repository.


## Long-term prospect

[According to HylaFAX+ developer Lee Howard](https://sourceforge.net/p/hylafax/mailman/message/38259441/), it might take months before one of these options (or a combination thereof) might be implemented:

*   a new package `tifftools` with the utility executables emerges
*   the HylaFAX+ source repository incorporates the source of the required executables and builds them by itself
*   HylaFAX+ gets rewritten so as to not use these programs
*   libtiff reincorporates the programs, maybe after fixing them

He already initiated [a discussion on the libtiff mailing list](https://www.asmail.be/msg0054915176.html).  In the meantime, [he recommends](https://sourceforge.net/p/hylafax/mailman/message/39730813/) for distributions with rolling releases to do what they usually do when such a situation arises.


## Notifications

*   libitff maintainer @alyssais : Should I also mention you as maintainer of `libtiff_4_5` ?
*   @trofi @risicle due to [your discussion about the removal of the executables](https://github.com/NixOS/nixpkgs/pull/261791#issuecomment-1771689841)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tes>
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkg>
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/bl>
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested the `hylafaxplus` package (with asterisk and a couple of iaxmodem instances) to send and receive some faxes, and it still works as before -- which is to be expected, as the only change from HylaFAX+' perspective are a few patches for libtiff 4.5.1.

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>hylafaxplus</li>
    <li>libtiff_4_5</li>
    <li>libtiff_4_5.bin</li>
    <li>libtiff_4_5.dev</li>
    <li>libtiff_4_5.dev_private</li>
    <li>libtiff_4_5.doc</li>
    <li>libtiff_4_5.man</li>
  </ul>
</details>