### PR TITLE
unimatrix: init at unstable-2023-04-25

### DIFF
--- a/pkgs/by-name/un/unimatrix/package.nix
+++ b/pkgs/by-name/un/unimatrix/package.nix
@@ -1,0 +1,36 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "unimatrix";
+  version = "unstable-2023-04-25";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "will8211";
+    repo = pname;
+    rev = "65793c237553bf657af2f2248d2a2dc84169f5c4";
+    hash = "sha256-fiaVEc0rtZarUQlUwe1V817qWRx4LnUyRD/j2vWX5NM=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./unimatrix.py $out/bin/unimatrix
+
+    runHook postInstall
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  meta = with lib; {
+    description = ''Python script to simulate the display from "The Matrix" in terminal'';
+    homepage = "https://github.com/will8211/unimatrix";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ anomalocaris ];
+    mainProgram = "unimatrix";
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds [unimatrix](https://github.com/will8211/unimatrix), a program that displays the falling code from "The Matrix" in a terminal. It is similar to cmatrix, but uses Unicode for Japanese characters so that they can be used out of the box.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
