### PR TITLE
bork: init at 7.0.0

### DIFF
--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -33,6 +33,12 @@ buildPythonPackage rec {
     wheel
   ];
 
+  pythonImportsCheck = [
+    "bork"
+    "bork.api"
+    "bork.cli"
+  ];
+
   meta = with lib; {
     description = "Python build and release management tool";
     homepage = "https://github.com/duckinator/bork";

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+
+, build
+, click
+, coloredlogs
+, packaging
+, toml
+, twine
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "bork";
+  version = "7.0.0";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "duckinator";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-frwkU2YesYK0RJNz9yqiXj1XeTZ8jg5oClri4hEYokg=";
+  };
+
+  propagatedBuildInputs = [
+    build
+    click
+    coloredlogs
+    packaging
+    toml
+    twine
+    wheel
+  ];
+
+  meta = with lib; {
+    description = "Python build and release management tool";
+    homepage = "https://github.com/duckinator/bork";
+    maintainers = with maintainers; [ nicoo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -4,7 +4,6 @@
 , pythonOlder
 
 , build
-, click
 , coloredlogs
 , packaging
 , toml
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     build
-    click
     coloredlogs
     packaging
     toml

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1569,6 +1569,8 @@ self: super: with self; {
     enablePython = true;
   });
 
+  bork = callPackage ../development/python-modules/bork { };
+
   boschshcpy = callPackage ../development/python-modules/boschshcpy { };
 
   bottombar = callPackage ../development/python-modules/bottombar { };


### PR DESCRIPTION
## Description of changes

Packaged `bork` v7.0.0, a Python build and release management tool.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
