### PR TITLE
devmode: migrate into pkgs/by-name

### DIFF
--- a/doc/shell.nix
+++ b/doc/shell.nix
@@ -7,8 +7,7 @@ let
   common = import ./common.nix;
   inherit (common) outputPath indexPath;
 
-  web-devmode = import ../pkgs/tools/nix/web-devmode.nix {
-    inherit pkgs;
+  web-devmode = pkgs.devmode.override {
     buildArgs = "./.";
     open = "/${outputPath}/${indexPath}";
   };

--- a/nixos/doc/manual/shell.nix
+++ b/nixos/doc/manual/shell.nix
@@ -7,8 +7,7 @@ let
   common = import ./common.nix;
   inherit (common) outputPath indexPath;
 
-  web-devmode = import ../../../pkgs/tools/nix/web-devmode.nix {
-    inherit pkgs;
+  web-devmode = pkgs.devmode.override {
     buildArgs = "../../release.nix -A manualHTML.${builtins.currentSystem}";
     open = "/${outputPath}/${indexPath}";
   };


### PR DESCRIPTION
This move will also make the tool available outside of nixpkgs codebase.
