### PR TITLE
tailwindcss-language-server: init at 0.0.14

### DIFF
--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, buildNpmPackage
+, fetchFromGitHub
+, python3
+, darwin
+, libsecret
+, pkg-config
+}:
+
+let
+  version = "0.0.14";
+in
+buildNpmPackage {
+  pname = "tailwindcss-language-server";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "tailwindlabs";
+    repo = "tailwindcss-intellisense";
+    rev = "@tailwindcss/language-server@v${version}";
+    hash = "sha256-EE1Gd0cmcJmyleoXVNtMJ8IKYpQIzRf2F42HOORHbwo=";
+  };
+
+  makeCacheWritable = true;
+  npmDepsHash = "sha256-gQgGIo/cS0P1B5lSmNpd8WOgucf3RbRk1YOvMXNbxb0=";
+  npmWorkspace = "packages/tailwindcss-language-server";
+
+  buildInputs = [ libsecret ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security AppKit ]);
+
+  nativeBuildInputs = [ python3 pkg-config ];
+
+  meta = with lib; {
+    description = "Intelligent Tailwind CSS tooling for Visual Studio Code";
+    homepage = "https://github.com/tailwindlabs/tailwindcss-intellisense";
+    license = licenses.mit;
+    maintainers = with maintainers; [ happysalada];
+    mainProgram = "tailwindcss-language-server";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

The fix for having the binary working with helix editor is just released, even though it doesn't appear anywhere in the release notes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
