### PR TITLE
celeste-classic: init at unstable-2020-12-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12116,6 +12116,14 @@
     github = "MrTarantoga";
     githubId = 53876219;
   };
+  mrtnvgr = {
+    name = "Egor Martynov";
+    github = "mrtnvgr";
+    githubId = 48406064;
+    keys = [{
+      fingerprint = "6FAD DB43 D5A5 FE52 6835  0943 5B33 79E9 81EF 48B1";
+    }];
+  };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";
     github = "mrVanDalo";

--- a/pkgs/by-name/ce/celeste-classic/package.nix
+++ b/pkgs/by-name/ce/celeste-classic/package.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+, autoPatchelfHook
+, SDL2
+, practiceMod ? false
+}:
+
+let
+  directory = if practiceMod then "CELESTE*Practice*" else "CELESTE";
+  srcbin = if practiceMod then "celeste_practice_mod" else "celeste";
+  outbin = if practiceMod then "celeste-classic-pm" else "celeste-classic";
+in
+stdenvNoCC.mkDerivation {
+  pname = outbin;
+  version = "unstable-2020-12-08";
+
+  # From https://www.speedrun.com/celestep8/resources
+  src = fetchzip {
+    url = "https://www.speedrun.com/static/resource/174ye.zip?v=f3dc98f";
+    hash = "sha256-GANHqKB0N905QJOLaePKWkUuPl9UlL1iqvkMMvw/CC8=";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [ SDL2 ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dsm755 ${directory}/${srcbin} $out/lib/${outbin}/${outbin}
+    install -Dm444 ${directory}/data.pod $out/lib/${outbin}/data.pod
+    mkdir -p $out/bin
+    ln -s $out/lib/${outbin}/${outbin} $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A PICO-8 platformer about climbing a mountain, made in four days${lib.optionalString practiceMod " (Practice Mod)"}";
+    homepage = "https://celesteclassic.github.io/";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    mainProgram = outbin;
+    maintainers = with maintainers; [ mrtnvgr ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -447,6 +447,10 @@ with pkgs;
 
   ccal = callPackage ../tools/misc/ccal { };
 
+  celeste-classic-pm = pkgs.celeste-classic.override {
+    practiceMod = true;
+  };
+
   cereal = cereal_1_3_0;
   cereal_1_3_0 = callPackage ../development/libraries/cereal/1.3.0.nix { };
   cereal_1_3_2 = callPackage ../development/libraries/cereal/1.3.2.nix { };


### PR DESCRIPTION
## Description of changes

This PR adds [celeste-classic](https://celesteclassic.github.io/) game with optional support for Practice Mod.

NOTE: requires [this](https://github.com/NixOS/nixpkgs/pull/258963/commits/b5f97b03a312d72bc19da535a504f25db481139e) commit

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
