### PR TITLE
multiviewer-for-f1: 1.26.6 -> 1.28.3

### DIFF
--- a/pkgs/applications/video/multiviewer-for-f1/default.nix
+++ b/pkgs/applications/video/multiviewer-for-f1/default.nix
@@ -23,15 +23,15 @@
 , xorg
 }:
 let
-  id = "123219506";
+  id = "133943726";
 in
 stdenvNoCC.mkDerivation rec {
   pname = "multiviewer-for-f1";
-  version = "1.26.2";
+  version = "1.28.3";
 
   src = fetchurl {
     url = "https://releases.multiviewer.dev/download/${id}/multiviewer-for-f1_${version}_amd64.deb";
-    sha256 = "sha256-nibPVqc4B3PHF/3wR5FsYZGVkkReQjy+4glfdnBysSU=";
+    sha256 = "sha256-xM5HyvUZuRal4X3SUMmLyQpVL3fJ1besgvrAVGo79RE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes
Superseeds #255160
### Program Changelog
#### v1.26.7
- Add more playback rate options
- Live timing seeking now updates while you drag
- Fix various issues related to animating position changes and new radios/race control messages
- Update FIAWEC timing for Fuji
#### v1.26.8
No changelog
#### v1.26.9
- Add audio notification for WEC race control messages
- Add "Laps since pitstop" column for WEC
#### v1.26.10
- Fix IndyCar page not showing
- Updates to sync algorithm
#### v1.26.11
- Update fit/fill button tooltip
- Add analytics to edit live timing layouts (to check if it's found by anyone)
- Add query parameters to to external manifest deeplink for clipping, latency settings
- Various improvements
#### v1.27.0
- New: My List allows you to add videos to watch later, shared across your devices
- Fix weekend warmup casing in schedule
- Add donate banner to the homepage
#### v1.27.1
- Launch of new Chrome/Firefox extension to help sign in and open content in MultiViewer
- Fix login issue related to entitlement token
#### v1.28.0
- New feature: Investigations tracker let's you keep track of all ongoing investigations, reviews and penalties
#### v1.28.1
- Fix: also match new format for multi-car investigations/inchidents
#### v1.28.2
- Hotfix: remove debug code from investigations
#### v1.28.3
- The Investigations Tracker window can now be saved & restored from a setup
- New race control messages are now identified and get icons/colors
- Improved the Investigations Tracker, now supports more message formats
- Lap chart now properly saves to setup, instead of being saved as championship predictions

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
