### PR TITLE
cldr-annotations: 43.0 -> 44.0

### DIFF
--- a/pkgs/data/misc/cldr-annotations/default.nix
+++ b/pkgs/data/misc/cldr-annotations/default.nix
@@ -2,12 +2,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "cldr-annotations";
-  version = "43.0";
+  version = "44.0";
 
   src = fetchzip {
     url = "https://unicode.org/Public/cldr/${lib.versions.major version}/cldr-common-${version}.zip";
     stripRoot = false;
-    hash = "sha256-L8ikzRpSw4mDCV79TiUqhPHWC0PmGi4i4He0OAB54R0=";
+    hash = "sha256-oK+NlzuRF45laEMJKhNDzr12RF4CHIfDFNBFsIjJh1I=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes
Release notes: https://cldr.unicode.org/index/downloads/cldr-44

CLDR 44 includes annotations for Emoji 15.1, and I manually checked that ibus built with it allows inputting those. 

Neither Noto Color Emoji, nor the maintained fork of Twemoji that we used have made an Emoji 15.1 release, but input is possible anyway (and all the 15.1 emojis are ZWJ sequences, so they just show decomposed).

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
