### PR TITLE
ctrtool: 0.7 -> 1.2.0

### DIFF
--- a/pkgs/tools/archivers/ctrtool/default.nix
+++ b/pkgs/tools/archivers/ctrtool/default.nix
@@ -1,25 +1,33 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "ctrtool";
-  version = "0.7";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner  = "jakcron";
     repo   = "Project_CTR";
     rev    = "ctrtool-v${version}";
-    sha256 = "07aayck82w5xcp3si35d7ghybmrbqw91fqqvmbpjrjcixc6m42z7";
+    sha256 = "wjU/DJHrAHE3MSB7vy+swUDVPzw0Jrv4ymOjhfr0BBk=";
   };
 
   sourceRoot = "${src.name}/ctrtool";
 
-  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "CXX=${stdenv.cc.targetPrefix}c++"];
   enableParallelBuilding = true;
+
+  preBuild = ''
+  make -j $NIX_BUILD_CORES deps
+  '';
+
+  # workaround for https://github.com/3DSGuy/Project_CTR/issues/145
+  env.NIX_CFLAGS_COMPILE = "-O0";
 
   installPhase = "
     mkdir $out/bin -p
-    cp ctrtool${stdenv.hostPlatform.extensions.executable} $out/bin/
+    cp bin/ctrtool${stdenv.hostPlatform.extensions.executable} $out/bin/
   ";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "ctrtool-v"; };
 
   meta = with lib; {
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes

See changelogs for ctrtool [1.0.0](https://github.com/3DSGuy/Project_CTR/releases/tag/ctrtool-v1.0.0) (a near-complete rewrite), [1.1.0](https://github.com/3DSGuy/Project_CTR/releases/tag/ctrtool-v1.1.0), and [1.2.0](https://github.com/3DSGuy/Project_CTR/releases/tag/ctrtool-v1.2.0). I've also added a `passthru.updateScript` using `gitUpdater`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
