### PR TITLE
python3Packages.libusb1: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "libusb1";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5792a9defee40f15d330a40d9b1800545c32e47ba7fc66b6f28f133c9fcc8538";
+    sha256 = "4ee9b0a55f8bd0b3ea7017ae919a6c1f439af742c4a4b04543c5fd7af89b828c";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Version bump, bug fix release

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files (none)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>electrum</li>
    <li>electrum-grs</li>
    <li>electrum-grs.dist</li>
    <li>electrum.dist</li>
  </ul>
</details>
<details>
  <summary>79 packages built:</summary>
  <ul>
    <li>electron-cash</li>
    <li>electron-cash.dist</li>
    <li>electrum-ltc</li>
    <li>electrum-ltc.dist</li>
    <li>ghost</li>
    <li>ghost.dist</li>
    <li>glasgow</li>
    <li>glasgow.dist</li>
    <li>home-assistant-component-tests.androidtv</li>
    <li>hwi (python311Packages.hwi)</li>
    <li>hwi.dist (python311Packages.hwi.dist)</li>
    <li>keepkey_agent (python311Packages.keepkey_agent)</li>
    <li>keepkey_agent.dist (python311Packages.keepkey_agent.dist)</li>
    <li>ledger_agent (python311Packages.ledger_agent)</li>
    <li>ledger_agent.dist (python311Packages.ledger_agent.dist)</li>
    <li>libfx2 (python311Packages.fx2)</li>
    <li>libfx2.dist (python311Packages.fx2.dist)</li>
    <li>nitrokey-app2</li>
    <li>nitrokey-app2.dist</li>
    <li>nrfutil</li>
    <li>nrfutil.dist</li>
    <li>pynitrokey</li>
    <li>pynitrokey.dist</li>
    <li>python310Packages.adb-homeassistant</li>
    <li>python310Packages.adb-homeassistant.dist</li>
    <li>python310Packages.adb-shell</li>
    <li>python310Packages.adb-shell.dist</li>
    <li>python310Packages.androidtv</li>
    <li>python310Packages.androidtv.dist</li>
    <li>python310Packages.firetv</li>
    <li>python310Packages.firetv.dist</li>
    <li>python310Packages.fx2</li>
    <li>python310Packages.fx2.dist</li>
    <li>python310Packages.hwi</li>
    <li>python310Packages.hwi.dist</li>
    <li>python310Packages.keepkey</li>
    <li>python310Packages.keepkey.dist</li>
    <li>python310Packages.keepkey_agent</li>
    <li>python310Packages.keepkey_agent.dist</li>
    <li>python310Packages.ledger_agent</li>
    <li>python310Packages.ledger_agent.dist</li>
    <li>python310Packages.ledgerblue</li>
    <li>python310Packages.ledgerblue.dist</li>
    <li>python310Packages.libusb1</li>
    <li>python310Packages.libusb1.dist</li>
    <li>python310Packages.nfcpy</li>
    <li>python310Packages.nfcpy.dist</li>
    <li>python310Packages.nkdfu</li>
    <li>python310Packages.nkdfu.dist</li>
    <li>python310Packages.trezor</li>
    <li>python310Packages.trezor.dist</li>
    <li>python310Packages.trezor_agent</li>
    <li>python310Packages.trezor_agent.dist</li>
    <li>python311Packages.adb-homeassistant</li>
    <li>python311Packages.adb-homeassistant.dist</li>
    <li>python311Packages.adb-shell</li>
    <li>python311Packages.adb-shell.dist</li>
    <li>python311Packages.androidtv</li>
    <li>python311Packages.androidtv.dist</li>
    <li>python311Packages.firetv</li>
    <li>python311Packages.firetv.dist</li>
    <li>python311Packages.keepkey</li>
    <li>python311Packages.keepkey.dist</li>
    <li>python311Packages.ledgerblue</li>
    <li>python311Packages.ledgerblue.dist</li>
    <li>python311Packages.libusb1</li>
    <li>python311Packages.libusb1.dist</li>
    <li>python311Packages.nfcpy</li>
    <li>python311Packages.nfcpy.dist</li>
    <li>python311Packages.nkdfu</li>
    <li>python311Packages.nkdfu.dist</li>
    <li>trezorctl (python311Packages.trezor)</li>
    <li>trezorctl.dist (python311Packages.trezor.dist)</li>
    <li>trezor_agent (python311Packages.trezor_agent)</li>
    <li>trezor_agent.dist (python311Packages.trezor_agent.dist)</li>
    <li>sparrow</li>
    <li>sparrow-unwrapped</li>
    <li>steamcontroller</li>
    <li>steamcontroller.dist</li>
  </ul>
</details>
