### PR TITLE
picom-allusive: 0.3.2 -> 1.2.3

### DIFF
--- a/pkgs/applications/window-managers/picom/picom-allusive.nix
+++ b/pkgs/applications/window-managers/picom/picom-allusive.nix
@@ -2,13 +2,13 @@
 
 picom.overrideAttrs (oldAttrs: rec {
   pname = "picom-allusive";
-  version = "0.3.2";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "allusive-dev";
     repo = "picom-allusive";
     rev = version;
-    hash = "sha256-1zWntz2QKp/O9ZuOUZy9NkCNXFsBqRRvcd0SAr+7G/o=";
+    hash = "sha256-SeL6wJNYF/v6ddDGTZ1xlUNRZA//YVrQQ21HVkSaJDI=";
   };
 
   nativeBuildInputs = [ installShellFiles ] ++ oldAttrs.nativeBuildInputs;
@@ -19,7 +19,7 @@ picom.overrideAttrs (oldAttrs: rec {
   '' + (lib.optionalString (oldAttrs ? postInstall) oldAttrs.postInstall);
 
   meta = (builtins.removeAttrs oldAttrs.meta [ "longDescription" ]) // {
-    description = "A fork of picom featuring improved animations and other features";
+    description = "The only Picom fork you will ever need. With Animations and More";
     homepage = "https://github.com/allusive-dev/picom-allusive";
     license = with lib.licenses; [ mit mpl20 ];
     maintainers = with lib.maintainers; [ allusive ];


### PR DESCRIPTION
## Description of changes

picom-allusive: 0.3.2 -> 1.2.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
