### PR TITLE
papirus-icon-theme: 20230901 -> 20231101

### DIFF
--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenvNoCC, fetchFromGitHub, gtk3, pantheon, breeze-icons, gnome-icon-theme, hicolor-icon-theme, papirus-folders, color ? null }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, pantheon
+, breeze-icons
+, gnome-icon-theme
+, hicolor-icon-theme
+, papirus-folders
+, color ? null
+, gitUpdater
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "papirus-icon-theme";
@@ -11,7 +22,10 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-FcTNZgCdPlYjpheA3PfZBR3apOkDi4+RafQtXdqchGI=";
   };
 
-  nativeBuildInputs = [ gtk3 papirus-folders ];
+  nativeBuildInputs = [
+    gtk3
+    papirus-folders
+  ];
 
   propagatedBuildInputs = [
     pantheon.elementary-icon-theme
@@ -24,6 +38,7 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/share/icons
     mv {,e}Papirus* $out/share/icons
 
@@ -34,6 +49,8 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     description = "Papirus icon theme";

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -13,13 +13,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "papirus-icon-theme";
-  version = "20230901";
+  version = "20231101";
 
   src = fetchFromGitHub {
     owner = "PapirusDevelopmentTeam";
     repo = pname;
     rev = version;
-    hash = "sha256-FcTNZgCdPlYjpheA3PfZBR3apOkDi4+RafQtXdqchGI=";
+    hash = "sha256-0ooHuMqGzlMLVTR/u+kCJLibfqTAtq662EG8i3JIzPA=";
   };
 
   nativeBuildInputs = [
@@ -53,7 +53,7 @@ stdenvNoCC.mkDerivation rec {
   passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
-    description = "Papirus icon theme";
+    description = "Pixel perfect icon theme for Linux";
     homepage = "https://github.com/PapirusDevelopmentTeam/papirus-icon-theme";
     license = licenses.gpl3Only;
     # darwin gives hash mismatch in source, probably because of file names differing only in case

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -2,12 +2,12 @@
 , stdenvNoCC
 , fetchFromGitHub
 , gtk3
-, pantheon
 , breeze-icons
-, gnome-icon-theme
+, elementary-icon-theme
 , hicolor-icon-theme
 , papirus-folders
 , color ? null
+, withElementary ? false
 , gitUpdater
 }:
 
@@ -28,10 +28,10 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    pantheon.elementary-icon-theme
     breeze-icons
-    gnome-icon-theme
     hicolor-icon-theme
+  ] ++ lib.optional withElementary [
+    elementary-icon-theme
   ];
 
   dontDropIconThemeCache = true;
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/share/icons
-    mv {,e}Papirus* $out/share/icons
+    mv ${lib.optionalString withElementary "{,e}"}Papirus* $out/share/icons
 
     for theme in $out/share/icons/*; do
       ${lib.optionalString (color != null) "${papirus-folders}/bin/papirus-folders -t $theme -o -C ${color}"}

--- a/pkgs/desktops/deepin/artwork/deepin-icon-theme/default.nix
+++ b/pkgs/desktops/deepin/artwork/deepin-icon-theme/default.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
-  postFixup = ''
+  preFixup = ''
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache $theme
     done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29267,6 +29267,8 @@ with pkgs;
 
   eduli = callPackage ../data/fonts/eduli { };
 
+  epapirus-icon-theme = papirus-icon-theme.override { withElementary = true; };
+
   moeli = eduli;
 
   edusong = callPackage ../data/fonts/edusong { };
@@ -29800,6 +29802,7 @@ with pkgs;
   paper-icon-theme = callPackage ../data/icons/paper-icon-theme { };
 
   papirus-icon-theme = callPackage ../data/icons/papirus-icon-theme {
+    inherit (pantheon) elementary-icon-theme;
     inherit (plasma5Packages) breeze-icons;
   };
 


### PR DESCRIPTION
## Description of changes

- Update to version [20231101](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20231101)
- Add `withElementary` optional argument
- `papirus-icon-theme` does not include _ePapirus_ and _ePapirus-Dark_ themes anymore
- `epapirus-icon-theme` is new and includes all themes
- Remove dependence on `gnome-icon-theme`, as it is not an inherited theme anymore.
- Add update script

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
