### PR TITLE
python3Packages.spectral-cube: upgrade to the latest upstream and fix tests

### DIFF
--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -46,6 +46,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # Tests must be run in the build directory.
+  preCheck = ''
+    cd build/lib
+  '';
+
   # On x86_darwin, this test fails with "Fatal Python error: Aborted"
   # when sandbox = true.
   disabledTestPaths = lib.optionals stdenv.isDarwin [
@@ -62,7 +67,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/radio-astro-tools/spectral-cube/releases/tag/v${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ smaret ];
-    # Tests fail to start, according to Hydra
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , aplpy
 , astropy
-, astropy-helpers
 , buildPythonPackage
 , casa-formats-io
 , dask
@@ -17,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "spectral-cube";
-  version = "0.6.2";
+  version = "0.6.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0Fr9PvUShi04z8SUsZE7zHuXZWg4rxt6gwSBb6lr2Pc=";
+    hash = "sha256-7wfvsravSkAGkTtuPE01wPW7wEHKVWT8kYQn93Q2B4M=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;


### PR DESCRIPTION
## Description of changes

- Upgrade to the [latest upstream](https://github.com/radio-astro-tools/spectral-cube/releases/tag/v0.6.3)
- Fix the tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
