### PR TITLE
python311Packages.pytest-ansible: 4.1.0 -> 4.1.1

### DIFF
--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -1,10 +1,9 @@
-{ stdenv
-, lib
-, buildPythonPackage
-, fetchFromGitHub
+{ lib
+, stdenv
 , ansible-core
+, buildPythonPackage
 , coreutils
-, coverage
+, fetchFromGitHub
 , pytest
 , pytestCheckHook
 , pythonOlder
@@ -15,16 +14,16 @@
 
 buildPythonPackage rec {
   pname = "pytest-ansible";
-  version = "4.1.0";
+  version = "4.1.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "ansible";
-    repo = pname;
+    repo = "pytest-ansible";
     rev = "refs/tags/v${version}";
-    hash = "sha256-TV/dR4eTiwjrgamwRCig10acaf3MpAzLu0fHF0V2pzw=";
+    hash = "sha256-51DQ+NwD454XaYLuRxriuWRZ8uTSX3ZpadXdxs7FspQ=";
   };
 
   postPatch = ''
@@ -49,7 +48,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    coverage
     pytestCheckHook
   ];
 
@@ -74,7 +72,10 @@ buildPythonPackage rec {
     "test_param_override_with_marker"
   ];
 
-  disabledTestPaths = lib.optionals stdenv.isDarwin [
+  disabledTestPaths = [
+    # Test want s to execute pytest in a subprocess
+    "tests/integration/test_molecule.py"
+  ] ++ lib.optionals stdenv.isDarwin [
     # These tests fail in the Darwin sandbox
     "tests/test_adhoc.py"
     "tests/test_adhoc_result.py"
@@ -85,7 +86,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Plugin for py.test to simplify calling ansible modules from tests or fixtures";
+    description = "Plugin for pytest to simplify calling ansible modules from tests or fixtures";
     homepage = "https://github.com/jlaska/pytest-ansible";
     changelog = "https://github.com/ansible-community/pytest-ansible/releases/tag/v${version}";
     license = licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/ansible/pytest-ansible/compare/refs/tags/v4.1.0...v4.1.1

Changelog: https://github.com/ansible-community/pytest-ansible/releases/tag/v4.1.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
