### PR TITLE
fstl: 0.9.4 -> 0.10.0

### DIFF
--- a/pkgs/applications/graphics/fstl/default.nix
+++ b/pkgs/applications/graphics/fstl/default.nix
@@ -4,18 +4,22 @@ mkDerivation rec {
   pname = "fstl";
   version = "0.10.0";
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
+    runHook preInstall
+
     mkdir -p $out/Applications
     mv fstl.app $out/Applications
+
+    runHook postInstall
   '';
 
   src = fetchFromGitHub {
     owner = "fstl-app";
     repo = "fstl";
     rev = "v" + version;
-    sha256 = "sha256-z2X78GW/IeiPCnwkeLBCLjILhfMe2sT3V9Gbw4TSf4c=";
+    hash = "sha256-z2X78GW/IeiPCnwkeLBCLjILhfMe2sT3V9Gbw4TSf4c=";
   };
 
   meta = with lib; {

--- a/pkgs/applications/graphics/fstl/default.nix
+++ b/pkgs/applications/graphics/fstl/default.nix
@@ -6,7 +6,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  postInstall = lib.optionalString stdenv.isDarwin ''
+  installPhase = lib.optionalString stdenv.isDarwin ''
     runHook preInstall
 
     mkdir -p $out/Applications

--- a/pkgs/applications/graphics/fstl/default.nix
+++ b/pkgs/applications/graphics/fstl/default.nix
@@ -1,18 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, mkDerivation, qtbase, mesa_glu }:
+{ lib, stdenv, fetchFromGitHub, mkDerivation, cmake }:
 
 mkDerivation rec {
   pname = "fstl";
-  version = "0.9.4";
+  version = "0.10.0";
 
-  buildInputs = [qtbase mesa_glu];
-
-  prePatch = ''
-    sed -i "s|/usr/bin|$out/bin|g" qt/fstl.pro
-  '';
-
-  preBuild = ''
-    qmake qt/fstl.pro
-  '';
+  buildInputs = [ cmake ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
@@ -20,15 +12,15 @@ mkDerivation rec {
   '';
 
   src = fetchFromGitHub {
-    owner = "mkeeter";
+    owner = "fstl-app";
     repo = "fstl";
     rev = "v" + version;
-    sha256 = "028hzdv11hgvcpc36q5scf4nw1256qswh37xhfn5a0iv7wycmnif";
+    sha256 = "sha256-z2X78GW/IeiPCnwkeLBCLjILhfMe2sT3V9Gbw4TSf4c=";
   };
 
   meta = with lib; {
     description = "The fastest STL file viewer";
-    homepage = "https://github.com/mkeeter/fstl";
+    homepage = "https://github.com/fstl-app/fstl";
     license = licenses.mit;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ tweber ];


### PR DESCRIPTION
Note that https://github.com/mkeeter/fstl now redirects to https://github.com/fstl-app/fstl. It would appear the old repo is no longer updated, and the version under fstl-app is the proper location.

## Description of changes

No breaking changes listed on https://github.com/fstl-app/fstl/releases/tag/v0.10.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
