### PR TITLE
Xfce updates 2023-11-01

### DIFF
--- a/pkgs/desktops/xfce/core/xfconf/default.nix
+++ b/pkgs/desktops/xfce/core/xfconf/default.nix
@@ -1,6 +1,5 @@
 { lib
 , mkXfceDerivation
-, fetchpatch
 , libxfce4util
 , gobject-introspection
 , vala
@@ -9,19 +8,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfconf";
-  version = "4.18.2";
+  version = "4.18.3";
 
-  sha256 = "sha256-FVNkcwOS4feMocx3vYhuWNs1EkXDrM1FaKkMhIOuPHI=";
-
-  patches = [
-    # fixes a segfault, can likely be removed with 4.18.3,
-    # see https://gitlab.xfce.org/xfce/xfconf/-/issues/35#note_81151
-    (fetchpatch {
-      name = "cache-fix-uncached-value.patch";
-      url = "https://gitlab.xfce.org/xfce/xfconf/-/commit/03f7ff961fd46c9141aba624a278e19de0bf3211.diff";
-      hash = "sha256-n9Wvt7NfKMxs2AcjUWgs4vZgzLUG9jyEVTZxINko4h8=";
-    })
-  ];
+  sha256 = "sha256-Iu/LHyk/lOvu8uJuJRDxIkabiX0vZB4H99vVKRiugVo=";
 
   nativeBuildInputs = [ gobject-introspection vala ];
 

--- a/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
@@ -11,10 +11,10 @@
 mkXfceDerivation {
   category = "thunar-plugins";
   pname  = "thunar-archive-plugin";
-  version = "0.5.1";
+  version = "0.5.2";
   odd-unstable = false;
 
-  sha256 = "sha256-TV70IaZClIyQnMGsJEPN0VxHzZAS5F5jSTLm8VwYuwI=";
+  sha256 = "sha256-vbuFosj2qxDus7vu9WfRiFpLwnTRnmLVGCDa0tNQecU=";
 
   nativeBuildInputs = [
     intltool


### PR DESCRIPTION
## Description of changes

(Not related: If you are testing on exactly the ff97a5cb6f9b6c02887aa500658be794af46ab8a checkout, don't use linux 6.6 since this does not have e00c606455cef66797d48b3a145e913b509a4077)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
