### PR TITLE
octoprint: fix flask compatibility

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -3,6 +3,7 @@
 , callPackage
 , lib
 , fetchFromGitHub
+, fetchPypi
 , python3
 , substituteAll
 , nix-update-script
@@ -16,6 +17,30 @@ let
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) (
       [
+        (
+          # Due to flask > 2.3 the login will not work
+          self: super: {
+            werkzeug = super.werkzeug.overridePythonAttrs (oldAttrs: rec {
+              version = "2.2.3";
+              format = "setuptools";
+              src = fetchPypi {
+                pname = "Werkzeug";
+                inherit version;
+                hash = "sha256-LhzMlBfU2jWLnebxdOOsCUOR6h1PvvLWZ4ZdgZ39Cv4=";
+              };
+            });
+            flask = super.flask.overridePythonAttrs (oldAttrs: rec {
+              version = "2.2.5";
+              format = "setuptools";
+              src = fetchPypi {
+                pname = "Flask";
+                inherit version;
+                hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
+              };
+            });
+          }
+        )
+
         # Built-in dependency
         (
           self: super: {


### PR DESCRIPTION
## Description of changes

After the major `flask` update, users fail to login to `octoprint` with the following error: 

```
Okt 31 18:35:33 kari octoprint[2265004]: 2023-10-31 18:35:33,201 - octoprint - ERROR - Exception on /api/login [POST]
Okt 31 18:35:33 kari octoprint[2265004]: Traceback (most recent call last):
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/flask/app.py", line 2190, in wsgi_app          Okt 31 18:35:33 kari octoprint[2265004]:     response = self.full_dispatch_request()
Okt 31 18:35:33 kari octoprint[2265004]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/flask/app.py", line 1486, in full_dispatch_request
Okt 31 18:35:33 kari octoprint[2265004]:     rv = self.handle_user_exception(e)
Okt 31 18:35:33 kari octoprint[2265004]:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/flask/app.py", line 1482, in full_dispatch_request
Okt 31 18:35:33 kari octoprint[2265004]:     rv = self.preprocess_request()                                                                                                                 Okt 31 18:35:33 kari octoprint[2265004]:          ^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/flask/app.py", line 1974, in preprocess_request
Okt 31 18:35:33 kari octoprint[2265004]:     rv = self.ensure_sync(before_func)()                                                                                                           Okt 31 18:35:33 kari octoprint[2265004]:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/octoprint/server/__init__.py", line 1519, in before_request
Okt 31 18:35:33 kari octoprint[2265004]:     g.locale = self._get_locale()                                                                                                                  Okt 31 18:35:33 kari octoprint[2265004]:                ^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/octoprint/server/__init__.py", line 1403, in _get_locale
Okt 31 18:35:33 kari octoprint[2265004]:     if "l10n" in request.values:
Okt 31 18:35:33 kari octoprint[2265004]:                  ^^^^^^^^^^^^^^                                                                                                                    Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/utils.py", line 106, in __get__
Okt 31 18:35:33 kari octoprint[2265004]:     value = self.fget(obj)  # type: ignore
Okt 31 18:35:33 kari octoprint[2265004]:             ^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 466, in values
Okt 31 18:35:33 kari octoprint[2265004]:     sources.append(self.form)
Okt 31 18:35:33 kari octoprint[2265004]:                    ^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/utils.py", line 106, in __get__                        Okt 31 18:35:33 kari octoprint[2265004]:     value = self.fget(obj)  # type: ignore
Okt 31 18:35:33 kari octoprint[2265004]:             ^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 446, in form                Okt 31 18:35:33 kari octoprint[2265004]:     self._load_form_data()                                                                                                                         Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/flask/wrappers.py", line 114, in _load_form_data
Okt 31 18:35:33 kari octoprint[2265004]:     super()._load_form_data()
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 271, in _load_form_data
Okt 31 18:35:33 kari octoprint[2265004]:     self._get_stream_for_parsing(),                                                                                                                Okt 31 18:35:33 kari octoprint[2265004]:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 298, in _get_stream_for_parsing
Okt 31 18:35:33 kari octoprint[2265004]:     return self.stream
Okt 31 18:35:33 kari octoprint[2265004]:            ^^^^^^^^^^^                                                                                                                             Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/utils.py", line 106, in __get__
Okt 31 18:35:33 kari octoprint[2265004]:     value = self.fget(obj)  # type: ignore
Okt 31 18:35:33 kari octoprint[2265004]:             ^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 350, in stream
Okt 31 18:35:33 kari octoprint[2265004]:     return get_input_stream(
Okt 31 18:35:33 kari octoprint[2265004]:            ^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wsgi.py", line 175, in get_input_stream
Okt 31 18:35:33 kari octoprint[2265004]:     content_length = get_content_length(environ)
Okt 31 18:35:33 kari octoprint[2265004]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/wsgi.py", line 129, in get_content_length
Okt 31 18:35:33 kari octoprint[2265004]:     return _sansio_utils.get_content_length(
Okt 31 18:35:33 kari octoprint[2265004]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/sansio/utils.py", line 157, in get_content_length
Okt 31 18:35:33 kari octoprint[2265004]:     return max(0, _plain_int(http_content_length))
Okt 31 18:35:33 kari octoprint[2265004]:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]:   File "/nix/store/jq5gma3a9g7wgzrf2sfrf9p0jn8giran-python3-3.11.5-env/lib/python3.11/site-packages/werkzeug/_internal.py", line 326, in _plain_int
Okt 31 18:35:33 kari octoprint[2265004]:     value = value.strip()
Okt 31 18:35:33 kari octoprint[2265004]:             ^^^^^^^^^^^
Okt 31 18:35:33 kari octoprint[2265004]: AttributeError: 'int' object has no attribute 'strip'
```

This PR pins the necessarry packages in octoprint.

Tested in a VM and on a raspberry pi 4.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
