### PR TITLE
libaribcaption: init at 1.1.1

### DIFF
--- a/pkgs/by-name/li/libaribcaption/package.nix
+++ b/pkgs/by-name/li/libaribcaption/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+
+, fontconfig
+, freetype
+
+, ApplicationServices
+, CoreFoundation
+, CoreGraphics
+, CoreText
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libaribcaption";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "xqq";
+    repo = "libaribcaption";
+    rev = "v${version}";
+    hash = "sha256-x6l0ZrTktSsqfDLVRXpQtUOruhfc8RF3yT991UVZiKA=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  buildInputs = lib.optionals (!stdenv.isDarwin) [
+    fontconfig
+    freetype
+  ] ++ lib.optionals stdenv.isDarwin [
+    ApplicationServices
+    CoreFoundation
+    CoreGraphics
+    CoreText
+  ];
+
+  meta = with lib; {
+    description = "Portable ARIB STD-B24 Caption Decoder/Renderer";
+    homepage = "https://github.com/xqq/libaribcaption";
+    changelog = "https://github.com/xqq/libaribcaption/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chayleaf ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22450,6 +22450,10 @@ with pkgs;
 
   libarchive-qt = libsForQt5.callPackage ../development/libraries/libarchive-qt { };
 
+  libaribcaption = callPackage ../by-name/li/libaribcaption/package.nix {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices CoreFoundation CoreGraphics CoreText;
+  };
+
   libasn1c = callPackage ../servers/osmocom/libasn1c/default.nix { };
 
   libasr = callPackage ../development/libraries/libasr { };


### PR DESCRIPTION
## Description of changes

https://github.com/xqq/libaribcaption - a library for decoding ARIB STD-B24 captions. In future versions of ffmpeg (6.1, should be released in a week or two) and VLC (4.0, probably early 2024?) it can be used as an optional dependency in place of libaribb24 which hasn't been updated in 8 years (and isn't in nixpkgs).

There is the option of packaging libaribb24 instead of (or alongside) libaribcaption which allows enabling ARIB STD-B24 caption support right now, but since libaribb24 is unmaintained and ARIB caption support isn't in high demand I figured the better option is packaging this even if it's only supported in unstable branches of ffmpeg/vlc.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
