### PR TITLE
python311Packages.objax: disable tests to fix build

### DIFF
--- a/pkgs/development/python-modules/objax/default.nix
+++ b/pkgs/development/python-modules/objax/default.nix
@@ -1,13 +1,17 @@
 { lib
-, fetchFromGitHub
 , buildPythonPackage
-, jax
+, fetchFromGitHub
+, fetchpatch
 , jaxlib
+, jax
 , numpy
 , parameterized
 , pillow
 , scipy
 , tensorboard
+, keras
+, pytestCheckHook
+, tensorflow
 }:
 
 buildPythonPackage rec {
@@ -17,9 +21,16 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "objax";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-1/XmxFZfU+XMD0Mlcv4xTUYZDwltAx1bZOlPuKWQQC0=";
   };
+
+  patches = [
+    (fetchpatch {  # https://github.com/google/objax/pull/266
+      url = "https://github.com/google/objax/pull/266/commits/a1bcb71ebd92c94fec98222349d7cd57048e541d.patch";
+      hash = "sha256-MO9/LAxbghjhRU8sbYWm3xa4RPuU+5m74YU3n3hJ09s=";
+    })
+  ];
 
   # Avoid propagating the dependency on `jaxlib`, see
   # https://github.com/NixOS/nixpkgs/issues/156767
@@ -38,6 +49,25 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "objax"
+  ];
+
+  # This is necessay to ignore the presence of two protobufs version (tensorflow is bringing an
+  # older version).
+  catchConflicts = false;
+
+  nativeCheckInputs = [
+    keras
+    pytestCheckHook
+    tensorflow
+  ];
+
+  pytestFlagsArray = [
+    "tests/*.py"
+  ];
+
+  disabledTests = [
+    # Test requires internet access for prefetching some weights
+    "test_pretrained_keras_weight_0_ResNet50V2"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

I cannot get the tests do run (duplicate packages in the closure)... so I disabled them.

In case anyone has an idea, here are the logs when I tried to add `pytestCheckHook` and `tensorflow` to `nativeCheckInputs`:

<details>

cc @ndl 

```
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
running install tests
no Makefile or custom installCheckPhase, doing nothing
pythonCatchConflictsPhase
/nix/store/q2zpnf017gccs9w9mb0ikdqhkf0k5v82-catch_conflicts.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
Found duplicated packages in closure for dependency 'grpcio':
  grpcio 1.27.3 (/nix/store/kvznrm3za4rxf3q106jq3q018rh65dyr-python3.11-grpcio-1.27.3/lib/python3.11/site-packages)
  grpcio 1.57.0 (/nix/store/0n366229mzg5ncdpk980fg07s89bsxvf-python3.11-grpcio-1.57.0/lib/python3.11/site-packages)
Found duplicated packages in closure for dependency 'protobuf':
  protobuf 4.21.12 (/nix/store/hngkl1d0n2j0cw3nv32jadgrfmqwy0c3-python3.11-protobuf-4.21.12/lib/python3.11/site-packages)
  protobuf 4.24.3 (/nix/store/6yd51vrzfmnzkr6pn7f8kwarwgdqwf8q-python3.11-protobuf-4.24.3/lib/python3.11/site-packages)
Found duplicated packages in closure for dependency 'tensorboard':
  tensorboard 2.14.0 (/nix/store/7kif9z36wy7z1hmnhkfzkp53l53aidcz-python3.11-tensorboard-2.14.0/lib/python3.11/site-packages)
  tensorboard 2.14.0 (/nix/store/5pm36bkbwgrrivhwd81kw493kkdippvz-python3.11-tensorboard-2.14.0/lib/python3.11/site-packages)
Found duplicated packages in closure for dependency 'tensorboard-plugin-profile':
  tensorboard-plugin-profile 2.11.1 (/nix/store/10d5h4x52znxm77n1aghm8bbaj8pzagw-python3.11-tensorboard_plugin_profile-2.11.1/lib/python3.11/site-packages)
  tensorboard-plugin-profile 2.11.1 (/nix/store/39g69ya6495jv0iszkww5ppjqnhnqp4x-python3.11-tensorboard_plugin_profile-2.11.1/lib/python3.11/site-packages)

Package duplicates found in closure, see above. Usually this happens if two packages depend on different version of the same dependency.
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
