### PR TITLE
container-diff: init at 0.17.0

### DIFF
--- a/pkgs/development/tools/container-diff/default.nix
+++ b/pkgs/development/tools/container-diff/default.nix
@@ -1,0 +1,37 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "container-diff";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "GoogleContainerTools";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-4sk6DqScaNf0tMZQ6Hj40ZEklFTUFwAkN63v67nUFn8=";
+  };
+
+  vendorSha256 = null;
+
+  preCheck = ''
+    # Tests require being able to write to the home directory
+    export HOME="$TMPDIR/home"
+    mkdir "$HOME"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    dir="$GOPATH/bin"
+    cp $dir/container-diff $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/GoogleContainerTools/container-diff";
+    description = "A tool for analyzing and comparing container images";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -543,6 +543,8 @@ with pkgs;
 
   conserver = callPackage ../tools/misc/conserver { };
 
+  container-diff = callPackage ../development/tools/container-diff { };
+
   containerlab = callPackage ../tools/networking/containerlab { };
 
   containerpilot = callPackage ../applications/networking/cluster/containerpilot { };


### PR DESCRIPTION
## Description of changes

This commit adds [container-diff][1], which helps to find differences between docker containers. Per their README:

> container-diff is a tool for analyzing and comparing container images. container-diff can examine images along several different criteria, including:
>
> * Docker Image History
> * Image file system
> * Image size
> * Apt packages
> * RPM packages
> * pip packages
> * npm packages
> These analyses can be performed on a single image, or a diff can be performed on two images to compare. The tool can help users better understand what is changing inside their images, and give them a better look at what their images contain.
>
> NOTE: container-diff is a Google project, but is not currently being officially supported by Google and is in maintenance mode. However, contributions are still welcome and encouraged!

[1]: https://github.com/GoogleContainerTools/container-diff

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Other notes

This is my first ... change ... in Nix. In general. I'm still trying to figure out how to test this correctly. There's a lot of documentation regarding how to contribute that I'm still trying to read through