### PR TITLE
c0: unstable-2022-10-25 -> unstable-2023-09-05

### DIFF
--- a/pkgs/development/compilers/c0/default.nix
+++ b/pkgs/development/compilers/c0/default.nix
@@ -10,17 +10,18 @@
 , libpng
 , ncurses
 , readline
+, unstableGitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "c0";
-  version = "unstable-2022-10-25";
+  version = "unstable-2023-09-05";
 
   src = fetchFromBitbucket {
     owner = "c0-lang";
     repo = "c0";
-    rev = "7ef3bc9ca232ec41936e93ec8957051e48cacfba";
-    sha256 = "sha256-uahF8fOp2ZJE8EhZke46sbPmN0MNHzsLkU4EXkV710U=";
+    rev = "608f97eef5d81bb85963d66f955730dd93996f67";
+    hash = "sha256-lRIEtclx+NKxAO72nsvnxVeEGCEe6glC6w8MXh1HEwY=";
   };
 
   patches = [
@@ -66,6 +67,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/emacs/site-lisp
     mv $out/c0-mode/ $out/share/emacs/site-lisp/
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://bitbucket.org/c0-lang/c0.git";
+  };
 
   meta = with lib; {
     description = "A small safe subset of the C programming language, augmented with contracts";


### PR DESCRIPTION
Diff: https://bitbucket.org/c0-lang/c0/branches/compare/608f97eef5d81bb85963d66f955730dd93996f67%0D7ef3bc9ca232ec41936e93ec8957051e48cacfba#diff

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
