### PR TITLE
perlPackages.Gtk2, scheme48, smpeg, stfl: fix build with clang 16

### DIFF
--- a/pkgs/development/interpreters/scheme48/default.nix
+++ b/pkgs/development/interpreters/scheme48/default.nix
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
     substituteInPlace build/build-usual-image --replace '"(made by $USER on $date)"' '""'
   '';
 
+  # Silence warnings related to use of implicitly declared library functions and implicit ints.
+  # TODO: Remove and/or fix with patches the next time this package is updated.
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=implicit-int"
+    ];
+  };
+
   meta = with lib; {
     homepage = "https://s48.org/";
     description = "Scheme 48 interpreter for R5RS";

--- a/pkgs/development/libraries/smpeg/default.nix
+++ b/pkgs/development/libraries/smpeg/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, SDL, autoconf, automake, libtool, gtk2, m4, pkg-config, libGLU, libGL, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, SDL, autoconf, automake, libtool, gtk2, m4, pkg-config, libGLU, libGL, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "smpeg";
@@ -16,7 +16,23 @@ stdenv.mkDerivation rec {
     ./gcc6.patch
     ./libx11.patch
     ./gtk.patch
+    # These patches remove use of the `register` storage class specifier,
+    # allowing smpeg to build with clang 16, which defaults to C++17.
+    (fetchpatch {
+      url = "https://github.com/icculus/smpeg/commit/cc114ba0dd8644c0d6205bbce2384781daeff44b.patch";
+      hash = "sha256-GxSD82j05pw0r2SxmPYAe/BXX4iUc+iHWhB9Ap4GzfA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/icculus/smpeg/commit/b369feca5bf99d6cff50d8eb316395ef48acf24f.patch";
+      hash = "sha256-U+a6dbc5cm249KlUcf4vi79yUiT4hgEvMv522K4PqUc=";
+    })
   ];
+
+  postPatch = ''
+    substituteInPlace video/gdith.cpp \
+      --replace 'register int' 'int' \
+      --replace 'register Uint16' 'Uint16'
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/stfl/default.nix
+++ b/pkgs/development/libraries/stfl/default.nix
@@ -13,6 +13,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses libiconv ];
 
+  # Silence warnings related to use of implicitly declared library functions and implicit ints.
+  # TODO: Remove and/or fix with patches the next time this package is updated.
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=implicit-int"
+    ];
+  };
+
   preBuild = ''
     sed -i s/gcc/cc/g Makefile
     sed -i s%ncursesw/ncurses.h%ncurses.h% stfl_internals.h

--- a/pkgs/development/perl-modules/Gtk2-fix-incompatible-pointer-conversion.patch
+++ b/pkgs/development/perl-modules/Gtk2-fix-incompatible-pointer-conversion.patch
@@ -1,0 +1,86 @@
+diff -ur a/gdk.typemap b/gdk.typemap
+--- a/gdk.typemap	2017-05-21 15:02:54.000000000 -0400
++++ b/gdk.typemap	2023-11-03 13:17:43.717890172 -0400
+@@ -23,6 +23,7 @@
+ TYPEMAP
+ 
+ # can be either a pointer or an integer, this handles both cases
++uintptr_t		T_UV
+ GdkNativeWindow		T_UV
+ 
+ # GdkBitmap doesn't get its own type id, but needs to be treated separately.
+diff -ur a/xs/GdkDnd.xs b/xs/GdkDnd.xs
+--- a/xs/GdkDnd.xs	2017-05-21 15:02:54.000000000 -0400
++++ b/xs/GdkDnd.xs	2023-11-03 13:23:22.478329089 -0400
+@@ -142,12 +142,12 @@
+ void
+ gdk_drag_get_protocol_for_display (class, display, xid)
+ 	GdkDisplay *display
+-	guint32 xid
++	uintptr_t xid
+     PREINIT:
+ 	GdkDragProtocol protocol;
+-	guint32 ret;
++	uintptr_t ret;
+     PPCODE:
+-	ret = gdk_drag_get_protocol_for_display (display, xid, &protocol);
++	ret = (uintptr_t)gdk_drag_get_protocol_for_display (display, INT2PTR(GdkNativeWindow, xid), &protocol);
+ 	XPUSHs (sv_2mortal (newSVuv (ret)));
+ 	XPUSHs (sv_2mortal (ret 
+ 	                    ? newSVGdkDragProtocol (protocol)
+@@ -184,12 +184,12 @@
+ =cut
+ void
+ gdk_drag_get_protocol (class, xid)
+-	guint32 xid
++	uintptr_t xid
+     PREINIT:
+ 	GdkDragProtocol protocol;
+-	guint32 ret;
++	uintptr_t ret;
+     PPCODE:
+-	ret = gdk_drag_get_protocol (xid, &protocol);
++	ret = (uintptr_t)gdk_drag_get_protocol (INT2PTR(GdkNativeWindow, xid), &protocol);
+ 	XPUSHs (sv_2mortal (newSVuv (ret)));
+ 	XPUSHs (sv_2mortal (newSVGdkDragProtocol (protocol)));
+ 	
+diff -ur a/xs/GdkSelection.xs b/xs/GdkSelection.xs
+--- a/xs/GdkSelection.xs	2017-05-21 15:02:54.000000000 -0400
++++ b/xs/GdkSelection.xs	2023-11-03 13:26:58.976888906 -0400
+@@ -147,7 +147,7 @@
+ ##  void gdk_selection_send_notify (guint32 requestor, GdkAtom selection, GdkAtom target, GdkAtom property, guint32 time_) 
+ void
+ gdk_selection_send_notify (class, requestor, selection, target, property, time_)
+-	guint32 requestor
++	GdkNativeWindow requestor
+ 	GdkAtom selection
+ 	GdkAtom target
+ 	GdkAtom property
+@@ -161,7 +161,7 @@
+ void
+ gdk_selection_send_notify_for_display (class, display, requestor, selection, target, property, time_)
+ 	GdkDisplay *display
+-	guint32 requestor
++	GdkNativeWindow requestor
+ 	GdkAtom selection
+ 	GdkAtom target
+ 	GdkAtom property
+diff -ur a/xs/GtkWindow.xs b/xs/GtkWindow.xs
+--- a/xs/GtkWindow.xs	2017-05-21 15:02:54.000000000 -0400
++++ b/xs/GtkWindow.xs	2023-11-03 13:32:53.673168678 -0400
+@@ -581,13 +581,13 @@
+ void
+ gtk_window_remove_embedded_xid (window, xid)
+ 	GtkWindow * window
+-	guint       xid
++	GdkNativeWindow       xid
+ 
+ ## void gtk_window_add_embedded_xid (GtkWindow *window, guint xid)
+ void
+ gtk_window_add_embedded_xid (window, xid)
+ 	GtkWindow * window
+-	guint       xid
++	GdkNativeWindow       xid
+ 
+ ##void gtk_window_reshow_with_initial_size (GtkWindow *window)
+ void

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11121,6 +11121,10 @@ with self; {
       url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-1.24993.tar.gz";
       hash = "sha256-ScRDdDsu7+EadoACck9/akxI78lP8806VZ+357aTyWc=";
     };
+    patches = [
+      # Fix incompatible function pointer conversion (assigning `GdkNativeWindow` to `guint32`).
+      ../development/perl-modules/Gtk2-fix-incompatible-pointer-conversion.patch
+    ];
     buildInputs = [ pkgs.gtk2 ];
     # https://rt.cpan.org/Public/Bug/Display.html?id=130742
     # doCheck = !stdenv.isDarwin;


### PR DESCRIPTION
## Description of changes

First batch of fixes for staging-next #263535.

* perlPackages.Gtk2: https://hydra.nixos.org/build/239567258
* scheme48: https://hydra.nixos.org/build/239627883
* smpeg: https://hydra.nixos.org/build/239416604
* stfl: https://hydra.nixos.org/build/239609986

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
