### PR TITLE
nixos/ebusd: clean up module

### DIFF
--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -4,67 +4,35 @@ with lib;
 
 let
   cfg = config.services.ebusd;
-
-  package = pkgs.ebusd;
-
-  arguments = [
-    "${package}/bin/ebusd"
-    "--foreground"
-    "--updatecheck=off"
-    "--device=${cfg.device}"
-    "--port=${toString cfg.port}"
-    "--configpath=${cfg.configpath}"
-    "--scanconfig=${cfg.scanconfig}"
-    "--log=main:${cfg.logs.main}"
-    "--log=network:${cfg.logs.network}"
-    "--log=bus:${cfg.logs.bus}"
-    "--log=update:${cfg.logs.update}"
-    "--log=other:${cfg.logs.other}"
-    "--log=all:${cfg.logs.all}"
-  ] ++ lib.optionals cfg.readonly [
-    "--readonly"
-  ] ++ lib.optionals cfg.mqtt.enable [
-    "--mqtthost=${cfg.mqtt.host}"
-    "--mqttport=${toString cfg.mqtt.port}"
-    "--mqttuser=${cfg.mqtt.user}"
-    "--mqttpass=${cfg.mqtt.password}"
-  ] ++ lib.optionals cfg.mqtt.home-assistant [
-    "--mqttint=${package}/etc/ebusd/mqtt-hassio.cfg"
-    "--mqttjson"
-  ] ++ lib.optionals cfg.mqtt.retain [
-    "--mqttretain"
-  ] ++ cfg.extraArguments;
-
-  usesDev = hasPrefix "/" cfg.device;
-
-  command = concatStringsSep " " arguments;
-
 in
 {
   meta.maintainers = with maintainers; [ nathan-gs ];
 
   options.services.ebusd = {
-    enable = mkEnableOption (lib.mdDoc "ebusd service");
+    enable = mkEnableOption (mdDoc "ebusd service");
+
+    package = mkPackageOptionMD pkgs "ebusd" { };
 
     device = mkOption {
       type = types.str;
       default = "";
       example = "IP:PORT";
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Use DEV as eBUS device [/dev/ttyUSB0].
         This can be either:
           enh:DEVICE or enh:IP:PORT for enhanced device (only adapter v3 and newer),
           ens:DEVICE for enhanced high speed serial device (only adapter v3 and newer with firmware since 20220731),
           DEVICE for serial device (normal speed, for all other serial adapters like adapter v2 as well as adapter v3 in non-enhanced mode), or
           [udp:]IP:PORT for network device.
-        https://github.com/john30/ebusd/wiki/2.-Run#device-options
+
+        Source: <https://github.com/john30/ebusd/wiki/2.-Run#device-options>
       '';
     };
 
     port = mkOption {
       default = 8888;
       type = types.port;
-      description = lib.mdDoc ''
+      description = mdDoc ''
         The port on which to listen on
       '';
     };
@@ -72,7 +40,7 @@ in
     readonly = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = mdDoc ''
          Only read from device, never write to it
       '';
     };
@@ -80,85 +48,40 @@ in
     configpath = mkOption {
       type = types.str;
       default = "https://cfg.ebusd.eu/";
-      description = lib.mdDoc ''
-        Read CSV config files from PATH (local folder or HTTPS URL) [https://cfg.ebusd.eu/]
+      description = mdDoc ''
+        Directory to read CSV config files from. This can be a local folder or an URL.
       '';
     };
 
     scanconfig = mkOption {
       type = types.str;
       default = "full";
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Pick CSV config files matching initial scan ("none" or empty for no initial scan message, "full" for full scan, or a single hex address to scan, default is to send a broadcast ident message).
         If combined with --checkconfig, you can add scan message data as arguments for checking a particular scan configuration, e.g. "FF08070400/0AB5454850303003277201". For further details on this option,
         see [Automatic configuration](https://github.com/john30/ebusd/wiki/4.7.-Automatic-configuration).
       '';
     };
 
-    logs = {
-      main = mkOption {
-        type = types.enum [ "error" "notice" "info" "debug"];
-        default = "info";
-        description = lib.mdDoc ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      network = mkOption {
-        type = types.enum [ "error" "notice" "info" "debug"];
-        default = "info";
-        description = lib.mdDoc ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      bus = mkOption {
-        type = types.enum [ "error" "notice" "info" "debug"];
-        default = "info";
-        description = lib.mdDoc ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      update = mkOption {
-        type = types.enum [ "error" "notice" "info" "debug"];
-        default = "info";
-        description = lib.mdDoc ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      other = mkOption {
-        type = types.enum [ "error" "notice" "info" "debug"];
-        default = "info";
-        description = lib.mdDoc ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      all = mkOption {
-        type = types.enum [ "error" "notice" "info" "debug"];
-        default = "info";
-        description = lib.mdDoc ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
-        '';
-      };
-    };
+    logs = let
+      areas = [ "main" "network" "bus" "update" "other" "all" ];
+      levels = [ "error" "notice" "info" "debug" ];
+    in listToAttrs (map (area: nameValuePair area (mkOption {
+      type = types.enum levels;
+      default = "notice";
+      example = "debug";
+      description = mdDoc ''
+        Only write log for matching `AREA`s (${concatStringsSep "|" areas}) below or equal to `LEVEL` (${concatStringsSep "|" levels})
+      '';
+    })) areas);
 
     mqtt = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Adds support for MQTT
-        '';
-      };
+      enable = mkEnableOption (mdDoc "support for MQTT");
 
       host = mkOption {
         type = types.str;
         default = "localhost";
-        description = lib.mdDoc ''
+        description = mdDoc ''
           Connect to MQTT broker on HOST.
         '';
       };
@@ -166,7 +89,7 @@ in
       port = mkOption {
         default = 1883;
         type = types.port;
-        description = lib.mdDoc ''
+        description = mdDoc ''
           The port on which to connect to MQTT
         '';
       };
@@ -174,61 +97,73 @@ in
       home-assistant = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = mdDoc ''
           Adds the Home Assistant topics to MQTT, read more at [MQTT Integration](https://github.com/john30/ebusd/wiki/MQTT-integration)
         '';
       };
 
-      retain = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Set the retain flag on all topics instead of only selected global ones
-        '';
-      };
+      retain = mkEnableOption (mdDoc "set the retain flag on all topics instead of only selected global ones");
 
       user = mkOption {
         type = types.str;
-        description = lib.mdDoc ''
+        description = mdDoc ''
           The MQTT user to use
         '';
       };
 
       password = mkOption {
         type = types.str;
-        description = lib.mdDoc ''
+        description = mdDoc ''
           The MQTT password.
         '';
       };
-
     };
 
     extraArguments = mkOption {
       type = types.listOf types.str;
       default = [];
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Extra arguments to the ebus daemon
       '';
     };
-
   };
 
-  config = mkIf (cfg.enable) {
-
+  config = let
+    usesDev = hasPrefix "/" cfg.device;
+  in mkIf cfg.enable {
     systemd.services.ebusd = {
       description = "EBUSd Service";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        ExecStart = command;
+        ExecStart = let
+          args = cli.toGNUCommandLineShell { } (foldr (a: b: a // b) { } [
+            {
+              inherit (cfg) device port configpath scanconfig readonly;
+              foreground = true;
+              updatecheck = "off";
+              log = mapAttrsToList (name: value: "${name}:${value}") cfg.logs;
+              mqttretain = cfg.mqtt.retain;
+            }
+            (optionalAttrs cfg.mqtt.enable {
+              mqtthost  = cfg.mqtt.host;
+              mqttport  = cfg.mqtt.port;
+              mqttuser  = cfg.mqtt.user;
+              mqttpass  = cfg.mqtt.password;
+            })
+            (optionalAttrs cfg.mqtt.home-assistant {
+              mqttint = "${cfg.package}/etc/ebusd/mqtt-hassio.cfg";
+              mqttjson = true;
+            })
+          ]);
+        in "${cfg.package}/bin/ebusd ${args} ${escapeShellArgs cfg.extraArguments}";
+
         DynamicUser = true;
         Restart = "on-failure";
 
         # Hardening
         CapabilityBoundingSet = "";
-        DeviceAllow = lib.optionals usesDev [
-          cfg.device
-        ] ;
+        DeviceAllow = optionals usesDev [ cfg.device ];
         DevicePolicy = "closed";
         LockPersonality = true;
         MemoryDenyWriteExecute = false;
@@ -254,9 +189,7 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
-        SupplementaryGroups = [
-          "dialout"
-        ];
+        SupplementaryGroups = [ "dialout" ];
         SystemCallArchitectures = "native";
         SystemCallFilter = [
           "@system-service @pkey"
@@ -265,6 +198,5 @@ in
         UMask = "0077";
       };
     };
-
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

This PR only cleans up the code of the `ebusd` module, with the intention of not changing the outcome.

In general, I've cleaned up a bunch of descriptions, inlined a few single element lists, removed some extra space. The two big changes are the automatic generation of the `services.ebusd.logs` options, and the use of `cli.toGNUCommandLineShell` for constructing the string of arguments. The latter has also been moved from the top of the file, closer to the `ExecStart` where it is used.

I've tested that the code evalutates manually, but it would be nice if this had a basic test. Not sure how easy that would be to make though, considering it's a hardware related program.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
