### PR TITLE
bellepoule: init at 5.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26445,6 +26445,11 @@
     githubId = 378734;
     name = "TG ⊗ Θ";
   };
+  tgi74 = {
+    github = "tgi74";
+    githubId = 1854712;
+    name = "tgi74";
+  };
   th0rgal = {
     email = "thomas.marchand@tuta.io";
     github = "Th0rgal";

--- a/pkgs/by-name/be/bellepoule/package.nix
+++ b/pkgs/by-name/be/bellepoule/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  goocanvas_1,
+  pkg-config,
+  gtk2,
+  libxml2,
+  curl,
+  libmicrohttpd,
+  libzip,
+  libusb1,
+  qrencode,
+  json-glib,
+  php,
+  libwebsockets,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bellepoule";
+  version = "5.5";
+
+  src =
+    (fetchgit {
+      url = "https://git.launchpad.net/bellepoule";
+      rev = finalAttrs.version;
+      hash = "sha256-SNL6yaaKk/GU8+EvHki4ysMuCHEQxFjPd3iwVIdJtCs=";
+    }).overrideAttrs
+      (oldAttrs: {
+        env = oldAttrs.env or { } // {
+          GIT_CONFIG_COUNT = 1;
+          GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+          GIT_CONFIG_VALUE_0 = "git@github.com:";
+        };
+      });
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    gtk2
+    libxml2
+    curl
+    libmicrohttpd
+    goocanvas_1
+    qrencode
+    openssl
+    json-glib
+    libzip
+    libusb1
+    libwebsockets
+  ];
+
+  makeFlags = [
+    "HOME=$(pwd)"
+    "DISTRIB=nixos"
+    "V=1"
+    "DESTDIR=$(out)"
+  ];
+
+  # Use system php
+  # Disable git soft depend
+  # Disable dch changelog generation
+  # FixUp `install` phase output
+  postPatch = ''
+    substituteInPlace ./sources/common/network/web_server.cpp --replace-fail "php7.4" "${php}/bin/php"
+    substituteInPlace ./build/BellePoule/debian/bellepoule.desktop.template --replace-fail "/usr" "$out"
+    substituteInPlace ./build/BellePoule/Makefile \
+      --replace-fail "git" "#git" \
+      --replace-fail "dch" "echo Ignoring: dch" \
+      --replace-fail "/usr" ""
+  '';
+
+  # Prepare release directory for buildPhase
+  preBuild = ''
+    cd build/BellePoule
+    make HOME=$(pwd) DISTRIB=nixos V=1 package
+    cd ./Perso/PPA/${finalAttrs.pname}/${finalAttrs.pname}_${finalAttrs.version}
+  '';
+
+  meta = {
+    description = "Fencing tournaments management software";
+    homepage = "http://betton.escrime.free.fr";
+    changelog = "https://git.launchpad.net/bellepoule/log/?h=${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tgi74 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "bellepoule-supervisor";
+  };
+})


### PR DESCRIPTION
## Description of changes

Hello hello, this PR adds the package `bellepoule`, an open-source fencing tournaments management software.

You can find the homepage over here: http://betton.escrime.free.fr/fencing-tournament-software/en/bellepoule/index.html
as well as the git repository over here: https://launchpad.net/bellepoule/

This software comes in 2 main parts:
- `bellepoule-supervisor`: the main software, used to manage the course of competition.
- `bellepoule-marshaller`: an additional software (used in conjunction with supervisor), used by referee dispatchers to assign matches to available tracks & referees.
- `bellepoule-backend`: binary used by supervisor & marshaller for LAN communication on port 35830-35835 (including with the SmartPoule smartphone app).

This is my first contribution in nixpkgs, don't hesitate to request changes. :slightly_smiling_face: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
