### PR TITLE
pandoc: remove GHC & haskell deps from closure, 5.2G => 250M

### DIFF
--- a/pkgs/development/tools/pandoc/default.nix
+++ b/pkgs/development/tools/pandoc/default.nix
@@ -24,6 +24,9 @@ in
       remove-references-to \
         -t ${haskellPackages.warp} \
         $out/bin/pandoc
+      remove-references-to \
+        -t ${haskellPackages.pandoc_3_1_8} \
+        $out/bin/pandoc
     '' + lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
       mkdir -p $out/share/bash-completion/completions
       $out/bin/pandoc --bash-completion > $out/share/bash-completion/completions/pandoc
@@ -36,5 +39,5 @@ in
     # lead to a transitive runtime dependency on the whole GHC distribution.
     # This should ideally be fixed in haskellPackages (or even Cabal),
     # but a minimal pandoc is important enough to patch it manually.
-    disallowedReferences = [ haskellPackages.pandoc-types haskellPackages.warp ];
+    disallowedReferences = [ haskellPackages.pandoc-types haskellPackages.warp haskellPackages.pandoc_3_1_8 ];
   })


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/264423, except it's targetting haskell-updates. (I'm too affraid doing something wrong and mass-pinging ppl on the other one)

## Description of changes

The Haskell dependencies were leaking through a haskellPackages.pandoc stray references:

$ strings ./result/bin/pandoc | grep /nix/store
 (...)
/nix/store/xk2acjd6587wyskg85xg54lj89mrvrv0-pandoc-3.1.8/etc /nix/store/xk2acjd6587wyskg85xg54lj89mrvrv0-pandoc-3.1.8/libexec/x86_64-linux-ghc-9.4.7/pandoc-3.1.8 /nix/store/l9mzh2nlq5qs50yfvb3ymphfpas0j7pd-pandoc-3.1.8-data/share/ghc-9.4.7/x86_64-linux-ghc-9.4.7/pandoc-3.1.8 /nix/store/xk2acjd6587wyskg85xg54lj89mrvrv0-pandoc-3.1.8/lib/ghc-9.4.7/x86_64-linux-ghc-9.4.7 /nix/store/xk2acjd6587wyskg85xg54lj89mrvrv0-pandoc-3.1.8/lib/ghc-9.4.7/x86_64-linux-ghc-9.4.7/pandoc-3.1.8-DUwbvTsa4nj3Hikhs5AQGF /nix/store/xk2acjd6587wyskg85xg54lj89mrvrv0-pandoc-3.1.8/bin

Removing these references using "remove-reference-to".

Before:
$ nix path-info --closure-size -h $(nix-build -A pandoc)
/nix/store/np2f5g1x25fgkp6q10n5p14352899km7-pandoc-cli-0.1.1.1     5.2G

After:
$ nix path-info --closure-size -h $(nix-build -A pandoc)
/nix/store/fpl2h3qs6vm0vb5cibb7cswzm90hc4yx-pandoc-cli-0.1.1.1   250.5M

Fixes https://github.com/NixOS/nixpkgs/issues/264399

Cc @maralorn 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
