### PR TITLE
androidenv fix avd directory, and making config options more available

### DIFF
--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -1,16 +1,26 @@
 { composeAndroidPackages, stdenv, lib, runtimeShell }:
-{ name, app ? null
+{ name
+, app ? null
 , platformVersion ? "33"
 , abiVersion ? "armeabi-v7a"
 , systemImageType ? "default"
-, enableGPU ? false
-, extraAVDFiles ? []
+, enableGPU ? false # Enable GPU acceleration. It's deprecated, instead use `configOptions` below.
+, configOptions ? (
+    # List of options to add in config.ini
+    lib.optionalAttrs enableGPU
+      (lib.warn
+        "enableGPU argument is deprecated and will be removed; use configOptions instead"
+        { "hw.gpu.enabled" = "yes"; }
+      )
+  )
+, extraAVDFiles ? [ ]
 , package ? null
 , activity ? null
 , androidUserHome ? null
 , avdHomeDir ? null # Support old variable with non-standard naming!
 , androidAvdHome ? avdHomeDir
-, sdkExtraArgs ? {}
+, deviceName ? "device"
+, sdkExtraArgs ? { }
 , androidAvdFlags ? null
 , androidEmulatorFlags ? null
 }:
@@ -99,27 +109,28 @@ stdenv.mkDerivation {
     export ANDROID_SERIAL="emulator-$port"
 
     # Create a virtual android device for testing if it does not exist
-    if [ "$(${sdk}/bin/avdmanager list avd | grep 'Name: device')" = "" ]
+    if [ "$(${sdk}/bin/avdmanager list avd | grep 'Name: ${deviceName}')" = "" ]
     then
         # Create a virtual android device
-        yes "" | ${sdk}/bin/avdmanager create avd --force -n device -k "system-images;android-${platformVersion};${systemImageType};${abiVersion}" -p $ANDROID_AVD_HOME $NIX_ANDROID_AVD_FLAGS
+        yes "" | ${sdk}/bin/avdmanager create avd --force -n ${deviceName} -k "system-images;android-${platformVersion};${systemImageType};${abiVersion}" -p $ANDROID_AVD_HOME/${deviceName}.avd $NIX_ANDROID_AVD_FLAGS
 
-        ${lib.optionalString enableGPU ''
-          # Enable GPU acceleration
-          echo "hw.gpu.enabled=yes" >> $ANDROID_AVD_HOME/device.avd/config.ini
-        ''}
+        ${builtins.concatStringsSep "\n" (
+          lib.mapAttrsToList (configKey: configValue: ''
+            echo "${configKey} = ${configValue}" >> $ANDROID_AVD_HOME/${deviceName}.avd/config.ini
+          '') configOptions
+        )}
 
         ${lib.concatMapStrings (extraAVDFile: ''
-          ln -sf ${extraAVDFile} $ANDROID_AVD_HOME/device.avd
+          ln -sf ${extraAVDFile} $ANDROID_AVD_HOME/${deviceName}.avd
         '') extraAVDFiles}
     fi
 
     # Launch the emulator
     echo "\nLaunch the emulator"
-    $ANDROID_SDK_ROOT/emulator/emulator -avd device -no-boot-anim -port $port $NIX_ANDROID_EMULATOR_FLAGS &
+    $ANDROID_SDK_ROOT/emulator/emulator -avd ${deviceName} -no-boot-anim -port $port $NIX_ANDROID_EMULATOR_FLAGS &
 
     # Wait until the device has completely booted
-    echo "Waiting until the emulator has booted the device and the package manager is ready..." >&2
+    echo "Waiting until the emulator has booted the ${deviceName} and the package manager is ready..." >&2
 
     ${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port wait-for-device
 

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -78,6 +78,7 @@ let
   androidComposition = androidEnv.composeAndroidPackages sdkArgs;
   androidEmulator = androidEnv.emulateApp {
     name = "android-sdk-emulator-demo";
+    configOptions = { "hw.keyboard" = "yes"; };
     sdkExtraArgs = sdkArgs;
   };
   androidSdk = androidComposition.androidsdk;


### PR DESCRIPTION
## Description of changes

Improvements for pkgs/development/mobile/androidenv/emulate-app.nix

- Fix the problem in https://github.com/NixOS/nixpkgs/issues/265479
- Add `configOptions`
- Add `deviceName`

## Things done

- The `configOptions` is a list of configs for AVDs that will be added to the `config.ini` file.
- The `deviceName` will give us the flexibility to define devices with different names.


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
