### PR TITLE
nixos/unpoller: allow host paths for password files

### DIFF
--- a/nixos/modules/services/monitoring/unpoller.nix
+++ b/nixos/modules/services/monitoring/unpoller.nix
@@ -89,12 +89,15 @@ in {
         '';
       };
       pass = mkOption {
-        type = types.path;
+        type = types.str;
         default = pkgs.writeText "unpoller-influxdb-default.password" "unifipoller";
         defaultText = literalExpression "unpoller-influxdb-default.password";
         description = lib.mdDoc ''
-          Path of a file containing the password for influxdb.
-          This file needs to be readable by the unifi-poller user.
+          Path of a file containing the password for influxdb. This can be
+          either a string or a path. In the first case, it represents a path
+          on the host system; that file must be readable by the unifi-poller
+          user. In the second case, note that the password will be
+          world-readable in the Nix store.
         '';
         apply = v: "file://${v}";
       };
@@ -138,12 +141,15 @@ in {
         '';
       };
       pass = mkOption {
-        type = types.path;
+        type = types.str;
         default = pkgs.writeText "unpoller-loki-default.password" "";
         defaultText = "unpoller-influxdb-default.password";
         description = lib.mdDoc ''
-          Path of a file containing the password for Loki.
-          This file needs to be readable by the unifi-poller user.
+          Path of a file containing the password for Loki. This can be
+          either a string or a path. In the first case, it represents a path
+          on the host system; that file must be readable by the unifi-poller
+          user. In the second case, note that the password will be
+          world-readable in the Nix store.
         '';
         apply = v: "file://${v}";
       };
@@ -187,12 +193,15 @@ in {
           '';
         };
         pass = mkOption {
-          type = types.path;
+          type = types.str;
           default = pkgs.writeText "unpoller-unifi-default.password" "unifi";
           defaultText = literalExpression "unpoller-unifi-default.password";
           description = lib.mdDoc ''
-            Path of a file containing the password for the unifi service user.
-            This file needs to be readable by the unifi-poller user.
+            Path of a file containing the password for the Unifi service user.
+            This can be either a string or a path. In the first case, it
+            represents a path on the host system; that file must be readable
+            by the unifi-poller user. In the second case, note that the
+            password will be world-readable in the Nix store.
           '';
           apply = v: "file://${v}";
         };


### PR DESCRIPTION
In the current module, the type checker restricts password files to paths; those are then coerced to strings (the resulting paths in the Nix store) and plugged into the unpoller config file as `file://${s}`. This isn't compatible with secret provisioning schemes (e.g. sops) that avoid having secrets in the Nix store.

Just switching the type to str avoids the problem. Configs that use paths will continue to work transparently via the coercion from path to str, and users that prefer provisioning secrets to paths on the host can do so.

## Things done

Prometheus tests pass on 23.05 and have existing build failures on master. 🙃 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).