### PR TITLE
stalwart-mail: 0.4.0 -> 0.4.2

### DIFF
--- a/pkgs/servers/mail/stalwart/Cargo.lock
+++ b/pkgs/servers/mail/stalwart/Cargo.lock
@@ -2276,7 +2276,7 @@ checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "imap"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "ahash 0.8.3",
  "dashmap",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "jmap"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2497,6 +2497,7 @@ dependencies = [
  "sequoia-openpgp",
  "serde",
  "serde_json",
+ "sha1",
  "sha2 0.10.8",
  "sieve-rs",
  "smtp",
@@ -2824,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "mail-server"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "directory",
  "imap",
@@ -2841,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "managesieve"
-version = "0.1.0"
+version = "0.4.2"
 dependencies = [
  "ahash 0.8.3",
  "bincode",
@@ -3031,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "nlp"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "ahash 0.8.3",
  "bincode",
@@ -4739,7 +4740,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smtp"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -5070,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "stalwart-cli"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "clap",
  "console",
@@ -5092,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "stalwart-install"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "base64 0.21.4",
  "clap",
@@ -5900,7 +5901,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "ahash 0.8.3",
  "chrono",

--- a/pkgs/servers/mail/stalwart/default.nix
+++ b/pkgs/servers/mail/stalwart/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "0.4.0";
+  version = "0.4.2";
 in
 rustPlatform.buildRustPackage {
   pname = "stalwart-mail";
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage {
     owner = "stalwartlabs";
     repo = "mail-server";
     rev = "v${version}";
-    hash = "sha256-T61GlSzKdJZiSyRyxyk7PKhm0jmEtrMxoaTyM3FeDCU=";
+    hash = "sha256-Ah53htK38Bm2yGN44IiC6iRWgxkMVRtrNvXXvPh+SJc=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/stalwartlabs/mail-server/releases/tag/v0.4.2
Diff: https://github.com/stalwartlabs/mail-server/compare/v0.4.0...v0.4.2

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).