### PR TITLE
glauth: init at 2.3.0

### DIFF
--- a/pkgs/by-name/gl/glauth/package.nix
+++ b/pkgs/by-name/gl/glauth/package.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, oath-toolkit
+, openldap
+}:
+
+buildGoModule rec {
+  pname = "glauth";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "glauth";
+    repo = "glauth";
+    rev = "v${version}";
+    hash = "sha256-XYNNR3bVLNtAl+vbGRv0VhbLf+em8Ay983jqcW7KDFU=";
+  };
+
+  vendorHash = "sha256-SFmGgxDokIbVl3ANDPMCqrB0ck8Wyva2kSV2mgNRogo=";
+
+  nativeCheckInputs = [
+    oath-toolkit
+    openldap
+  ];
+
+  modRoot = "v2";
+
+  # Disable go workspaces to fix build.
+  env.GOWORK = "off";
+
+  # Fix this build error:
+  #   main module (github.com/glauth/glauth/v2) does not contain package github.com/glauth/glauth/v2/vendored/toml
+  excludedPackages = [ "vendored/toml" ];
+
+  # Based on ldflags in <glauth>/Makefile.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.GitClean=1"
+    "-X main.LastGitTag=v${version}"
+    "-X main.GitTagIsCommit=1"
+  ];
+
+  # Tests fail in the sandbox.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A lightweight LDAP server for development, home use, or CI";
+    homepage = "https://github.com/glauth/glauth";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bjornfor ];
+    mainProgram = "glauth";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add glauth, an LDAP server with nice declarative properties.

https://github.com/glauth/glauth

Fixes https://github.com/NixOS/nixpkgs/issues/239396 ("Package request: glauth")

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
