### PR TITLE
rubyPackages.iconv, v8: fix build with clang 16

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -369,7 +369,12 @@ in
   };
 
   iconv = attrs: {
+    dontBuild = false;
     buildFlags = lib.optional stdenv.isDarwin "--with-iconv-dir=${libiconv}";
+    patches = [
+      # Fix incompatible function pointer conversion errors with clang 16
+      ./iconv-fix-incompatible-function-pointer-conversions.patch
+    ];
   };
 
   idn-ruby = attrs: {

--- a/pkgs/development/ruby-modules/gem-config/iconv-fix-incompatible-function-pointer-conversions.patch
+++ b/pkgs/development/ruby-modules/gem-config/iconv-fix-incompatible-function-pointer-conversions.patch
@@ -1,0 +1,51 @@
+diff --git a/ext/iconv/iconv.c b/ext/iconv/iconv.c
+index 2801049..77fae7e 100644
+--- a/ext/iconv/iconv.c
++++ b/ext/iconv/iconv.c
+@@ -188,7 +188,7 @@ static VALUE iconv_convert _((iconv_t cd, VALUE str, long start, long length, in
+ static VALUE iconv_s_allocate _((VALUE klass));
+ static VALUE iconv_initialize _((int argc, VALUE *argv, VALUE self));
+ static VALUE iconv_s_open _((int argc, VALUE *argv, VALUE self));
+-static VALUE iconv_s_convert _((struct iconv_env_t* env));
++static VALUE iconv_s_convert _((VALUE env));
+ static VALUE iconv_s_iconv _((int argc, VALUE *argv, VALUE self));
+ static VALUE iconv_init_state _((VALUE cd));
+ static VALUE iconv_finish _((VALUE self));
+@@ -204,7 +204,7 @@ static VALUE charset_map;
+  * Returns the map from canonical name to system dependent name.
+  */
+ static VALUE
+-charset_map_get(void)
++charset_map_get(VALUE klass)
+ {
+     return charset_map;
+ }
+@@ -642,7 +642,7 @@ iconv_s_allocate(VALUE klass)
+ }
+ 
+ static VALUE
+-get_iconv_opt_i(VALUE i, VALUE arg)
++get_iconv_opt_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, arg))
+ {
+     VALUE name;
+ #if defined ICONV_SET_TRANSLITERATE || defined ICONV_SET_DISCARD_ILSEQ
+@@ -784,8 +784,9 @@ iconv_s_open(int argc, VALUE *argv, VALUE self)
+ }
+ 
+ static VALUE
+-iconv_s_convert(struct iconv_env_t* env)
++iconv_s_convert(VALUE env_value)
+ {
++    struct iconv_env_t* env = (struct iconv_env_t*)env_value;
+     VALUE last = 0;
+ 
+     for (; env->argc > 0; --env->argc, ++env->argv) {
+@@ -906,7 +907,7 @@ list_iconv(unsigned int namescount, const char *const *names, void *data)
+ 
+ #if defined(HAVE_ICONVLIST) || defined(HAVE___ICONV_FREE_LIST)
+ static VALUE
+-iconv_s_list(void)
++iconv_s_list(VALUE klass)
+ {
+ #ifdef HAVE_ICONVLIST
+     int state;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25465,7 +25465,16 @@ with pkgs;
 
   ucommon = callPackage ../development/libraries/ucommon { };
 
-  v8 = darwin.apple_sdk_11_0.callPackage ../development/libraries/v8 { };
+  v8 = callPackage ../development/libraries/v8 (
+    let
+      stdenv' = if stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc.cc) "16"
+        then overrideLibcxx llvmPackages_15.stdenv
+        else stdenv;
+    in
+    {
+      stdenv = if stdenv'.isDarwin then overrideSDK stdenv' "11.0" else stdenv';
+    }
+  );
 
   intel-vaapi-driver = callPackage ../development/libraries/intel-vaapi-driver { };
 


### PR DESCRIPTION
## Description of changes

Second batch of fixes for staging-next #263535.

* rubyPackages.iconv: https://hydra.nixos.org/build/239596701
* v8: https://hydra.nixos.org/build/239551487

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
