### PR TITLE
otel-desktop-viewer: init at 0.1.4

### DIFF
--- a/pkgs/by-name/ot/otel-desktop-viewer/package.nix
+++ b/pkgs/by-name/ot/otel-desktop-viewer/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, testers
+, otel-desktop-viewer
+}:
+
+buildGoModule rec {
+  pname = "otel-desktop-viewer";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "CtrlSpice";
+    repo = "otel-desktop-viewer";
+    rev = "v${version}";
+    hash = "sha256-kMgcco4X7X9WoCCH8iZz5qGr/1dWPSeQOpruTSUnonI=";
+  };
+
+  # https://github.com/CtrlSpice/otel-desktop-viewer/issues/139
+  patches = [ ./version-0.1.4.patch ];
+
+  subPackages = [ "..." ];
+
+  vendorHash = "sha256-pH16DCYeW8mdnkkRi0zqioovZu9slVc3gAdhMYu2y98=";
+
+  ldflags = [ "-s" "-w" ];
+
+  passthru.tests.version = testers.testVersion {
+    inherit version;
+    package = otel-desktop-viewer;
+    command = "otel-desktop-viewer --version";
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/CtrlSpice/otel-desktop-viewer/releases/tag/v${version}";
+    description = "Receive & visualize OpenTelemtry traces locally within one CLI tool";
+    homepage = "https://github.com/CtrlSpice/otel-desktop-viewer";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gaelreyrol ];
+    mainProgram = "otel-desktop-viewer";
+  };
+}

--- a/pkgs/by-name/ot/otel-desktop-viewer/version-0.1.4.patch
+++ b/pkgs/by-name/ot/otel-desktop-viewer/version-0.1.4.patch
@@ -1,0 +1,13 @@
+diff --git a/main.go b/main.go
+index 7e43908..062385c 100644
+--- a/main.go
++++ b/main.go
+@@ -15,7 +15,7 @@ func main() {
+ 	info := component.BuildInfo{
+ 		Command:     "otel-desktop-viewer",
+ 		Description: "Basic OTel with Custom Desktop Exporter",
+-		Version:     "0.1.1",
++		Version:     "0.1.4",
+ 	}
+ 
+ 	if err := run(info); err != nil {


### PR DESCRIPTION
## Description of changes

This PR adds the package otel-desktop-viewer: https://github.com/CtrlSpice/otel-desktop-viewer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
