### PR TITLE
networkd-dispatcher: don't patch conf file path, add extraArgs option

### DIFF
--- a/nixos/modules/services/networking/networkd-dispatcher.nix
+++ b/nixos/modules/services/networking/networkd-dispatcher.nix
@@ -62,6 +62,15 @@ in {
         });
       };
 
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Extra arguments to pass to the networkd-dispatcher command.
+        '';
+        apply = escapeShellArgs;
+      };
+
     };
   };
 
@@ -71,27 +80,28 @@ in {
       packages = [ pkgs.networkd-dispatcher ];
       services.networkd-dispatcher = {
         wantedBy = [ "multi-user.target" ];
-        # Override existing ExecStart definition
-        serviceConfig.ExecStart = let
-          scriptDir = pkgs.symlinkJoin {
-            name = "networkd-dispatcher-script-dir";
-            paths = lib.mapAttrsToList (name: cfg:
-              (map(state:
-                pkgs.writeTextFile {
-                  inherit name;
-                  text = cfg.script;
-                  destination = "/${state}.d/${name}";
-                  executable = true;
-                }
-              ) cfg.onState)
-            ) cfg.rules;
-          };
-        in [
-          ""
-          "${pkgs.networkd-dispatcher}/bin/networkd-dispatcher -v --script-dir ${scriptDir} $networkd_dispatcher_args"
-        ];
+        environment.networkd_dispatcher_args = cfg.extraArgs;
       };
     };
+
+    services.networkd-dispatcher.extraArgs = let
+      scriptDir = pkgs.symlinkJoin {
+        name = "networkd-dispatcher-script-dir";
+        paths = lib.mapAttrsToList (name: cfg:
+          (map(state:
+            pkgs.writeTextFile {
+              inherit name;
+              text = cfg.script;
+              destination = "/${state}.d/${name}";
+              executable = true;
+            }
+          ) cfg.onState)
+        ) cfg.rules;
+      };
+    in [
+      "--verbose"
+      "--script-dir" "${scriptDir}"
+    ];
 
   };
 }

--- a/pkgs/by-name/ne/networkd-dispatcher/package.nix
+++ b/pkgs/by-name/ne/networkd-dispatcher/package.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Fix paths in systemd unit file
     substituteInPlace networkd-dispatcher.service \
-      --replace "/usr/bin/networkd-dispatcher" "$out/bin/networkd-dispatcher" \
-      --replace "/etc/conf.d" "$out/etc/conf.d"
+      --replace "/usr/bin/networkd-dispatcher" "$out/bin/networkd-dispatcher"
     # Remove conditions on existing rules path
     sed -i '/ConditionPathExistsGlob/g' networkd-dispatcher.service
   '';


### PR DESCRIPTION
## Description of changes

The empty conf file in the store isn't useful since it cannot be modified. On NixOS, the /etc/conf.d/network-dispatcher file will be missing, which is okay because the service file doesn't require it. On non-NixOS systems, this change allows the environment vars to be configured more easily.

Adds an `extraArgs` option to the `services.networkd-dispatcher` module for easier configuration on NixOS.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Ping maintainers

@onny 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
