### PR TITLE
nixos/systemd-boot: add option to boot from systemd-stub

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -7,12 +7,20 @@ let
 
   efi = config.boot.loader.efi;
 
+  systemdUkify = pkgs.systemdMinimal.override {
+    withEfi = true;
+    withBootloader = true;
+    withUkify = true;
+  };
+
   systemdBootBuilder = pkgs.substituteAll {
     src = ./systemd-boot-builder.py;
 
     isExecutable = true;
 
     inherit (pkgs) python3;
+
+    inherit systemdUkify;
 
     systemd = config.systemd.package;
 
@@ -238,6 +246,15 @@ in {
       '';
     };
 
+    useSystemdStub = mkOption {
+      default = false;
+      type = types.bool;
+      description = lib.mdDoc ''
+        Boot from a Unified Kernel Image composed from system-stub, the linux kernel and the initramfs image.
+        Activating this option will induce a steep increase of the size a single generation takes on the boot partition.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -308,5 +325,8 @@ in {
         (isYes "EFI_STUB")
       ];
     };
+
+    boot.bootspec.extensions.useSystemdStub = cfg.useSystemdStub;
+
   };
 }

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -322,4 +322,20 @@ in
         machine.wait_for_unit("multi-user.target")
       '';
     };
+  systemdStub = makeTest {
+    name = "systemd-stub";
+    meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
+
+    nodes.machine = { pkgs, lib, ... }: {
+      imports = [ common ];
+      boot.loader.systemd-boot.useSystemdStub = true;
+      virtualisation.mountHostNixStore = true;
+      virtualisation.memorySize = 8000;
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+    '';
+  };
 }


### PR DESCRIPTION
## Description of changes

This depends on #263442, and will stay in draft until it is merged for that reason.
Enables the possibility to boot from `systemd-stub`, in preparation for a followup PR allowing encrypted initrd secrets. 
Booting from `systemd-stub`, even if secure boot is not enabled brings some benefits including tpm measurement and forwarding of the encrypted credentials to the `initrd`.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
