### PR TITLE
joycond-cemuhook: init at unstable-2023-08-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12995,6 +12995,13 @@
     githubId = 40049608;
     name = "Andy Chun";
   };
+  noodlez1232 = {
+    email = "contact@nathanielbarragan.xyz";
+    matrix = "@noodlez1232:matrix.org";
+    github = "Noodlez1232";
+    githubId = 12480453;
+    name = "Nathaniel Barragan";
+  };
   nook = {
     name = "Tom Nook";
     email = "0xnook@protonmail.com";

--- a/nixos/modules/programs/joycond-cemuhook.nix
+++ b/nixos/modules/programs/joycond-cemuhook.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, config, ... }:
+with lib;
+{
+  options.programs.joycond-cemuhook = {
+    enable = mkEnableOption (lib.mdDoc "joycond-cemuhook, a program to enable support for cemuhook's UDP protocol for joycond devices.");
+  };
+
+  config = lib.mkIf config.programs.joycond-cemuhook.enable {
+    assertions = [
+      {
+        assertion = config.services.joycond.enable;
+        message = "joycond must be enabled through `services.joycond.enable`";
+      }
+    ];
+    environment.systemPackages = [ pkgs.joycond-cemuhook ];
+  };
+}

--- a/pkgs/by-name/jo/joycond-cemuhook/package.nix
+++ b/pkgs/by-name/jo/joycond-cemuhook/package.nix
@@ -1,0 +1,36 @@
+{ lib, python3Packages, fetchFromGitHub}:
+
+python3Packages.buildPythonApplication {
+  pname = "joycond-cemuhook";
+  pyproject = true;
+  version = "unstable-2023-08-09";
+
+  src = fetchFromGitHub {
+    owner = "joaorb64";
+    repo = "joycond-cemuhook";
+    rev = "3c0e07374ff431a0f8ae70dbb0b5a62fb3de06ee";
+    hash = "sha256-K24CEmYWhgkvVX4geg2bylH8TSvHIpsWjsPwY5BpquI=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    setuptools-git-versioning
+    setuptools-git
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    dbus-python
+    evdev
+    pyudev
+    termcolor
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/joaorb64/joycond-cemuhook";
+    description = "Support for cemuhook's UDP protocol for joycond devices";
+    license = licenses.mit;
+    maintainers = [ maintainers.noodlez1232 ];
+    mainProgram = "joycond-cemuhook";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
