### PR TITLE
lomiri.telephony-service: init at 0.5.2

### DIFF
--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -30,6 +30,7 @@ in {
         ayatana-indicator-messages
       ] ++ (with pkgs.lomiri; [
         lomiri-indicator-network
+        telephony-service
       ]);
     };
 
@@ -42,6 +43,25 @@ in {
 
     networking.networkmanager.enable = true; # lomiri-network-indicator
     # TODO potentially urfkill for lomiri-network-indicator?
+
+    services.dbus.packages = with pkgs.lomiri; [
+      libusermetrics
+    ];
+
+    environment.systemPackages = with pkgs.lomiri; [
+      lomiri-schemas
+    ];
+
+    services.telepathy.enable = true;
+
+    users.users.usermetrics = {
+      group = "usermetrics";
+      home = "/var/lib/usermetrics";
+      createHome = true;
+      isSystemUser = true;
+    };
+
+    users.groups.usermetrics = { };
   };
 
   # TODO session indicator starts up in a semi-broken state, but works fine after a restart. maybe being started before graphical session is truly up & ready?
@@ -69,7 +89,7 @@ in {
 
     # Now check if all indicators were brought up successfully, and kill them for later
   '' + (runCommandOverAyatanaIndicators (service: let serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service; in ''
-    machine.succeed("pgrep -f ${serviceExec}")
+    machine.succeed("pgrep -u ${user} -f ${serviceExec}")
     machine.succeed("pkill -f ${serviceExec}")
   '')) + ''
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -42,6 +42,7 @@ let
     lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
     lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     mediascanner2 = callPackage ./services/mediascanner2 { };
+    telephony-service = callPackage ./services/telephony-service { };
   };
 in
   lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -1,0 +1,227 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, fetchpatch2
+, gitUpdater
+, nixosTests
+, ayatana-indicator-messages
+, bash
+, cmake
+, dbus
+, dbus-glib
+, dbus-test-runner
+, dconf
+, gettext
+, glib
+, gnome
+, history-service
+, libnotify
+, libphonenumber
+, libpulseaudio
+, libusermetrics
+, lomiri-ui-toolkit
+, lomiri-url-dispatcher
+, makeWrapper
+, pkg-config
+, protobuf
+, python3
+, qtbase
+, qtdeclarative
+, qtfeedback
+, qtmultimedia
+, qtpim
+, telepathy
+, telepathy-glib
+, telepathy-mission-control
+, xvfb-run
+}:
+
+let
+  replaceDbusService = pkg: name: "--replace \"\\\${DBUS_SERVICES_DIR}/${name}\" \"${pkg}/share/dbus-1/services/${name}\"";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "telephony-service";
+  version = "0.5.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/telephony-service";
+    rev = finalAttrs.version;
+    hash = "sha256-9KxM8UWTIBpMMPosar2ZV9W35WmCLIWXD1ulWtqCKxM=";
+  };
+
+  patches = [
+    # Remove when version > 0.5.2
+    (fetchpatch {
+      name = "0001-telephony-service-CMakeLists-Fix-Cross-conditional-for-QT_INSTALL_QML-determining.patch";
+      url = "https://gitlab.com/ubports/development/core/telephony-service/-/commit/c19463444af257c263f35127284d9787f3522f1f.patch";
+      hash = "sha256-Dr/uev/z4pEiV4/QRmQ15+6wrD8rh+8vRcfWIi8FBCU=";
+    })
+
+    # Remove when version > 0.5.2
+    (fetchpatch {
+      name = "0002-telephony-service-tests-libtelephonyservice-CMakeLists-Fix-ProtocolTest-build.patch";
+      url = "https://gitlab.com/ubports/development/core/telephony-service/-/commit/d8f0f38f8b723569c03d601ac803b079ed51d09e.patch";
+      hash = "sha256-asDEzh8Yg6LXl6fdwan6IhwLEuzmDfmHI+pjpxJRbeE=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/telephony-service/-/merge_requests/89 merged & in release
+    (fetchpatch2 {
+      name = "0003-telephony-service-Add-more-better-GNUInstallDirs-variables-usage.patch";
+      url = "https://gitlab.com/ubports/development/core/telephony-service/-/commit/9a35a50c587ebfdfb1e08b54ffec0d2e6fef1950.patch";
+      hash = "sha256-jGeJlwbyVr0WkyGKY7Lw5dY/V9yN43DpZmuli6oRho0=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/telephony-service/-/merge_requests/90 merged & in release
+    (fetchpatch {
+      name = "0004-telephony-service-CMakeLists-Make-tests-optional.patch";
+      url = "https://gitlab.com/ubports/development/core/telephony-service/-/commit/9a8297bcf9b34d77ffdae3dfe4ad2636022976fb.patch";
+      hash = "sha256-Za4ZGKnw9iz2RP1LzLhKrEJ1vLUufWk8J07LmWDW40E=";
+    })
+
+    # libphonenumber -> protobuf -> abseil-cpp demands C++14
+    # But uses std::string_view which is C++17?
+    # Remove when version > 0.5.2
+    (fetchpatch {
+      name = "0005-telephony-service-Upgrade-C++-standard-to-C++17.patch";
+      url = "https://gitlab.com/ubports/development/core/telephony-service/-/commit/b77349acb4ab3f857a55481eeaf2af1dcecfb775.patch";
+      hash = "sha256-vNtelYu/I9lv8EkNn8gB6zNgLJ24Znp9HYmLG9olFe8=";
+    })
+  ];
+
+  postPatch = ''
+    # Queries qmake for the QML installation path, which returns a reference to Qt5's build directory
+    substituteInPlace CMakeLists.txt \
+      --replace "\''${QMAKE_EXECUTABLE} -query QT_INSTALL_QML" "echo $out/${qtbase.qtQmlPrefix}"
+
+  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
+    substituteInPlace tests/common/dbus-services/CMakeLists.txt \
+      ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.MissionControl5.service"} \
+      ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.AccountManager.service"} \
+      ${replaceDbusService dconf "ca.desrt.dconf.service"}
+
+    substituteInPlace cmake/modules/GenerateTest.cmake \
+      --replace '/usr/lib/dconf' '${lib.getLib dconf}/libexec' \
+      --replace '/usr/lib/telepathy' '${lib.getLib telepathy-mission-control}/libexec'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    ayatana-indicator-messages
+    bash
+    dbus-glib
+    dbus
+    dconf
+    gettext
+    glib
+    history-service
+    libnotify
+    libphonenumber
+    libpulseaudio
+    libusermetrics
+    lomiri-url-dispatcher
+    protobuf
+    (python3.withPackages (ps: with ps; [
+      dbus-python
+      pygobject3
+    ]))
+    qtbase
+    qtdeclarative
+    qtfeedback
+    qtmultimedia
+    qtpim
+    telepathy
+    telepathy-glib
+    telepathy-mission-control
+  ];
+
+  nativeCheckInputs = [
+    dbus-test-runner
+    dconf
+    gnome.gnome-keyring
+    telepathy-mission-control
+    xvfb-run
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    # These rely on libphonenumber reformatting inputs to certain results
+    # Seem to be broken for a small amount of numbers, maybe libphonenumber version change?
+    (lib.cmakeBool "SKIP_QML_TESTS" true)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
+      # Exclude tests
+      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
+        # Flaky, randomly failing to launch properly & stuck until test timeout
+        "^HandlerTest"
+        "^OfonoAccountEntryTest"
+        "^TelepathyHelperSetupTest"
+        "^AuthHandlerTest"
+        "^ChatManagerTest"
+      ]})")
+    ]))
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString ([
+    "-I${lib.getDev telepathy-glib}/include/telepathy-1.0" # it's in telepathy-farstream's Requires.private, so it & its dependencies don't get pulled in
+    "-I${lib.getDev dbus-glib}/include/dbus-1.0" # telepathy-glib dependency
+    "-I${lib.getDev dbus}/include/dbus-1.0" # telepathy-glib dependency
+  ]);
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Starts & talks to D-Bus services, breaks with parallelism
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export QT_QPA_PLATFORM=minimal
+    export QT_PLUGIN_PATH=${lib.makeSearchPathOutput "bin" qtbase.qtPluginPrefix [ qtbase qtpim ]}
+  '';
+
+  postInstall = ''
+    patchShebangs $out/bin/{ofono-setup,phone-gsettings-migration.py}
+
+    # Still missing getprop from libhybris, we don't have it packaged (yet?)
+    wrapProgram $out/bin/ofono-setup \
+      --prefix PATH : ${lib.makeBinPath [ dbus dconf gettext glib telepathy-mission-control ]}
+
+    # These SystemD services are referenced by the installed D-Bus services, but not part of the installation. Why?
+    for service in telephony-service-{approver,indicator}; do
+      install -Dm644 ../debian/telephony-service."$service".user.service $out/lib/systemd/user/"$service".service
+
+      # ofono-setup.service would be rovided by ubuntu-touch-session, we don't plan to package it
+      substituteInPlace $out/lib/systemd/user/"$service".service \
+        --replace '/usr' "$out" \
+        --replace 'Requires=ofono-setup.service' "" \
+        --replace 'After=ofono-setup.service' "" \
+
+      sed -i $out/lib/systemd/user/"$service".service \
+        -e '/ofono-setup.service/d'
+    done
+  '';
+
+  passthru = {
+    ayatana-indicators = [
+      "telephony-service-indicator"
+    ];
+    tests.vm = nixosTests.ayatana-indicators;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Backend dispatcher service for various mobile phone related operations";
+    homepage = "https://gitlab.com/ubports/development/core/telephony-service";
+    changelog = "https://gitlab.com/ubports/development/core/telephony-service/-/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[`telephony-service`](https://gitlab.com/ubports/development/core/telephony-service) is a dispatcher service for mobile phone related operations. The Lomiri shell and the dialer, address book & messaging app request it.

QML tests are disabled due to some issue with phone number formatting. Maybe some assumptions about how `libphonenumber` formats certain numbers has changed since they were written? For example, expects `+558187042155` to be re-formatted as `+55 81 8704-2155` but it turns into `+55 81 87042-155` instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
