### PR TITLE
python3Packages.icontract: fix build by bumping dependencies

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -2,30 +2,26 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
-, isPyPy
-, lazy-object-proxy
 , setuptools
 , wheel
 , typing-extensions
-, typed-ast
 , pip
 , pylint
 , pytestCheckHook
-, wrapt
 }:
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.15.6"; # Check whether the version is compatible with pylint
+  version = "3.0.1"; # Check whether the version is compatible with pylint
   format = "pyproject";
 
-  disabled = pythonOlder "3.7.2";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-0oNNEVD8rYGkM11nGUD+XMwE7xgk7mJIaplrAXaECFg=";
+    hash = "sha256-z6FmB3I3VmiIx0MSsrkvHmDVv2h3CaaeXlDG3DewGXw=";
   };
 
   nativeBuildInputs = [
@@ -33,24 +29,10 @@ buildPythonPackage rec {
     wheel
   ];
 
-  propagatedBuildInputs = [
-    lazy-object-proxy
-    wrapt
-  ] ++ lib.optionals (pythonOlder "3.11") [
-    typing-extensions
-  ] ++ lib.optionals (!isPyPy && pythonOlder "3.8") [
-    typed-ast
-  ];
-
   nativeCheckInputs = [
     pip
     pytestCheckHook
     typing-extensions
-  ];
-
-  disabledTests = [
-    # DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('tests.testdata.python3.data.path_pkg_resources_1.package')`.
-    "test_identify_old_namespace_package_protocol"
   ];
 
   passthru.tests = {

--- a/pkgs/development/python-modules/asttokens/default.nix
+++ b/pkgs/development/python-modules/asttokens/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "asttokens";
-  version = "2.4.0";
+  version = "2.4.1";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-LgFxuZGyyVmsxsSTGASSNoRKXaHWW6JnLEiAwciUg04=";
+    hash = "sha256-sDhpcYuppusCfhNL/fafOKI21oHIPBYNUQdorxElS6A=";
   };
 
   nativeBuildInputs = [
@@ -33,11 +33,6 @@ buildPythonPackage rec {
   disabledTests = [
     # Test is currently failing on Hydra, works locally
     "test_slices"
-  ];
-
-  disabledTestPaths = [
-    # incompatible with astroid 2.11.0, pins <= 2.5.3
-    "tests/test_astroid.py"
   ];
 
   pythonImportsCheck = [ "asttokens" ];

--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "deal";
-  version = "4.24.2";
+  version = "4.24.3";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "life4";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-bdIoKOOC7qSer9Cp9A55HG960xunKXT2WiXp0UC6tsI=";
+    hash = "sha256-QlM3d/jmg6v3L3D45+cgcCej71U1dl4uZ6sAYGGm3tU=";
   };
 
   postPatch = ''
@@ -77,13 +77,17 @@ buildPythonPackage rec {
     "test_scheme_contract_is_satisfied_when_setting_arg"
     "test_scheme_contract_is_satisfied_within_chain"
     "test_scheme_errors_rewrite_message"
-    # broken since pytest > 7.1.3
-    "test_exception_hook"
+    # assert errors
+    "test_doctest"
+    "test_no_violations"
   ];
 
   disabledTestPaths = [
     # needs internet access
     "tests/test_runtime/test_offline.py"
+    # depends on typeguard <4.0.0 for tests, but >=4.0.0 seems fine for runtime
+    # https://github.com/life4/deal/blob/9be70fa1c5a0635880619b2cea83a9f6631eb236/pyproject.toml#L40
+    "tests/test_testing.py"
   ];
 
   pythonImportsCheck = [ "deal" ];

--- a/pkgs/development/python-modules/icontract/default.nix
+++ b/pkgs/development/python-modules/icontract/default.nix
@@ -50,6 +50,8 @@ buildPythonPackage rec {
     # mypy decorator checks don't pass. For some reason mypy
     # doesn't check the python file provided in the test.
     "tests/test_mypy_decorators.py"
+    # those tests seems to simply re-run some typeguard tests
+    "tests/test_typeguard.py"
   ];
 
   pythonImportsCheck = [ "icontract" ];

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -2,7 +2,6 @@
 , lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pythonOlder
 , astroid
 , dill
@@ -24,31 +23,17 @@
 
 buildPythonPackage rec {
   pname = "pylint";
-  version = "2.17.5";
+  version = "3.0.2";
   format = "pyproject";
 
-  disabled = pythonOlder "3.7.2";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pylint-dev";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-cmH6Q6/XJXx8EXDIsik1Aheu9hYGvvlNvWBUCdmC3P8=";
+    hash = "sha256-q0UZ146jxzWV/ld5I+Zz1SQ4dq+SncoptiXVOX6vI3c=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "update-setuptools.patch";
-      url = "https://github.com/pylint-dev/pylint/commit/1d029b594aa258fa01570632d001e801f9257d60.patch";
-      hash = "sha256-brQwelZVkSX9h0POH8OJeapZuWZ8p7BY/ZzhYzGbiHY=";
-    })
-    # https://github.com/pylint-dev/pylint/pull/8961
-    (fetchpatch {
-      name = "unpin-setuptools.patch";
-      url = "https://github.com/pylint-dev/pylint/commit/a0ac282d6f8df381cc04adc0a753bec66fc4db63.patch";
-      hash = "sha256-15O72LE2WQK590htNc3jghdbVoGLHUIngERDpqT8pK8=";
-    })
-  ];
 
   nativeBuildInputs = [
     setuptools
@@ -64,7 +49,7 @@ buildPythonPackage rec {
     tomlkit
   ] ++ lib.optionals (pythonOlder "3.11") [
     tomli
-  ] ++ lib.optionals (pythonOlder "3.9") [
+  ] ++ lib.optionals (pythonOlder "3.10") [
     typing-extensions
   ];
 
@@ -80,11 +65,6 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    # DeprecationWarning: pyreverse will drop support for resolving and
-    # displaying implemented interfaces in pylint 3.0. The
-    # implementation relies on the '__implements__'  attribute proposed
-    # in PEP 245, which was rejected in 2006.
-    "-W" "ignore::DeprecationWarning"
     "-v"
   ];
 
@@ -96,9 +76,6 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     "tests/benchmark"
-    # tests miss multiple input files
-    # FileNotFoundError: [Errno 2] No such file or directory
-    "tests/pyreverse/test_writer.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
## Description of changes

Alternative PR for https://github.com/NixOS/nixpkgs/pull/264772.

Bumped some packages until I got `python3Packages.icontract` to build again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
