### PR TITLE
haskellPackages.changelog-d: init

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -7,6 +7,8 @@
 # files.
 self: super: {
 
+  changelog-d = self.callPackage ../misc/haskell/changelog-d {};
+
   dconf2nix = self.callPackage ../tools/haskell/dconf2nix/dconf2nix.nix { };
 
   # Used by maintainers/scripts/regenerate-hackage-packages.sh, and generated
@@ -36,4 +38,5 @@ self: super: {
   # Unofficial fork until PRs are merged https://github.com/pcapriotti/optparse-applicative/pulls/roberth
   # cabal2nix --maintainer roberth https://github.com/hercules-ci/optparse-applicative.git > pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
   hercules-ci-optparse-applicative = self.callPackage ../misc/haskell/hercules-ci-optparse-applicative.nix {};
+
 }

--- a/pkgs/development/misc/haskell/changelog-d/changelog-d.nix
+++ b/pkgs/development/misc/haskell/changelog-d/changelog-d.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, base, bytestring, cabal-install-parsers
+, Cabal-syntax, containers, directory, fetchgit, filepath
+, generic-lens-lite, lib, mtl, optparse-applicative, parsec, pretty
+, regex-applicative
+}:
+mkDerivation {
+  pname = "changelog-d";
+  version = "0.1";
+  src = fetchgit {
+    url = "https://codeberg.org/fgaz/changelog-d";
+    sha256 = "0r0gr3bl88am9jivic3i8lfi9l5v1dj7xx4fvw6hhy3wdx7z50z7";
+    rev = "2816ddb78cec8b7fa4462c25028437ebfe3ad314";
+    fetchSubmodules = true;
+  };
+  isLibrary = false;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring cabal-install-parsers Cabal-syntax containers
+    directory filepath generic-lens-lite mtl parsec pretty
+    regex-applicative
+  ];
+  executableHaskellDepends = [
+    base bytestring Cabal-syntax directory filepath
+    optparse-applicative
+  ];
+  doHaddock = false;
+  description = "Concatenate changelog entries into a single one";
+  license = lib.licenses.gpl3Plus;
+  mainProgram = "changelog-d";
+}

--- a/pkgs/development/misc/haskell/changelog-d/default.nix
+++ b/pkgs/development/misc/haskell/changelog-d/default.nix
@@ -3,7 +3,7 @@
 , pkgs
 }:
 
-(callPackage ./changelog-d.nix { }).overrideAttrs (oldAttrs: {
+(callPackage ./changelog-d.nix { }).overrideAttrs (finalAttrs: oldAttrs: {
 
   version = oldAttrs.version + "-git-${lib.strings.substring 0 7 oldAttrs.src.rev}";
 
@@ -17,6 +17,31 @@
       cabal2nix https://codeberg.org/fgaz/changelog-d >changelog-d.nix
     '';
   });
+  passthru.tests = {
+    basic = pkgs.runCommand "changelog-d-basic-test" {
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+      } ''
+        mkdir changelogs
+        cat > changelogs/config <<EOF
+        organization: NixOS
+        repository: boondoggle
+        EOF
+        cat > changelogs/a <<EOF
+        synopsis: Support numbers with incrementing base-10 digits
+        issues: #1234
+        description: {
+        This didn't work before.
+        }
+        EOF
+        changelog-d changelogs >$out
+        cat -n $out
+        echo Checking the generated output
+        set -x
+        grep -F 'Support numbers with incrementing base-10 digits' $out >/dev/null
+        grep -F 'https://github.com/NixOS/boondoggle/issues/1234' $out >/dev/null
+        set +x
+      '';
+  };
 
   meta = oldAttrs.meta // {
     homepage = "https://codeberg.org/fgaz/changelog-d";

--- a/pkgs/development/misc/haskell/changelog-d/default.nix
+++ b/pkgs/development/misc/haskell/changelog-d/default.nix
@@ -1,0 +1,26 @@
+{ callPackage
+, lib
+, pkgs
+}:
+
+(callPackage ./changelog-d.nix { }).overrideAttrs (oldAttrs: {
+
+  version = oldAttrs.version + "-git-${lib.strings.substring 0 7 oldAttrs.src.rev}";
+
+  passthru.updateScript = lib.getExe (pkgs.writeShellApplication {
+    name = "update-changelog-d";
+    runtimeInputs = [
+      pkgs.cabal2nix
+    ];
+    text = ''
+      cd pkgs/development/misc/haskell/changelog-d
+      cabal2nix https://codeberg.org/fgaz/changelog-d >changelog-d.nix
+    '';
+  });
+
+  meta = oldAttrs.meta // {
+    homepage = "https://codeberg.org/fgaz/changelog-d";
+    maintainers = [ lib.maintainers.roberth ];
+  };
+
+})


### PR DESCRIPTION
## Description of changes

Add a nice little tool for release notes automation. I'd like to use it in NixOS/nix.

@fgaz how would you feel about releasing the tool on Hackage? I'd be happy to maintain a custom expression for it, but I guess the standard Nixpkgs Haskell process would be nicer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
