### PR TITLE
treewide: switch to texlive.withPackages

### DIFF
--- a/pkgs/applications/editors/apostrophe/default.nix
+++ b/pkgs/applications/editors/apostrophe/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitLab, meson, ninja
 , wrapGAppsHook, pkg-config, desktop-file-utils
 , appstream-glib, pythonPackages, glib, gobject-introspection
-, gtk3, webkitgtk, glib-networking, gnome, gspell, texlive
+, gtk3, webkitgtk, glib-networking, gnome, gspell, texliveMedium
 , shared-mime-info, libhandy, fira, sassc
 }:
 
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
     appstream-glib wrapGAppsHook sassc gobject-introspection ];
 
   buildInputs = [ glib pythonEnv gtk3
-    gnome.adwaita-icon-theme webkitgtk gspell texlive
+    gnome.adwaita-icon-theme webkitgtk gspell texliveMedium
     glib-networking libhandy ];
 
   postPatch = ''
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$out/lib/python${pythonEnv.pythonVersion}/site-packages/"
-      --prefix PATH : "${texlive}/bin"
+      --prefix PATH : "${texliveMedium}/bin"
       --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
     )
   '';

--- a/pkgs/applications/editors/ne/default.nix
+++ b/pkgs/applications/editors/ne/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ncurses, texinfo6, texlive, perl, ghostscript }:
+{ lib, stdenv, fetchFromGitHub, ncurses, texinfo6, texliveMedium, perl, ghostscript }:
 
 stdenv.mkDerivation rec {
   pname = "ne";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/makefile --replace "-lcurses" "-lncurses"
   '';
 
-  nativeBuildInputs = [ texlive.combined.scheme-medium texinfo6 perl ghostscript ];
+  nativeBuildInputs = [ texliveMedium texinfo6 perl ghostscript ];
   buildInputs = [ ncurses ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];

--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -2,7 +2,7 @@
   guile_1_8, xmodmap, which, freetype,
   libjpeg,
   sqlite,
-  tex ? null,
+  texliveSmall ? null,
   aspell ? null,
   git ? null,
   python3 ? null,
@@ -23,7 +23,8 @@ let
   pname = "texmacs";
   version = "2.1.2";
   common = callPackage ./common.nix {
-    inherit tex extraFonts chineseFonts japaneseFonts koreanFonts;
+    inherit extraFonts chineseFonts japaneseFonts koreanFonts;
+    tex = texliveSmall;
   };
 in
 stdenv.mkDerivation {
@@ -70,7 +71,7 @@ stdenv.mkDerivation {
       which
       ghostscriptX
       aspell
-      tex
+      texliveSmall
       git
       python3
     ])

--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -13,7 +13,7 @@
 , libspiro
 , lua5
 , qtbase
-, texlive
+, texliveSmall
 , wrapQtAppsHook
 , zlib
 , withTeXLive ? true
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     qtbase
     zlib
   ] ++ (lib.optionals withTeXLive [
-    texlive
+    texliveSmall
   ]);
 
   makeFlags = [
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     "IPE_NO_SPELLCHECK=1" # qtSpell is not yet packaged
   ];
 
-  qtWrapperArgs = lib.optionals withTeXLive [ "--prefix PATH : ${lib.makeBinPath [ texlive ]}" ];
+  qtWrapperArgs = lib.optionals withTeXLive [ "--prefix PATH : ${lib.makeBinPath [ texliveSmall ]}" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/therion/default.nix
+++ b/pkgs/applications/misc/therion/default.nix
@@ -10,7 +10,7 @@
 , expat
 , bwidget
 , python3
-, texlive
+, texliveTeTeX
 , survex
 , makeWrapper
 , fmt
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     pkg-config
     perl
     python3
-    texlive.combined.scheme-tetex
+    texliveTeTeX
     makeWrapper
     tcl.tclPackageHook
   ];
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
   fixupPhase = ''
     runHook preFixup
     wrapProgram $out/bin/therion \
-      --prefix PATH : ${lib.makeBinPath [ survex texlive.combined.scheme-tetex ]}
+      --prefix PATH : ${lib.makeBinPath [ survex texliveTeTeX ]}
     wrapProgram $out/bin/xtherion \
       --prefix PATH : ${lib.makeBinPath [ tk ]}
     runHook postFixup

--- a/pkgs/applications/misc/zettlr/default.nix
+++ b/pkgs/applications/misc/zettlr/default.nix
@@ -1,6 +1,6 @@
-{ callPackage, texlive }:
+{ callPackage, texliveMedium }:
 
-builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; inherit texlive; })) {
+builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; inherit texliveMedium; })) {
   zettlr = {
     version = "3.0.2";
     hash = "sha256-xwBq+kLmTth15uLiYWJOhi/YSPZVJNO6JTrKFojSDXA=";

--- a/pkgs/applications/misc/zettlr/generic.nix
+++ b/pkgs/applications/misc/zettlr/generic.nix
@@ -4,7 +4,7 @@
 , appimageTools
 , lib
 , fetchurl
-, texlive
+, texliveMedium
 , pandoc
 }:
 
@@ -23,7 +23,7 @@ appimageTools.wrapType2 rec {
   inherit name src;
 
   multiArch = false; # no 32bit needed
-  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ texlive pandoc ];
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ texliveMedium pandoc ];
   extraInstallCommands = ''
     mv $out/bin/{${name},${pname}}
     install -m 444 -D ${appimageContents}/Zettlr.desktop $out/share/applications/Zettlr.desktop

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
@@ -1,7 +1,7 @@
 { lib
 , newScope
 , pidgin
-, texlive
+, texliveBasic
 , config
 }:
 
@@ -19,7 +19,7 @@ lib.makeScope newScope (self:
     pidgin-indicator = callPackage ./pidgin-indicator { };
 
     pidgin-latex = callPackage ./pidgin-latex {
-      texLive = texlive.combined.scheme-basic;
+      texLive = texliveBasic;
     };
 
     pidgin-msn-pecan = callPackage ./msn-pecan { };

--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -13,7 +13,7 @@
 , gettext
 , gobject-introspection
 , gdk-pixbuf
-, texlive
+, texliveSmall
 , imagemagick
 , perlPackages
 , writeScript
@@ -21,9 +21,7 @@
 
 let
   documentation_deps = [
-    (texlive.combine {
-      inherit (texlive) scheme-small wrapfig gensymb;
-    })
+    (texliveSmall.withPackages (ps: with ps; [ wrapfig gensymb ]))
     xvfb-run
     imagemagick
     perlPackages.Po4a

--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -8,7 +8,7 @@
 , blas-ilp64
 , hdf5-cpp
 , python3
-, texlive
+, texliveMinimal
 , armadillo
 , libxc
 , makeWrapper
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
     perl
     gfortran
     cmake
-    texlive.combined.scheme-minimal
+    texliveMinimal
     makeWrapper
     autoPatchelfHook
   ];

--- a/pkgs/applications/science/electronics/xyce/default.nix
+++ b/pkgs/applications/science/electronics/xyce/default.nix
@@ -16,7 +16,7 @@
 , trilinos
 , withMPI ? false
   # for doc
-, texlive
+, texliveMedium
 , pandoc
 , enableDocs ? true
   # for tests
@@ -81,16 +81,14 @@ stdenv.mkDerivation rec {
     gfortran
     libtool_2
   ] ++ lib.optionals enableDocs [
-    (texlive.combine {
-      inherit (texlive)
-        scheme-medium
+    (texliveMedium.withPackages (ps: with ps; [
         koma-script
         optional
         framed
         enumitem
         multirow
-        preprint;
-    })
+        preprint
+      ]))
   ];
 
   buildInputs = [

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, bzip2, gfortran, libX11, libXmu, libXt, libjpeg, libpng
-, libtiff, ncurses, pango, pcre2, perl, readline, tcl, texlive, texLive, tk, xz, zlib
+, libtiff, ncurses, pango, pcre2, perl, readline, tcl, texlive, texliveSmall, tk, xz, zlib
 , less, texinfo, graphviz, icu, pkg-config, bison, imake, which, jdk, blas, lapack
 , curl, Cocoa, Foundation, libobjc, libcxx, tzdata
 , withRecommendedPackages ? true
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     bzip2 gfortran libX11 libXmu libXt libXt libjpeg libpng libtiff ncurses
-    pango pcre2 perl readline texLive xz zlib less texinfo graphviz icu
+    pango pcre2 perl readline (texliveSmall.withPackages (ps: with ps; [ inconsolata helvetic ps.texinfo fancyvrb cm-super rsfs ])) xz zlib less texinfo graphviz icu
     bison imake which blas lapack curl tcl tk jdk tzdata
   ] ++ lib.optionals stdenv.isDarwin [ Cocoa Foundation libobjc libcxx ];
 

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, texlive, bison, flex, lapack, blas
+{ stdenv, lib, fetchurl, fetchpatch, texliveSmall, bison, flex, lapack, blas
 , autoreconfHook, gmp, mpfr, pari, ntl, gsl, mpfi, ecm, glpk, nauty
 , buildPackages, readline, gettext, libpng, libao, gfortran, perl
 , enableGUI ? false, libGL, libGLU, xorg, fltk
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    autoreconfHook texlive.combined.scheme-small bison flex
+    autoreconfHook texliveSmall bison flex
   ];
 
   # perl is only needed for patchShebangs fixup.

--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -7,7 +7,7 @@
 , libpthreadstubs
 , perl
 , readline
-, tex
+, texliveBasic
 , withThread ? true
 }:
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     libX11
     perl
     readline
-    tex
+    texliveBasic
   ] ++ lib.optionals withThread [
     libpthreadstubs
   ];

--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -17,7 +17,7 @@
 # use letters instead of numbers for post-appendix chapters, and we
 # want it to match the upstream format because sage depends on it.
 , texinfo4
-, texlive
+, texliveSmall
 , enableDocs ? !stdenv.isDarwin
 , enableGfanlib ? true
 }:
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     graphviz
     latex2html
     texinfo4
-    texlive.combined.scheme-small
+    texliveSmall
   ] ++ lib.optionals stdenv.isDarwin [ getconf ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 

--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -4,7 +4,7 @@
 
 , cairo
 , ffmpeg
-, texlive
+, texliveInfraOnly
 
 , python3
 }:
@@ -21,11 +21,10 @@ let
   #   https://github.com/yihui/tinytex/blob/master/tools/pkgs-custom.txt
   #
   # these two combined add up to:
-  manim-tinytex = {
-    inherit (texlive)
+  manim-tinytex = texliveInfraOnly.withPackages (ps: with ps; [
 
     # tinytex
-    scheme-infraonly amsfonts amsmath atbegshi atveryend auxhook babel bibtex
+    amsfonts amsmath atbegshi atveryend auxhook babel bibtex
     bigintcalc bitset booktabs cm dehyph dvipdfmx dvips ec epstopdf-pkg etex
     etexcmds etoolbox euenc everyshi fancyvrb filehook firstaid float fontspec
     framed geometry gettitlestring glyphlist graphics graphics-cfg graphics-def
@@ -41,8 +40,8 @@ let
     # manim-latex
     standalone everysel preview doublestroke ms setspace rsfs relsize ragged2e
     fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super
-    babel-english gnu-freefont mathastext cbfonts-fd;
-  };
+    babel-english gnu-freefont mathastext cbfonts-fd
+  ]);
 
   python = python3.override {
     packageOverrides = self: super: {
@@ -129,13 +128,13 @@ in python.pkgs.buildPythonApplication rec {
   makeWrapperArgs = [
     "--prefix" "PATH" ":" (lib.makeBinPath [
       ffmpeg
-      (texlive.combine manim-tinytex)
+      manim-tinytex
     ])
   ];
 
   nativeCheckInputs = [
     ffmpeg
-    (texlive.combine manim-tinytex)
+    manim-tinytex
   ] ++ (with python.pkgs; [
     pytest-xdist
     pytestCheckHook

--- a/pkgs/development/compilers/asl/default.nix
+++ b/pkgs/development/compilers/asl/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchzip
-, tex
+, texliveMedium
 , buildDocs ? false
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "doc" "man" ];
 
-  nativeBuildInputs = lib.optionals buildDocs [ tex ];
+  nativeBuildInputs = lib.optionals buildDocs [ texliveMedium ];
 
   postPatch = lib.optionalString (!buildDocs) ''
     substituteInPlace Makefile --replace "all: binaries docs" "all: binaries"

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -19,7 +19,7 @@
 , gmp-static
 , verilog
 , asciidoctor
-, tex
+, texliveFull
 , which
 }:
 
@@ -88,7 +88,7 @@ in stdenv.mkDerivation rec {
     ghcWithPackages
     perl
     pkg-config
-    tex
+    texliveFull
   ];
 
   makeFlags = [

--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -13,7 +13,7 @@
 # docs
 , help2man
 , texinfo
-, texlive
+, texliveBasic
 # test
 , writeText
 }:
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     libtool
     help2man
     texinfo
-    texlive.combined.scheme-basic
+    texliveBasic
   ];
 
   buildInputs = [

--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -4,7 +4,7 @@
 , makeWrapper
 , gnum4
 , texinfo
-, texLive
+, texliveSmall
 , automake
 , autoconf
 , libtool
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
       $out/lib/mit-scheme${arch}-${version}
   '';
 
-  nativeBuildInputs = [ makeWrapper gnum4 texinfo texLive automake ghostscript autoconf libtool ];
+  nativeBuildInputs = [ makeWrapper gnum4 texinfo (texliveSmall.withPackages (ps: with ps; [ epsf ps.texinfo ])) automake ghostscript autoconf libtool ];
 
   # XXX: The `check' target doesn't exist.
   doCheck = false;

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb-compat-0_1, libelf
 , libftdi1, readline
 # documentation building is broken on darwin
-, docSupport ? (!stdenv.isDarwin), texlive, texinfo, texi2html, unixtools }:
+, docSupport ? (!stdenv.isDarwin), texliveMedium, texinfo, texi2html, unixtools }:
 
 stdenv.mkDerivation rec {
   pname = "avrdude";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake bison flex ] ++ lib.optionals docSupport [
     unixtools.more
-    texlive.combined.scheme-medium
+    texliveMedium
     texinfo
     texi2html
   ];

--- a/pkgs/development/libraries/cddlib/default.nix
+++ b/pkgs/development/libraries/cddlib/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , gmp
 , autoreconfHook
-, texlive
+, texliveSmall
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [gmp];
   nativeBuildInputs = [
     autoreconfHook
-    texlive.combined.scheme-small # for building the documentation
+    texliveSmall # for building the documentation
   ];
   # No actual checks yet (2018-05-05), but maybe one day.
   # Requested here: https://github.com/cddlib/cddlib/issues/25

--- a/pkgs/development/libraries/physics/rivet/default.nix
+++ b/pkgs/development/libraries/physics/rivet/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, fastjet, fastjet-contrib, ghostscript, hepmc, imagemagick, less, python3, rsync, texlive, yoda, which, makeWrapper }:
+{ lib, stdenv, fetchurl, fetchpatch, fastjet, fastjet-contrib, ghostscript, hepmc, imagemagick, less, python3, rsync, texliveBasic, yoda, which, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "rivet";
@@ -9,8 +9,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-dbPz1BnKY4jR/S7A7afh+Q8yS5lszwWR9IpdLijczBM=";
   };
 
-  latex = texlive.combine { inherit (texlive)
-    scheme-basic
+  latex = texliveBasic.withPackages (ps: with ps; [
     collection-pstricks
     collection-fontsrecommended
     l3kernel
@@ -24,7 +23,7 @@ stdenv.mkDerivation rec {
     xcolor
     xkeyval
     xstring
-    ;};
+  ]);
 
   nativeBuildInputs = [ rsync makeWrapper ];
   buildInputs = [ hepmc imagemagick python3 latex python3.pkgs.yoda ];

--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -39,7 +39,7 @@
 , dia
 , tetex ? null
 , ghostscript ? null
-, texlive ? null
+, texliveMedium ? null
 
   # generates python bindings
 , pythonSupport ? true
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   # ncurses is a hidden dependency of waf when checking python
   buildInputs = lib.optionals pythonSupport [ castxml ncurses ]
     ++ lib.optionals enableDoxygen [ doxygen graphviz imagemagick ]
-    ++ lib.optionals withManual [ dia tetex ghostscript imagemagick texlive.combined.scheme-medium ]
+    ++ lib.optionals withManual [ dia tetex ghostscript imagemagick texliveMedium ]
     ++ [
     libxml2
     pythonEnv

--- a/pkgs/development/python-modules/dot2tex/default.nix
+++ b/pkgs/development/python-modules/dot2tex/default.nix
@@ -6,7 +6,7 @@
 , pyparsing
 , graphviz
 , pytestCheckHook
-, texlive
+, texliveSmall
 }:
 
 buildPythonPackage rec {
@@ -36,9 +36,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    (texlive.combine {
-      inherit (texlive) scheme-small preview pstricks;
-    })
+    (texliveSmall.withPackages (ps: with ps; [ preview pstricks ]))
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -6,7 +6,7 @@
 , poetry-core
 , pythonOlder
 , substituteAll
-, texlive
+, texliveSmall
 }:
 
 buildPythonPackage rec {
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    texlive.combined.scheme-small
+    texliveSmall
     pandocfilters
   ];
 

--- a/pkgs/development/python-modules/scapy/default.nix
+++ b/pkgs/development/python-modules/scapy/default.nix
@@ -5,7 +5,7 @@
 , withCryptography ? true, cryptography
 , withVoipSupport ? true, sox
 , withPlottingSupport ? true, matplotlib
-, withGraphicsSupport ? false, pyx, texlive, graphviz, imagemagick
+, withGraphicsSupport ? false, pyx, texliveBasic, graphviz, imagemagick
 , withManufDb ? false, wireshark
 , libpcap
 # 2D/3D graphics and graphs TODO: VPython
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     ++ lib.optional withCryptography cryptography
     ++ lib.optional withVoipSupport sox
     ++ lib.optional withPlottingSupport matplotlib
-    ++ lib.optionals withGraphicsSupport [ pyx texlive.combined.scheme-basic graphviz imagemagick ];
+    ++ lib.optionals withGraphicsSupport [ pyx texliveBasic graphviz imagemagick ];
 
   # Running the tests seems too complicated:
   doCheck = false;

--- a/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , sphinx
 , pdf2svg
-, texLive
+, texliveSmall
 }:
 
 buildPythonPackage rec {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace sphinxcontrib/tikz.py \
-      --replace "config.latex_engine" "'${texLive}/bin/pdflatex'" \
+      --replace "config.latex_engine" "'${texliveSmall.withPackages (ps: with ps; [ standalone pgfplots ])}/bin/pdflatex'" \
       --replace "system(['pdf2svg'" "system(['${pdf2svg}/bin/pdf2svg'"
   '';
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -546,7 +546,7 @@ let
     AMOUNTAIN = [ pkgs.gsl ];
     Rsymphony = with pkgs; [ pkg-config doxygen graphviz subversion ];
     tcltk2 = with pkgs; [ tcl tk ];
-    tikzDevice = with pkgs; [ which texlive.combined.scheme-medium ];
+    tikzDevice = with pkgs; [ which texliveMedium ];
     gridGraphics = [ pkgs.which ];
     adimpro = with pkgs; [ which xorg.xdpyinfo ];
     rsvg = [ pkgs.librsvg.dev ];

--- a/pkgs/development/rocm-modules/5/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/5/migraphx/default.nix
@@ -22,7 +22,7 @@
 , blaze
 , cppcheck
 , rocm-device-libs
-, texlive
+, texliveSmall
 , doxygen
 , sphinx
 , docutils
@@ -33,8 +33,7 @@
 }:
 
 let
-  latex = lib.optionalAttrs buildDocs texlive.combine {
-    inherit (texlive) scheme-small
+  latex = lib.optionalAttrs buildDocs (texliveSmall.withPackages (ps: with ps; [
     latexmk
     tex-gyre
     fncychap
@@ -45,8 +44,8 @@ let
     tabulary
     varwidth
     titlesec
-    epstopdf;
-  };
+    epstopdf
+  ]));
 in stdenv.mkDerivation (finalAttrs: {
   pname = "migraphx";
   version = "5.7.1";

--- a/pkgs/development/rocm-modules/5/miopen/default.nix
+++ b/pkgs/development/rocm-modules/5/miopen/default.nix
@@ -22,7 +22,7 @@
 , bzip2
 , lbzip2
 , nlohmann_json
-, texlive
+, texliveSmall
 , doxygen
 , sphinx
 , zlib
@@ -71,8 +71,7 @@ let
     '';
   };
 
-  latex = lib.optionalAttrs buildDocs texlive.combine {
-    inherit (texlive) scheme-small
+  latex = lib.optionalAttrs buildDocs (texliveSmall.withPackages (ps: with ps; [
     latexmk
     tex-gyre
     fncychap
@@ -82,8 +81,8 @@ let
     needspace
     tabulary
     varwidth
-    titlesec;
-  };
+    titlesec
+  ]));
 
   gfx900 = runCommand "miopen-gfx900.kdb" { preferLocalBuild = true; } ''
     ${lbzip2}/bin/lbzip2 -ckd ${src}/src/kernels/gfx900.kdb.bz2 > $out

--- a/pkgs/development/rocm-modules/5/miopengemm/default.nix
+++ b/pkgs/development/rocm-modules/5/miopengemm/default.nix
@@ -6,7 +6,7 @@
 , rocm-cmake
 , clr
 , clblast
-, texlive
+, texliveSmall
 , doxygen
 , sphinx
 , openblas
@@ -17,8 +17,7 @@
 }:
 
 let
-  latex = lib.optionalAttrs buildDocs texlive.combine {
-    inherit (texlive) scheme-small
+  latex = lib.optionalAttrs buildDocs (texliveSmall.withPackages (ps: with ps; [
     latexmk
     tex-gyre
     fncychap
@@ -28,8 +27,8 @@ let
     needspace
     tabulary
     varwidth
-    titlesec;
-  };
+    titlesec
+  ]));
 in stdenv.mkDerivation (finalAttrs: {
   pname = "miopengemm";
   version = "5.5.0";

--- a/pkgs/development/rocm-modules/5/rdc/default.nix
+++ b/pkgs/development/rocm-modules/5/rdc/default.nix
@@ -11,15 +11,14 @@
 , openssl
 , doxygen
 , graphviz
-, texlive
+, texliveSmall
 , gtest
 , buildDocs ? true
 , buildTests ? false
 }:
 
 let
-  latex = lib.optionalAttrs buildDocs texlive.combine {
-    inherit (texlive) scheme-small
+  latex = lib.optionalAttrs buildDocs (texliveSmall.withPackages (ps: with ps; [
     changepage
     latexmk
     varwidth
@@ -37,8 +36,8 @@ let
     etoc
     helvetic
     wasy
-    courier;
-  };
+    courier
+  ]));
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rdc";
   version = "5.7.1";

--- a/pkgs/development/rocm-modules/5/rocdbgapi/default.nix
+++ b/pkgs/development/rocm-modules/5/rocdbgapi/default.nix
@@ -8,15 +8,14 @@
 , rocm-comgr
 , rocm-runtime
 , hwdata
-, texlive
+, texliveSmall
 , doxygen
 , graphviz
 , buildDocs ? true
 }:
 
 let
-  latex = lib.optionalAttrs buildDocs texlive.combine {
-    inherit (texlive) scheme-small
+  latex = lib.optionalAttrs buildDocs (texliveSmall.withPackages (ps: with ps; [
     changepage
     latexmk
     varwidth
@@ -34,8 +33,8 @@ let
     etoc
     helvetic
     wasy
-    courier;
-  };
+    courier
+  ]));
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocdbgapi";
   version = "5.7.1";

--- a/pkgs/development/tools/literate-programming/nuweb/default.nix
+++ b/pkgs/development/tools/literate-programming/nuweb/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, tex}:
+{lib, stdenv, fetchurl, texliveMedium}:
 
 stdenv.mkDerivation rec {
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-JVqPYkYPXBT0xLNWuW4DV6N6ZlKuBYQGT46frhnpU64=";
   };
 
-  buildInputs = [ tex ];
+  buildInputs = [ texliveMedium ];
 
   patchPhase = ''
     sed -ie 's|nuweb -r|./nuweb -r|' Makefile

--- a/pkgs/development/tools/parsing/ragel/default.nix
+++ b/pkgs/development/tools/parsing/ragel/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fig2dev, tex, ghostscript, colm
+{ lib, stdenv, fetchurl, fig2dev, texliveSmall, ghostscript, colm
 , build-manual ? false
 }:
 
@@ -13,7 +13,7 @@ let
         inherit sha256;
       };
 
-      buildInputs = lib.optionals build-manual [ fig2dev ghostscript tex ];
+      buildInputs = lib.optionals build-manual [ fig2dev ghostscript texliveSmall ];
 
       preConfigure = lib.optionalString build-manual ''
         sed -i "s/build_manual=no/build_manual=yes/g" DIST

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, stdenvNoCC, gccStdenv, lib, recurseIntoAttrs, libsForQt5, newScope, texlive, perlPackages, jdk8, jre8 }:
+{ stdenv, stdenvNoCC, gccStdenv, lib, recurseIntoAttrs, libsForQt5, newScope, texliveBasic, perlPackages, jdk8, jre8 }:
 
 # To whomever it may concern:
 #
@@ -46,9 +46,7 @@ let
   versionToName = version: "dwarf-fortress_${lib.replaceStrings ["."] ["_"] version}";
 
   dwarf-therapist-original = libsForQt5.callPackage ./dwarf-therapist {
-    texlive = texlive.combine {
-      inherit (texlive) scheme-basic float caption wrapfig adjmulticol sidecap preprint enumitem;
-    };
+    texlive = texliveBasic.withPackages (ps: with ps; [ float caption wrapfig adjmulticol sidecap preprint enumitem ]);
   };
 
   # A map of names to each Dwarf Fortress package we know about.

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -3,9 +3,7 @@
 , fontconfig, freetype, pango, fontforge, help2man, zip, netpbm, groff
 , freefont_ttf, makeFontsConf
 , makeWrapper, t1utils, boehmgc, rsync
-, texlive, tex ? texlive.combine {
-    inherit (texlive) scheme-small lh metafont epsf fontinst;
-  }
+, texliveSmall, tex ? texliveSmall.withPackages (ps: with ps; [ lh metafont epsf fontinst ])
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/misc/sagetex/default.nix
+++ b/pkgs/misc/sagetex/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , writeShellScript
-, texlive
+, texliveBasic
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   outputs = [ "tex" ];
 
   nativeBuildInputs = [
-    texlive.combined.scheme-basic
+    texliveBasic
     # multiple-outputs.sh fails if $out is not defined
     (writeShellScript "force-tex-output.sh" ''
       out="''${tex-}"

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -644,7 +644,7 @@ rec {
   # ease of testing
   fixedHashes = with lib; let
     fods = lib.concatMap
-      (p: lib.optional (p ? tex) p.tex
+      (p: lib.optional (p ? tex && isDerivation p.tex) p.tex
         ++ lib.optional (p ? texdoc) p.texdoc
         ++ lib.optional (p ? texsource) p.texsource
         ++ lib.optional (p ? tlpkg) p.tlpkg)

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -623,7 +623,7 @@ rec {
           (savedLicensesAttrNames scheme) != (correctLicensesAttrNames scheme);
         incorrectSchemes = lib.filterAttrs
           (n: hasLicenseMismatch)
-          texlive.combined;
+          (texlive.combined // texlive.schemes);
         prettyPrint = name: scheme:
           ''
             license info for ${name} is incorrect! Note that order is enforced.

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildEnv, runCommand, fetchurl, file, texlive, writeShellScript, writeText }:
+{ lib, stdenv, buildEnv, runCommand, fetchurl, file, texlive, writeShellScript, writeText, texliveInfraOnly, texliveSmall, texliveMedium, texliveFull }:
 
 rec {
 
@@ -6,7 +6,7 @@ rec {
     { name
     , format
     , text
-    , texLive ? texlive.combined.scheme-small
+    , texLive ? texliveSmall
     , options ? "-interaction=errorstopmode"
     , preTest ? ""
     , postTest ? ""
@@ -43,7 +43,7 @@ rec {
     lualatex = mkTeXTest {
       name = "opentype-fonts-lualatex";
       format = "lualatex";
-      texLive = texlive.combine { inherit (texlive) scheme-small libertinus-fonts; };
+      texLive = texliveSmall.withPackages (ps: [ ps.libertinus-fonts ]);
       text = ''
         \documentclass{article}
         \usepackage{fontspec}
@@ -61,7 +61,7 @@ rec {
 
   chktex = runCommand "texlive-test-chktex" {
     nativeBuildInputs = [
-      (texlive.combine { inherit (texlive) scheme-infraonly chktex; })
+      (texlive.withPackages (ps: [ ps.chktex ]))
     ];
     input = builtins.toFile "chktex-sample.tex" ''
       \documentclass{article}
@@ -77,7 +77,7 @@ rec {
   dvipng = lib.recurseIntoAttrs {
     # https://github.com/NixOS/nixpkgs/issues/75605
     basic = runCommand "texlive-test-dvipng-basic" {
-      nativeBuildInputs = [ file texlive.combined.scheme-medium ];
+      nativeBuildInputs = [ file texliveMedium ];
       input = fetchurl {
         name = "test_dvipng.tex";
         url = "http://git.savannah.nongnu.org/cgit/dvipng.git/plain/test_dvipng.tex?id=b872753590a18605260078f56cbd6f28d39dc035";
@@ -99,7 +99,7 @@ rec {
 
     # test dvipng's limited capability to render postscript specials via GS
     ghostscript = runCommand "texlive-test-ghostscript" {
-      nativeBuildInputs = [ file (texlive.combine { inherit (texlive) scheme-small dvipng; }) ];
+      nativeBuildInputs = [ file (texliveSmall.withPackages (ps: [ ps.dvipng ])) ];
       input = builtins.toFile "postscript-sample.tex" ''
         \documentclass{minimal}
         \begin{document}
@@ -140,7 +140,7 @@ rec {
 
   # https://github.com/NixOS/nixpkgs/issues/75070
   dvisvgm = runCommand "texlive-test-dvisvgm" {
-    nativeBuildInputs = [ file texlive.combined.scheme-medium ];
+    nativeBuildInputs = [ file texliveMedium ];
     input = builtins.toFile "dvisvgm-sample.tex" ''
       \documentclass{article}
       \begin{document}
@@ -166,10 +166,7 @@ rec {
 
   texdoc = runCommand "texlive-test-texdoc" {
     nativeBuildInputs = [
-      (texlive.combine {
-        inherit (texlive) scheme-infraonly luatex texdoc;
-        pkgFilter = pkg: lib.elem pkg.tlType [ "run" "bin" "doc" ];
-      })
+      (texlive.withPackages (ps: with ps; [ luatex ps.texdoc ps.texdoc.texdoc ]))
     ];
   } ''
     texdoc --version
@@ -214,7 +211,7 @@ rec {
   };
 
   # check that all languages are available, including synonyms
-  allLanguages = let hyphenBase = lib.head texlive.hyphen-base.pkgs; texLive = texlive.combined.scheme-full; in
+  allLanguages = let hyphenBase = lib.head texlive.hyphen-base.pkgs; texLive = texliveFull; in
     lib.recurseIntoAttrs {
       # language.def
       etex = mkTeXTest {
@@ -290,8 +287,8 @@ rec {
   # test that language files are generated as expected
   hyphen-base = runCommand "texlive-test-hyphen-base" {
     hyphenBase = lib.head texlive.hyphen-base.pkgs;
-    schemeFull = texlive.combined.scheme-full;
-    schemeInfraOnly = texlive.combined.scheme-infraonly;
+    schemeFull = texliveFull;
+    schemeInfraOnly = texliveInfraOnly;
   } ''
     mkdir -p "$out"/{scheme-infraonly,scheme-full}
 
@@ -323,7 +320,7 @@ rec {
   # test that fmtutil.cnf is fully regenerated on scheme-full
   fmtutilCnf = runCommand "texlive-test-fmtutil.cnf" {
     kpathsea = lib.head texlive.kpathsea.pkgs;
-    schemeFull = texlive.combined.scheme-full;
+    schemeFull = texliveFull;
   } ''
     mkdir -p "$out"
 
@@ -335,7 +332,7 @@ rec {
   # verify that the restricted mode gets enabled when
   # needed (detected by checking if it disallows --gscmd)
   repstopdf = runCommand "texlive-test-repstopdf" {
-    nativeBuildInputs = [ (texlive.combine { inherit (texlive) scheme-infraonly epstopdf; }) ];
+    nativeBuildInputs = [ (texlive.withPackages (ps: [ ps.epstopdf ])) ];
   } ''
     ! (epstopdf --gscmd echo /dev/null 2>&1 || true) | grep forbidden >/dev/null
     (repstopdf --gscmd echo /dev/null 2>&1 || true) | grep forbidden >/dev/null
@@ -345,7 +342,7 @@ rec {
   # verify that the restricted mode gets enabled when
   # needed (detected by checking if it disallows --gscmd)
   rpdfcrop = runCommand "texlive-test-rpdfcrop" {
-    nativeBuildInputs = [ (texlive.combine { inherit (texlive) scheme-infraonly pdfcrop; }) ];
+    nativeBuildInputs = [ (texlive.withPackages (ps: [ ps.pdfcrop ])) ];
   } ''
     ! (pdfcrop --gscmd echo $(command -v pdfcrop) 2>&1 || true) | grep 'restricted mode' >/dev/null
     (rpdfcrop --gscmd echo $(command -v pdfcrop) 2>&1 || true) | grep 'restricted mode' >/dev/null
@@ -460,7 +457,7 @@ rec {
     runCommand "texlive-test-binaries"
       {
         inherit binaries contextTestTex latexTestTex texTestTex;
-        texliveScheme = texlive.combined.scheme-full;
+        texliveScheme = texliveFull;
       }
       ''
         loadables="$(command -v bash)"

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -211,7 +211,7 @@ rec {
   };
 
   # check that all languages are available, including synonyms
-  allLanguages = let hyphenBase = lib.head texlive.hyphen-base.pkgs; texLive = texliveFull; in
+  allLanguages = let hyphenBase = texlive.pkgs.hyphen-base; texLive = texliveFull; in
     lib.recurseIntoAttrs {
       # language.def
       etex = mkTeXTest {
@@ -286,7 +286,7 @@ rec {
 
   # test that language files are generated as expected
   hyphen-base = runCommand "texlive-test-hyphen-base" {
-    hyphenBase = lib.head texlive.hyphen-base.pkgs;
+    hyphenBase = texlive.pkgs.hyphen-base;
     schemeFull = texliveFull;
     schemeInfraOnly = texliveInfraOnly;
   } ''
@@ -319,7 +319,7 @@ rec {
 
   # test that fmtutil.cnf is fully regenerated on scheme-full
   fmtutilCnf = runCommand "texlive-test-fmtutil.cnf" {
-    kpathsea = lib.head texlive.kpathsea.pkgs;
+    kpathsea = texlive.pkgs.kpathsea.tex;
     schemeFull = texliveFull;
   } ''
     mkdir -p "$out"

--- a/pkgs/tools/graphics/asymptote/default.nix
+++ b/pkgs/tools/graphics/asymptote/default.nix
@@ -4,7 +4,7 @@
 , boehmgc, libGLU, libGL, mesa, ncurses, readline, gsl, libsigsegv
 , python3, qtbase, qtsvg, boost
 , zlib, perl, curl
-, texLive, texinfo
+, texliveSmall, texinfo
 , darwin
 }:
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     ghostscriptX imagemagick fftw
     boehmgc ncurses readline gsl libsigsegv
     zlib perl curl qtbase qtsvg boost
-    texLive
+    (texliveSmall.withPackages (ps: with ps; [ epsf cm-super ps.texinfo media9 ocgx2 collection-latexextra ]))
     (python3.withPackages (ps: with ps; [ cson numpy pyqt5 ]))
   ];
 

--- a/pkgs/tools/graphics/enblend-enfuse/default.nix
+++ b/pkgs/tools/graphics/enblend-enfuse/default.nix
@@ -13,7 +13,7 @@
 , help2man
 , pkg-config
 , perl
-, texlive
+, texliveSmall
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost freeglut glew gsl lcms2 libpng libtiff libGLU libGL vigra ];
 
-  nativeBuildInputs = [ autoreconfHook help2man perl pkg-config texlive.combined.scheme-small ];
+  nativeBuildInputs = [ autoreconfHook help2man perl pkg-config texliveSmall ];
 
   preConfigure = ''
     patchShebangs src/embrace

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, makeWrapper, pkg-config, texinfo
 , cairo, gd, libcerf, pango, readline, zlib
-, withTeXLive ? false, texlive
+, withTeXLive ? false, texliveSmall
 , withLua ? false, lua
 , withCaca ? false, libcaca
 , libX11 ? null
@@ -32,7 +32,7 @@ in
 
   buildInputs =
     [ cairo gd libcerf pango readline zlib ]
-    ++ lib.optional withTeXLive (texlive.combine { inherit (texlive) scheme-small; })
+    ++ lib.optional withTeXLive texliveSmall
     ++ lib.optional withLua lua
     ++ lib.optional withCaca libcaca
     ++ lib.optionals withX [ libX11 libXpm libXt libXaw ]

--- a/pkgs/tools/misc/pandoc-acro/default.nix
+++ b/pkgs/tools/misc/pandoc-acro/default.nix
@@ -5,7 +5,7 @@
 , lib
 , pandoc
 , pandoc-acro
-, texlive
+, texliveTeTeX
 , runCommand
 }:
 
@@ -35,13 +35,7 @@ buildPythonApplication {
           nativeBuildInputs = [
             pandoc
             pandoc-acro
-            (texlive.combine {
-              inherit (texlive)
-                scheme-tetex
-                acro
-                translations
-                ;
-            })
+            (texliveTeTeX.withPackages (ps: with ps; [ acro translations ]))
           ];
         };
       in

--- a/pkgs/tools/misc/pandoc-drawio-filter/default.nix
+++ b/pkgs/tools/misc/pandoc-drawio-filter/default.nix
@@ -5,7 +5,7 @@
 , pandoc
 , pandocfilters
 , runCommand
-, texlive
+, texliveTeTeX
 }:
 
 let
@@ -34,7 +34,7 @@ let
           nativeBuildInputs = [
             pandoc
             pandoc-drawio-filter
-            texlive.combined.scheme-tetex
+            texliveTeTeX
           ];
         };
       in

--- a/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
+++ b/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, makeWrapper, fetchFromGitLab, perl, flex
-, gnused, coreutils, which, opensp, groff, texlive, texinfo, withLatex ? false
+, gnused, coreutils, which, opensp, groff, texliveMedium, texinfo, withLatex ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ flex which makeWrapper ];
 
   buildInputs = [ opensp groff texinfo perl gnused coreutils ]
-    ++ lib.optionals withLatex [ texlive.combined.scheme-medium ];
+    ++ lib.optionals withLatex [ texliveMedium ];
 
   meta = with lib; {
     description = "Toolset for processing LinuxDoc DTD SGML files";

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -6,7 +6,7 @@
 , highlight
 , pygments
 , graphviz
-, texlive
+, texliveMinimal
 , dblatexFull
 , libxslt
 , w3m
@@ -54,6 +54,11 @@ let
   _enableAafigureFilter = enableExtraPlugins || enableAafigureFilter;
   _enableDeckjsBackend = enableExtraPlugins || enableDeckjsBackend;
   _enableOdfBackend = enableExtraPlugins || enableOdfBackend;
+
+  #
+  # texlive environment
+  #
+  texlive = texliveMinimal.withPackages (ps: [ ps.dvipng ]);
 
   #
   # filters

--- a/pkgs/tools/typesetting/skribilo/default.nix
+++ b/pkgs/tools/typesetting/skribilo/default.nix
@@ -13,7 +13,7 @@
 , enableEmacs ? false, emacs
 , enableLout ? stdenv.isLinux, lout
 , enablePloticus ? stdenv.isLinux, ploticus
-, enableTex ? true, tex
+, enableTex ? true, texliveSmall
 }:
 
 let
@@ -44,7 +44,7 @@ in stdenv.mkDerivation (finalAttrs: {
   ++ optional enableEmacs emacs
   ++ optional enableLout lout
   ++ optional enablePloticus ploticus
-  ++ optional enableTex tex;
+  ++ optional enableTex texliveSmall;
 
   postInstall = ''
     wrapProgram $out/bin/skribilo \

--- a/pkgs/tools/typesetting/tex/advi/default.nix
+++ b/pkgs/tools/typesetting/tex/advi/default.nix
@@ -4,7 +4,7 @@
 , writeShellScriptBin
 , ghostscriptX
 , ocamlPackages
-, texlive
+, texliveMedium
 , which
 }:
 
@@ -51,7 +51,7 @@ ocamlPackages.buildDunePackage rec {
 
   duneVersion = "3";
 
-  nativeBuildInputs = [ fake-opam kpsexpand makeWrapper texlive.combined.scheme-medium which ];
+  nativeBuildInputs = [ fake-opam kpsexpand makeWrapper texliveMedium which ];
   buildInputs = with ocamlPackages; [ camlimages ghostscriptX graphics ];
 
   # install additional files (such as man pages)

--- a/pkgs/tools/typesetting/tex/auctex/default.nix
+++ b/pkgs/tools/typesetting/tex/auctex/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, emacs, texlive, ghostscript }:
+{ lib, stdenv, fetchurl, emacs, texliveBasic, ghostscript }:
 
 let auctex = stdenv.mkDerivation ( rec {
   # Make this a valid tex(live-new) package;
@@ -17,7 +17,7 @@ let auctex = stdenv.mkDerivation ( rec {
   buildInputs = [
     emacs
     ghostscript
-    (texlive.combine { inherit (texlive) scheme-basic hypdoc;  })
+    (texliveBasic.withPackages (ps: [ ps.hypdoc ]))
   ];
 
   preConfigure = ''

--- a/pkgs/tools/typesetting/tex/blahtexml/default.nix
+++ b/pkgs/tools/typesetting/tex/blahtexml/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, lib, stdenv, libiconv, texlive, xercesc }:
+{ fetchFromGitHub, lib, stdenv, libiconv, texliveFull, xercesc }:
 
 stdenv.mkDerivation rec {
   pname = "blahtexml";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ];
 
-  nativeBuildInputs = [ texlive.combined.scheme-full ]; # scheme-full needed for ucs package
+  nativeBuildInputs = [ texliveFull ]; # scheme-full needed for ucs package
   buildInputs = [ xercesc ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   buildFlags =

--- a/pkgs/tools/typesetting/tex/catdvi/default.nix
+++ b/pkgs/tools/typesetting/tex/catdvi/default.nix
@@ -3,14 +3,13 @@
 , fetchurl
 , fetchpatch
 , texlive
+, texliveInfraOnly
 , buildPackages
 }:
 
 let
   buildPlatformTools = [ "pse2unic" "adobe2h" ];
-  tex = texlive.combine {
-    inherit (texlive) collection-fontsrecommended;
-  };
+  tex = texliveInfraOnly.withPackages (ps: [ ps.collection-fontsrecommended ]);
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -1,13 +1,13 @@
-{ lib, stdenv, fetchurl, python3, libxslt, texlive
+{ lib, stdenv, fetchurl, python3, libxslt, texliveBasic
 , enableAllFeatures ? false, imagemagick, fig2dev, inkscape, fontconfig, ghostscript
 
-, tex ? texlive.combine { # satisfy all packages that ./configure mentions
-    inherit (texlive) scheme-basic epstopdf anysize appendix changebar
-      fancybox fancyvrb float footmisc listings jknapltx/*for mathrsfs.sty*/
-      multirow overpic pdfpages pdflscape graphics stmaryrd subfigure titlesec wasysym
-      # pkgs below don't seem requested by dblatex, but our manual fails without them
-      ec zapfding symbol eepic times rsfs cs tex4ht courier helvetic ly1;
-  }
+, tex ? texliveBasic.withPackages (ps: with ps; [ # satisfy all packages that ./configure mentions
+    epstopdf anysize appendix changebar
+    fancybox fancyvrb float footmisc listings jknapltx/*for mathrsfs.sty*/
+    multirow overpic pdfpages pdflscape graphics stmaryrd subfigure titlesec wasysym
+    # pkgs below don't seem requested by dblatex, but our manual fails without them
+    ec zapfding symbol eepic times rsfs cs tex4ht courier helvetic ly1
+  ])
 }:
 
 # NOTE: enableAllFeatures just purifies the expression, it doesn't actually

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -194,6 +194,11 @@ let
       )
   );
 
+  schemes = lib.listToAttrs (map (s: {
+    name = "texlive" + s;
+    value = lib.addMetaAttrs { license = licenses.${"scheme-" + (lib.toLower s)}; } (buildTeXEnv { requiredTeXPackages = ps: [ ps.${"scheme-" + (lib.toLower s)} ]; });
+  }) [ "Basic" "BookPub" "ConTeXt" "Full" "GUST" "InfraOnly" "Medium" "Minimal" "Small" "TeTeX" ]);
+
 in
   allPkgLists // {
     pkgs = tl;
@@ -212,6 +217,8 @@ in
     combine = assert assertions; combine;
 
     combined = assert assertions; combined;
+
+    inherit schemes;
 
     # convenience alias
     withPackages = (buildTeXEnv { }).withPackages;

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -148,6 +148,7 @@ let
   # The correctness of this collation is tested by tests.texlive.licenses
   licenses = with lib.licenses; {
     scheme-basic = [ free gfl gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
+    scheme-bookpub = [ artistic2 asl20 fdl13Only free gfl gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain ];
     scheme-context = [ bsd2 bsd3 cc-by-sa-40 free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21
       lppl1 lppl13c mit ofl publicDomain x11 ];
     scheme-full = [ artistic1-cl8 artistic2 asl20 bsd2 bsd3 bsdOriginal cc-by-10 cc-by-40 cc-by-sa-10 cc-by-sa-20
@@ -175,7 +176,7 @@ let
   };
 
   combined = recurseIntoAttrs (
-    lib.genAttrs [ "scheme-basic" "scheme-context" "scheme-full" "scheme-gust" "scheme-infraonly"
+    lib.genAttrs [ "scheme-basic" "scheme-bookpub" "scheme-context" "scheme-full" "scheme-gust" "scheme-infraonly"
       "scheme-medium" "scheme-minimal" "scheme-small" "scheme-tetex" ]
       (pname:
         (buildTeXEnv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13830,7 +13830,6 @@ with pkgs;
 
   texmacs = libsForQt5.callPackage ../applications/editors/texmacs {
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
-    tex = texlive.combined.scheme-small;
     extraFonts = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41965,9 +41965,7 @@ with pkgs;
 
   zalgo = callPackage ../tools/misc/zalgo { };
 
-  inherit (callPackage ../applications/misc/zettlr {
-    texlive = texlive.combined.scheme-medium;
-  }) zettlr;
+  inherit (callPackage ../applications/misc/zettlr { }) zettlr;
 
   unpoller = callPackage ../servers/monitoring/unpoller { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13279,9 +13279,7 @@ with pkgs;
 
   sipcalc = callPackage ../tools/networking/sipcalc { };
 
-  skribilo = callPackage ../tools/typesetting/skribilo {
-    tex = texlive.combined.scheme-small;
-  };
+  skribilo = callPackage ../tools/typesetting/skribilo { };
 
   skytemple = callPackage ../applications/misc/skytemple { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26086,9 +26086,6 @@ with pkgs;
 
   R = darwin.apple_sdk_11_0.callPackage ../applications/science/math/R {
     # TODO: split docs into a separate output
-    texLive = texlive.combine {
-      inherit (texlive) scheme-small inconsolata helvetic texinfo fancyvrb cm-super rsfs;
-    };
     withRecommendedPackages = false;
     inherit (darwin.apple_sdk_11_0.frameworks) Cocoa Foundation;
     inherit (darwin) libobjc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19941,9 +19941,7 @@ with pkgs;
 
   randoop = callPackage ../development/tools/analysis/randoop { };
 
-  inherit (callPackages ../development/tools/parsing/ragel {
-      tex = texlive.combined.scheme-small;
-    }) ragelStable ragelDev;
+  inherit (callPackages ../development/tools/parsing/ragel { }) ragelStable ragelDev;
 
   hammer = callPackage ../development/tools/parsing/hammer { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6585,7 +6585,6 @@ with pkgs;
 
   asciidoc = callPackage ../tools/typesetting/asciidoc {
     inherit (python3.pkgs) pygments matplotlib numpy aafigure recursivePthLoader;
-    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
     w3m = w3m-batch;
     enableStandardFeatures = false;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3319,9 +3319,7 @@ with pkgs;
 
   astc-encoder = callPackage ../tools/graphics/astc-encoder { };
 
-  asymptote = libsForQt5.callPackage ../tools/graphics/asymptote {
-    texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super texinfo media9 ocgx2 collection-latexextra; };
-  };
+  asymptote = libsForQt5.callPackage ../tools/graphics/asymptote { };
 
   async = callPackage ../development/tools/async { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39877,7 +39877,7 @@ with pkgs;
     };
   };
 
-  pari = callPackage ../applications/science/math/pari { tex = texlive.combined.scheme-basic; };
+  pari = callPackage ../applications/science/math/pari { };
   gp2c = callPackage ../applications/science/math/pari/gp2c.nix { };
 
   palp = callPackage ../applications/science/math/palp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5445,7 +5445,7 @@ with pkgs;
   texFunctions = callPackage ../tools/typesetting/tex/nix pkgs;
 
   # TeX Live; see https://nixos.org/nixpkgs/manual/#sec-language-texlive
-  texlive = recurseIntoAttrs (callPackage ../tools/typesetting/tex/texlive { });
+  texlive = callPackage ../tools/typesetting/tex/texlive { };
   inherit (texlive.schemes) texliveBasic texliveBookPub texliveConTeXt texliveFull texliveGUST texliveInfraOnly texliveMedium texliveMinimal texliveSmall texliveTeTeX;
 
   fop = callPackage ../tools/typesetting/fop {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30438,7 +30438,6 @@ with pkgs;
 
   apostrophe = callPackage ../applications/editors/apostrophe {
     pythonPackages = python3Packages;
-    texlive = texlive.combined.scheme-medium;
   };
 
   ardour = callPackage ../applications/audio/ardour { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16800,7 +16800,6 @@ with pkgs;
   mitama-cpp-result = callPackage ../development/libraries/mitama-cpp-result { };
 
   mitscheme = callPackage ../development/compilers/mit-scheme {
-    texLive = texlive.combine { inherit (texlive) scheme-small epsf texinfo; };
     texinfo = texinfo6;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19205,9 +19205,7 @@ with pkgs;
   # NOTE: Override and set useIcon = false to use Awk instead of Icon.
   noweb = callPackage ../development/tools/literate-programming/noweb { };
 
-  nuweb = callPackage ../development/tools/literate-programming/nuweb {
-    tex = texlive.combined.scheme-medium;
-  };
+  nuweb = callPackage ../development/tools/literate-programming/nuweb { };
 
   eztrace = callPackage ../development/tools/profiling/EZTrace { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15558,9 +15558,7 @@ with pkgs;
 
   as31 = callPackage ../development/compilers/as31 { };
 
-  asl = callPackage ../development/compilers/asl {
-    tex = texlive.combined.scheme-medium;
-  };
+  asl = callPackage ../development/compilers/asl { };
 
   aspectj = callPackage ../development/compilers/aspectj { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15594,7 +15594,6 @@ with pkgs;
 
   bluespec = callPackage ../development/compilers/bluespec {
     gmp-static = gmp.override { withStatic = true; };
-    tex = texlive.combined.scheme-full;
   };
 
   bun = callPackage ../development/web/bun { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5446,6 +5446,7 @@ with pkgs;
 
   # TeX Live; see https://nixos.org/nixpkgs/manual/#sec-language-texlive
   texlive = recurseIntoAttrs (callPackage ../tools/typesetting/tex/texlive { });
+  inherit (texlive.schemes) texliveBasic texliveBookPub texliveConTeXt texliveFull texliveGUST texliveInfraOnly texliveMedium texliveMinimal texliveSmall texliveTeTeX;
 
   fop = callPackage ../tools/typesetting/fop {
     jdk = openjdk8;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32914,7 +32914,6 @@ with pkgs;
 
   ipe = qt6Packages.callPackage ../applications/graphics/ipe {
     ghostscript = ghostscriptX;
-    texlive = texlive.combine { inherit (texlive) scheme-small; };
     lua5 = lua5_3;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13244,9 +13244,7 @@ self: super: with self; {
 
   sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
 
-  sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz {
-    texLive = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-small standalone pgfplots; };
-  };
+  sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz { };
 
   sphinxcontrib-wavedrom = callPackage ../development/python-modules/sphinxcontrib-wavedrom { };
 


### PR DESCRIPTION
## Description of changes
Remove almost all calls to `texlive.combine` or `texlive.combined.scheme-*` with equivalent `texliveSmall.withPackages` calls – including new `texliveFull`, etc. at the top level. Rationale:
- a drop in evaluation time (I hope!)
- better ergonomics: `.withPackages` is composable, so dependencies can now live in the package definition instead of all-packages.nix, and users can easily override `texliveSmall` to pass a different TeX Live environment

There may bugs caused by TeX Live packages having the same name as a Nixpkgs package in scope, e.g. `with ps; [ texinfo ]` can accidentally refer to `pkgs.texinfo` instead of `ps.texinfo`. Hopefully I spotted all of them but please verify.

Not sure if we can fit this in time with 23.11 – it may cause a large rebuild. Let's see what ofborg says.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).