### PR TITLE
video-downloader: init at 0.12.20

### DIFF
--- a/pkgs/by-name/vi/video-downloader/package.nix
+++ b/pkgs/by-name/vi/video-downloader/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  ffmpeg,
+  python3Packages,
+  meson,
+  yt-dlp,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  ninja,
+  gobject-introspection,
+  glib,
+  pkg-config,
+  gtk4,
+  librsvg,
+  libadwaita,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "video-downloader";
+  version = "0.12.20";
+  pyproject = false; # Built with meson
+
+  src = fetchFromGitHub {
+    owner = "Unrud";
+    repo = "video-downloader";
+    tag = "v${version}";
+    hash = "sha256-UaSEcqD4hYRacQfLHgkXgO+/lIV5GxMX9NDOTLhTw+o=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    yt-dlp
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    wrapGAppsHook4
+    desktop-file-utils
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    librsvg
+    libadwaita
+  ];
+
+  # would require network connectivity
+  doCheck = false;
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
+    )
+  '';
+
+  meta = {
+    homepage = "https://github.com/Unrud/video-downloader";
+    changelog = "https://github.com/Unrud/video-downloader/releases";
+    description = "GUI application based on yt-dlp";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ fliegendewurst ];
+    mainProgram = "video-downloader";
+  };
+}


### PR DESCRIPTION
## Description of changes

Simple package of https://github.com/Unrud/video-downloader.

Fixes #239832

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): downloading works
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).