### PR TITLE
thud: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/by-name/th/thud/package.nix
+++ b/pkgs/by-name/th/thud/package.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -32,6 +33,8 @@ rustPlatform.buildRustPackage rec {
       --fish <(cat target/completions/thud.fish) \
       --zsh <(cat target/completions/_thud)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Generate directory thumbnails for GTK-based file browsers from images inside them";

--- a/pkgs/by-name/th/thud/package.nix
+++ b/pkgs/by-name/th/thud/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "thud";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "donovanglover";
     repo = "thud";
     rev = version;
-    hash = "sha256-3MxmVKs0huXPnL9mqDniaIarkAvJmwSOMii2ntXtOos=";
+    hash = "sha256-BmrJaZ1IKXjx4/QkBDZyXvTTaalfEOKsBp9ZCW8px7I=";
   };
 
-  cargoHash = "sha256-Hk3HlcA253FAA9hw5p9W+Mvec84zLo7bEmM2/BbmjiM=";
+  cargoHash = "sha256-rmVVdes7GuGV+ClqJGxNIrs7oSwe8/ZHFD6OfP/UW7A=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -25,12 +25,12 @@ rustPlatform.buildRustPackage rec {
     install -Dm644 assets/thud.thumbnailer $out/share/thumbnailers/thud.thumbnailer
     substituteInPlace $out/share/thumbnailers/thud.thumbnailer --replace "thud" "$out/bin/thud"
 
-    installManPage man/thud.1
+    installManPage target/man/thud.1
 
     installShellCompletion --cmd thud \
-      --bash <(cat completions/thud.bash) \
-      --fish <(cat completions/thud.fish) \
-      --zsh <(cat completions/_thud)
+      --bash <(cat target/completions/thud.bash) \
+      --fish <(cat target/completions/thud.fish) \
+      --zsh <(cat target/completions/_thud)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

- https://github.com/donovanglover/thud/releases/tag/0.3.1
- https://github.com/donovanglover/thud/compare/0.3.0...0.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
