### PR TITLE
passt: init at 2023_11_10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -189,6 +189,12 @@
     githubId = 12578560;
     name = "Quinn Bohner";
   };
+  _8aed = {
+    email = "8aed@riseup.net";
+    github = "8aed";
+    githubId = 140662578;
+    name = "Huit Aed";
+  };
   _8-bit-fox = {
     email = "sebastian@markwaerter.de";
     github = "8-bit-fox";

--- a/pkgs/by-name/pa/passt/package.nix
+++ b/pkgs/by-name/pa/passt/package.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchgit }:
+
+stdenv.mkDerivation {
+  pname = "passt";
+  version = "0.2023_11_10.5ec3634";
+  src = fetchgit {
+    url = "git://passt.top/passt";
+    rev = "5ec3634b07215337c2e69d88f9b1d74711897d7d";
+    hash = "sha256-76CD9PYD/NcBkmRYFSZaYl381QJjuWo0VsNdh31d6/M=";
+  };
+  nativeBuildInputs = [ ];
+  buildInputs = [];
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share/man/man1
+    cp passt pasta qrap $out/bin/
+    cp passt.1 pasta.1 qrap.1 $out/share/man/man1/
+  '' + (lib.optionalString stdenv.hostPlatform.avx2Support ''
+    cp passt.avx2 pasta.avx2 $out/bin/
+    runHook postInstall
+  '');
+  meta = with lib; {
+    homepage = "https://passt.top/passt/about/";
+    description = "Translation layer between a Layer-2 network interface and native Layer-4 sockets";
+    longDescription = ''
+      passt implements a translation layer between a Layer-2 network interface
+      and native Layer-4 sockets (TCP, UDP, ICMP/ICMPv6 echo) on a host.
+      It doesn't require any capabilities or privileges, and it can be used as
+      a simple replacement for Slirp.
+
+      pasta (same binary as passt, different command) offers equivalent
+      functionality, for network namespaces: traffic is forwarded using a tap
+      interface inside the namespace, without the need to create further
+      interfaces on the host, hence not requiring any capabilities or
+      privileges.
+    '';
+    license = lib.licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ _8aed ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This package provides [a user-mode networking tool](https://passt.top/passt/about/) that can be used with virtual machines (`passt`) and namespaces (`pasta`), like `SLIRP` and `slirp4netns`, which are already packaged in NixOS.

It is especially useful when one wants to provide networking access to an unprivileged container.  It uses a different implementation than SLIRP, supports zero-copy  for local connections, is more optimized and generally provides higher throughput than other MTU-based solutions. When available, It is the default networking mode for rootlless podman.

## Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).