### PR TITLE
python311Packages.urllib3: 2.0.6 -> 2.0.7

### DIFF
--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -1,4 +1,5 @@
 { lib
+, backports-zoneinfo
 , brotli
 , brotlicffi
 , buildPythonPackage
@@ -8,18 +9,16 @@
 , hatchling
 , idna
 , isPyPy
-, mock
 , pyopenssl
 , pysocks
-, pytest-freezegun
 , pytest-timeout
 , pytestCheckHook
-, python-dateutil
+, pythonOlder
 , tornado
 , trustme
 }:
 
-buildPythonPackage rec {
+let self = buildPythonPackage rec {
   pname = "urllib3";
   version = "2.0.7";
   pyproject = true;
@@ -31,41 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-  ];
-
-  # FIXME: remove backwards compatbility hack
-  propagatedBuildInputs = passthru.optional-dependencies.brotli
-    ++ passthru.optional-dependencies.socks;
-
-  nativeCheckInputs = [
-    python-dateutil
-    mock
-    pytest-freezegun
-    pytest-timeout
-    pytestCheckHook
-    tornado
-    trustme
-  ];
-
-  # Tests in urllib3 are mostly timeout-based instead of event-based and
-  # are therefore inherently flaky. On your own machine, the tests will
-  # typically build fine, but on a loaded cluster such as Hydra random
-  # timeouts will occur.
-  #
-  # The urllib3 test suite has two different timeouts in their test suite
-  # (see `test/__init__.py`):
-  # - SHORT_TIMEOUT
-  # - LONG_TIMEOUT
-  # When CI is in the env, LONG_TIMEOUT will be significantly increased.
-  # Still, failures can occur and for that reason tests are disabled.
-  doCheck = false;
-
-  preCheck = ''
-    export CI # Increases LONG_TIMEOUT
-  '';
-
-  pythonImportsCheck = [
-    "urllib3"
   ];
 
   passthru.optional-dependencies = {
@@ -86,11 +50,44 @@ buildPythonPackage rec {
     ];
   };
 
+  nativeCheckInputs = [
+    pytest-timeout
+    pytestCheckHook
+    tornado
+    trustme
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    backports-zoneinfo
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  # Tests in urllib3 are mostly timeout-based instead of event-based and
+  # are therefore inherently flaky. On your own machine, the tests will
+  # typically build fine, but on a loaded cluster such as Hydra random
+  # timeouts will occur.
+  #
+  # The urllib3 test suite has two different timeouts in their test suite
+  # (see `test/__init__.py`):
+  # - SHORT_TIMEOUT
+  # - LONG_TIMEOUT
+  # When CI is in the env, LONG_TIMEOUT will be significantly increased.
+  # Still, failures can occur and for that reason tests are disabled.
+  doCheck = false;
+
+  passthru.tests.pytest = self.overridePythonAttrs (_: { doCheck = true; });
+
+  preCheck = ''
+    export CI # Increases LONG_TIMEOUT
+  '';
+
+  pythonImportsCheck = [
+    "urllib3"
+  ];
+
   meta = with lib; {
-    description = "Powerful, sanity-friendly HTTP client for Python";
-    homepage = "https://github.com/shazow/urllib3";
+    description = "Powerful, user-friendly HTTP client for Python";
+    homepage = "https://github.com/urllib3/urllib3";
     changelog = "https://github.com/urllib3/urllib3/blob/${version}/CHANGES.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };
-}
+};
+in self

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -21,12 +21,12 @@
 
 buildPythonPackage rec {
   pname = "urllib3";
-  version = "2.0.6";
-  format = "pyproject";
+  version = "2.0.7";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-sZ4ahdIGtW198dXmg99KdyUlKpZOOZNkjdD7WhwVdWQ=";
+    hash = "sha256-yX394fe9Q6ccjSpY42npsr9pLRM06p+crlWt19DdD4Q=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/urllib3/urllib3/releases/tag/2.0.7
https://github.com/advisories/GHSA-g4mx-q9vg-27p4

Fixes: CVE-2023-45803

23.05 in #264914 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
