### PR TITLE
gatus: init at 5.7.0

### DIFF
--- a/pkgs/by-name/ga/gatus/package.nix
+++ b/pkgs/by-name/ga/gatus/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "gatus";
+  version = "5.7.0";
+
+  src = fetchFromGitHub {
+    owner = "TwiN";
+    repo = "gatus";
+    rev = "v${version}";
+    hash = "sha256-GG5p2sAIameGo6IFt3IBwFuLfVFRbfHjrQrG6Ei9odA=";
+  };
+
+  vendorHash = "sha256-VYHBqVFXX7fUuW2UqPOlbRDEfcysYvjSlfm0UJ2mMGM=";
+
+  # Disable all tests that require network access in some form
+  checkFlags = let disabledTests = [
+    "TestCanCreateTCPConnection"
+    "TestCanPerformStartTLS"
+    "TestCanPerformTLS"
+    "TestChecker_IsConnected"
+    "TestConfig_RegisterHandlers"
+    "TestEndpoint/domain-expiration"
+    "TestEndpoint/endpoint-that-will-time-out-and-hidden-hostname"
+    "TestEndpoint/endpoint-that-will-time-out-and-hidden-url"
+    "TestGetDomainExpiration"
+    "TestIntegrationEvaluateHealth"
+    "TestIntegrationQuery"
+    "TestOIDCConfig_callbackHandler"
+    "TestPing"
+  ]; in [
+    "-skip=${builtins.concatStringsSep "|" disabledTests}"
+  ];
+
+  meta = {
+    description = "Automated developer-oriented status page";
+    homepage = "https://gatus.io";
+    changelog = "https://github.com/TwiN/gatus/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ christoph-heiss ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [Gatus](https://github.com/TwiN/gatus), a developer-oriented service status page for self-hosting.

When this gets merged, I will also provide a service module. 

Edit 14-11-2023: Updated initial PR 5.6.0 -> 5.7.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
