### PR TITLE
llvmPackages_12.openmp,llvmPackages_13.openmp: fix cross

### DIFF
--- a/pkgs/development/compilers/llvm/12/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/12/openmp/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , llvm_meta
 , fetch
+, fetchpatch
 , cmake
 , llvm
 , targetLlvm
@@ -14,6 +15,16 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetch pname "14dh0r6h2xh747ffgnsl4z08h0ri04azi9vf79cbz7ma1r27kzk0";
+
+  patches = [
+    # Fix cross.
+    (fetchpatch {
+      url = "https://github.com/llvm/llvm-project/commit/5e2358c781b85a18d1463fd924d2741d4ae5e42e.patch";
+      hash = "sha256-UxIlAifXnexF/MaraPW0Ut6q+sf3e7y1fMdEv1q103A=";
+    })
+  ];
+
+  patchFlags = [ "-p2" ];
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [

--- a/pkgs/development/compilers/llvm/13/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/13/openmp/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , llvm_meta
 , src
+, fetchpatch
 , cmake
 , llvm
 , targetLlvm
@@ -15,6 +16,16 @@ stdenv.mkDerivation rec {
 
   inherit src;
   sourceRoot = "${src.name}/${pname}";
+
+  patches = [
+    # Fix cross.
+    (fetchpatch {
+      url = "https://github.com/llvm/llvm-project/commit/5e2358c781b85a18d1463fd924d2741d4ae5e42e.patch";
+      hash = "sha256-UxIlAifXnexF/MaraPW0Ut6q+sf3e7y1fMdEv1q103A=";
+    })
+  ];
+
+  patchFlags = [ "-p2" ];
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [


### PR DESCRIPTION
## Description of changes

CMake commit faa950a155 ("try_compile: Run native build tool with verbose output") did not play well with these versions of openmp, which have a faulty failure regex that considers "unknown" in the build output to indicate a failure.  When cross compiling, the string "unknown" is very likely to occur as part of triples.  Fix by backporting a patch that improves the failure regex check to not be tripped up by triples.

The same problem affects LLVM 11 and possibly earlier, but the patch doesn't apply that far back, so I didn't bother for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
