### PR TITLE
crossplane-cli: init at 1.14.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16250,6 +16250,12 @@
     githubId = 4927883;
     matrix = "@seirl:matrix.org";
   };
+  selfuryon = {
+    name = "Sergei Iakovlev";
+    email = "siakovlev@pm.me";
+    github = "selfuryon";
+    githubId = 2993917;
+  };
   sellout = {
     email = "greg@technomadic.org";
     github = "sellout";

--- a/pkgs/by-name/cr/crossplane-cli/package.nix
+++ b/pkgs/by-name/cr/crossplane-cli/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nix-update-script
+}:
+
+buildGoModule rec {
+  pname = "crossplane-cli";
+  version = "1.14.3";
+
+  src = fetchFromGitHub {
+    owner = "crossplane";
+    repo = "crossplane";
+    rev = "v${version}";
+    hash = "sha256-rxN0Zi1UgQjDOkY2OJlG6826ARBzlEObJk4nDEc9784=";
+  };
+
+  vendorHash = "sha256-vkXvnEstD/czBDxmI96TIQB/L4jxhMwIS1XpHqVtxqY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/crossplane/crossplane/internal/version.version=v${version}"
+  ];
+
+  subPackages = [ "cmd/crank" ];
+
+  postInstall = ''
+    mv $out/bin/crank $out/bin/crossplane
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    homepage = "https://www.crossplane.io/";
+    changelog = "https://github.com/crossplane/crossplane/releases/tag/v${version}";
+    description = "Utility to make using Crossplane easier";
+    mainProgram = "crossplane";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ selfuryon ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Crossplane [released](https://docs.crossplane.io/latest/release-notes/1.14.0/) a [crossplane cli](https://docs.crossplane.io/latest/cli/) tool with 1.14.0 release version.

Nixpkgs already has a [crossplane](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/crossplane/default.nix#L31) tool, so I decided to name it `crossplane-cli`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
