### PR TITLE
flycast: 2.1 -> 2.2

### DIFF
--- a/pkgs/applications/emulators/flycast/default.nix
+++ b/pkgs/applications/emulators/flycast/default.nix
@@ -6,35 +6,24 @@
 , makeWrapper
 , alsa-lib
 , curl
-, egl-wayland
 , libao
-, libdecor
-, libevdev
-, libffi
-, libGL
 , libpulseaudio
-, libX11
-, libXext
-, libxkbcommon
 , libzip
-, mesa
+, lua
 , miniupnpc
-, udev
-, vulkan-headers
+, SDL2
 , vulkan-loader
-, wayland
-, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "flycast";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "flyinghead";
     repo = "flycast";
-    rev = "V${version}";
-    sha256 = "sha256-PRInOqg9OpaUVLwSj1lOxDtjpVaYehkRsp0jLrVKPyY=";
+    rev = "v${version}";
+    sha256 = "sha256-eQMKaUaZ1b0oXre4Ouli4qIyNaG64KntyRGk3/YIopc=";
     fetchSubmodules = true;
   };
 
@@ -47,23 +36,16 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsa-lib
     curl
-    egl-wayland
     libao
-    libdecor
-    libevdev
-    libffi
-    libGL
     libpulseaudio
-    libX11
-    libXext
-    libxkbcommon
     libzip
-    mesa # for libgbm
+    lua
     miniupnpc
-    udev
-    vulkan-headers
-    wayland
-    zlib
+    SDL2
+  ];
+
+  cmakeFlags = [
+    "-DUSE_HOST_SDL=ON"
   ];
 
   postFixup = ''


### PR DESCRIPTION
## Description of changes

https://github.com/flyinghead/flycast/releases/tag/v2.2

Thanks to the new CMake option `USE_HOST_SDL`, I threw out many dependencies that were there just for the bundled SDL.
Tested the BIOS, with both OpenGL and Vulkan, and both X11 and Wayland (`SDL_VIDEODRIVER`).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
