### PR TITLE
oneVPL for intel gpus

### DIFF
--- a/pkgs/by-name/on/onevpl-intel-gpu/package.nix
+++ b/pkgs/by-name/on/onevpl-intel-gpu/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libdrm
+, libva
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onevpl-intel-gpu";
+  version = "23.4.3";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneVPL-intel-gpu";
+    rev = "intel-onevpl-${version}";
+    sha256 = "sha256-oDwDMUq6JpRJH5nbANb7TJLW7HRYA9y0xZxEsoepx/U=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libdrm libva ];
+
+  meta = {
+    description = "oneAPI Video Processing Library Intel GPU implementation";
+    homepage = "https://github.com/oneapi-src/oneVPL-intel-gpu";
+    changelog = "https://github.com/oneapi-src/oneVPL-intel-gpu/releases/tag/${src.rev}";
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.linux;
+    # CMake adds x86 specific compiler flags in <source>/builder/FindGlobals.cmake
+    # NOTE: https://github.com/oneapi-src/oneVPL-intel-gpu/issues/303
+    broken = !stdenv.hostPlatform.isx86;
+    maintainers = [ lib.maintainers.evanrichter ];
+  };
+}

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -92,6 +92,7 @@
 , withVmaf ? withFullDeps && !stdenv.isAarch64 && lib.versionAtLeast version "5" # Netflix's VMAF (Video Multi-Method Assessment Fusion)
 , withVoAmrwbenc ? withFullDeps && withVersion3 # AMR-WB encoder
 , withVorbis ? withHeadlessDeps # Vorbis de/encoding, native encoder exists
+, withVpl ? false # Hardware acceleration via intel libvpl
 , withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform # VP8 & VP9 de/encoding
 , withVulkan ? withFullDeps && !stdenv.isDarwin
 , withWebp ? withFullDeps # WebP encoder
@@ -237,6 +238,7 @@
 , libvdpau
 , libvmaf
 , libvorbis
+, libvpl
 , libvpx
 , libwebp
 , libX11
@@ -319,6 +321,7 @@ assert withGPLv3 -> withGPL && withVersion3;
  *  Build dependencies
  */
 assert withPixelutils -> buildAvutil;
+assert !(withMfx && withVpl); # incompatible features
 /*
  *  Program dependencies
  */
@@ -529,6 +532,9 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withV4l2M2m "v4l2-m2m")
     (enableFeature withVaapi "vaapi")
     (enableFeature withVdpau "vdpau")
+  ] ++ optionals (versionAtLeast version "6.0")  [
+    (enableFeature withVpl "libvpl")
+  ] ++ [
     (enableFeature withVidStab "libvidstab") # Actual min. version 2.0
     (enableFeature withVmaf "libvmaf")
     (enableFeature withVoAmrwbenc "libvo-amrwbenc")
@@ -643,6 +649,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withVmaf [ libvmaf ]
   ++ optionals withVoAmrwbenc [ vo-amrwbenc ]
   ++ optionals withVorbis [ libvorbis ]
+  ++ optionals withVpl [ libvpl ]
   ++ optionals withVpx [ libvpx ]
   ++ optionals withVulkan [ vulkan-headers vulkan-loader ]
   ++ optionals withWebp [ libwebp ]


### PR DESCRIPTION
## Description of changes

fresh PR continuing from #242359, sorry for the mass-ping over there :(

ping for the people who seem interested: @Atemu @PJungkamp @J-Swift

outstanding question for @midchildan: should intel-media-sdk be marked deprecated? The [upstream repo](https://github.com/Intel-Media-SDK/MediaSDK#media-sdk-support-matrix) is archived and suggests transitioning to onevpl

also todo: Atemu says ofborg build failed for onevpl-intel-gpu on aarch-linux, but I can't find the CI run for it. marking as draft until that's re-run and I can debug it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
