### PR TITLE
wyoming-openwakeword: 1.5.1 -> 1.8.1

### DIFF
--- a/nixos/modules/services/audio/wyoming/openwakeword.nix
+++ b/nixos/modules/services/audio/wyoming/openwakeword.nix
@@ -8,6 +8,7 @@ let
   cfg = config.services.wyoming.openwakeword;
 
   inherit (lib)
+    concatStringsSep
     concatMapStringsSep
     escapeShellArgs
     mkOption
@@ -15,6 +16,7 @@ let
     mkEnableOption
     mkIf
     mkPackageOptionMD
+    mkRemovedOptionModule
     types
     ;
 
@@ -25,6 +27,10 @@ let
 in
 
 {
+  imports = [
+    (mkRemovedOptionModule [ "services" "wyoming" "openwakeword" "models" ] "Configuring models has been removed, they are now dynamically discovered and loaded at runtime")
+  ];
+
   meta.buildDocsInSandbox = false;
 
   options.services.wyoming.openwakeword = with types; {
@@ -41,24 +47,25 @@ in
       '';
     };
 
-    models = mkOption {
-      type = listOf str;
-      default = [
-        # wyoming_openwakeword/models/*.tflite
-        "alexa"
-        "hey_jarvis"
-        "hey_mycroft"
-        "hey_rhasspy"
-        "ok_nabu"
-      ];
-      description = mdDoc ''
-        List of wake word models that should be made available.
+    customModelsDirectories = mkOption {
+      type = listOf types.path;
+      default = [];
+      description = lib.mdDoc ''
+        Paths to directories with custom wake word models (*.tflite model files).
       '';
     };
 
     preloadModels = mkOption {
       type = listOf str;
       default = [
+        "ok_nabu"
+      ];
+      example = [
+        # wyoming_openwakeword/models/*.tflite
+        "alexa"
+        "hey_jarvis"
+        "hey_mycroft"
+        "hey_rhasspy"
         "ok_nabu"
       ];
       description = mdDoc ''
@@ -112,14 +119,15 @@ in
         DynamicUser = true;
         User = "wyoming-openwakeword";
         # https://github.com/home-assistant/addons/blob/master/openwakeword/rootfs/etc/s6-overlay/s6-rc.d/openwakeword/run
-        ExecStart = ''
-          ${cfg.package}/bin/wyoming-openwakeword \
-            --uri ${cfg.uri} \
-            ${concatMapStringsSep " " (model: "--model ${model}") cfg.models} \
-            ${concatMapStringsSep " " (model: "--preload-model ${model}") cfg.preloadModels} \
-            --threshold ${cfg.threshold} \
-            --trigger-level ${cfg.triggerLevel} ${cfg.extraArgs}
-        '';
+        ExecStart = concatStringsSep " " [
+          "${cfg.package}/bin/wyoming-openwakeword"
+          "--uri ${cfg.uri}"
+          (concatMapStringsSep " " (model: "--preload-model ${model}") cfg.preloadModels)
+          (concatMapStringsSep " " (dir: "--custom-model-dir ${toString dir}") cfg.customModelDirectories)
+          "--threshold ${cfg.threshold}"
+          "--trigger-level ${cfg.triggerLevel}"
+          "${cfg.extraArgs}"
+        ];
         CapabilityBoundingSet = "";
         DeviceAllow = "";
         DevicePolicy = "closed";

--- a/pkgs/tools/audio/wyoming/openwakeword.nix
+++ b/pkgs/tools/audio/wyoming/openwakeword.nix
@@ -1,52 +1,41 @@
 { lib
-, python3
 , python3Packages
 , fetchFromGitHub
 , fetchpatch
 }:
 
-python3.pkgs.buildPythonApplication {
+python3Packages.buildPythonApplication rec {
   pname = "wyoming-openwakeword";
-  version = "1.5.1";
+  version = "1.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
-    repo = "rhasspy3";
-    rev = "e16d7d374a64f671db48142c7b635b327660ebcf";
-    hash = "sha256-SbWsRmR1hfuU3yJbuu+r7M43ugHeNwLgu5S8MqkbCQA=";
+    repo = "wyoming-openwakeword";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-N/EjdNQLsYLpJ4kOxY/z+/dMMmF1PPAIEEzSHfnZWaM=";
   };
 
   patches = [
     (fetchpatch {
       # import tflite entrypoint from tensorflow
-      url = "https://github.com/rhasspy/rhasspy3/commit/23b1bc9cf1e9aa78453feb11e27d5dafe26de068.patch";
-      hash = "sha256-fjLJ+VI4c8ABBWx1IjZ6nS8MGqdry4rgcThKiaAvz+Q=";
+      url = "https://github.com/rhasspy/wyoming-openwakeword/commit/8f4ba2750d8c545e77549a7230cdee1301dac09a.patch";
+      hash = "sha256-WPvywpGv0sYYVGc7he4bt7APIsa3ziKaWqpFlx3v+V8=";
     })
     (fetchpatch {
       # add commandline entrypoint
-      url = "https://github.com/rhasspy/rhasspy3/commit/7662b82cd85e16817a3c6f4153e855bf57436ac3.patch";
-      hash = "sha256-41CLkVDSAJJpZ5irwIf/Z4wHoCuKDrqFBAjKCx7ta50=";
+      url = "https://github.com/rhasspy/wyoming-openwakeword/commit/f40e5635543b2315217538dd89a9fe40fe817cfe.patch";
+      hash = "sha256-HNlGqt7bMzwyvhx5Hw7mkTHeQmBpgDCU3pUbZzss1bY=";
     })
   ];
 
-  postPatch = ''
-    cd programs/wake/openwakeword-lite/server
-  '';
-
   nativeBuildInputs = with python3Packages; [
     setuptools
-    wheel
   ];
 
   propagatedBuildInputs = with python3Packages; [
-    tensorflow-bin
-    webrtc-noise-gain
+    tensorflow
     wyoming
-  ];
-
-  passthru.optional-dependencies.webrtc = with python3Packages; [
-    webrtc-noise-gain
   ];
 
   pythonImportsCheck = [
@@ -54,8 +43,9 @@ python3.pkgs.buildPythonApplication {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/rhasspy/wyoming-openwakeword/blob/v${version}/CHANGELOG.md";
     description = "An open source voice assistant toolkit for many human languages";
-    homepage = "https://github.com/rhasspy/rhasspy3/commit/fe44635132079db74d0c76c6b3553b842aa1e318";
+    homepage = "https://github.com/rhasspy/wyoming-openwakeword";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
     mainProgram = "wyoming-openwakeword";


### PR DESCRIPTION
```
commit e458280606907749759bcb323c09ba652045b3ef (HEAD -> wyoming-openwakeword-1.8.1, mweinelt/wyoming-openwakeword-1.8.1)
Author: Martin Weinelt <hexa@darmstadt.ccc.de>
Date:   Mon Oct 30 17:57:48 2023 +0100

    nixos/wyoming/openwakeword: update for 1.8.1
    
    Remove the deprecated --models option, as models are now discovered
    and loaded dynamically from all configured model dirs at runtime.
    
    Allow setting up custom model directories, so wake words other than the
    built-in ones can be used, e.g. from
    https://github.com/fwartner/home-assistant-wakewords-collection.

commit 48e6ac6d4fccb3dbce456229f78500ffe7e36d4b
Author: Martin Weinelt <hexa@darmstadt.ccc.de>
Date:   Mon Oct 30 17:43:07 2023 +0100

    wyoming-openwakeword: 1.5.1 -> 1.8.1
    
    https://github.com/rhasspy/wyoming-openwakeword/blob/v1.8.1/CHANGELOG.md
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
