### PR TITLE
buuf-icon-theme: init at 3.45

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16410,6 +16410,12 @@
     githubId = 158321;
     name = "Stewart Mackenzie";
   };
+  sk4rd = {
+    email = "mikolaj.bajtkiewicz@tutanota.de";
+    github = "sk4rd";
+    githubId = 42469640;
+    name = "Mikolaj Bajtkiewicz";
+  };
   skeidel = {
     email = "svenkeidel@gmail.com";
     github = "svenkeidel";

--- a/pkgs/data/icons/buuf-icon-theme/default.nix
+++ b/pkgs/data/icons/buuf-icon-theme/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation {
+  pname = "buuf-icon-theme";
+  version = "3.45";
+
+  src = fetchzip {
+    url = "http://buuficontheme.free.fr/buuf3.45.tar.xz";
+    hash = "sha256-TrUHW3W4fMR8esirEenKxV+cxnzjC5U0raPfutear+g=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons/
+    cp -r . $out/share/icons/buuf-icon-theme
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A whimsical and unique icon theme adapted for Gnome";
+    homepage = "http://buuficontheme.free.fr/";
+    platforms = platforms.all;
+    license = licenses.cc-by-nc-sa-25;
+    maintainers = with maintainers; [ sk4rd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29076,6 +29076,8 @@ with pkgs;
 
   arc-theme = callPackage ../data/themes/arc { };
 
+  buuf-icon-theme = callPackage ../data/icons/buuf-icon-theme { };
+
   arkpandora_ttf = callPackage ../data/fonts/arkpandora { };
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };


### PR DESCRIPTION
## Description of changes

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).