### PR TITLE
minizincide: 2.5.5 -> 2.7.6

### DIFF
--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "minizinc-ide";
-  version = "2.5.5";
+  version = "2.7.6";
 
   src = fetchFromGitHub {
     owner = "MiniZinc";
     repo = "MiniZincIDE";
     rev = version;
-    sha256 = "sha256-0U3KFRDam8psbCaEOcrwqzICAy1oBgo8SFEiR/PMqZk=";
+    sha256 = "sha256-NUGQmOkdnEZq+wr/VhjSR/IBwF565U4QlTkmpjOYJes=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -8,7 +8,7 @@ mkDerivation rec {
     owner = "MiniZinc";
     repo = "MiniZincIDE";
     rev = version;
-    sha256 = "sha256-NUGQmOkdnEZq+wr/VhjSR/IBwF565U4QlTkmpjOYJes=";
+    sha256 = "sha256-Fwt4zuIKwurCx0EriwSOea4zAJ7Bmr8Stt0dQ8Ux0cs=";
     fetchSubmodules = true;
   };
 
@@ -20,7 +20,7 @@ mkDerivation rec {
   dontWrapQtApps = true;
 
   postInstall = ''
-    wrapProgram $out/bin/MiniZincIDE --prefix PATH ":" ${lib.makeBinPath [ minizinc ]}
+    wrapProgram $out/bin/MiniZincIDE --prefix PATH ":" ${lib.makeBinPath [ minizinc ]} --set QT_QPA_PLATFORM_PLUGIN_PATH "${qtbase.bin}/lib/qt-${qtbase.version}/plugins/platforms"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

MinizinIDE was unable to be launched because it cannot found plugins
![image](https://github.com/NixOS/nixpkgs/assets/10145351/8427cddb-8cac-47b6-9456-c581460db025)

This MR update MinizincIDE the to latest version and add `QT_QPA_PLATFORM_PLUGIN_PATH` variable to the wrapper

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
