### PR TITLE
menulibre: init at 2.2.3

### DIFF
--- a/pkgs/by-name/me/menulibre/package.nix
+++ b/pkgs/by-name/me/menulibre/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, gnome-menus
+, gtk3
+, intltool
+, gobject-introspection
+, wrapGAppsHook
+, testers
+, menulibre
+}:
+
+python3Packages.buildPythonApplication rec {
+  name = "menulibre";
+  version = "2.2.3";
+
+  src = fetchFromGitHub {
+    owner = "bluesabre";
+    repo = "menulibre";
+    rev = "menulibre-${version}";
+    hash = "sha256-E0ukq3q4YaakOI2mDs3dh0ncZX/dqspCA+97r3JwWyA=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    gnome-menus
+    psutil
+    distutils-extra
+  ];
+
+  nativeBuildInputs = [
+    gtk3
+    intltool
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'data_dir =' "data_dir = '$out/share/menulibre' #" \
+      --replace-fail 'update_desktop_file(desktop_file, script_path)' ""
+  '';
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = menulibre;
+    command = "HOME=$TMPDIR menulibre --version | cut -d' ' -f2";
+  };
+
+  meta = with lib; {
+    description = "An advanced menu editor with an easy-to-use interface";
+    homepage = "https://bluesabre.org/projects/menulibre";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lelgenio ];
+    mainProgram = "menulibre";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

MenuLibre is an advanced menu editor that provides modern features in a clean, easy-to-use interface. 

Homepage: https://bluesabre.org/projects/menulibre
Repo: https://github.com/bluesabre/menulibre

Fixes: #84652 

Currently is does not seem to fill all icons for categories correctly, but that also happens in the flatpak version.

![image](https://github.com/NixOS/nixpkgs/assets/31388299/0c39398d-e7b1-4e21-9fe7-54f97ed73086)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
