### PR TITLE
jasp-desktop: init at 0.18.1

### DIFF
--- a/pkgs/applications/science/math/jasp-desktop/default.nix
+++ b/pkgs/applications/science/math/jasp-desktop/default.nix
@@ -1,0 +1,105 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, copyDesktopItems
+, glew
+, libffi
+, wrapQtAppsHook
+, qtbase
+, qtmultimedia
+, libzip
+, makeDesktopItem
+, makeWrapper
+, pkg-config
+, python3
+, snappy
+, vulkan-loader
+, wayland
+, boost179
+, jsoncpp
+, libarchive
+, openssl
+, zlib
+, bison
+, flex
+, gfortran
+, qtwebengine
+, qt5compat
+, readstat
+, rWrapper
+, substituteAll
+, rPackages
+, jags
+, qtcreator
+}:
+
+let
+  R = rWrapper.override { packages = with rPackages; [ renv RInside ]; };
+in
+stdenv.mkDerivation rec {
+  pname = "jasp-desktop";
+  version = "0.18.1";
+
+  src = fetchFromGitHub {
+    owner = "jasp-stats";
+    repo = "jasp-desktop";
+    rev = "v${version}";
+    hash = "sha256-1m0URudMF50pnR7xYuu/d5817ouybaNLTG/h2d1J7rY=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./no-static-boost.patch;
+      r_include = "${R}/lib/R/include";
+    })
+  ];
+
+  R_HOME = "${R}";
+
+  nativeBuildInputs = [
+    cmake
+    qtcreator
+    copyDesktopItems
+    makeWrapper
+    pkg-config
+    wrapQtAppsHook
+    gfortran
+  ];
+
+  buildInputs = [
+    boost179
+    jsoncpp
+    libarchive
+    openssl
+    readstat
+    R
+    jags
+    zlib
+    bison
+    flex
+    qtbase
+    qtmultimedia
+    qtwebengine
+    qt5compat
+  ];
+
+  cmakeFlags = [
+    "-DLINUX_LOCAL_BUILD=OFF"
+    "-DAPPLE=OFF"
+    "-DWIN32=OFF"
+    "-DRENV_PATH=${rPackages.renv}/library/renv"
+    "-DRINSIDE_PATH=${rPackages.RInside}/library/RInside"
+    "-Djags_HOME=${jags}"
+  ];
+
+  GITHUB_PAT = "xxx";
+
+  meta = {
+    homepage = "https://jasp-stats.org/";
+    description = "Statistical package for both Bayesian and Frequentist statistical methods";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.fliegendewurst ];
+    platforms = lib.platforms.linux; # TODO: package for darwin
+  };
+}

--- a/pkgs/applications/science/math/jasp-desktop/no-static-boost.patch
+++ b/pkgs/applications/science/math/jasp-desktop/no-static-boost.patch
@@ -1,0 +1,95 @@
+diff --git a/Tools/CMake/Libraries.cmake b/Tools/CMake/Libraries.cmake
+index 5382ca6..3bdb0bc 100644
+--- a/Tools/CMake/Libraries.cmake
++++ b/Tools/CMake/Libraries.cmake
+@@ -41,6 +41,7 @@ endif()
+ find_package(ZLIB 1.2 REQUIRED)
+ find_package(Iconv 1.16 REQUIRED)
+ find_package(SQLite3 3.37.0 REQUIRED)
++find_library(LIB_READSTAT NAMES libreadstat.so)
+ 
+ #if(USE_CONAN)
+ #  find_package(jsoncpp 1.9 REQUIRED)
+@@ -67,7 +68,7 @@ if((NOT LibArchive_FOUND) AND (NOT WIN32))
+   endif()
+ endif()
+ 
+-set(Boost_USE_STATIC_LIBS ON)
++add_definitions(-DBOOST_LOG_DYN_LINK)
+ find_package(
+   Boost 1.78 REQUIRED
+   COMPONENTS filesystem
+@@ -174,29 +175,6 @@ if(LINUX)
+     message(FATAL_ERROR "librt is required for building libCommon on Linux")
+   endif()
+ 
+-  if(FLATPAK_USED)
+-    set(LIBREADSTAT_INCLUDE_DIRS /app/include)
+-    set(LIBREADSTAT_LIBRARY_DIRS /app/lib)
+-  else()
+-    set(LIBREADSTAT_INCLUDE_DIRS /usr/local/include /usr/include)
+-    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib)
+-  endif()
+-
+-  message(CHECK_START "Looking for libreadstat.so")
+-  find_file(LIBREADSTAT_LIBRARIES libreadstat.so
+-            HINTS ${LIBREADSTAT_LIBRARY_DIRS} REQUIRED)
+-
+-  if(EXISTS ${LIBREADSTAT_LIBRARIES})
+-    message(CHECK_PASS "found")
+-    message(STATUS "  ${LIBREADSTAT_LIBRARIES}")
+-  else()
+-    message(CHECK_FAIL "not found")
+-    message(
+-      FATAL_ERROR
+-        "ReadStat is required for building on Windows, please follow the build instruction before you continue."
+-    )
+-  endif()
+-
+   find_package(PkgConfig)
+   #pkg_check_modules(_PKGCONFIG_LIB_JSONCPP REQUIRED jsoncpp>=1.9)
+ 
+diff --git a/Tools/CMake/R.cmake b/Tools/CMake/R.cmake
+index 4f1db3d..43e4dbb 100644
+--- a/Tools/CMake/R.cmake
++++ b/Tools/CMake/R.cmake
+@@ -582,8 +582,8 @@ elseif(WIN32)
+   set(R_EXECUTABLE "${R_HOME_PATH}/bin/R")
+   set(R_INCLUDE_PATH "${R_HOME_PATH}/include")
+   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
+-  set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
+-  set(RENV_PATH "${R_LIBRARY_PATH}/renv")
++  #set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
++  #set(RENV_PATH "${R_LIBRARY_PATH}/renv")
+   
+ 
+   # This will be added to the install.packages calls
+@@ -778,8 +778,6 @@ elseif(LINUX)
+   set(R_EXECUTABLE "${R_HOME_PATH}/bin/R")
+   set(RSCRIPT_EXECUTABLE "${R_HOME_PATH}/bin/Rscript")
+   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
+-  set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
+-  set(RENV_PATH "${R_LIBRARY_PATH}/renv")
+ 
+   set(USE_LOCAL_R_LIBS_PATH ", lib='${R_LIBRARY_PATH}'")
+ 
+@@ -794,7 +792,7 @@ elseif(LINUX)
+       find_file(
+         _R_H
+         NAMES R.h
+-        PATHS /usr/include /usr/include/R /usr/share/R/include)
++        PATHS @r_include@)
+       if(_R_H)
+         get_filename_component(R_INCLUDE_PATH ${_R_H} DIRECTORY)
+         message(CHECK_PASS "found")
+@@ -817,8 +815,8 @@ elseif(LINUX)
+   message(CHECK_START "Checking for 'libR'")
+   find_library(
+     _LIB_R
+-    NAMES R
+-    PATHS ${R_HOME_PATH}/lib
++    NAMES libR.so
++    PATHS ${R_HOME_PATH}/lib/R/lib
+     NO_DEFAULT_PATH NO_CACHE REQUIRED)
+ 
+   if(_LIB_R)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -42091,4 +42091,6 @@ with pkgs;
   code-maat = callPackage ../development/tools/code-maat {};
 
   mdhtml = callPackage ../tools/text/mdhtml { };
+
+  jasp-desktop = qt6Packages.callPackage ../applications/science/math/jasp-desktop { };
 }


### PR DESCRIPTION
## Description of changes

An attempt at packaging https://github.com/jasp-stats/jasp-desktop.

Currently fails because it can't find `Engine/jaspBase/R/utility.R` in the source directory. I have no clue where this file is supposed to come from.

Fixes #264279
cc @prehonor

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).