### PR TITLE
nixos/guix: init module

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,34 @@
+# nix build -I nixos-config=$PWD/configuration.nix -I nixpkgs=$PWD --file ./nixos vm
+{
+  config,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  guix = {
+    enable = true;
+    maxJobs = 4;
+  };
+
+  users.users.alice = {
+    isNormalUser = true;
+    extraGroups = ["wheel" "systemd-journal"];
+    initialPassword = "alice";
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  virtualisation.vmVariant = {
+    virtualisation = {
+      graphics = false;
+      cores = 4;
+      memorySize = 4098;
+      diskSize = 1024 * 10;
+    };
+  };
+
+  services.getty.autologinUser = "alice";
+
+  documentation.enable = false;
+  system.stateVersion = "23.05";
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1197,6 +1197,7 @@
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix
   ./services/system/earlyoom.nix
+  ./services/system/guix-daemon.nix
   ./services/system/kerberos/default.nix
   ./services/system/localtimed.nix
   ./services/system/nix-daemon.nix

--- a/nixos/modules/services/system/guix-daemon.nix
+++ b/nixos/modules/services/system/guix-daemon.nix
@@ -1,0 +1,72 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  cfg = config.guix;
+in {
+  options = with lib; {
+    guix = {
+      enable = mkEnableOption "guix";
+
+      package = mkOption {
+        type = with types; package;
+        default = pkgs.guix;
+        defaultText = literalExpression "pkgs.guix";
+        description = mdDoc ''
+          This option specifies the Guix package to be used in the system.
+        '';
+      };
+
+      substituteUrls = mkOption {
+        type = with types; listOf str;
+        default = [
+          "https://ci.guix.gnu.org"
+          "https://bordeaux.guix.gnu.org"
+        ];
+        description = mdDoc ''
+          List of urls to be used as substituters.
+        '';
+      };
+
+      cores = mkOption {
+        type = with types; int;
+        default = 0;
+        description = mdDoc ''
+          Number of CPU cores to build each derivation, 0 means as many as available.
+        '';
+      };
+
+      maxJobs = mkOption {
+        type = with types; int;
+        default = 1;
+        description = mdDoc ''
+          Allow at most n build jobs in parallel. The default value is 1. Setting it to 0 means that no builds will be performed locally; instead, the daemon will offload builds (see Using the Offload Facility), or simply fail.
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = with types; listOf (coercedTo anything (x: "${x}") str);
+        default = [];
+        description = mdDoc ''
+          Extra flags passed to guix-daemon. Inteded for flags that don't have a setting equivalent.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+
+    systemd.services.guix-daemon = {
+      path = [cfg.package];
+      script = ''
+        ${cfg.package}/bin/guix-daemon \
+          --build-users-group=nixbld \
+          --substitute-urls='${lib.escapeShellArgs cfg.substituteUrls}'
+      '';
+      wantedBy = ["multi-user.target"];
+    };
+  };
+}


### PR DESCRIPTION
## Description of changes

Guix was recently merged #246975 . This module would configure the guix-daemon, and add guix to path, similarly to the nix-daemon module.

This is a draft PR and I've added a VM configuration to be deleted, so that changes can be quickly tested.

Todo:
- [ ] Configuring relevant daemon options.
- [ ] Tests
- [ ] ? Boostrapping channels
- [ ] ? Binfmt cross-compilation


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
