### PR TITLE
scala-cli: 1.0.4 -> 1.0.5

### DIFF
--- a/pkgs/development/tools/build-managers/scala-cli/sources.json
+++ b/pkgs/development/tools/build-managers/scala-cli/sources.json
@@ -1,21 +1,21 @@
 {
-  "version": "1.0.4",
+  "version": "1.0.5",
   "assets": {
     "aarch64-darwin": {
       "asset": "scala-cli-aarch64-apple-darwin.gz",
-      "sha256": "1gqnsm8pcwrk1v1v4xaj0j0w5xsmh3xv61h6sv72297illxxkbgq"
+      "sha256": "1p2ibii71digdz7qqqyahvdmmxyx19crwgn4bmas0hahl6mz553x"
     },
     "aarch64-linux": {
       "asset": "scala-cli-aarch64-pc-linux.gz",
-      "sha256": "124xqn18xyn35pg18p0rz40d8vjgijp6sc6wg4i81ih2mrxqxsbc"
+      "sha256": "1y9ghb829jz9yg4l7bgwnbl3cm7z7c20cyfc71v9iz8bq5ns9akr"
     },
     "x86_64-darwin": {
       "asset": "scala-cli-x86_64-apple-darwin.gz",
-      "sha256": "0r581a1zzlk7qbcsfbv79asj5y56zzx9249h099k29rbdjc3ya26"
+      "sha256": "12qjrm979pfbr0j7s59dyn7xkk585av7l0qxf77rz71009kvql0a"
     },
     "x86_64-linux": {
       "asset": "scala-cli-x86_64-pc-linux.gz",
-      "sha256": "018cmr71qhdqvmprrfb8clsj718gfkdvyw48dqkf2jsafq0kglk2"
+      "sha256": "17x4nv5f8g1kx8l4n8ncxf60zwhwpqg8fh5cl8qy9s5h9h81n0rz"
     }
   }
 }


### PR DESCRIPTION
## Description of changes

Update scala-cli from [1.0.4] to [1.0.5].

[1.0.4]: https://github.com/VirtusLab/scala-cli/releases/tag/v1.0.4
[1.0.5]: https://github.com/VirtusLab/scala-cli/releases/tag/v1.0.5

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).