### PR TITLE
mecab-nodic,mecab,python3Package.uamqp,source-highlight: fix build with clang 16

### DIFF
--- a/pkgs/development/python-modules/uamqp/clang-fix-incompatible-function-pointer-conversion.patch
+++ b/pkgs/development/python-modules/uamqp/clang-fix-incompatible-function-pointer-conversion.patch
@@ -1,0 +1,13 @@
+diff --git a/src/message_receiver.pyx b/src/message_receiver.pyx
+index b99647c..479cc9c 100644
+--- a/src/message_receiver.pyx
++++ b/src/message_receiver.pyx
+@@ -120,7 +120,7 @@ cdef class cMessageReceiver(StructBase):
+ 
+ #### Callbacks (context is a MessageReceiver instance)
+ 
+-cdef void on_message_receiver_state_changed(void* context, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG new_state, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG previous_state):
++cdef void on_message_receiver_state_changed(const void* context, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG new_state, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG previous_state):
+     if context != NULL:
+         context_pyobj = <PyObject*>context
+         if context_pyobj.ob_refcnt == 0: # context is being garbage collected, skip the callback

--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -27,6 +27,9 @@ buildPythonPackage rec {
 
   patches = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
     ./darwin-azure-c-shared-utility-corefoundation.patch
+  ] ++ [
+    # Fix incompatible function pointer conversion error with clang 16.
+    ./clang-fix-incompatible-function-pointer-conversion.patch
   ];
 
   postPatch = lib.optionalString (stdenv.isDarwin && !stdenv.isx86_64) ''

--- a/pkgs/tools/text/mecab/base.nix
+++ b/pkgs/tools/text/mecab/base.nix
@@ -15,5 +15,9 @@ finalAttrs: {
     "--with-charset=utf8"
   ];
 
+  # mecab uses several features that have been removed in C++17.
+  # Force the language mode to C++14, so that it can compile with clang 16.
+  makeFlags = [ "CXXFLAGS=-std=c++14" ];
+
   doCheck = true;
 }

--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -14,16 +14,24 @@ stdenv.mkDerivation rec {
   patches = [
     # gcc-11 compat upstream patch
     (fetchpatch {
-      url = "http://git.savannah.gnu.org/cgit/src-highlite.git/patch/?id=904949c9026cb772dc93fbe0947a252ef47127f4";
-      sha256 = "1wnj0jmkmrwjww7qk9dvfxh8h06jdn7mi8v2fvwh95b6x87z5l47";
+      url = "https://git.savannah.gnu.org/cgit/src-highlite.git/patch/?id=904949c9026cb772dc93fbe0947a252ef47127f4";
+      hash = "sha256-h9DyD+pmlQT5dmKjWI9t0gCIYHe7pYkP55LnOqsE0vI=";
       excludes = [ "ChangeLog" ];
     })
 
     # Upstream fix for clang-13 and gcc-12 test support
     (fetchpatch {
       name = "gcc-12.patch";
-      url = "http://git.savannah.gnu.org/cgit/src-highlite.git/patch/?id=ab9fe5cb9b85c5afab94f2a7f4b6d7d473c14ee9";
-      sha256 = "1v33zd2766k7cdgmajw2lffw9wd7v4f8z01f40z53f6bp608nr62";
+      url = "https://git.savannah.gnu.org/cgit/src-highlite.git/patch/?id=ab9fe5cb9b85c5afab94f2a7f4b6d7d473c14ee9";
+      hash = "sha256-wmSLgLnLuFE+IC6AjxzZp/HEnaOCS1VfY2cac0T7Y+w=";
+    })
+  ] ++ lib.optionals stdenv.cc.isClang [
+    # Adds compatibility with C++17 by removing the `register` storage class specifier.
+    (fetchpatch {
+      name = "remove-register-keyword";
+      url = "https://git.savannah.gnu.org/cgit/src-highlite.git/patch/?id=416b39758dba2c74515584514a959ad1b0ad50d1";
+      hash = "sha256-R5A7IGHhU82EqceMCsuNBanhRz4dFVqiaH8637dr7jw=";
+      includes = [ "lib/*" ];
     })
   ];
 


### PR DESCRIPTION
## Description of changes

Second batch of fixes for staging-next #263535.

* mecab-nodic (dependency of mecab): https://hydra.nixos.org/build/239420366
* pythonPackages.uamqp: https://hydra.nixos.org/build/239522988
* source-highlight: https://hydra.nixos.org/build/239488141

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
