### PR TITLE
meld: avoid -dev paths in runtime closure

### DIFF
--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -47,7 +47,7 @@ python3.pkgs.buildPythonApplication rec {
     gnome.adwaita-icon-theme
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  pythonPath = with python3.pkgs; [
     pygobject3
     pycairo
   ];


### PR DESCRIPTION
Use `pythonPath` instead of `propagatedBuildInputs`.

Closure before the change:

    $ nix path-info -rsSh $(nix-build '<nixpkgs>' -A meld) | unnix | nl | tail -n1
    185  /<<NIX>>/meld-3.22.0 5.2M  512.7M

After the change:

     $ nix path-info -rsSh $(nix-build -A meld) | unnix | nl | tail -n1
    155  /<<NIX>>/meld-3.22.0 5.2M  480.8M

This way we avoid 30 depends and 32MB of closure. Those were the following packages:

    /<<NIX>>/brotli-1.1.0
    /<<NIX>>/brotli-1.1.0-dev
    /<<NIX>>/bzip2-1.0.8-dev
    /<<NIX>>/cairo-1.16.0-dev
    /<<NIX>>/expat-2.5.0-dev
    /<<NIX>>/fontconfig-2.14.2-bin
    /<<NIX>>/fontconfig-2.14.2-dev
    /<<NIX>>/freetype-2.13.2-dev
    /<<NIX>>/gettext-0.21.1
    /<<NIX>>/glib-2.76.4-bin
    /<<NIX>>/glib-2.76.4-dev
    /<<NIX>>/glibc-2.38-23-bin
    /<<NIX>>/glibc-2.38-23-dev
    /<<NIX>>/glibc-iconv-2.38
    /<<NIX>>/libelf-0.8.13
    /<<NIX>>/libffi-3.4.4-dev
    /<<NIX>>/libGL-1.6.0-dev
    /<<NIX>>/libglvnd-1.6.0-dev
    /<<NIX>>/libpng-apng-1.6.40-dev
    /<<NIX>>/libX11-1.8.7-dev
    /<<NIX>>/libXau-1.0.11-dev
    /<<NIX>>/libxcb-1.16-dev
    /<<NIX>>/libXext-1.3.5-dev
    /<<NIX>>/libXrender-0.9.11-dev
    /<<NIX>>/linux-headers-6.5
    /<<NIX>>/python3.11-pygobject-3.44.1-dev
    /<<NIX>>/xcb-util-0.4.1
    /<<NIX>>/xcb-util-0.4.1-dev
    /<<NIX>>/xorgproto-2023.2
    /<<NIX>>/zlib-1.3-dev

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
