### PR TITLE
apr-util: find correct BDB when using clang 16

### DIFF
--- a/pkgs/development/libraries/apr-util/clang-bdb.patch
+++ b/pkgs/development/libraries/apr-util/clang-bdb.patch
@@ -1,0 +1,12 @@
+diff -ur a/build/dbm.m4 b/build/dbm.m4
+--- a/build/dbm.m4	2013-11-23 13:00:53.000000000 -0500
++++ b/build/dbm.m4	2023-10-22 20:16:37.764571446 -0400
+@@ -235,7 +235,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <$apu_try_berkeley_db_header>
+-main ()
++int main ()
+ {
+   int major, minor, patch;
+ 

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -19,15 +19,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-pBB243EHRjJsOUUEKZStmk/KwM4Cd92P6gdv7DyXcrU=";
   };
 
-  patches = [ ./fix-libxcrypt-build.patch ]
-    ++ lib.optional stdenv.isFreeBSD ./include-static-dependencies.patch;
+  patches = [
+    ./fix-libxcrypt-build.patch
+    # Fix incorrect Berkeley DB detection with newer versions of clang due to implicit `int` on main errors.
+    ./clang-bdb.patch
+  ] ++ lib.optional stdenv.isFreeBSD ./include-static-dependencies.patch;
 
   NIX_CFLAGS_LINK = [ "-lcrypt" ];
 
   outputs = [ "out" "dev" ];
   outputBin = "dev";
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isFreeBSD autoreconfHook;
+  nativeBuildInputs = [ makeWrapper autoreconfHook ];
 
   configureFlags = [ "--with-apr=${apr.dev}" "--with-expat=${expat.dev}" ]
     ++ lib.optional (!stdenv.isCygwin) "--with-crypto"


### PR DESCRIPTION
## Description of changes

Fix an implicit `int` in `dbm.m4` that causes the `configure` script to fail to find the correct Berkeley DB version (resulting in Subversion’s failing to build with clang 16).

This fixes the subversion build failure on Darwin in staging-next. #263535

https://hydra.nixos.org/build/239486210
https://hydra.nixos.org/build/239632728

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
