### PR TITLE
libdatachannel: 0.19.2 -> 0.19.3, fix include path

### DIFF
--- a/pkgs/development/libraries/libdatachannel/default.nix
+++ b/pkgs/development/libraries/libdatachannel/default.nix
@@ -46,9 +46,9 @@ stdenv.mkDerivation rec {
   ];
 
   postFixup = ''
-    # Fix shared library path that will be incorrect on move to "dev" output
-    substituteInPlace "$dev/lib/cmake/LibDataChannel/LibDataChannelTargets-release.cmake" \
-      --replace "\''${_IMPORT_PREFIX}/lib" "$out/lib"
+    # Fix include path that will be incorrect due to the "dev" output
+    substituteInPlace "$dev/lib/cmake/LibDataChannel/LibDataChannelTargets.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/include" "$dev/include"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libdatachannel/default.nix
+++ b/pkgs/development/libraries/libdatachannel/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libdatachannel";
-  version = "0.19.2";
+  version = "0.19.3";
 
   src = fetchFromGitHub {
     owner = "paullouisageneau";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-x7/jgoaFVfx5j+CP8S/uIwkzjGskEqsY2Jxsd/Mj4VM=";
+    hash = "sha256-Cx+AfoeLOcqlrEVNuvMPJaY6K7ufu07p9XdjNwtPYf0=";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
## Description of changes

Previously it referred to $out/include which doesn't exist.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
