### PR TITLE
poppler: 23.08.0 -> 23.11.0

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -25,6 +25,7 @@
 , withData ? true, poppler_data
 , qt5Support ? false, qt6Support ? false, qtbase ? null
 , introspectionSupport ? false, gobject-introspection ? null
+, gpgmeSupport ? false, gpgme ? null
 , utils ? false, nss ? null
 , minimal ? false
 , suffix ? "glib"
@@ -47,13 +48,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "poppler-${suffix}";
-  version = "23.08.0"; # beware: updates often break cups-filters build, check texlive and scribus too!
+  version = "23.10.0"; # beware: updates often break cups-filters build, check scribus too!
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://poppler.freedesktop.org/poppler-${version}.tar.xz";
-    hash = "sha256-Skv3/JA7nxoqt9BLfF2CINubxiYcxz/bmoJtwnL0mqg=";
+    hash = "sha256-MaPf3qefSSJALTE3N0FaRNRNwU1rMX+VmnfFu6Bkfdk=";
   };
 
   nativeBuildInputs = [
@@ -88,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: rec {
     qtbase
   ] ++ lib.optionals introspectionSupport [
     gobject-introspection
+  ] ++ lib.optionals gpgmeSupport [
+    gpgme
   ];
 
   cmakeFlags = [
@@ -95,9 +98,13 @@ stdenv.mkDerivation (finalAttrs: rec {
     (mkFlag (!minimal) "GLIB")
     (mkFlag (!minimal) "CPP")
     (mkFlag (!minimal) "LIBCURL")
+    (mkFlag (!minimal) "LCMS")
+    (mkFlag (!minimal) "LIBTIFF")
+    (mkFlag (!minimal) "NSS3")
     (mkFlag utils "UTILS")
     (mkFlag qt5Support "QT5")
     (mkFlag qt6Support "QT6")
+    (mkFlag gpgmeSupport "GPGME")
   ] ++ lib.optionals finalAttrs.doCheck [
     "-DTESTDATADIR=${testData}"
   ];
@@ -110,13 +117,24 @@ stdenv.mkDerivation (finalAttrs: rec {
     sed -i -e '1i cmake_policy(SET CMP0025 NEW)' CMakeLists.txt
   '';
 
+  # Work around gpgme trying to write to $HOME during qt5 and qt6 tests:
+  preCheck = lib.optionalString gpgmeSupport ''
+    HOME_orig="$HOME"
+    export HOME="$(mktemp -d)"
+  '';
+
+  postCheck = lib.optionalString gpgmeSupport ''
+    export HOME="$HOME_orig"
+    unset -v HOME_orig
+  '';
+
   doCheck = true;
 
   passthru = {
     inherit testData;
     tests = {
       # These depend on internal poppler code that frequently changes.
-      inherit inkscape cups-filters texlive scribus;
+      inherit inkscape cups-filters scribus;
     };
   };
 

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -48,13 +48,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "poppler-${suffix}";
-  version = "23.10.0"; # beware: updates often break cups-filters build, check scribus too!
+  version = "23.11.0"; # beware: updates often break cups-filters build, check scribus too!
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://poppler.freedesktop.org/poppler-${version}.tar.xz";
-    hash = "sha256-MaPf3qefSSJALTE3N0FaRNRNwU1rMX+VmnfFu6Bkfdk=";
+    hash = "sha256-+ZzKZ5nLnLbJL8Hg63hUe2EctzN1CrfLBHyw5sJGU5w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24548,7 +24548,6 @@ with pkgs;
   });
 
   poppler_min = poppler.override { # TODO: maybe reduce even more
-    # this is currently only used by texlive.bin.
     minimal = true;
     suffix = "min";
   };


### PR DESCRIPTION
## Description of changes

https://lists.freedesktop.org/archives/poppler/2023-September/015569.html
https://lists.freedesktop.org/archives/poppler/2023-October/015576.html
https://lists.freedesktop.org/archives/poppler/2023-November/015580.html

Upstream [enables GPGME by default](https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-23.10.0/CMakeLists.txt#L82), so we have to handle this here; disable it by default.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Builds of `cups-filters`, `scribus` and `inkscape` succeed locally on `x86_64-linux`.
`texlive` does not depend on `poppler` anymore.