### PR TITLE
jack_capture: 0.9.73 -> 0.9.73.2023-01-04

### DIFF
--- a/pkgs/applications/audio/jack-capture/default.nix
+++ b/pkgs/applications/audio/jack-capture/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, libjack2, libsndfile, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, libjack2, libsndfile, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "jack_capture";
-  version = "0.9.73";
+  version = "0.9.73.2023-01-04";
 
-  src = fetchurl {
-    url = "https://archive.notam02.no/arkiv/src/${pname}-${version}.tar.gz";
-    sha256 = "1pji0zdwm3kxjrkbzj7fnxhr8ncrc8pyqnwyrh47fhypgqjv1br1";
+  src = fetchFromGitHub {
+    owner = "kmatheussen";
+    repo = "jack_capture";
+    rev = "a539d444d388c4cfed7279e385830e7767d59c41";
+    sha256 = "sha256-2DavZS4esV17a3vkiPvfCfp0QF94ZcXqdIw84h9HDjA=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -23,9 +25,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A program for recording soundfiles with jack";
-    homepage = "http://archive.notam02.no/arkiv/src";
+    homepage = "https://github.com/kmatheussen/jack_capture/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = with maintainers; [ goibhniu orivej ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes #263505 (broken build)

Upstream has fixed this in 2021 (https://github.com/kmatheussen/jack_capture/pull/45) but has made no releases since (https://github.com/kmatheussen/jack_capture/issues/32)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
