### PR TITLE
formats.libconfig: fix unstable store path dependency in test

### DIFF
--- a/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/default.nix
@@ -6,12 +6,9 @@ let
     val = 1;
   };
 
-  include_file = (writeText "libconfig-test-include" ''
+  include_file = writeText "libconfig-test-include" ''
     val=1;
-  '').overrideAttrs {
-    outputHashAlgo = "sha256";
-    outputHashMode = "flat";
-  };
+  '';
 
   expression = {
     simple_top_level_attr = "1.0";
@@ -63,12 +60,15 @@ in
 
     doCheck = true;
     checkPhase = ''
-      diff -U3 ${./expected.txt} ${libconfig-test-cfg}
+      cp ${./expected.txt} expected.txt
+      substituteInPlace expected.txt \
+          --subst-var-by include_file "${include_file}"
+      diff -U3 ./expected.txt ${libconfig-test-cfg}
     '';
 
     installPhase = ''
       mkdir $out
-      cp ${./expected.txt} $out/expected.txt
+      cp expected.txt $out
       cp ${libconfig-test-cfg} $out/libconfig-test.cfg
       cp ${libconfig-test-cfg.passthru.json} $out/libconfig-test.json
     '';

--- a/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/expected.txt
+++ b/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/expected.txt
@@ -1,6 +1,6 @@
 array1d=[1, 5, 2];array2d=([1, 2], [2, 1]);list1d=(1, "mixed!", 5, 2);list2d=(1, (1, 1.2, "foo"), ("bar", 1.2, 1));nasty_string="\"@
 \\	^*bf
 0\";'''$";nested={attrset={has={a={integer={value=100;};};};};};simple_top_level_attr="1.0";some_floaty=29.95;weirderTypes={
-@include "/nix/store/jdz5yhzbbj4j77yrr7l20x1cs4kbwkj2-libconfig-test-include"
+@include "@include_file@"
 array_of_ints=[0732, 0xa3, 1234];bigint=9223372036854775807;float=0.0012;hex=0x1fc3;list_of_weird_types=(3.141592654, 9223372036854775807, 0x1fc3, 027, 1.2e-32, 1.0);octal=027;pi=3.141592654;};
 


### PR DESCRIPTION
## Description of changes

Previously, this test would verify a writeText file with a constant content is at a precise store path, but this is not actually the case and the store path has changed maybe twice since the original PR was started (#246115), the latest time being after it was merged.

We now placehold the store path in expected.txt and substitute it just before we run the diff, alleviating the problem.

Fixes https://github.com/NixOS/nixpkgs/pull/246115#issuecomment-1786464121, a `nixpkgs-unstable` regression.

cc @vcunat @h7x4
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
