### PR TITLE
pyqt6: 6.5.2 -> 6.6.0

### DIFF
--- a/pkgs/development/python-modules/pyqt-builder/default.nix
+++ b/pkgs/development/python-modules/pyqt-builder/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "pyqt-builder";
-  version = "1.15.2";
+  version = "1.15.3";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "PyQt-builder";
     inherit version;
-    hash = "sha256-dGz+g8A+v/RFjUeKHAZxR5Dvk+RY7NWii8KDe6yI63Q=";
+    hash = "sha256-WzPpnty3fUpjo4YF9EV6BM/04lTHce1SnryViZBszbE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "PyQt6";
-  version = "6.5.2";
+  version = "6.6.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-FIfuc1D5/7ZtYKtBdlGSUsKzcXYsvo+DQP2VH2OAEoA=";
+    hash = "sha256-1BUS1mBEwt+cX1FaVqkiFw1oo3s0Bv/dyLStxXGBtXY=";
   };
 
   patches = [
@@ -131,9 +131,6 @@ buildPythonPackage rec {
   # ++ lib.optional withConnectivity "PyQt6.QtConnectivity"
   ++ lib.optional withLocation "PyQt6.QtPositioning"
   ;
-
-  # fix build with qt 6.6
-  env.NIX_CFLAGS_COMPILE = "-fpermissive";
 
   meta = with lib; {
     description = "Python bindings for Qt6";

--- a/pkgs/development/python-modules/pyqt6-charts.nix
+++ b/pkgs/development/python-modules/pyqt6-charts.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "PyQt6_Charts";
-  version = "6.5.0";
+  version = "6.6.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-b/APZbJRf5m/EG3dKMdvPKNE+R7PW6aBkeIKLZACSWI=";
+    sha256 = "sha256-FMxuXRnK6AEpUkpC+mMy0NXa2kKCqUI0Jea5rhtrxW0=";
   };
 
   # fix include path and increase verbosity

--- a/pkgs/development/python-modules/pyqt6-webengine.nix
+++ b/pkgs/development/python-modules/pyqt6-webengine.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "PyQt6_WebEngine";
-  version = "6.5.0";
+  version = "6.6.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-i6nbVsTBgaKi+rFnPKNeW2PcaRE/CFAn3cQ8cQttbuk=";
+    hash = "sha256-1QuYTD+F5AnmkrFWEychUi1OjPm2wl4M+Sfuot+zlIc=";
   };
 
   # fix include path and increase verbosity

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "sip";
-  version = "6.7.11";
+  version = "6.7.12";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8Nwyh6CxcuVmSTHIeEd1DUfk/c2k/jYrUUr47dZVtGk=";
+    hash = "sha256-COZvdCWS64GKyP2kFz4u1kyfLUC3C+4R2xxJkSfZhFA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

update to match current qt release version.

~Also included is a fix for ffado package to remove the GUI mixer by default, since that causes webengine to depend on pyqt unnecessarily.~

~There is no way way to avoid a costly rebuild of qtwebengine for this change, but this fix will resolve having to do so each time we bump pyqt.~ addressed in #269467

Because a bump of `sip` was also required, there are quite a few package rebuilds.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->