### PR TITLE
gnunet-gtk: copy missing logo image

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet/gtk.nix
+++ b/pkgs/applications/networking/p2p/gnunet/gtk.nix
@@ -38,7 +38,11 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-gnunet=${gnunet}" ];
 
-  patchPhase = "patchShebangs pixmaps/icon-theme-installer";
+  postPatch = "patchShebangs pixmaps/icon-theme-installer";
+
+  postInstall = ''
+    ln -s $out/share/gnunet-gtk/gnunet_logo.png $out/share/gnunet/gnunet-logo-color.png
+  '';
 
   meta = gnunet.meta // {
     description = "GNUnet GTK User Interface";


### PR DESCRIPTION
## Description of changes

Fixes #121435

I assume "gnunet_logo.png" is the logo that's supposed to show up:

![image](https://github.com/NixOS/nixpkgs/assets/12560461/5d8bccbe-9aa5-4d06-99a3-b7a7793aa3a5)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).