### PR TITLE
hyprdim: 2.2.1 -> 2.2.2

### DIFF
--- a/pkgs/applications/misc/hyprdim/default.nix
+++ b/pkgs/applications/misc/hyprdim/default.nix
@@ -2,38 +2,41 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "hyprdim";
-  version = "2.2.1";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "donovanglover";
-    repo = pname;
+    repo = "hyprdim";
     rev = version;
-    hash = "sha256-6HeVLgEJDPy4cWL5td3Xl7+a6WUFZWUFynvBzPhItcg=";
+    hash = "sha256-b2T/ueinKiheuK+siV29vJfEsEodq6qT2J3XxvoD/14=";
   };
 
-  cargoHash = "sha256-qYX5o64X8PsFcTYuZ82lIShyUN69oTzQIHrQH4B7iIw=";
+  cargoHash = "sha256-Sf32vaqcxVdg6/kDidxBSr5XDWg3aNEBpEl31do2ZJ8=";
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
   postInstall = ''
-    installManPage man/hyprdim.1
+    installManPage target/man/hyprdim.1
 
     installShellCompletion --cmd hyprdim \
-      --bash <(cat completions/hyprdim.bash) \
-      --fish <(cat completions/hyprdim.fish) \
-      --zsh <(cat completions/_hyprdim)
+      --bash <(cat target/completions/hyprdim.bash) \
+      --fish <(cat target/completions/hyprdim.fish) \
+      --zsh <(cat target/completions/_hyprdim)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Automatically dim windows in Hyprland when switching between them";
     homepage = "https://github.com/donovanglover/hyprdim";
-    license = licenses.mit;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ donovanglover ];
     mainProgram = "hyprdim";


### PR DESCRIPTION
## Description of changes

- Release: https://github.com/donovanglover/hyprdim/releases/tag/2.2.2
- Changes: https://github.com/donovanglover/hyprdim/compare/2.2.1...2.2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
