### PR TITLE
geany: 1.38 -> 2.0

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -7,19 +7,26 @@
 , file
 , libintl
 , hicolor-icon-theme
+, python3
 , wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "geany";
-  version = "1.38";
+  version = "2.0";
 
   outputs = [ "out" "dev" "doc" "man" ];
 
   src = fetchurl {
-    url = "https://download.geany.org/${pname}-${version}.tar.bz2";
-    sha256 = "abff176e4d48bea35ee53037c49c82f90b6d4c23e69aed6e4a5ca8ccd3aad546";
+    url = "https://download.geany.org/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-VltM0vAxHB46Fn7HHEoy26ZC4P5VSuW7a4F3t6dMzJI=";
   };
+
+  patches = [
+    # The test runs into UB in headless environments and crashes at least on headless Darwin.
+    # Remove if https://github.com/geany/geany/pull/3676 is merged (or the issue fixed otherwise).
+    ./disable-test-sidebar.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -28,12 +35,18 @@ stdenv.mkDerivation rec {
     which
     file
     hicolor-icon-theme
+    python3
     wrapGAppsHook
   ];
 
   buildInputs = [
     gtk3
   ];
+
+  preCheck = ''
+    patchShebangs --build tests/ctags/runner.sh
+    patchShebangs --build scripts
+  '';
 
   doCheck = true;
 
@@ -61,9 +74,9 @@ stdenv.mkDerivation rec {
       - Plugin interface
     '';
     homepage = "https://www.geany.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ frlan ];
     platforms = platforms.all;
     mainProgram = "geany";
   };
-}
+})

--- a/pkgs/applications/editors/geany/disable-test-sidebar.patch
+++ b/pkgs/applications/editors/geany/disable-test-sidebar.patch
@@ -1,0 +1,11 @@
+--- a/tests/Makefile.in	2023-10-19 18:10:06.000000000 +0200
++++ b/tests/Makefile.in	2023-11-10 00:13:09.816498568 +0100
+@@ -86,7 +86,7 @@
+ POST_UNINSTALL = :
+ build_triplet = @build@
+ host_triplet = @host@
+-check_PROGRAMS = test_utils$(EXEEXT) test_sidebar$(EXEEXT)
++check_PROGRAMS = test_utils$(EXEEXT)
+ subdir = tests
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx.m4 \


### PR DESCRIPTION
## Description of changes

Highlights from https://www.geany.org/news/geany-20-is-out/:

- Split "session data" into session.conf, preferences are written to and read from geany.conf.
- Require GTK 3.24.
- Simplify project creation from existing directories with sources.
- Update Scintilla to 5.3.7 and Lexilla to 5.2.7.
- Use "Prof-Gnome" GTK theme by default on Windows for a better experience, the "Adwaita" theme can still be activated.
- Sync many parsers from the Universal Ctags project, this leads to updated symbol parsers.
- Many updated filetypes: Kotlin, Markdown (Robert Di Pardo), Nim (Zoom), PHP, Python.
- New filetypes: AutoIt (Skif-off), GDScript (David Yang).
- Updated translations: cz, da, de, fr, es, kk, lv, it, nl, pt, si, sk, ru, ua.

Full release notes:
https://www.geany.org/documentation/releasenotes/2.0/

Change the license indication on this occasion; the correct one to use is `GPL-2.0-or-later`, as indicated in [`README`](https://github.com/geany/geany/tree/2.0.0#license).

Geany now supports building via Meson, which is declared experimental at the time of writing; Autotools is still the default [(see here)](https://github.com/geany/geany/pull/2761/commits). I kept using Autotools for now.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
