### PR TITLE
keym: init at unstable-2022-07-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3504,6 +3504,12 @@
     githubId = 40290417;
     name = "Seb Blair";
   };
+  CompileTime = {
+    email = "socialcoms@posteo.de";
+    github = "Compile-Time";
+    githubId = 18414241;
+    name = "Andreas Erdes";
+  };
   confus = {
     email = "con-f-use@gmx.net";
     github = "con-f-use";

--- a/pkgs/by-name/ke/keym/package.nix
+++ b/pkgs/by-name/ke/keym/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libX11
+, libXtst
+, libXi
+}:
+
+stdenv.mkDerivation {
+  pname = "keym";
+  version = "unstable-2022-07-10";
+
+  src = fetchFromGitHub {
+    owner = "cwkx";
+    repo = "keym";
+    rev = "67a6d39d45e17221353e06c39283b5636b46d25c";
+    hash = "sha256-v2eS7un2ABnpWBwuKq+0CeLX8ivtlNUjM2jRboKumOE=";
+  };
+
+  buildInputs = [ libX11 libXtst libXi ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cwkx/keym";
+    description = "C tool to control mouse with keyboard for X11";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "keym";
+    maintainers = with maintainers; [ CompileTime ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This pull request add a simple derivation for the tool "keym": https://github.com/cwkx/keym

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
