### PR TITLE
memtree: init at unstable-2023-11-04

### DIFF
--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, nix-update-script
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "memtree";
+  version = "unstable-2023-11-04";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nbraud";
+    repo = "memtree";
+    rev = "093caeef26ee944b5bf4408710f63494e442b5ff";
+    hash = "sha256-j4LqWy7DxeV7pjwnCfpkHwug4p48kux6BM6oDJmvuUo=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    rich
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    hypothesis
+    pytest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    python -m pytest -v
+    runHook postCheck
+  '';
+
+  pythonImportChecks = [ "memtree" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = with lib; {
+    description = "Render cgroups tree annotated by memory usage";
+    homepage = "https://github.com/nbraud/memtree";
+    maintainers = with maintainers; [ nicoo ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Packaged new utility `memtree`, which renders a cgroups
tree, coloring and sorting based on memory usage.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
