### PR TITLE
lib/fixed-points.nix: correct typo

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -45,7 +45,7 @@ rec {
     }
     ```
 
-    This is where `fix` comes in, it contains the syntactic that's not in `f` anymore.
+    This is where `fix` comes in, it contains the syntactic recursion that's not in `f` anymore.
 
     ```nix
     nix-repl> fix = f:


### PR DESCRIPTION
Corrects a minor (but significant) typo/omission in the comment description of `fix`; namely that `fix` allows factoring out syntactic *recursion* from another function.