### PR TITLE
arrow-cpp: fix crash in tests on x86_64-darwin

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/202103.nix
+++ b/pkgs/development/libraries/abseil-cpp/202103.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/abseil/abseil-cpp/commit/808bc202fc13e85a7948db0d7fb58f0f051200b1.patch";
       sha256 = "sha256-ayY/aV/xWOdEyFSDqV7B5WDGvZ0ASr/aeBeYwP5RZVc=";
     })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Don’t propagate the path to CoreFoundation. Otherwise, it’s impossible to build packages
+    # that require a different SDK other than the default one.
+    ./cmake-core-foundation.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/abseil-cpp/202111.nix
+++ b/pkgs/development/libraries/abseil-cpp/202111.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sSXT6D4JSrk3dA7kVaxfKkzOMBpqXQb0WbMYWG+nGwk=";
   };
 
+  patches = lib.optionals stdenv.isDarwin [
+    # Don’t propagate the path to CoreFoundation. Otherwise, it’s impossible to build packages
+    # that require a different SDK other than the default one.
+    ./cmake-core-foundation.patch
+  ];
+
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
   ] ++ lib.optionals (cxxStandard != null) [

--- a/pkgs/development/libraries/abseil-cpp/202206.nix
+++ b/pkgs/development/libraries/abseil-cpp/202206.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-Od1FZOOWEXVQsnZBwGjDIExi6LdYtomyL0STR44SsG8=";
   };
 
+  patches = lib.optionals stdenv.isDarwin [
+    # Don’t propagate the path to CoreFoundation. Otherwise, it’s impossible to build packages
+    # that require a different SDK other than the default one.
+    ./cmake-core-foundation.patch
+  ];
+
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
   ] ++ lib.optionals (cxxStandard != null) [

--- a/pkgs/development/libraries/abseil-cpp/202301.nix
+++ b/pkgs/development/libraries/abseil-cpp/202301.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-PLoI7ix+reUqkZ947kWzls8lujYqWXk9A9a55UcfahI=";
   };
 
+  patches = lib.optionals stdenv.isDarwin [
+    # Don’t propagate the path to CoreFoundation. Otherwise, it’s impossible to build packages
+    # that require a different SDK other than the default one.
+    ./cmake-core-foundation.patch
+  ];
+
   cmakeFlags = [
     "-DABSL_BUILD_TEST_HELPERS=ON"
     "-DABSL_USE_EXTERNAL_GOOGLETEST=ON"

--- a/pkgs/development/libraries/abseil-cpp/202308.nix
+++ b/pkgs/development/libraries/abseil-cpp/202308.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-uNGrTNg5G5xFGtc+BSWE389x0tQ/KxJQLHfebNWas/k=";
   };
 
+  patches = lib.optionals stdenv.isDarwin [
+    # Don’t propagate the path to CoreFoundation. Otherwise, it’s impossible to build packages
+    # that require a different SDK other than the default one.
+    ./cmake-core-foundation.patch
+  ];
+
   cmakeFlags = [
     "-DABSL_BUILD_TEST_HELPERS=ON"
     "-DABSL_USE_EXTERNAL_GOOGLETEST=ON"

--- a/pkgs/development/libraries/abseil-cpp/cmake-core-foundation.patch
+++ b/pkgs/development/libraries/abseil-cpp/cmake-core-foundation.patch
@@ -1,0 +1,12 @@
+diff -ur a/absl/time/CMakeLists.txt b/absl/time/CMakeLists.txt
+--- a/absl/time/CMakeLists.txt	1969-12-31 19:00:01.000000000 -0500
++++ b/absl/time/CMakeLists.txt	2023-10-30 21:50:32.639061785 -0400
+@@ -55,7 +55,7 @@
+ )
+ 
+ if(APPLE)
+-  find_library(CoreFoundation CoreFoundation)
++  set(CoreFoundation "-framework CoreFoundation")
+ endif()
+ 
+ absl_cc_library(

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -262,6 +262,9 @@ rec {
       ) darwinMinVersion darwinSdkVersion;
 
       sdk = pkgs.darwin."apple_sdk_${lib.replaceStrings [ "." ] [ "_" ] darwinSdkVersion}";
+      # TODO: Make this unconditional after #229210 has been merged,
+      # and the 10.12 SDK is updated to follow the new structure.
+      Libsystem = if darwinSdkVersion == "10.12" then pkgs.darwin.Libsystem else sdk.Libsystem;
 
       replacePropagatedFrameworks = pkg:
         let
@@ -349,8 +352,8 @@ rec {
         // lib.genAttrs atBuildInputs (input: map mapRuntimeToSDK (args."${input}" or [ ]));
 
       mkCC = cc: cc.override {
-        bintools = cc.bintools.override { libc = sdk.Libsystem; };
-        libc = sdk.Libsystem;
+        bintools = cc.bintools.override { libc = Libsystem; };
+        libc = Libsystem;
       };
     in
     # TODO: make this work across all input types and not just propagatedBuildInputs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20515,10 +20515,30 @@ with pkgs;
 
   aalib = callPackage ../development/libraries/aalib { };
 
-  abseil-cpp_202103 = callPackage ../development/libraries/abseil-cpp/202103.nix { };
-  abseil-cpp_202206 = callPackage ../development/libraries/abseil-cpp/202206.nix { };
-  abseil-cpp_202301 = callPackage ../development/libraries/abseil-cpp/202301.nix { };
-  abseil-cpp_202308 = callPackage ../development/libraries/abseil-cpp/202308.nix { };
+  abseil-cpp_202103 = callPackage ../development/libraries/abseil-cpp/202103.nix {
+    # If abseil-cpp doesn’t have a deployment target of 10.13+, arrow-cpp crashes in libgrpc.dylib.
+    stdenv = if stdenv.isDarwin && stdenv.isx86_64
+      then overrideSDK stdenv { darwinMinVersion = "10.13"; }
+      else stdenv;
+  };
+  abseil-cpp_202206 = callPackage ../development/libraries/abseil-cpp/202206.nix {
+    # If abseil-cpp doesn’t have a deployment target of 10.13+, arrow-cpp crashes in libgrpc.dylib.
+    stdenv = if stdenv.isDarwin && stdenv.isx86_64
+      then overrideSDK stdenv { darwinMinVersion = "10.13"; }
+      else stdenv;
+  };
+  abseil-cpp_202301 = callPackage ../development/libraries/abseil-cpp/202301.nix {
+    # If abseil-cpp doesn’t have a deployment target of 10.13+, arrow-cpp crashes in libgrpc.dylib.
+    stdenv = if stdenv.isDarwin && stdenv.isx86_64
+      then overrideSDK stdenv { darwinMinVersion = "10.13"; }
+      else stdenv;
+  };
+  abseil-cpp_202308 = callPackage ../development/libraries/abseil-cpp/202308.nix {
+    # If abseil-cpp doesn’t have a deployment target of 10.13+, arrow-cpp crashes in libgrpc.dylib.
+    stdenv = if stdenv.isDarwin && stdenv.isx86_64
+      then overrideSDK stdenv { darwinMinVersion = "10.13"; }
+      else stdenv;
+  };
   abseil-cpp = abseil-cpp_202301;
 
   accountsservice = callPackage ../development/libraries/accountsservice { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21827,13 +21827,9 @@ with pkgs;
   grilo-plugins = callPackage ../development/libraries/grilo-plugins { };
 
   grpc = callPackage ../development/libraries/grpc {
-    stdenv = if (stdenv.isDarwin && stdenv.isx86_64) then
-      # Work around Clang check for 10.13 when using aligned allocations with C++17.
-      stdenv.override (old: {
-        hostPlatform = old.hostPlatform // { darwinMinVersion = "10.13"; };
-        buildPlatform = old.buildPlatform // { darwinMinVersion = "10.13"; };
-        targetPlatform = old.targetPlatform // { darwinMinVersion = "10.13"; };
-      })
+    # Work around Clang check for 10.13 when using aligned allocations with C++17.
+    stdenv = if stdenv.isDarwin && stdenv.isx86_64
+      then overrideSDK stdenv { darwinMinVersion = "10.13"; }
       else stdenv;
   };
 


### PR DESCRIPTION
## Description of changes

arrow-cpp crash fixes on x86_64-darwin for staging-next #263535.

* arrow-cpp: https://hydra.nixos.org/build/239718549

The crash was happening GRPC due apparently the differing deployment targets. I cherry-picked #264503 as part of the troubleshooting and have opted to leave it included in the PR to avoid having to wait for another arrow-cpp rebuild.

I tested that arrow-cpp built on x86_64-darwin, but arrow-s3fs-test failed for me due to #265102. It is expected arrow-cpp should build successfully on Hydra.

Closes #264503.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
