### PR TITLE
jitsi-meet: Update list of enabled Prosody modules

### DIFF
--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -193,7 +193,14 @@ in
           roomDefaultPublicJids = true;
           extraConfig = ''
             storage = "memory"
+            muc_password_whitelist = {
+              "focus@auth.${cfh.hostName}"
+            }
           '';
+          #Note: Configuration is missing "muc_meeting_id", "polls",
+          #      "muc_domain_mapper" and "muc_password_whitelist"
+          #      modules, but Prosody doesn’t provide an extraModules
+          #      key to conviniently add those to the config
         }
         {
           domain = "internal.${cfg.hostName}";

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -220,6 +220,15 @@ in
       extraConfig = lib.mkMerge [ (mkAfter ''
         Component "focus.${cfg.hostName}" "client_proxy"
           target_address = "focus@auth.${cfg.hostName}"
+
+        Component "speakerstats.${cfg.hostName}" "speakerstats_component"
+          muc_component = "conference.${cfg.hostName}"
+
+        Component "conferenceduration.${cfg.hostName}" "conference_duration_component"
+          muc_component = "conference.${cfg.hostName}"
+
+        Component "metadata.${cfg.hostName}" "room_metadata_component"
+          muc_component = "conference.${cfg.hostName}"
         '')
         (mkBefore ''
           cross_domain_websocket = true;
@@ -237,6 +246,11 @@ in
           smacks_hibernation_time = 60
           smacks_max_hibernated_sessions = 1
           smacks_max_old_sessions = 1
+
+          room_metadata_component = "metadata.${cfg.hostName}"
+          main_muc = "conference.${cfg.hostName}"
+          speakerstats_component = "speakerstats.${cfg.hostName}"
+          conference_duration_component = "conferenceduration.${cfg.hostName}"
         '';
         ssl = {
           cert = "/var/lib/jitsi-meet/jitsi-meet.crt";

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -215,7 +215,7 @@ in
           #-- muc_room_cache_size = 1000
         }
       ];
-      extraModules = [ "conference_duration" "pubsub" "room_metadata" "speakerstats" ];
+      extraModules = [ "conference_duration" "jitsi_session" "pubsub" "room_metadata" "speakerstats" ];
       extraPluginPaths = [ "${pkgs.jitsi-meet-prosody}/share/prosody-plugins" ];
       extraConfig = lib.mkMerge [ (mkAfter ''
         Component "focus.${cfg.hostName}" "client_proxy"

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -205,7 +205,7 @@ in
           #-- muc_room_cache_size = 1000
         }
       ];
-      extraModules = [ "pubsub" "smacks" ];
+      extraModules = [ "conference_duration" "pubsub" "room_metadata" "speakerstats" ];
       extraPluginPaths = [ "${pkgs.jitsi-meet-prosody}/share/prosody-plugins" ];
       extraConfig = lib.mkMerge [ (mkAfter ''
         Component "focus.${cfg.hostName}" "client_proxy"

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -198,6 +198,9 @@ in
         {
           domain = "internal.${cfg.hostName}";
           name = "Jitsi Meet Videobridge MUC";
+          restrictRoomCreation = true;
+          roomLocking = false;
+          roomDefaultPublicJids = true;
           extraConfig = ''
             storage = "memory"
             admins = { "focus@auth.${cfg.hostName}", "jvb@auth.${cfg.hostName}" }


### PR DESCRIPTION
## Description of changes

Update the list of enabled extraModules and instantiated components in Prosody by the jitsi-meet service to match those default-enabled by the official Jitsi Meet Prosody Docker container: https://github.com/jitsi/docker-jitsi-meet/blob/8555fe1c4a7ea434960ec61e7774f1091400d16a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua#L178-L216

Modules already enabled in the Prosody base configuration of NixOS (including “smacks”) were not included in the extraModules. This makes the speaker stats work in the UI (bug fix) and is also part of the prerequirements for the Whiteboard (which requires a bunch of further configuration). Only modules enabled in the minimal Docker image are enabled here, breakout rooms etc would require more modules and config but are not part of the base set so were not considered.*The `jitsi_session` module is manually enabled due to the shipped `room_metadata` missing a dependency on it – this prevented the whiteboard from working for a completely non-obvious reason and [has been fixed only in latest upstream master]([https://github.com/jitsi/jitsi-meet/pull/14012](https://github.com/jitsi/jitsi-meet/pull/14012#event-10837404487)).* Some MUC configuration set in the Docker image was also carried over while I was at it, even if it doesn’t appear to change anything noticable…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
@cleeyv @ryantm

EDIT: Added component instantiations for the added modules and some minor MUC customization done by upstream. Also added workaround for missing dependency of *room_metadata* module on *jitsi_session* (upstream bug fixed in latest master).