### PR TITLE
cie-middleware-linux: 1.4.4.0 -> 1.5.0

### DIFF
--- a/pkgs/tools/security/cie-middleware-linux/default.nix
+++ b/pkgs/tools/security/cie-middleware-linux/default.nix
@@ -20,13 +20,13 @@
 
 let
   pname = "cie-middleware-linux";
-  version = "1.4.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "M0rf30";
     repo = pname;
-    rev = "${version}-podofo";
-    sha256 = "sha256-Kyr9OTiY6roJ/wVJS/1aWfrrzDNQbuRTJQqo0akbMUU=";
+    rev = version;
+    sha256 = "sha256-Z8K2Ibg5bBfSql5HEapKgdfiCf/EIKTTD15oVeysQGk=";
   };
 
   gradle = gradle_7;
@@ -44,6 +44,7 @@ let
     buildPhase = ''
       # Run the fetchDeps task
       export GRADLE_USER_HOME=$(mktemp -d)
+      ls -l
       gradle --no-daemon -b cie-java/build.gradle fetchDeps
     '';
 
@@ -60,7 +61,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-WzT5vYF9yCMU2A7EkLZyjgWrN3gD7pnkPXc3hDFqpD8=";
+    outputHash = "sha256-jtaH8dBpnx8KMJe+jzJfkvcx1NO4nL5jsRO4+GI+d0c=";
   };
 
 in
@@ -84,7 +85,7 @@ stdenv.mkDerivation {
   buildInputs = [
     cryptopp
     fontconfig
-    podofo
+    podofo.dev
     openssl
     pcsclite
     curl
@@ -95,6 +96,10 @@ stdenv.mkDerivation {
     # substitute the cieid command with this $out/bin/cieid
     substituteInPlace libs/pkcs11/src/CSP/AbilitaCIE.cpp \
       --replace 'file = "cieid"' 'file = "'$out'/bin/cieid"'
+
+    # revert https://github.com/M0Rf30/cie-middleware-linux/commit/1a389d8
+    sed -i libs/meson.build \
+        -e "s@podofo_dep = .\+@podofo_dep = dependency('libpodofo')@g"
   '';
 
   # Note: we use pushd/popd to juggle between the


### PR DESCRIPTION
## Description of changes

Minor updates, fixes several graphical issues

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change (none)
- [x] Tested PKCS#11, digital signature.
- [x] Tested basic functionality of all binary files (cieid)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
