### PR TITLE
glibc: NVCC aarch64 intrinsics are unsupported

### DIFF
--- a/pkgs/development/libraries/glibc/0001-aarch64-math-vector.h-add-NVCC-include-guard.patch
+++ b/pkgs/development/libraries/glibc/0001-aarch64-math-vector.h-add-NVCC-include-guard.patch
@@ -1,0 +1,37 @@
+From 44d0a3a9bd8c6fe59f6ccb44206a50a900bfcf4a Mon Sep 17 00:00:00 2001
+From: Connor Baker <connor.baker@tweag.io>
+Date: Tue, 31 Oct 2023 14:30:24 +0000
+Subject: [PATCH] aarch64/math-vector.h: add NVCC include guard
+
+---
+ sysdeps/aarch64/fpu/bits/math-vector.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/sysdeps/aarch64/fpu/bits/math-vector.h b/sysdeps/aarch64/fpu/bits/math-vector.h
+index 7c200599c1..583a426494 100644
+--- a/sysdeps/aarch64/fpu/bits/math-vector.h
++++ b/sysdeps/aarch64/fpu/bits/math-vector.h
+@@ -25,17 +25,17 @@
+ /* Get default empty definitions for simd declarations.  */
+ #include <bits/libm-simd-decl-stubs.h>
+ 
+-#if __GNUC_PREREQ(9, 0)
++#if __GNUC_PREREQ(9, 0) && !defined(__CUDACC__)
+ #  define __ADVSIMD_VEC_MATH_SUPPORTED
+ typedef __Float32x4_t __f32x4_t;
+ typedef __Float64x2_t __f64x2_t;
+-#elif __glibc_clang_prereq(8, 0)
++#elif __glibc_clang_prereq(8, 0) && !defined(__CUDACC__)
+ #  define __ADVSIMD_VEC_MATH_SUPPORTED
+ typedef __attribute__ ((__neon_vector_type__ (4))) float __f32x4_t;
+ typedef __attribute__ ((__neon_vector_type__ (2))) double __f64x2_t;
+ #endif
+ 
+-#if __GNUC_PREREQ(10, 0) || __glibc_clang_prereq(11, 0)
++#if (__GNUC_PREREQ(10, 0) || __glibc_clang_prereq(11, 0)) && !defined(__CUDACC__)
+ #  define __SVE_VEC_MATH_SUPPORTED
+ typedef __SVFloat32_t __sv_f32_t;
+ typedef __SVFloat64_t __sv_f64_t;
+-- 
+2.42.0
+


### PR DESCRIPTION
## Context

The GLIBC 2.38 update introduces intrinsics for `aarch64-linux` in `math.h`. NVCC (NVIDIA's CUDA Compiler) is now unable to compile any CUDA file for `aarch64-linux` because it does not support these intrinsics: <https://forums.developer.nvidia.com/t/nvcc-fails-to-build-with-arm-neon-instructions-cpp-vs-cu/248355/2>. As a result, PyTorch, Magma, Jax, and any other CUDA-enabled package now fail to build on `aarch64-linux`.

An alternative approach might be to patch the GLIBC used by NVCC. This approach is not taken for several reasons:

- Users with `config.cudaSupport = true` would need to bootstrap a second copy of Nixpkgs with a `glibc` containing these changes.
- Manually patching NVCC, CMake, and the include paths of a package like Magma was not enough:  CMake's compiler identification routine fails to build its trivial CUDA file because it picks the unpatched GLIBC.
- Assuming a manual patch against NVCC and or the build systems does work, every CUDA-enabled package must incorporate the relevant changes to ensure the unpatched GLIBC does not make its way in.
- This patch follows the precedent set by upstream by guarding against inclusion of these intrinsics when an unsupported compiler is detected. We ensure that only NVCC is affected by this patch.

## Description of changes

GLIBC 2.37 -> 2.38 broke CUDA compilation on ARM because it introduced ARM intrinsics in `math.h`. Here are the ones which are causing the errors: https://github.com/bminor/glibc/blob/36f2487f13e3540be9ee0fb51876b1da72176d3f/sysdeps/aarch64/fpu/bits/math-vector.h#L28-L36.

NVCC declares itself to be the same compiler as its host compiler. This causes inclusion of unsupported `aarch64-linux` intrinsics.

This patch follows the precedent set by upstream by guarding against inclusion of such intrinsics when an unsupported compiler (like NVCC) is detected.

Note: upstream does not intend to fix this. Instead, they place the onus (perhaps rightly) on downstream compilers/pre-processors (like NVCC), with the reasoning that they should not claim to implement a version of a compiler that they do not.

The patch is applied only for `aarch64-linux`.

## References

- GLIBC bug report about this issue: <https://sourceware.org/bugzilla/show_bug.cgi?id=30909>
- GLIBC patch: <https://patchwork.sourceware.org/project/glibc/patch/20230927141839.57421-1-simon.chopin@canonical.com/>
  - Note that this patch was dropped and will not move forward
  - Upstream believes compilers should not pretend to implement recent GCC versions if they do not

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
