### PR TITLE
python3Packages.editableInstallHook: init

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -458,6 +458,8 @@ Python 2 namespace packages may provide `__init__.py` that collide. In that case
 The following are setup hooks specifically for Python packages. Most of these
 are used in [`buildPythonPackage`](#buildpythonpackage-function).
 
+- `editableInstallHook` to use `pip install -e .` to install the current package
+  in development/editable mode.
 - `eggUnpackhook` to move an egg to the correct folder so it can be installed
   with the `eggInstallHook`
 - `eggBuildHook` to skip building for eggs.
@@ -487,11 +489,9 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
 
 ### Development mode {#development-mode}
 
-Development or editable mode is supported. To develop Python packages
-[`buildPythonPackage`](#buildpythonpackage-function) has additional logic inside `shellPhase` to run `pip
-install -e . --prefix $TMPDIR/`for the package.
-
-Warning: `shellPhase` is executed only if `setup.py` exists.
+Development or editable mode is supported. To develop Python packages,
+`editableInstallHook` is required. This adds a `shellPhase` to run `pip
+install -e .` into a temporary prefix for the package.
 
 Given a `default.nix`:
 
@@ -500,7 +500,7 @@ with import <nixpkgs> {};
 
 python3Packages.buildPythonPackage {
   name = "myproject";
-  buildInputs = with python3Packages; [ pyramid ];
+  buildInputs = with python3Packages; [ editableInstallHook pyramid ];
 
   src = ./.;
 }
@@ -1445,23 +1445,26 @@ referencing it using `sphinxHook` from top-level.
 
 ### Develop local package {#develop-local-package}
 
-As a Python developer you're likely aware of [development mode](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode)
-(`python setup.py develop`); instead of installing the package this command
-creates a special link to the project code. That way, you can run updated code
-without having to reinstall after each and every change you make. Development
-mode is also available. Let's see how you can use it.
+As a Python developer you're likely aware of
+[development mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html)
+(`pip install -e`). Instead of installing the package this command creates a
+special link to the project code. That way, you can run updated code without
+having to reinstall after each and every change you make. Development mode is
+also available in Nix. Let's see how you can use it.
 
 In the previous Nix expression the source was fetched from a url. We can also
 refer to a local source instead using `src = ./path/to/source/tree;`
 
-If we create a `shell.nix` file which calls [`buildPythonPackage`](#buildpythonpackage-function), and if `src`
-is a local source, and if the local source has a `setup.py`, then development
-mode is activated.
+If we create a `shell.nix` file which calls
+[`buildPythonPackage`](#buildpythonpackage-function) and if
+`editableInstallHook` is added, then development mode will be activated when
+`nix-shell` is run using that file.
 
 In the following example, we create a simple environment that has a Python 3.11
 version of our package in it, as well as its dependencies and other packages we
-like to have in the environment, all specified with [`propagatedBuildInputs`](#var-stdenv-propagatedBuildInputs).
-Indeed, we can just add any package we like to have in our environment to
+like to have in the environment, all specified with
+[`propagatedBuildInputs`](#var-stdenv-propagatedBuildInputs). Indeed, we can
+just add any package we like to have in our environment to
 [`propagatedBuildInputs`](#var-stdenv-propagatedBuildInputs).
 
 ```nix
@@ -1471,6 +1474,8 @@ with python311Packages;
 buildPythonPackage rec {
   name = "mypackage";
   src = ./path/to/package/source;
+  nativeBuildInputs = [ editableInstallHook ];
+
   propagatedBuildInputs = [
     pytest
     numpy
@@ -1480,7 +1485,8 @@ buildPythonPackage rec {
 ```
 
 It is important to note that due to how development mode is implemented on Nix
-it is not possible to have multiple packages simultaneously in development mode.
+it is not possible to have multiple packages simultaneously in development mode
+using this method.
 
 ### Organising your packages {#organising-your-packages}
 

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -177,7 +177,7 @@ in {
       name = "setuptools-setup-hook";
       propagatedBuildInputs = [ setuptools wheel ];
       substitutions = {
-        inherit pythonInterpreter pythonSitePackages setuppy;
+        inherit pythonInterpreter setuppy;
       };
     } ./setuptools-build-hook.sh) {};
 

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -24,6 +24,15 @@ in {
       propagatedBuildInputs = [];
     } ./conda-unpack-hook.sh) {};
 
+  editableInstallHook = disabledIf (!isPy3k) (callPackage ({ makePythonHook, pip, setuptools, wheel }:
+    makePythonHook {
+      name = "editable-install-hook";
+      propagatedBuildInputs = [ pip setuptools wheel ];
+      substitutions = {
+        inherit pythonInterpreter pythonSitePackages;
+      };
+    } ./editable-install-hook.sh) {});
+
   eggBuildHook = callPackage ({ makePythonHook }:
     makePythonHook {
       name = "egg-build-hook.sh";

--- a/pkgs/development/interpreters/python/hooks/editable-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/editable-install-hook.sh
@@ -1,0 +1,30 @@
+editableInstallHook() {
+    echo "Executing editableInstallHook"
+    runHook preShellHook
+
+    # We make a temporary directory to hold the editable install. We don't
+    # really have a way to clean it up as it must exist past the shell lifetime
+    # for tools like direnv to work properly. However, the total contents are
+    # only a few kilobytes (independent of the size of the edited package) and
+    # the operating system will clean it up e.g. on reboot.
+    tmp_path=$(mktemp -d)
+    export PATH="$tmp_path/bin:$PATH"
+    export PYTHONPATH="$tmp_path/@pythonSitePackages@:$PYTHONPATH"
+    mkdir -p "$tmp_path/@pythonSitePackages@"
+    eval "@pythonInterpreter@ -m pip install -e . --prefix $tmp_path \
+      --no-build-isolation >&2"
+
+    # Process pth file installed in tmp path. This allows one to actually import
+    # the editable installation. Note site.addsitedir appends, not prepends,
+    # new paths. Hence, it is not possible to override an existing installation
+    # of the package. https://github.com/pypa/setuptools/issues/2612
+    export NIX_PYTHONPATH="$tmp_path/@pythonSitePackages@:${NIX_PYTHONPATH-}"
+
+    runHook postShellHook
+    echo "Finished executing editableInstallHook"
+}
+
+if [ -z "${dontUseEditableInstallHook:-}" ] && [ -z "${shellHook-}" ]; then
+    echo "Using editableInstallHook"
+    shellHook=editableInstallHook
+fi

--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -23,36 +23,7 @@ setuptoolsBuildPhase() {
     echo "Finished executing setuptoolsBuildPhase"
 }
 
-setuptoolsShellHook() {
-    echo "Executing setuptoolsShellHook"
-    runHook preShellHook
-
-    if test -e setup.py; then
-        tmp_path=$(mktemp -d)
-        export PATH="$tmp_path/bin:$PATH"
-        export PYTHONPATH="$tmp_path/@pythonSitePackages@:$PYTHONPATH"
-        mkdir -p "$tmp_path/@pythonSitePackages@"
-        eval "@pythonInterpreter@ -m pip install -e . --prefix $tmp_path \
-          --no-build-isolation >&2"
-
-        # Process pth file installed in tmp path. This allows one to
-        # actually import the editable installation. Note site.addsitedir
-        # appends, not prepends, new paths. Hence, it is not possible to override
-        # an existing installation of the package.
-        # https://github.com/pypa/setuptools/issues/2612
-        export NIX_PYTHONPATH="$tmp_path/@pythonSitePackages@:${NIX_PYTHONPATH-}"
-    fi
-
-    runHook postShellHook
-    echo "Finished executing setuptoolsShellHook"
-}
-
 if [ -z "${dontUseSetuptoolsBuild-}" ] && [ -z "${buildPhase-}" ]; then
     echo "Using setuptoolsBuildPhase"
     buildPhase=setuptoolsBuildPhase
-fi
-
-if [ -z "${dontUseSetuptoolsShellHook-}" ] && [ -z "${shellHook-}" ]; then
-    echo "Using setuptoolsShellHook"
-    shellHook=setuptoolsShellHook
 fi


### PR DESCRIPTION
## Description of changes

Serves as a replacement for the old and busted `setuptoolsShellHook`. It
needs to be added manually to reduce the magic factor.

Supports `pyproject.toml`-based projects in addition to `setup.py`.
Always runs (vs. detecting the existence of these files) to reduce the
magic factor. If no suitable project is found, then a big red error
message is displayed by `pip` but shell initialization nonetheless
continues as normal.

Documentation is updated to describe existence and usage.

The old and busted `setuptoolsShellHook` is also removed.

Fixes https://github.com/NixOS/nixpkgs/issues/259812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
