### PR TITLE
nixos/sway: reimplement enableRealtime and disable it by default

### DIFF
--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -66,7 +66,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       fi
     '';
 
-    programs.sway.enable = true;
+    programs.sway = {
+      enable = true;
+      enableRealtime = true;
+    };
 
     # To test pinentry via gpg-agent:
     programs.gnupg.agent.enable = true;

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -44,8 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Use /run/current-system/sw/share and /etc instead of /nix/store
     # references:
     ./sway-config-nixos-paths.patch
-    # Drop ambient capabilities after getting SCHED_RR
-    ./drop_ambient_capabilities.patch
   ];
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes
Alternative for https://github.com/NixOS/nixpkgs/pull/265358.

This will reimplement this option using `security.pam.loginLimits` instead of `security.wrappers`. Has the advantage that it doesn't break any programs, doesn't need an extra patch and also work in Home-Manager.

However this also has the caveat that will allow any program from users in `@users` group to have real-time privilegies. This is why this option is disabled by default now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
