### PR TITLE
yersinia: 0.8.2 -> unstable-2022-11-20 unmark broken aarch64-linux

### DIFF
--- a/pkgs/tools/security/yersinia/default.nix
+++ b/pkgs/tools/security/yersinia/default.nix
@@ -8,31 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "yersinia";
-  version = "0.8.2";
+  version = "unstable-2022-11-20";
 
   src = fetchFromGitHub {
     owner = "tomac";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "06yfpf9iyi525rly1ychsihzvw3sas8kp0nxxr99xkwiqp5dc78b";
+    rev = "867b309eced9e02b63412855440cd4f5f7727431";
+    sha256 = "sha256-VShg9Nzd8dzUNiqYnKcDzRgqjwar/8XRGEJCJL25aR0=";
   };
-
-  patches = [
-    # ncurses-6.3 support, included in next release
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/tomac/yersinia/commit/d91bbf6f475e7ea39f131b77ce91b2de9646d5ca.patch";
-      sha256 = "fl1pZKWA+nLtBm9+3FBFqaeuVZjszQCNkNl6Cf++BAI=";
-    })
-
-    # Pull upstream fix for -fno-common toolchain support:
-    #   https://github.com/tomac/yersinia/pull/66
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/tomac/yersinia/commit/36247225dc7a6f38c4ba70537e20351f04762749.patch";
-      sha256 = "KHaN8gfgNROEico27gWnYiP9ZVhpWz0KjFYy2t5tPBo=";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libpcap libnet ncurses ]
@@ -58,7 +41,5 @@ stdenv.mkDerivation rec {
     # so not sure, but it could work on openbsd, illumos, and freebsd
     # if you have a machine to test with, feel free to add these
     platforms = with platforms; linux;
-    # never built on aarch64-linux since first introduction in nixpkgs
-    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
## Description of changes

fixes https://github.com/NixOS/nixpkgs/issues/176530

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
