### PR TITLE
wifi4wofi: Init at unstable-2023-08-24

### DIFF
--- a/pkgs/applications/misc/wifi4wofi/default.nix
+++ b/pkgs/applications/misc/wifi4wofi/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, iw
+, networkmanager
+, wofi
+, yad
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wifi4wofi";
+  version = "unstable-2023-08-24";
+
+  src = fetchFromGitHub {
+    owner = "fearlessgeekmedia";
+    repo = "wifi4wofi";
+    rev = "03f809a14fdf10acaeb56b09e3fa2e3bf1fd6200";
+    hash = "sha256-a3nLCYZhXcW9dKdPUBp7z98tM7jaCSk1AaebfIde2tg=";
+  };
+
+  buildInputs = [ iw networkmanager wofi yad ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/${pname} $out/bin/${pname}
+  '';
+
+  meta = with lib; {
+    description = "A fork of wofi-wifi-menu. A wifi menu for wofi";
+    homepage = "https://github.com/fearlessgeekmedia/wifi4wofi";
+    changelog = "https://github.com/fearlessgeekmedia/wifi4wofi/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    mainProgram = "wifi4wofi";
+    inherit (wofi.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36514,6 +36514,8 @@ with pkgs;
 
   wofi-emoji = callPackage ../applications/misc/wofi-emoji { };
 
+  wifi4wofi = callPackage ../applications/misc/wifi4wofi { };
+
   cl-wordle = callPackage ../games/cl-wordle { };
 
   wordbook = callPackage ../applications/misc/wordbook { };


### PR DESCRIPTION
Closes #264009

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
