### PR TITLE
python3Packages.torch: check in patch for PyTorch PR 108847

### DIFF
--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -145,10 +145,8 @@ in buildPythonPackage rec {
     ./pthreadpool-disable-gcd.diff
   ] ++ lib.optionals stdenv.isLinux [
     # Propagate CUPTI to Kineto by overriding the search path with environment variables.
-    (fetchpatch {
-      url = "https://github.com/pytorch/pytorch/pull/108847/commits/7ae4d7c0e2dec358b4fe81538efe9da5eb580ec9.patch";
-      hash = "sha256-skFaDg98xcJqJfzxWk+qhUxPLHDStqvd0mec3PgksIg=";
-    })
+    # https://github.com/pytorch/pytorch/pull/108847
+    ./pytorch-pr-108847.patch
   ];
 
   postPatch = lib.optionalString rocmSupport ''

--- a/pkgs/development/python-modules/torch/pytorch-pr-108847.patch
+++ b/pkgs/development/python-modules/torch/pytorch-pr-108847.patch
@@ -1,0 +1,31 @@
+From bf4050edab9f294a8e0060c47f906cd7a80f25a2 Mon Sep 17 00:00:00 2001
+From: Samuel Ainsworth <skainsworth@gmail.com>
+Date: Sat, 9 Sep 2023 02:04:09 +0000
+Subject: [PATCH] Dependencies.cmake: support building against CUPTI outside of
+ CUDA_SOURCE_DIR
+
+Limitation discovered in https://github.com/NixOS/nixpkgs/pull/249259.
+---
+ cmake/Dependencies.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index 0602d534dc4c14..5f6a5f79f3e3dc 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -1879,6 +1879,7 @@ if(USE_KINETO)
+         ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
+         ${CUDA_SOURCE_DIR}/lib
+         ${CUDA_SOURCE_DIR}/lib64
++        $ENV{CUPTI_LIBRARY_DIR}
+         NO_DEFAULT_PATH)
+ 
+     find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
+@@ -1886,6 +1887,7 @@ if(USE_KINETO)
+         ${CUDA_INCLUDE_DIRS}
+         ${CUDA_SOURCE_DIR}
+         ${CUDA_SOURCE_DIR}/include
++        $ENV{CUPTI_INCLUDE_DIR}
+         NO_DEFAULT_PATH)
+ 
+     if(CUPTI_LIBRARY_PATH AND CUPTI_INCLUDE_DIR)


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As pointed out in https://github.com/nixified-ai/flake/issues/58 and https://github.com/NixOS/nixpkgs/issues/264334, the patch from https://github.com/pytorch/pytorch/pull/108847 was lost when the PyTorch bot force-pushed the branch.

This PR checks in the patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
