### PR TITLE
nominatim: fix issues with package

### DIFF
--- a/pkgs/servers/nominatim/default.nix
+++ b/pkgs/servers/nominatim/default.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, fetchFromGitHub, fetchurl
-, clang-tools, cmake, bzip2, zlib, expat, boost, git, pandoc, gzip
-, postgresql_12
-, python3, python3Packages, php
+, clang-tools, cmake, bzip2, zlib, expat, boost, git, pandoc
+# Nominatim needs to be built with the same postgres version it will target
+, postgresql
+, python3, php
 }:
 
 let
@@ -36,21 +37,19 @@ stdenv.mkDerivation rec {
     zlib
     expat
     boost
-    python3
+    (python3.withPackages (ps: with ps; [
+      pyyaml
+      python-dotenv
+      psycopg2
+      psutil
+      jinja2
+      pyicu
+      datrie
+    ]))
     # python3Packages.pylint  # We don't want to run pylint because the package could break on pylint bumps which is really annoying.
     # python3Packages.pytest  # disabled since I can't get it to run tests anyway
     # python3Packages.behave  # disabled since I can't get it to run tests anyway
-    postgresql_12
-  ];
-
-  propagatedBuildInputs = with python3Packages; [
-    pyyaml
-    python-dotenv
-    psycopg2
-    psutil
-    jinja2
-    pyicu
-    datrie
+    postgresql
   ];
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1953,7 +1953,9 @@ with pkgs;
 
   node-glob = callPackage ../tools/misc/node-glob { };
 
-  nominatim = callPackage ../servers/nominatim { };
+  nominatim = callPackage ../servers/nominatim {
+    postgresql = postgresql_12;
+  };
 
   npm-check-updates = callPackage ../tools/package-management/npm-check-updates { };
 


### PR DESCRIPTION
There are two issues that make the package unusable as is:
- The python dependencies are not taken into account, giving import errors on launch
   ```
   Traceback (most recent call last):
     File "/home/traxys/Documents/nixpkgs/./result/bin/nominatim", line 9, in <module>
       from nominatim import cli
     File "/nix/store/nii59hzhnns46wknvmbhc4ifqflmc2qq-nominatim-4.0.1/lib/nominatim/lib-python/nominatim/cli.py", line 11, in <module>
       from nominatim.config import Configuration
     File "/nix/store/nii59hzhnns46wknvmbhc4ifqflmc2qq-nominatim-4.0.1/lib/nominatim/lib-python/nominatim/config.py", line 8, in <module>
       import yaml
   ModuleNotFoundError: No module named 'yaml'
   ```
- nominatim needs to be built with the same postgres version it will run on. It's a bit dirty to do an override `postgresql_12 = postgresql_another_version`, so this commit adds a `postgres` attribute to be more consistent

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
