### PR TITLE
ocamlPackages: small fixes for OCaml ≥ 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -6,8 +6,6 @@ buildDunePackage rec {
   pname = "camlimages";
   version = "5.0.4";
 
-  duneVersion = "3";
-
   minimalOCamlVersion = "4.07";
 
   src = fetchFromGitLab {
@@ -16,6 +14,10 @@ buildDunePackage rec {
     rev = version;
     sha256 = "1m2c76ghisg73dikz2ifdkrbkgiwa0hcmp21f2fm2rkbf02rq3f4";
   };
+
+  postPatch = ''
+    substituteInPlace core/{images,units}.ml --replace String.lowercase String.lowercase_ascii
+  '';
 
   nativeBuildInputs = [ cppo ];
   buildInputs = [ dune-configurator findlib graphics lablgtk stdio ];

--- a/pkgs/development/ocaml-modules/cry/default.nix
+++ b/pkgs/development/ocaml-modules/cry/default.nix
@@ -11,6 +11,10 @@ buildDunePackage rec {
     sha256 = "sha256-1Omp3LBKGTPVwEBd530H0Djn3xiEjOHLqso6S8yIJSQ=";
   };
 
+  postPatch = ''
+    substituteInPlace src/dune --replace bytes ""
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/savonet/ocaml-cry";
     description = "OCaml client for the various icecast & shoutcast source protocols";

--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "0yrxl97szjc0s2ghngs346x3y0xszx2chidgzxk93frjjpsr1mlr";
   };
 
+  postPatch = ''
+      substituteInPlace "dum.ml" \
+      --replace "Lazy.lazy_is_val" "Lazy.is_val" \
+      --replace "Obj.final_tag" "Obj.custom_tag"
+  '';
+
   nativeBuildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ easy-format ];
 

--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, which, sedlex, easy-format, xmlm, base64 }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "piqi is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   version = "0.6.16";
   pname = "piqi";

--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, ctypes, libsodium }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "sodium is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-sodium";
   version = "0.6.0";


### PR DESCRIPTION
## Description of changes

Fix or simply disable a few libraries.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
