### PR TITLE
ocamlPackages.semver: 0.1.0 → 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/semver/default.nix
+++ b/pkgs/development/ocaml-modules/semver/default.nix
@@ -1,29 +1,19 @@
-{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild }:
+{ lib, fetchurl, buildDunePackage, ocaml, alcotest }:
 
-lib.throwIfNot (lib.versionAtLeast ocaml.version "4.02")
-  "semver is not available on OCaml older than 4.02"
-
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-semver";
-  version = "0.1.0";
-  src = fetchzip {
-    url = "https://github.com/rgrinberg/ocaml-semver/archive/v${version}.tar.gz";
-    sha256 = "sha256-0BzeuVTpuRIQjadGg08hTvMzZtKCl2utW2YK269oETk=";
+buildDunePackage rec {
+  pname = "semver";
+  version = "0.2.1";
+  src = fetchurl {
+    url = "https://github.com/rgrinberg/ocaml-semver/releases/download/${version}/semver-${version}.tbz";
+    hash = "sha256-CjzDUtoe5Hvt6zImb+EqVIulRUUUQd9MmuJ4BH/2mLg=";
   };
 
-  nativeBuildInputs = [
-    ocaml
-    findlib
-    ocamlbuild
-  ];
-
-  strictDeps = true;
-  createFindlibDestdir = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  checkInputs = [ alcotest ];
 
   meta = {
     homepage = "https://github.com/rgrinberg/ocaml-semver";
     description = "Semantic versioning module";
-    platforms = ocaml.meta.platforms;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };


### PR DESCRIPTION
## Description of changes

https://github.com/rgrinberg/ocaml-semver/blob/0.2.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
