### PR TITLE
tuxmux: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/by-name/tu/tuxmux/package.nix
+++ b/pkgs/by-name/tu/tuxmux/package.nix
@@ -2,26 +2,25 @@
 , stdenv
 , fetchFromGitHub
 , rustPlatform
-, openssl
+, libiconv
 , pkg-config
 , installShellFiles
-, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "tuxmux";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "edeneast";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-QySDC/aEU9Fo0UbRUNvgBQLfESYzENGfS8Tl/ycn1YY=";
+    hash = "sha256-BZ1Vo1NIpzUBGyvd/UbxLaFbrLzoaP8kn/8GoAYBmlo=";
   };
 
-  cargoHash = "sha256-MlLTaN+KMeF0A1hh0oujLYWqjwrbmoNzoRoXjeCUf7I=";
+  cargoHash = "sha256-HIYQPHLMhQtpCIkl5EzjJGHXzBtw7mY85l5bqapw3rg=";
 
-  buildInputs = [ openssl ] ++ (lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ]);
+  buildInputs = [ libiconv ];
   nativeBuildInputs = [ pkg-config installShellFiles ];
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes

The dependencies have been simplified and no longer requires libgit2 which required openssl.

- Release [0.1.1](https://github.com/EdenEast/tuxmux/releases/tag/v0.1.1)
- [Changelog](https://github.com/EdenEast/tuxmux/blob/main/CHANGELOG.md#changelog)

Closes: #264846  

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
