### PR TITLE
cosmic-settings: wrap cosmic-icons

### DIFF
--- a/pkgs/applications/window-managers/cosmic/settings/default.nix
+++ b/pkgs/applications/window-managers/cosmic/settings/default.nix
@@ -3,8 +3,9 @@
 , fetchFromGitHub
 , rust
 , rustPlatform
-, cargo
 , cmake
+, makeWrapper
+, cosmic-icons
 , just
 , pkg-config
 , libxkbcommon
@@ -19,13 +20,13 @@
 , util-linuxMinimal
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "cosmic-settings";
   version = "unstable-2023-10-26";
 
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = "cosmic-settings";
+    repo = pname;
     rev = "d15ebbd340dee7adf184831311b5da73faaa80f5";
     hash = "sha256-OlQ2jjT/ygO+hpl5Cc3h8Yp/SVo+pmI/EH7pqvY9GXI=";
   };
@@ -50,7 +51,7 @@ rustPlatform.buildRustPackage {
     substituteInPlace justfile --replace '#!/usr/bin/env' "#!$(command -v env)"
   '';
 
-  nativeBuildInputs = [ cmake just pkg-config which lld util-linuxMinimal ];
+  nativeBuildInputs = [ cmake just pkg-config which lld util-linuxMinimal makeWrapper ];
   buildInputs = [ libxkbcommon libinput fontconfig freetype wayland expat udev ];
 
   dontUseJustBuild = true;
@@ -63,6 +64,11 @@ rustPlatform.buildRustPackage {
     "bin-src"
     "target/${rust.lib.toRustTargetSpecShort stdenv.hostPlatform}/release/cosmic-settings"
   ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/cosmic-settings" \
+      --suffix XDG_DATA_DIRS : "${cosmic-icons}/share"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/pop-os/cosmic-settings";


### PR DESCRIPTION
## Description of changes

Wrap cosmic-settings, so it can find the icon set it is looking for.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
