### PR TITLE
deepin.dde-daemon: fix build with ddcutil 2

### DIFF
--- a/pkgs/desktops/deepin/go-package/dde-daemon/0006-fix-build-with-ddcutil-2.patch
+++ b/pkgs/desktops/deepin/go-package/dde-daemon/0006-fix-build-with-ddcutil-2.patch
@@ -1,0 +1,17 @@
+diff --git a/bin/backlight_helper/ddcci/ddcci.go b/bin/backlight_helper/ddcci/ddcci.go
+index 679beea3..ccbfc508 100644
+--- a/bin/backlight_helper/ddcci/ddcci.go
++++ b/bin/backlight_helper/ddcci/ddcci.go
+@@ -103,11 +103,6 @@ func newDDCCI() (*ddcci, error) {
+ 		displayHandleMap: make(map[string]*displayHandle),
+ 	}
+ 
+-	status := C.ddca_set_max_tries(C.DDCA_MULTI_PART_TRIES, 5)
+-	if status < C.int(0) {
+-		return nil, fmt.Errorf("brightness: Error setting retries: %d", status)
+-	}
+-
+ 	err := ddc.RefreshDisplays()
+ 	if err != nil {
+ 		return nil, err
+

--- a/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
@@ -62,6 +62,7 @@ buildGoPackage rec {
       src = ./0005-fix-custom-wallpapers-path.diff;
       inherit coreutils;
     })
+    ./0006-fix-build-with-ddcutil-2.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes
https://gitlab.archlinux.org/archlinux/packaging/packages/deepin-daemon/-/commit/18e60cd055a58841df29c69b8446dc58eeea9af1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
