### PR TITLE
xfce.xfconf: fix xfwm4 segfaults after update to 4.18.2

### DIFF
--- a/pkgs/desktops/xfce/core/xfconf/default.nix
+++ b/pkgs/desktops/xfce/core/xfconf/default.nix
@@ -1,4 +1,10 @@
-{ lib, mkXfceDerivation, libxfce4util, gobject-introspection, vala }:
+{ lib
+, mkXfceDerivation
+, fetchpatch
+, libxfce4util
+, gobject-introspection
+, vala
+}:
 
 mkXfceDerivation {
   category = "xfce";
@@ -6,6 +12,16 @@ mkXfceDerivation {
   version = "4.18.2";
 
   sha256 = "sha256-FVNkcwOS4feMocx3vYhuWNs1EkXDrM1FaKkMhIOuPHI=";
+
+  patches = [
+    # fixes a segfault, can likely be removed with 4.18.3,
+    # see https://gitlab.xfce.org/xfce/xfconf/-/issues/35#note_81151
+    (fetchpatch {
+      name = "cache-fix-uncached-value.patch";
+      url = "https://gitlab.xfce.org/xfce/xfconf/-/commit/03f7ff961fd46c9141aba624a278e19de0bf3211.diff";
+      hash = "sha256-n9Wvt7NfKMxs2AcjUWgs4vZgzLUG9jyEVTZxINko4h8=";
+    })
+  ];
 
   nativeBuildInputs = [ gobject-introspection vala ];
 


### PR DESCRIPTION
## Description of changes

xfconf 4.18.2 introduced with https://github.com/NixOS/nixpkgs/pull/261644 causes xfwm4 to segfault almost instantly after I login: `Process .... (.xfwm4-wrapped) of user .... dumped core.`  Upstream already has a patch available https://gitlab.xfce.org/xfce/xfconf/-/merge_requests/35 .  The pull request at hand adds this patch to our build recipe until the next release supersedes it.

Notifying author of xfconf update pull request @bobby285271 , and other xfce maintainer team members @romildo and @muscaln .


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>3 packages marked as broken and skipped:</summary>
  <ul>
    <li>xfce.xfce4-embed-plugin</li>
    <li>xfce.xfce4-namebar-plugin</li>
    <li>xmonad_log_applet_xfce</li>
  </ul>
</details>
<details>
  <summary>96 packages built:</summary>
  <ul>
    <li>caffeine-ng</li>
    <li>fastfetch</li>
    <li>xfce.catfish</li>
    <li>xfce.catfish.dist</li>
    <li>xfce.exo</li>
    <li>xfce.exo.dev</li>
    <li>xfce.garcon</li>
    <li>xfce.garcon.dev</li>
    <li>xfce.libxfce4ui</li>
    <li>xfce.libxfce4ui.dev</li>
    <li>xfce.orage</li>
    <li>xfce.orage.dev</li>
    <li>xfce.parole</li>
    <li>xfce.parole.dev</li>
    <li>xfce.ristretto</li>
    <li>xfce.ristretto.dev</li>
    <li>xfce.thunar</li>
    <li>xfce.thunar-archive-plugin</li>
    <li>xfce.thunar-archive-plugin.dev</li>
    <li>xfce.thunar-dropbox-plugin</li>
    <li>xfce.thunar-media-tags-plugin</li>
    <li>xfce.thunar-media-tags-plugin.dev</li>
    <li>xfce.thunar-volman</li>
    <li>xfce.thunar-volman.dev</li>
    <li>xfce.thunar.dev</li>
    <li>xfce.xfburn</li>
    <li>xfce.xfburn.dev</li>
    <li>xfce.xfce4-appfinder</li>
    <li>xfce.xfce4-appfinder.dev</li>
    <li>xfce.xfce4-battery-plugin</li>
    <li>xfce.xfce4-battery-plugin.dev</li>
    <li>xfce.xfce4-clipman-plugin</li>
    <li>xfce.xfce4-clipman-plugin.dev</li>
    <li>xfce.xfce4-cpufreq-plugin</li>
    <li>xfce.xfce4-cpufreq-plugin.dev</li>
    <li>xfce.xfce4-cpugraph-plugin</li>
    <li>xfce.xfce4-cpugraph-plugin.dev</li>
    <li>xfce.xfce4-datetime-plugin</li>
    <li>xfce.xfce4-datetime-plugin.dev</li>
    <li>xfce.xfce4-dict</li>
    <li>xfce.xfce4-dict.dev</li>
    <li>xfce.xfce4-dockbarx-plugin</li>
    <li>xfce.xfce4-eyes-plugin</li>
    <li>xfce.xfce4-fsguard-plugin</li>
    <li>xfce.xfce4-genmon-plugin</li>
    <li>xfce.xfce4-i3-workspaces-plugin</li>
    <li>xfce.xfce4-mailwatch-plugin</li>
    <li>xfce.xfce4-mpc-plugin</li>
    <li>xfce.xfce4-netload-plugin</li>
    <li>xfce.xfce4-netload-plugin.dev</li>
    <li>xfce.xfce4-notes-plugin</li>
    <li>xfce.xfce4-notifyd</li>
    <li>xfce.xfce4-notifyd.dev</li>
    <li>xfce.xfce4-panel</li>
    <li>xfce.xfce4-panel-profiles</li>
    <li>xfce.xfce4-panel-profiles.dev</li>
    <li>xfce.xfce4-panel.dev</li>
    <li>xfce.xfce4-power-manager</li>
    <li>xfce.xfce4-power-manager.dev</li>
    <li>xfce.xfce4-pulseaudio-plugin</li>
    <li>xfce.xfce4-pulseaudio-plugin.dev</li>
    <li>xfce.xfce4-screensaver</li>
    <li>xfce.xfce4-screensaver.dev</li>
    <li>xfce.xfce4-screenshooter</li>
    <li>xfce.xfce4-screenshooter.dev</li>
    <li>xfce.xfce4-sensors-plugin</li>
    <li>xfce.xfce4-session</li>
    <li>xfce.xfce4-session.dev</li>
    <li>xfce.xfce4-settings</li>
    <li>xfce.xfce4-settings.dev</li>
    <li>xfce.xfce4-systemload-plugin</li>
    <li>xfce.xfce4-taskmanager</li>
    <li>xfce.xfce4-taskmanager.dev</li>
    <li>xfce.xfce4-terminal</li>
    <li>xfce.xfce4-terminal.dev</li>
    <li>xfce.xfce4-time-out-plugin</li>
    <li>xfce.xfce4-time-out-plugin.dev</li>
    <li>xfce.xfce4-timer-plugin</li>
    <li>xfce.xfce4-verve-plugin</li>
    <li>xfce.xfce4-verve-plugin.dev</li>
    <li>xfce.xfce4-volumed-pulse</li>
    <li>xfce.xfce4-volumed-pulse.dev</li>
    <li>xfce.xfce4-weather-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin.dev</li>
    <li>xfce.xfce4-windowck-plugin</li>
    <li>xfce.xfce4-xkb-plugin</li>
    <li>xfce.xfce4-xkb-plugin.dev</li>
    <li>xfce.xfconf</li>
    <li>xfce.xfconf.dev</li>
    <li>xfce.xfdashboard</li>
    <li>xfce.xfdashboard.dev</li>
    <li>xfce.xfdesktop</li>
    <li>xfce.xfdesktop.dev</li>
    <li>xfce.xfwm4</li>
    <li>xfce.xfwm4.dev</li>
  </ul>
</details>
