### PR TITLE
python3Packages.flask-seasurf: mark broken

### DIFF
--- a/pkgs/development/python-modules/flask-seasurf/default.nix
+++ b/pkgs/development/python-modules/flask-seasurf/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "flask_seasurf" ];
 
   meta = with lib; {
+    broken = true; # https://github.com/maxcountryman/flask-seasurf/issues/141
     description = "A Flask extension for preventing cross-site request forgery";
     homepage = "https://github.com/maxcountryman/flask-seasurf";
     license = licenses.bsd3;


### PR DESCRIPTION
## Description of changes

We can maybe wait merging this until the end of ZHF, but i have little faith this package can be fixed. I fixed 14 errors properly in the diff below, but the 3 remaining disabled tests check for essential functionality.

<details>
<summary>
Attempted fix:
</summary>

```diff
diff --git a/pkgs/development/python-modules/flask-seasurf/default.nix b/pkgs/development/python-modules/flask-seasurf/default.nix
index 79d024f5b34f..1ceb71de44d4 100644
--- a/pkgs/development/python-modules/flask-seasurf/default.nix
+++ b/pkgs/development/python-modules/flask-seasurf/default.nix
@@ -1,4 +1,12 @@
-{ lib, fetchFromGitHub, buildPythonPackage, isPy3k, flask, mock, unittestCheckHook }:
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, buildPythonPackage
+, isPy3k
+, flask
+, mock
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "Flask-SeaSurf";
@@ -12,16 +20,45 @@ buildPythonPackage rec {
     hash = "sha256-L/ZUEqqHmsyXG5eShcITII36ttwQlZN5GBngo+GcCdw=";
   };
 
+  patches = [
+    # https://github.com/maxcountryman/flask-seasurf/pull/132
+    (fetchpatch {
+      name = "Remove-usage-of-deprecated-flask._app_ctx_stack-.patch";
+      url = "https://github.com/maxcountryman/flask-seasurf/commit/9039764a4e44aeb1acb6ae7747deb438bee0826b.patch";
+      hash = "sha256-bVYzJN6MXzH3fNMknd2bh+04JlPJRkU0cLcWv+Rigqc=";
+    })
+    # https://github.com/maxcountryman/flask-seasurf/pull/130
+    (fetchpatch {
+      name = "validate-request-is-json.patch";
+      url = "https://github.com/maxcountryman/flask-seasurf/commit/3a04f2c3e84f8a6b00070037c233e5df180c10b5.patch";
+      hash = "sha256-RASc8g4gE7XviHdITZ0S+NjxrU2QdkQiv8LuqPM+0x8=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace test_seasurf.py \
+      --replace \
+        ".cookie_jar.clear()" \
+        "._cookies.clear()"
+  '';
+
   propagatedBuildInputs = [ flask ];
 
   nativeCheckInputs = [
-    unittestCheckHook
+    pytestCheckHook
     mock
   ];
 
+  disabledTests = [
+    "test_header_set_on_post"
+    "test_https_good_referer"
+    "test_https_referer_check_disabled"
+  ];
+
   pythonImportsCheck = [ "flask_seasurf" ];
 
   meta = with lib; {
     description = "A Flask extension for preventing cross-site request forgery";
     homepage = "https://github.com/maxcountryman/flask-seasurf";
     license = licenses.bsd3;
```
</details>



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
