### PR TITLE
simde: init at 0.7.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18989,6 +18989,12 @@
       fingerprint = "640B EDDE 9734 310A BFA3  B257 52ED AE6A 3995 AFAB";
     }];
   };
+  whiteley = {
+    email = "mattwhiteley@gmail.com";
+    github = "whiteley";
+    githubId = 2215;
+    name = "Matt Whiteley";
+  };
   WhittlesJr = {
     email = "alex.joseph.whitt@gmail.com";
     github = "WhittlesJr";

--- a/pkgs/by-name/si/simde/package.nix
+++ b/pkgs/by-name/si/simde/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, meson, ninja }:
 
 stdenv.mkDerivation rec {
   pname = "simde";
@@ -11,16 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-pj+zaD5o9XYkTavezcQFzM6ao0IdQP1zjP9L4vcCyEY=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/include
-    cp -a ${pname} $out/include
-
-    install -Dt $out/share/doc/${pname} README.md
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ meson ninja ];
 
   meta = with lib; {
     homepage = "https://simd-everywhere.github.io";

--- a/pkgs/by-name/si/simde/package.nix
+++ b/pkgs/by-name/si/simde/package.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "simde";
+  version = "0.7.6";
+
+  src = fetchFromGitHub {
+    owner = "simd-everywhere";
+    repo = "simde";
+    rev = "v${version}";
+    hash = "sha256-pj+zaD5o9XYkTavezcQFzM6ao0IdQP1zjP9L4vcCyEY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include
+    cp -a ${pname} $out/include
+
+    install -Dt $out/share/doc/${pname} README.md
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://simd-everywhere.github.io";
+    description = "Implementations of SIMD instruction sets for systems which don't natively support them.";
+    license = with licenses; [mit];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/si/simde/package.nix
+++ b/pkgs/by-name/si/simde/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://simd-everywhere.github.io";
-    description = "Implementations of SIMD instruction sets for systems which don't natively support them.";
+    description = "Implementations of SIMD instruction sets for systems which don't natively support them";
     license = with licenses; [mit];
     platforms = flatten (with platforms; [
       arm

--- a/pkgs/by-name/si/simde/package.nix
+++ b/pkgs/by-name/si/simde/package.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     homepage = "https://simd-everywhere.github.io";
     description = "Implementations of SIMD instruction sets for systems which don't natively support them";
     license = with licenses; [mit];
+    maintainers = with maintainers; [ whiteley ];
     platforms = flatten (with platforms; [
       arm
       armv7

--- a/pkgs/by-name/si/simde/package.nix
+++ b/pkgs/by-name/si/simde/package.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
     homepage = "https://simd-everywhere.github.io";
     description = "Implementations of SIMD instruction sets for systems which don't natively support them.";
     license = with licenses; [mit];
-    platforms = platforms.unix;
+    platforms = flatten (with platforms; [
+      arm
+      armv7
+      aarch64
+      x86
+      power
+      mips
+    ]);
   };
 }


### PR DESCRIPTION
## Description of changes

SIMDe is a header-only library with implementations of SIMD instruction sets for systems which don't natively support them.
https://simd-everywhere.github.io


I looked around a bit in nixpkgs for something similar since I wasn't sure what all should be done here. For example, is it preferred to set `dontConfigure`, `dontBuild`, etc to `true` to be explicit or accept the fact that the tooling correctly skips those phases? The [fedora spec](https://src.fedoraproject.org/rpms/simde/blob/rawhide/f/simde.spec) does some checks around making sure all the copied files are `*.h`. I'm happy to do add more here if someone has suggestions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
