### PR TITLE
[23.05] libtiff: patch for CVE-2023-40745 & CVE-2023-41175

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , nix-update-script
 
 , autoreconfHook
@@ -34,6 +35,18 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # cf. https://bugzilla.redhat.com/2224974
+    (fetchpatch {
+      name = "CVE-2023-40745.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/bdf7b2621c62e04d0408391b7d5611502a752cd0.diff";
+      hash = "sha256-HdU02YJ1/T3dnCT+yG03tUyAHkgeQt1yjZx/auCQxyw=";
+    })
+    # cf. https://bugzilla.redhat.com/2224971
+    (fetchpatch {
+      name = "CVE-2023-41175.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/965fa243004e012adc533ae8e38db3055f101a7f.diff";
+      hash = "sha256-Pvg6JfJWOIaTrfFF0YSREZkS9saTG9IsXnsXtcyKILA=";
+    })
     # FreeImage needs this patch
     ./headers.patch
     # libc++abi 11 has an `#include <version>`, this picks up files name


### PR DESCRIPTION
###### Description of changes

Inspired by https://github.com/NixOS/nixpkgs/pull/264226#issuecomment-1785921434 , this adds two patches to libtiff to fix those CVEs.

Notifying commenter @risicle , maintainer @alyssais

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested this by building the `passthru.test` packages of `libtiff`, and by building/using `hylafaxplus` to send/receive some faxes.
