### PR TITLE
linuxPackages.nvidia_x11: 530.41.03 -> 545.29.02

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -36,21 +36,15 @@ rec {
   };
 
   latest = selectHighestVersion production (generic {
-    version = "530.41.03";
-    sha256_64bit = "sha256-riehapaMhVA/XRYd2jQ8FgJhKwJfSu4V+S4uoKy3hLE=";
-    sha256_aarch64 = "sha256-uM5zMEO/AO32VmqUOzmc05FFm/lz76jPSSaQmeZUlFo=";
-    openSha256 = "sha256-etbtw6LMRUcFoZC9EDDRrTDekV8JFRYmkp3idLaMk5g=";
-    settingsSha256 = "sha256-8KB6T9f+gWl8Ni+uOyrJKiiH5mNx9eyfCcW/RjPTQQA=";
-    persistencedSha256 = "sha256-zrstlt/0YVGnsPGUuBbR9ULutywi2wNDVxh7OhJM7tM=";
+    version = "545.29.02";
+    sha256_64bit = "sha256-RncPlaSjhvBFUCOzWdXSE3PAfRPCIrWAXyJMdLPKuIU=";
+    sha256_aarch64 = "sha256-Y2RDOuDtiIclr06gmLrPDfE5VFmFamXxiIIKtKAewro=";
+    openSha256 = "sha256-PukpOBtG5KvZKWYfJHVQO6SuToJUd/rkjpOlEi8pSmk=";
+    settingsSha256 = "sha256-zj173HCZJaxAbVV/A2sbJ9IPdT1+3yrwyxD+AQdkSD8=";
+    persistencedSha256 = "sha256-mmMi2pfwzI1WYOffMVdD0N1HfbswTGg7o57x9/IiyVU=";
 
     patchFlags = [ "-p1" "-d" "kernel" ];
-    patches = [
-      # source: https://gist.github.com/joanbm/77f0650d45747b9a4dc8e330ade2bf5c
-      (fetchpatch {
-        url = "https://gist.github.com/joanbm/77f0650d45747b9a4dc8e330ade2bf5c/raw/688b612624945926676de28059fe749203b4b549/nvidia-470xx-fix-linux-6.4.patch";
-        hash = "sha256-OyRmezyzqAi7mSJHDjsWQVocSsgJPTW5DvHDFVNX7Dk=";
-      })
-    ];
+    patches = [];
   });
 
   beta = selectHighestVersion latest (generic {

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -69,7 +69,9 @@ stdenv.mkDerivation {
       url = "https://github.com/NVIDIA/nvidia-settings/commit/a7c1f5fce6303a643fadff7d85d59934bd0cf6b6.patch";
       hash = "sha256-ZwF3dRTYt/hO8ELg9weoz1U/XcU93qiJL2d1aq1Jlak=";
     })
-    ++ lib.optional (lib.versionAtLeast nvidia_x11.settingsVersion "515.43.04")
+  ++ lib.optional
+    ((lib.versionAtLeast nvidia_x11.settingsVersion "515.43.04")
+      && (lib.versionOlder nvidia_x11.settingsVersion "545.29"))
     (fetchpatch {
       # fix wayland support for compositors that use wl_output version 4
       url = "https://github.com/NVIDIA/nvidia-settings/pull/99/commits/2e0575197e2b3247deafd2a48f45afc038939a06.patch";


### PR DESCRIPTION
## Description of changes

- Added experimental HDMI 10 bits per component support; enable by loading nvidia-modeset with `hdmi_deepcolor=1`.
- Added support for the CTM, DEGAMMA_LUT, and GAMMA_LUT DRM-KMS CRTC properties. These are used by features such as the "Night Light" feature in GNOME and the "Night Color" feature in KDE, when they are used as Wayland compositors.
- Added CERTIFIED-quality support for GeForce and Workstation GPUs to open kernelmodules. Please see the "Open Linux Kernel Modules" chapter in the README for details.
- Added initial experimental support for runtime D3 (RTD3) power management on Desktop GPUs. Please see the 'PCI-Express Runtime D3 (RTD3) Power Management' chapter in the README for more details.
- Added support for the EGL_ANDROID_native_fence_sync EGL extension and the VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT and VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT Vulkan external handle types when the nvidia-drm kernel module is loaded with the modeset=1 parameter.
- Added experimental support for framebuffer consoles provided by nvidia-drm. On kernels that implement drm_fbdev_generic_setup and drm_aperture_remove_conflicting_pci_framebuffers, nvidia-drm will install a framebuffer console when loaded with both `modeset=1` and `fbdev=1` kernel module parameters. This will replace the Linux boot console driven by a system framebuffer driver such as efifb or vesafb.
- Note that when an nvidia-drm framebuffer console is enabled, unloading nvidia-drm will cause the screen to turn off.
- Updated nvidia-installer to allow installing the driver while an existing NVIDIA driver is already loaded.
- Added support for virtual reality displays, such as the SteamVR platform, on Wayland compositors that support DRM leasing. Support requires xwayland version 22.1.0 and wayland-protocols version 1.22, or later. Tested on sway, minimum version 1.7 with wlroots version 0.15, and also on Kwin, minimum version 5.24.
- Note: Before xwayland 23.2, there is a known issue with HDMI displays where the headset will fail to start a second time after closing SteamVR. This can be worked around by unplugging and replugging in the headset.
- Fixed a bug that prevented VRR (Variable Refresh Rate) from working with Wayland.
- Added support to the NVIDIA VDPAU driver for running in Xwayland. Please refer to the "Xwayland support in VDPAU" section of the README for further details.
- Added libnvidia-gpucomp.so to the driver package. This is a helper library used for GPU shader compilation.
- Removed libnvidia-vulkan-producer.so from the driver package. This helper library is no longer needed by the Wayland WSI.
- Fixed a bug that intermittently caused the display to freeze when resuming from suspend on some Ada GPUs.
- Fixed a bug that could cause monitors to flicker when the performance state changes on Turing GPUs.
- Added support for HDR signaling via the HDR_OUTPUT_METADATA and Colorspace per-connector DRM properties when nvidia-drm is loaded with the `modeset=1` parameter.
- Added support for PRIME render offload to Vulkan Wayland WSI.
- Fixed a bug that could cause modes to fail validation when Option "ModeValidation" "NoExtendedGpuCapabilitiesCheck" is specified in xorg.conf.
- Fixed a bug which could cause some DisplayPort monitors to flicker.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
