### PR TITLE
libsForQt5.networkmanager-qt: backport patch to fix NM 1.44 incompatibility

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
@@ -2,10 +2,25 @@
   mkDerivation, lib,
   extra-cmake-modules,
   networkmanager, qtbase,
+  fetchpatch
 }:
 
 mkDerivation {
   pname = "networkmanager-qt";
+
+  # backport patches for NetworkManager 1.44 compatibility
+  # FIXME: remove in 5.112
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/networkmanager-qt/-/commit/d9a938ddbfb5800503935926301ff2865ab77a6d.patch";
+      hash = "sha256-EjFBcU0YJQocp8skDZUTxCQhfrtQP5Fdo8q1BC9lLnQ=";
+    })
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/networkmanager-qt/-/commit/d35c6cb97443424d228dfd8eee8282af6632b5f5.patch";
+      hash = "sha256-KmRcCjdHGGk+5PY5JKNbk0BHCtdwibns+Hw4aNRaoZI=";
+    })
+  ];
+
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ networkmanager qtbase ];
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
## Description of changes

Fixes #263985 (hopefully).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
