### PR TITLE
open-goal-launcher: init at 2.4.0

### DIFF
--- a/pkgs/by-name/op/open-goal-launcher/package.nix
+++ b/pkgs/by-name/op/open-goal-launcher/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, appimageTools
+, fetchurl
+}:
+
+let
+  pname = "open-goal-launcher";
+  version = "2.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/open-goal/launcher/releases/download/v${version}/open-goal-launcher_${version}_amd64.AppImage";
+    sha256 = "sha256-aVzuf3Ml2a0jBCuDbdJnYRBNABTUhT/f3u1tNymVxXY=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/usr/share/applications/${pname}.desktop -t $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "A launcher for the OpenGOAL Project to simplify usage and installation";
+    homepage = "https://github.com/open-goal/launcher";
+    license = licenses.isc;
+    maintainers = with maintainers; [ martfont ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "open-goal-launcher";
+  };
+}


### PR DESCRIPTION
## Description of changes

Now that the blocker #200955 is solved, I can finally add this.
Tested Jak 2.

Two problems to solve before merging:
- `jak-project` only works on CPUs that support AVX. Is there a way to make the installation fail if that's not the case?
- The application is unable to open links to files/websites externally: clicking does nothing.
  - Adding `xdgOpenUsePortal = true;` to `configuration.nix` doesn't fix it
  - If the link is a local file, the following error is logged:
```
/nix/store/m42y05yfzrlf41i22rznw015gxrina43-glib-2.78.1-bin/bin/gdbus: symbol lookup error: /nix/store/m42y05yfzrlf41i22rznw015gxrina43-glib-2.78.1-bin/bin/gdbus: undefined symbol: g_string_free_and_steal
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
