### PR TITLE
[staging-next] perlPackages.XMLLibXML: fix darwin build

### DIFF
--- a/pkgs/development/perl-modules/XML-LibXML-clang16.patch
+++ b/pkgs/development/perl-modules/XML-LibXML-clang16.patch
@@ -1,0 +1,47 @@
+From 8751785951fbde48ffa16a476da3e4adb2bbcde5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 16 Jan 2023 18:50:10 -0800
+Subject: [PATCH] libxml-mm: Fix function prototypes in function pointers
+
+This is now detected with latest clang16+
+
+Fixes
+error: incompatible function pointer types passing 'void (void *, void *, xmlChar *)' (aka 'void (void *, void *, unsigned char *)') to parameter of type 'xmlHashScanner' (aka 'void (*)(void *, void *, const unsigned char *)') [-Wincompatible-function-pointer-types]
+                xmlHashScan(r, PmmRegistryDumpHashScanner, NULL);
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ perl-libxml-mm.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/perl-libxml-mm.c b/perl-libxml-mm.c
+index a3e78a2..ec2b5ea 100644
+--- a/perl-libxml-mm.c
++++ b/perl-libxml-mm.c
+@@ -121,7 +121,7 @@ PmmFreeHashTable(xmlHashTablePtr table)
+ extern SV* PROXY_NODE_REGISTRY_MUTEX;
+ 
+ /* Utility method used by PmmDumpRegistry */
+-void PmmRegistryDumpHashScanner(void * payload, void * data, xmlChar * name)
++void PmmRegistryDumpHashScanner(void * payload, void * data, const xmlChar * name)
+ {
+ 	LocalProxyNodePtr lp = (LocalProxyNodePtr) payload;
+ 	ProxyNodePtr node = (ProxyNodePtr) lp->proxy;
+@@ -215,7 +215,7 @@ PmmRegisterProxyNode(ProxyNodePtr proxy)
+ /* PP: originally this was static inline void, but on AIX the compiler
+    did not chew it, so I'm removing the inline */
+ static void
+-PmmRegistryHashDeallocator(void *payload, xmlChar *name)
++PmmRegistryHashDeallocator(void *payload, const xmlChar *name)
+ {
+ 	Safefree((LocalProxyNodePtr) payload);
+ }
+@@ -279,7 +279,7 @@ PmmRegistryREFCNT_dec(ProxyNodePtr proxy)
+  * internal, used by PmmCloneProxyNodes
+  */
+ void *
+-PmmRegistryHashCopier(void *payload, xmlChar *name)
++PmmRegistryHashCopier(void *payload, const xmlChar *name)
+ {
+ 	ProxyNodePtr proxy = ((LocalProxyNodePtr) payload)->proxy;
+ 	LocalProxyNodePtr lp;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28473,6 +28473,9 @@ with self; {
     SKIP_SAX_INSTALL = 1;
     buildInputs = [ AlienBuild AlienLibxml2 ]
       ++ lib.optionals stdenv.isDarwin (with pkgs; [ libiconv zlib ]);
+    patches = [
+      ../development/perl-modules/XML-LibXML-clang16.patch
+    ];
     # Remove test that fails after LibXML 2.11 upgrade
     postPatch = ''
       rm t/35huge_mode.t


### PR DESCRIPTION
## Description of changes

Applies patch from upstream that fixes build with clang

https://github.com/shlomif/perl-XML-LibXML/commit/8751785951fbde48ffa16a476da3e4adb2bbcde5.patch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
