### PR TITLE
python3.pkgs.mastodon-py: 1.8.1 -> unstable-2023-06-24 (fixes build)

### DIFF
--- a/pkgs/development/python-modules/mastodon-py/default.nix
+++ b/pkgs/development/python-modules/mastodon-py/default.nix
@@ -14,24 +14,23 @@
 , pytest-mock
 , pytest-vcr
 , requests-mock
+, setuptools
+, pytest-cov
 }:
 
 buildPythonPackage rec {
   pname = "mastodon-py";
-  version = "1.8.1";
+  # tests are broken on last release, check after next release (> 1.8.1)
+  version = "unstable-2023-06-24";
 
-  format = "setuptools";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "halcy";
     repo = "Mastodon.py";
-    rev = "refs/tags/${version}";
-    hash = "sha256-r0AAUjd2MBfZANEpyztMNyaQTlGWvWoUVjJNO1eL218=";
+    rev = "cd86887d88bbc07de462d1e00a8fbc3d956c0151";
+    hash = "sha256-rJocFvtBPrSSny3lwENuRsQdAzi3u8b+SfDNGloniWI=";
   };
-
-  postPatch = ''
-    sed -i '/^addopts/d' setup.cfg
-  '';
 
   propagatedBuildInputs = [
     blurhash
@@ -49,7 +48,9 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-mock
     pytest-vcr
+    pytest-cov
     requests-mock
+    setuptools
   ];
 
   pythonImportsCheck = [ "mastodon" ];


### PR DESCRIPTION
Tests on current version breaks. Checking the git log shows that there CI have been broken for a long time. Now it seems stable again

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
