### PR TITLE
nixos/socketActivation: init

### DIFF
--- a/nixos/modules/misc/socket-activation.nix
+++ b/nixos/modules/misc/socket-activation.nix
@@ -1,0 +1,188 @@
+{ options, config, pkgs, lib, ... }:
+let
+  inherit (lib) mkOption types mdDoc;
+in
+{
+  options.socketActivation = mkOption {
+    type = types.attrsOf (types.submodule ({ name, ... }: {
+      options = {
+        enable = lib.mkEnableOption "socket activation for a systemd service";
+
+        service = mkOption {
+          type = types.str;
+          default = name;
+          defaultText = "<name>";
+          example = "gitea";
+          description = mdDoc "Systemd service name";
+        };
+
+        privateNamespace = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = mdDoc ''
+            Whether to isolate the network of the original service.
+
+            This is recommended, but might be impractical if the original
+            service also uses networking for its own operation.
+          '';
+        };
+
+        originalSocketAddress = mkOption {
+          type = types.str;
+          example = "localhost:8080";
+          description = mdDoc ''
+            Socket that the original service is listening to.
+
+            This could be an INET/6 or UNIX socket.
+          '';
+        };
+
+        newSocketAddress = mkOption {
+          type = with types; either str port;
+          default = "/run/${name}.socket";
+          defaultText = "/run/<name>.socket";
+          example = "localhost:8080";
+          description = mdDoc ''
+            Address of the new systemd socket.
+
+            This could be an INET/6 or UNIX socket.
+          '';
+        };
+
+        connectionsMax = mkOption {
+          type = types.ints.unsigned;
+          default = 256;
+          example = 1024;
+          description = mdDoc ''
+            Sets the maximum number of simultaneous connections.
+            If the limit of concurrent connections is reached further connections will be refused.
+
+            See <https://www.freedesktop.org/software/systemd/man/systemd-socket-proxyd.html#--connections-max=>
+          '';
+        };
+
+        exitIdleTime = mkOption {
+          type = types.nullOr types.str;
+          default = "5m";
+          example = "1h";
+          description = mdDoc ''
+            Amount of inactivity time, before systemd shuts down the service.
+            If this is set to `null`, the service will never stop.
+
+            See <https://www.freedesktop.org/software/systemd/man/systemd-socket-proxyd.html#--exit-idle-time=>
+          '';
+        };
+
+        openFirewall = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = mdDoc ''
+            Whether to open the firewall for {var}`newSocketAddress`
+          '';
+        };
+
+        createNginxUpstream = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = mdDoc ''
+            Whether to create an http upstream entry for {var}`newSocketAddress` in nginx.
+
+            See <https://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream>
+          '';
+        };
+
+        extraSocketConfig = mkOption {
+          type = types.attrs; # TODO: not exactly sure how to type this,
+                              #       maybe reexposing this through the module is a bad idea?
+          default = { };
+          example = {
+            KeepAlive = true;
+            MaxConnectionsPerSource = 3;
+            Priority = 2;
+          };
+          description = mdDoc ''
+            Extra configuration to go into the [socket] section of the systemd unit.
+
+            See <https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html>
+          '';
+        };
+      };
+    }));
+    description = mdDoc "Socket activated services using {command}`systemd-socket-proxyd`.";
+    default = { };
+  };
+
+  config = let
+    activeServices = lib.filterAttrs (_: value: value.enable) config.socketActivation;
+    foreachService = f: lib.mapAttrsToList f activeServices;
+  in {
+    assertions = foreachService (name: value: {
+      # NOTE: This assertion is just covering for the most basic invalid usecases, but misses a lot.
+      #       The original socket address could've been "localhost:1234" and now only "1234",
+      #         while still meaning the same thing.
+      assertion = lib.any (b: b) [
+        value.privateNamespace
+        # If this is a UNIX socket, the paths themself
+        # would clash even if in a private namespace
+        (lib.hasPrefix "/" value.originalSocketAddress)
+        (lib.hasPrefix "@" value.originalSocketAddress)
+      ] -> (value.originalSocketAddress != value.newSocketAddress);
+      message = ''
+        The new proxied socket of "${name}" has a new socket address of "${toString value.newSocketAddress}",
+        which clashes with its original address of "${toString value.originalSocketAddress}".
+
+        Either enable privateNamespace to isolate the original service' network, or use a separate socket address.
+      '';
+    });
+
+    services.nginx.upstreams = let
+      servicesWithNginxUpstream = lib.filterAttrs (_: value: value.createNginxUpstream) activeServices;
+    in lib.mapAttrsToList (name: value: let
+      protocol = if lib.any (p: lib.hasPrefix p value.newSocketAddress) [ "/" "@" ]  then "unix" else "http";
+    in {
+      ${name}.servers."${protocol}:${value.newSocketAddress}" = { };
+    }) servicesWithNginxUpstream;
+
+    systemd = lib.mkMerge (foreachService (name: value: let
+      originalService = config.systemd.services.${value.service};
+    in {
+      sockets."${name}-proxy" = {
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = value.newSocketAddress;
+          MaxConnections = value.connectionsMax;
+        };
+      };
+
+      services."${name}-proxy" = rec {
+        requires = [
+          "${name}.service"
+          "${name}-proxy.socket"
+        ];
+        after = requires;
+
+        unitConfig.JoinsNamespaceOf = lib.mkIf value.privateNamespace "${value.service}.service";
+
+        serviceConfig = {
+          ExecStart = let
+            args = lib.cli.toGNUCommandLineShell { } {
+              exit-idle-time = if value.exitIdleTime != null then value.exitIdleTime else "infinity";
+              connections-max = value.connectionsMax;
+            };
+          in ''${pkgs.systemd}/lib/systemd/systemd-socket-proxyd ${args} "${value.originalSocketAddress}"'';
+          PrivateNetwork = value.privateNamespace;
+        };
+      };
+
+      services.${name} = {
+        unitConfig.StopWhenUnneeded = true;
+        serviceConfig.PrivateNetwork = value.privateNamespace;
+      };
+    }));
+  };
+
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -133,6 +133,7 @@
   ./misc/nixops-autoluks.nix
   ./misc/nixpkgs.nix
   ./misc/passthru.nix
+  ./misc/socket-activation.nix
   ./misc/version.nix
   ./misc/wordlist.nix
   ./programs/_1password-gui.nix


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This module uses [`systemd-socket-proxyd`](https://www.freedesktop.org/software/systemd/man/latest/systemd-socket-proxyd.html) to create a way to make services socket activated. This should allow programs which does not support socket activation out of the box to support it through this proxy. It also enables automatically shutting down the services after a certain period of no traffic.

I am not very confident in the location and naming of this module. In one sense, it should be called `systemd-socket-proxyd`, as that is the main program that makes this possible. On the other hand, this is not a pure service module for that program, as it binds together a bunch of stuff. I'd really like to hear some thoughts about this.

I'm also wondering whether there's a good way to extend it to be used with [`Accept=yes`](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html#Accept=) services as well, but at that point it might be out of scope for what the module is intended to do?

### Remaining todos:

- [ ] Documentation
      This should have some documentation, preferably with examples of integrations with nginx, and programs that use the nginx auth_request module (e.g. vouch-proxy, oauth2-proxy).
- [ ] NixOS tests

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

---

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
