### PR TITLE
bazel_6: Fix `pythonBinPath` and `pythonBinPathWithNixHacks` tests

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -51,6 +51,7 @@ let
     py_binary(
       name = "bin",
       srcs = [ "bin.py" ],
+      imports = [ "." ],
       deps = [ ":lib" ],
     )
   '';


### PR DESCRIPTION
## Description of changes

The tests started to fail after the repo-wide python 3.10 -> 3.11 update.

This is caused by Bazel's py_binary rule setting the [`PYTHONSAFEPATH`][1]
environment variable, which only has an effect for Python >= 3.11.

Setting this variable avoids prepending the current working directory and the
script's directory to the `PYTHONPATH`. The current test code relied on this behavior and thus
failed with:

```
Traceback (most recent call last):
  File "/build/.cache/bazel/_bazel_build/8bcfff1c77854f2a2b07d1413b0fc106/execroot/our_workspace/bazel-out/k8-fastbuild/bin/python/bin.runfiles/our_workspace/python/bin.py", line 6, in <module>
    from lib import foo
ModuleNotFoundError: No module named 'lib'
```

See also [bazelbuild/bazel#7091][2]

[1]: https://docs.python.org/3.11/using/cmdline.html#envvar-PYTHONSAFEPATH
[2]: https://github.com/bazelbuild/bazel/issues/7091

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

