### PR TITLE
opencv4: cuda: fix libstdc++ errors downstream, plus upkeep

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchFromGitHub
 , fetchpatch
+, callPackage
 , cmake, pkg-config, unzip, zlib, pcre, hdf5
 , glog, boost, gflags, protobuf3_21
 , config
@@ -289,7 +290,11 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "bindnow" "relro" ];
 
-  passthru = lib.optionalAttrs enablePython { pythonPath = []; };
+  passthru = lib.optionalAttrs enablePython { pythonPath = []; } // {
+    tests = lib.optionalAttrs enableCuda {
+      no-libstdcxx-errors = callPackage ./libstdcxx-test.nix { attrName = "opencv3"; };
+    };
+  };
 
   meta = with lib; {
     description = "Open Computer Vision Library with more than 500 algorithms";

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -15,8 +15,7 @@
 , enableOpenblas  ? true, openblas, blas, lapack
 , enableContrib   ? true
 
-, enableCuda      ? config.cudaSupport &&
-                    stdenv.hostPlatform.isx86_64
+, enableCuda      ? config.cudaSupport
 , cudaPackages ? { }
 , enableUnfree    ? false
 , enableIpp       ? false

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -495,7 +495,7 @@ effectiveStdenv.mkDerivation {
       };
     }
     // lib.optionalAttrs (enableCuda) {
-      no-libstdcxx-errors = callPackage ./libstdcxx-test.nix { };
+      no-libstdcxx-errors = callPackage ./libstdcxx-test.nix { attrName = "opencv4"; };
     };
   } // lib.optionalAttrs enablePython { pythonPath = [ ]; };
 

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -37,7 +37,7 @@
 , blas
 , enableContrib ? true
 
-, enableCuda ? config.cudaSupport && stdenv.hostPlatform.isx86_64
+, enableCuda ? config.cudaSupport
 , enableCublas ? enableCuda
 , enableCudnn ? false # NOTE: CUDNN has a large impact on closure size so we disable it by default
 , enableCufft ? enableCuda

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -83,10 +83,15 @@
 , Accelerate
 , bzip2
 , callPackage
-}:
+}@inputs:
 
 let
   version = "4.7.0";
+
+  # It's necessary to consistently use backendStdenv when building with CUDA
+  # support, otherwise we get libstdc++ errors downstream
+  stdenv = throw "Use effectiveStdenv instead";
+  effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else inputs.stdenv;
 
   src = fetchFromGitHub {
     owner = "opencv";
@@ -121,11 +126,11 @@ let
       sha256 = "1msbkc3zixx61rcg6a04i1bcfhw1phgsrh93glq1n80hgsk3nbjq";
     } + "/ippicv";
     files = let name = platform: "ippicv_2019_${platform}_general_20180723.tgz"; in
-      if stdenv.hostPlatform.system == "x86_64-linux" then
+      if effectiveStdenv.hostPlatform.system == "x86_64-linux" then
         { ${name "lnx_intel64"} = "c0bd78adb4156bbf552c1dfe90599607"; }
-      else if stdenv.hostPlatform.system == "i686-linux" then
+      else if effectiveStdenv.hostPlatform.system == "i686-linux" then
         { ${name "lnx_ia32"} = "4f38432c30bfd6423164b7a24bbc98a0"; }
-      else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      else if effectiveStdenv.hostPlatform.system == "x86_64-darwin" then
         { ${name "mac_intel64"} = "fe6b2bb75ae0e3f19ad3ae1a31dfa4a2"; }
       else
         throw "ICV is not available for this platform (or not yet supported by this package)";
@@ -232,10 +237,11 @@ let
   #https://github.com/xianyi/OpenBLAS/wiki/Faq/4bded95e8dc8aadc70ce65267d1093ca7bdefc4c#multi-threaded
   openblas_ = blas.provider.override { singleThreaded = true; };
 
-  inherit (cudaPackages) backendStdenv cudaFlags cudaVersion;
+  inherit (cudaPackages) cudaFlags cudaVersion;
   inherit (cudaFlags) cudaCapabilities;
 
   cuda-common-redist = with cudaPackages; [
+    cuda_cudart
     cuda_cccl # <thrust/*>
     libnpp # npp.h
   ] ++ lib.optionals enableCublas [
@@ -246,21 +252,13 @@ let
     libcufft # cufft.h
   ];
 
-  cuda-native-redist = symlinkJoin {
-    name = "cuda-native-redist-${cudaVersion}";
-    paths = with cudaPackages; [
-      cuda_cudart # cuda_runtime.h
-      cuda_nvcc
-    ] ++ cuda-common-redist;
-   };
-
   cuda-redist = symlinkJoin {
     name = "cuda-redist-${cudaVersion}";
     paths = cuda-common-redist;
    };
 in
 
-stdenv.mkDerivation {
+effectiveStdenv.mkDerivation {
   pname = "opencv";
   inherit version src;
 
@@ -319,7 +317,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib pcre boost gflags protobuf3_21 ]
     ++ lib.optional enablePython pythonPackages.python
-    ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) hdf5
+    ++ lib.optional (effectiveStdenv.buildPlatform == effectiveStdenv.hostPlatform) hdf5
     ++ lib.optional enableGtk2 gtk2
     ++ lib.optional enableGtk3 gtk3
     ++ lib.optional enableVtk vtk
@@ -330,7 +328,7 @@ stdenv.mkDerivation {
     ++ lib.optionals enableEXR [ openexr ilmbase ]
     ++ lib.optional enableJPEG2000 openjpeg
     ++ lib.optional enableFfmpeg ffmpeg
-    ++ lib.optionals (enableFfmpeg && stdenv.isDarwin)
+    ++ lib.optionals (enableFfmpeg && effectiveStdenv.isDarwin)
       [ VideoDecodeAcceleration bzip2 ]
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good ])
     ++ lib.optional enableOvis ogre
@@ -343,7 +341,7 @@ stdenv.mkDerivation {
     # tesseract & leptonica.
     ++ lib.optionals enableTesseract [ tesseract leptonica ]
     ++ lib.optional enableTbb tbb
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals effectiveStdenv.isDarwin [
       bzip2 AVFoundation Cocoa VideoDecodeAcceleration CoreMedia MediaToolbox Accelerate
     ]
     ++ lib.optionals enableDocs [ doxygen graphviz-nox ]
@@ -357,7 +355,9 @@ stdenv.mkDerivation {
     pythonPackages.pip
     pythonPackages.wheel
     pythonPackages.setuptools
-  ] ++ lib.optionals enableCuda [ cuda-native-redist ];
+  ] ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+  ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString enableEXR "-I${ilmbase.dev}/include/OpenEXR";
 
@@ -400,17 +400,14 @@ stdenv.mkDerivation {
     (opencvFlag "ENABLE_LTO" enableLto)
     (opencvFlag "ENABLE_THIN_LTO" (
       enableLto && (
-        # Only clang supports thin LTO, so we must either be using clang through the stdenv,
-        stdenv.cc.isClang ||
-          # or through the backend stdenv.
-          (enableCuda && backendStdenv.cc.isClang)
+        # Only clang supports thin LTO, so we must either be using clang through the effectiveStdenv,
+        effectiveStdenv.cc.isClang ||
+          # or through the backend effectiveStdenv.
+          (enableCuda && effectiveStdenv.cc.isClang)
       )
     ))
   ] ++ lib.optionals enableCuda [
     "-DCUDA_FAST_MATH=ON"
-    # We need to set the C and C++ host compilers for CUDA to the same compiler.
-    "-DCMAKE_C_COMPILER=${backendStdenv.cc}/bin/cc"
-    "-DCMAKE_CXX_COMPILER=${backendStdenv.cc}/bin/c++"
     "-DCUDA_NVCC_FLAGS=--expt-relaxed-constexpr"
 
     # OpenCV respects at least three variables:
@@ -421,7 +418,7 @@ stdenv.mkDerivation {
     "-DCUDA_ARCH_PTX=${lib.last cudaCapabilities}"
 
     "-DNVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH=${nvidia-optical-flow-sdk}"
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals effectiveStdenv.isDarwin [
     "-DWITH_OPENCL=OFF"
     "-DWITH_LAPACK=OFF"
 
@@ -435,7 +432,7 @@ stdenv.mkDerivation {
     "-DBUILD_JPEG=OFF"
     "-DBUILD_PNG=OFF"
     "-DBUILD_WEBP=OFF"
-  ] ++ lib.optionals (!stdenv.isDarwin) [
+  ] ++ lib.optionals (!effectiveStdenv.isDarwin) [
     "-DOPENCL_LIBRARY=${ocl-icd}/lib/libOpenCL.so"
   ] ++ lib.optionals enablePython [
     "-DOPENCV_SKIP_PYTHON_LOADER=ON"
@@ -489,9 +486,9 @@ stdenv.mkDerivation {
     tests = {
       inherit (gst_all_1) gst-plugins-bad;
     }
-    // lib.optionalAttrs (!stdenv.isDarwin) { inherit qimgv; }
+    // lib.optionalAttrs (!effectiveStdenv.isDarwin) { inherit qimgv; }
     // lib.optionalAttrs (!enablePython) { pythonEnabled = pythonPackages.opencv4; }
-    // lib.optionalAttrs (stdenv.buildPlatform != "x86_64-darwin") {
+    // lib.optionalAttrs (effectiveStdenv.buildPlatform != "x86_64-darwin") {
       opencv4-tests = callPackage ./tests.nix {
         inherit enableGStreamer enableGtk2 enableGtk3 runAccuracyTests runPerformanceTests testDataSrc;
         inherit opencv4;

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -495,8 +495,11 @@ stdenv.mkDerivation {
       opencv4-tests = callPackage ./tests.nix {
         inherit enableGStreamer enableGtk2 enableGtk3 runAccuracyTests runPerformanceTests testDataSrc;
         inherit opencv4;
-        };
       };
+    }
+    // lib.optionalAttrs (enableCuda) {
+      no-libstdcxx-errors = callPackage ./libstdcxx-test.nix { };
+    };
   } // lib.optionalAttrs enablePython { pythonPath = [ ]; };
 
   meta = with lib; {

--- a/pkgs/development/libraries/opencv/libstdcxx-test.nix
+++ b/pkgs/development/libraries/opencv/libstdcxx-test.nix
@@ -1,0 +1,17 @@
+{ python3Packages, runCommand }:
+
+runCommand "${python3Packages.opencv4.pname}-libstdcxx-test"
+{
+  nativeBuildInputs = [
+    (python3Packages.python.withPackages (ps: with ps; [
+      (opencv4.override { enableCuda = true; })
+      scikit-image
+    ]))
+  ];
+} ''
+  python << EOF
+  import cv2
+  from skimage.transform import pyramid_reduce
+  EOF
+  touch $out
+''

--- a/pkgs/development/libraries/opencv/libstdcxx-test.nix
+++ b/pkgs/development/libraries/opencv/libstdcxx-test.nix
@@ -1,11 +1,11 @@
-{ python3Packages, runCommand }:
+{ python3Packages, runCommand, attrName }:
 
-runCommand "${python3Packages.opencv4.pname}-libstdcxx-test"
+runCommand "${python3Packages.${attrName}.name}-libstdcxx-test"
 {
   nativeBuildInputs = [
-    (python3Packages.python.withPackages (ps: with ps; [
-      (opencv4.override { enableCuda = true; })
-      scikit-image
+    (python3Packages.python.withPackages (ps: [
+      (ps.${attrName}.override { enableCuda = true; })
+      ps.scikit-image
     ]))
   ];
 } ''


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/258327

Adds a test for and fixes the following libstdc++ mismatch error:

```
python3.11-pytlsd> ==================================== ERRORS ====================================
python3.11-pytlsd> _______________________ ERROR collecting tests/tests.py ________________________
python3.11-pytlsd> ImportError while importing test module '/build/source/tests/tests.py'.
python3.11-pytlsd> Hint: make sure your test modules/packages have valid Python names.
python3.11-pytlsd> Traceback:
python3.11-pytlsd> /nix/store/ffll6glz3gwx342z0ch8wx30p5cnqz1z-python3-3.11.5/lib/python3.11/importlib/__init__.py:126: in import_module
python3.11-pytlsd>     return _bootstrap._gcd_import(name[level:], package, level)
python3.11-pytlsd> tests/tests.py:7: in <module>
python3.11-pytlsd>     from skimage.transform import pyramid_reduce
python3.11-pytlsd> /nix/store/zr2pijvixax0say6n6d1s0mg3f970xv2-python3.11-scikit-image-0.21.0/lib/python3.11/site-packages/skimage/transform/__init__.py:38: in <module>
python3.11-pytlsd>     from .radon_transform import (radon, iradon, iradon_sart,
python3.11-pytlsd> /nix/store/zr2pijvixax0say6n6d1s0mg3f970xv2-python3.11-scikit-image-0.21.0/lib/python3.11/site-packages/skimage/transform/radon_transform.py:3: in <module>
python3.11-pytlsd>     from scipy.interpolate import interp1d
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/interpolate/__init__.py:167: in <module>
python3.11-pytlsd>     from ._interpolate import *
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/interpolate/_interpolate.py:12: in <module>
python3.11-pytlsd>     from . import _fitpack_py
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/interpolate/_fitpack_py.py:10: in <module>
python3.11-pytlsd>     from ._bsplines import BSpline
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/interpolate/_bsplines.py:9: in <module>
python3.11-pytlsd>     from scipy.optimize import minimize_scalar
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/optimize/__init__.py:422: in <module>
python3.11-pytlsd>     from ._linprog import linprog, linprog_verbose_callback
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/optimize/_linprog.py:21: in <module>
python3.11-pytlsd>     from ._linprog_highs import _linprog_highs
python3.11-pytlsd> /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/optimize/_linprog_highs.py:20: in <module>
python3.11-pytlsd>     from ._highs._highs_wrapper import _highs_wrapper
python3.11-pytlsd> E   ImportError: /nix/store/n0gf2wl3g6229q275r4cxs2yhnam0xvg-gcc-11.4.0-lib/lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /nix/store/nab40hl5f2hk4i1x5rlkimmn20dyqh40-python3.11-scipy-1.11.3/lib/python3.11/site-packages/scipy/optimize/_highs/_highs_wrapper.cpython-311-x86_64-linux-gnu.so)
python3.11-pytlsd> =========================== short test summary info ============================
python3.11-pytlsd> ERROR tests/tests.py
python3.11-pytlsd> !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
python3.11-pytlsd> =============================== 1 error in 0.28s ===============================
python3.11-pytlsd> /nix/store/bbxdw4rgwwl3gnajri82yidr1nlsfskf-stdenv-linux/setup: line 1596: pop_var_context: head of shell_variables not a function context
error: builder for '/nix/store/jfpbrdgvfr2qbac02lml42p1kvh4p1nf-python3.11-pytlsd-0.0.5.drv' failed with exit code 2;
```

...observed when importing `cv2` (built with cuda support and the older nvcc-compatible gcc) before importing a native python extension from nixpkgs (which uses the newer libstdc++) like so: https://github.com/iago-suarez/pytlsd/blob/81e0fee35f1fdaf546ec73c71ad3ed488c8ee83b/tests/tests.py#L3-L7

The test passes for the opencv3 attribute because it's just built with the newer gcc(12). I decided not to touch it further, but my expectation is that `opencv3` with CUDA will start failing once we bump gcc.

The tests can be run as follows:

```
❯ nix build -f . --arg config '{ cudaSupport = true; cudaCapabilities = [ "8.6" ]; enableForwardCompat = false; allowUnfree = true; }' opencv4.tests.no-libstdcxx-errors
❯ nix build -f . --arg config '{ cudaSupport = true; cudaCapabilities = [ "8.6" ]; enableForwardCompat = false; allowUnfree = true; }' opencv3.tests.no-libstdcxx-errors
```

You can check out the first commit and verify that `opencv4.no-libstdcxx-errors` fails until it's updated in the next commit

In the longer run we should kill `backendStdenv` and instead implement https://github.com/NixOS/nixpkgs/issues/226165

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@NixOS/cuda-maintainers 