### PR TITLE
fg-virgil: init at 0.16.1

### DIFF
--- a/pkgs/data/fonts/fg-virgil/default.nix
+++ b/pkgs/data/fonts/fg-virgil/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fg-virgil";
+  version = "0.16.1";
+
+  src = fetchFromGitHub {
+    owner = "excalidraw";
+    repo = "excalidraw";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-iziCCHacaShPqb0f5nI8cCinFFs5fB3TcMJrifNhg4I=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 444 public/Virgil.woff2 -t $out/share/fonts/woff2
+    install -D -m 444 public/FG_Virgil.woff2 -t $out/share/fonts/woff2
+    install -D -m 444 public/FG_Virgil.ttf -t $out/share/fonts/ttf
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/excalidraw/virgil";
+    description = "The font that powers Excalidraw";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ drupol ];
+    license = lib.licenses.ofl;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29305,6 +29305,8 @@ with pkgs;
 
   ferrum = callPackage ../data/fonts/ferrum { };
 
+  fg-virgil = callPackage ../data/fonts/fg-virgil { };
+
   fixedsys-excelsior = callPackage ../data/fonts/fixedsys-excelsior { };
 
   graphs = callPackage ../data/misc/graphs { };


### PR DESCRIPTION
This is the font used in Excalidraw.

See info about the licence: https://github.com/excalidraw/excalidraw/issues/7179


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
