### PR TITLE
ocaml-top: cleaning

### DIFF
--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -1,10 +1,8 @@
-{ lib, fetchFromGitHub, ncurses, ocamlPackages }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
 with ocamlPackages; buildDunePackage rec {
   pname = "ocaml-top";
   version = "1.2.0";
-
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
@@ -13,13 +11,7 @@ with ocamlPackages; buildDunePackage rec {
     hash = "sha256-xmPGGB/zUpfeAxUIhR1PhfoESAJq7sTpqHuf++EH3Lw=";
   };
 
-  nativeBuildInputs = [ ocp-build ];
-  buildInputs = [ ncurses lablgtk3-sourceview3 ocp-index ];
-
-  configurePhase = ''
-    export TERM=xterm
-    ocp-build -init
-  '';
+  buildInputs = [ lablgtk3-sourceview3 ocp-index ];
 
   meta = {
     homepage = "https://www.typerex.org/ocaml-top.html";

--- a/pkgs/development/tools/ocaml/ocamlify/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlify/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "ocamlify is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocamlify";
   version = "0.0.2";

--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, ncurses, cmdliner_1_0, re }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "ocp-build is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ocp-build";
   version = "1.99.21";


### PR DESCRIPTION
## Description of changes

This makes it possible to build `ocaml-top` with latest versions of OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
