### PR TITLE
[23.05] bitwarden: 2023.4.0 -> 2023.9.3

### DIFF
--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -1,10 +1,8 @@
 { lib
-, applyPatches
 , buildNpmPackage
 , dbus
-, electron_24
+, electron_25
 , fetchFromGitHub
-, fetchpatch
 , glib
 , gnome
 , gtk3
@@ -25,31 +23,21 @@ let
   icon = "bitwarden";
 
   buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_18; };
-  electron = electron_24;
+  electron = electron_25;
 
-  version = "2023.4.0";
-  src = applyPatches {
-    src = fetchFromGitHub {
-      owner = "bitwarden";
-      repo = "clients";
-      rev = "desktop-v${version}";
-      sha256 = "sha256-TTKDl6Py3k+fAy/kcyiMbAAKQdhVnZTyRXV8D/VpKBE=";
-    };
-
-    patches = [
-      # Bump electron to 24 and node to 18
-      (fetchpatch {
-        url = "https://github.com/bitwarden/clients/pull/5205.patch";
-        hash = "sha256-sKSrh8RHXtxGczyZScjTeiGZgTZCQ7f45ULj/j9cp6M=";
-      })
-    ];
+  version = "2023.9.3";
+  src = fetchFromGitHub {
+    owner = "bitwarden";
+    repo = "clients";
+    rev = "desktop-v${version}";
+    sha256 = "sha256-NiMJmtCx+yD24BCyMgHLpRApNwoIJRps5qmmlVdB0G0=";
   };
 
   desktop-native = rustPlatform.buildRustPackage {
     pname = "bitwarden-desktop-native";
     inherit src version;
-    sourceRoot = "source-patched/apps/desktop/desktop_native";
-    cargoSha256 = "sha256-VW9DmSh9jvqFCZjH1SAYkydSGjXSVEbv4CmtoJBiw5Y=";
+    sourceRoot = "${src.name}/apps/desktop/desktop_native";
+    cargoSha256 = "sha256-1A5YfgiUHeyvyHEBe5MrC/MkQRZFbDkTaGKN0JY0pp4=";
 
     nativeBuildInputs = [
       pkg-config
@@ -102,7 +90,7 @@ buildNpmPackage' {
   npmBuildFlags = [
     "--workspace apps/desktop"
   ];
-  npmDepsHash = "sha256-UXDn09qyM8GwfUiWLDhhyrGFZeKtTRmQArstw+tm5iE=";
+  npmDepsHash = "sha256-HQPxmATA9bUc4NTfvYsL6fGuicU9baySCmNHahs8EF4=";
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
## Description of changes

Backport from master, but backport failed because there have been a lot of changes. This tries to be a minimal backport. Notably, trying to backport 8aba8953dc6c4814022748eea02eece4002adcd7 caused build failures, presumably due to some difference in buildNpmPackage.

Backport is needed to get off insecure electron_24.

Compare with https://github.com/NixOS/nixpkgs/pull/264472

## Things done

I have only tested in a lightweight sandbox due to needing to hide the GPU to disable hardware accel. as GL drivers fail to load due to glibc version conflict (as my system is on nixos-unstable).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
