### PR TITLE
stdenvAdapters.overrideSDK: propagate SDK override to bintools.

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -54,7 +54,16 @@ let
     if stdenv.isAarch64 then cc
     else
       cc.override {
-        bintools = stdenv.cc.bintools.override { libc = packages.Libsystem; };
+        bintools = stdenv.cc.bintools.override {
+          # Override to update the bintools-wrapper with the requested deployment target and SDK.
+          stdenvNoCC = stdenvNoCC.override (old: {
+            targetPlatform = old.targetPlatform // {
+              darwinMinVersion = "10.12";
+              darwinSdkVersion = "11.0";
+            };
+          });
+          libc = packages.Libsystem;
+        };
         libc = packages.Libsystem;
       };
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -349,7 +349,15 @@ rec {
         // lib.genAttrs atBuildInputs (input: map mapRuntimeToSDK (args."${input}" or [ ]));
 
       mkCC = cc: cc.override {
-        bintools = cc.bintools.override { libc = sdk.Libsystem; };
+        bintools = cc.bintools.override {
+          libc = sdk.Libsystem;
+          # Override to update the bintools-wrapper with the requested deployment target and SDK.
+          stdenvNoCC = pkgs.stdenvNoCC.override (old: {
+            buildPlatform = old.buildPlatform // { inherit darwinMinVersion darwinSdkVersion; };
+            hostPlatform = old.hostPlatform // { inherit darwinMinVersion darwinSdkVersion; };
+            targetPlatform = old.targetPlatform // { inherit darwinMinVersion darwinSdkVersion; };
+          });
+        };
         libc = sdk.Libsystem;
       };
     in


### PR DESCRIPTION
## Description of changes

The deployment target and SDK version is set in the bintools-wrapper. While not having the correct SDK is mostly harmless, failing to propagate it results in x86_64-darwin applications built with the 11.0 SDK that fail to support dark mode on macOS releases supporting it.

The overrides were tested by building them and examining the contents of `nix-support/add-local-ldflags-before.sh` for the cctools wrapper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
