### PR TITLE
zxtune: init at r5054

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4976,6 +4976,12 @@
     githubId = 424946;
     name = "James Earl Douglas";
   };
+  EBADBEEF = {
+    name = "EBADBEEF";
+    email = "errno@ebadf.com";
+    github = "EBADBEEF";
+    githubId = 4167946;
+  };
   ebbertd = {
     email = "daniel@ebbert.nrw";
     github = "ebbertd";

--- a/pkgs/by-name/zx/zxtune/disable_updates.patch
+++ b/pkgs/by-name/zx/zxtune/disable_updates.patch
@@ -1,0 +1,20 @@
+--- ./apps/zxtune-qt/ui/desktop/mainwindow.cpp.orig	2023-11-03 10:58:54.073651511 -0700
++++ ./apps/zxtune-qt/ui/desktop/mainwindow.cpp	2023-11-03 10:59:08.900608850 -0700
+@@ -106,14 +106,9 @@
+       Require(connect(actionReportBug, &QAction::triggered, this, &DesktopMainWindowImpl::ReportIssue));
+       Require(connect(actionAboutQt, &QAction::triggered, this, &DesktopMainWindowImpl::ShowAboutQt));
+       Require(connect(actionPreferences, &QAction::triggered, this, &DesktopMainWindowImpl::ShowPreferences));
+-      if (Update::CheckOperation* op = Update::CheckOperation::Create(*this))
+-      {
+-        Require(connect(actionCheckUpdates, &QAction::triggered, op, &Update::CheckOperation::Execute));
+-      }
+-      else
+-      {
+-        actionCheckUpdates->setEnabled(false);
+-      }
++
++      // Nix: disable update checks completely
++      actionCheckUpdates->setEnabled(false);
+ 
+       Require(connect(Controls, &PlaybackControls::OnPrevious, MultiPlaylist, &Playlist::UI::ContainerView::Prev));
+       Require(connect(Controls, &PlaybackControls::OnNext, MultiPlaylist, &Playlist::UI::ContainerView::Next));

--- a/pkgs/by-name/zx/zxtune/package.nix
+++ b/pkgs/by-name/zx/zxtune/package.nix
@@ -1,0 +1,148 @@
+{ lib
+, stdenv
+, fetchFromBitbucket
+, nix-update-script
+, boost
+, zlib
+# File backends (for decoding and encoding)
+, withMp3 ? true
+, lame
+, withOgg ? true
+, libvorbis
+, withFlac ? true
+, flac
+# Audio backends (for playback)
+, withOpenal ? false
+, openal
+, withSDL ? false
+, SDL
+, withOss ? false
+, withAlsa ? stdenv.hostPlatform.isLinux
+, alsa-lib
+, withPulse ? stdenv.hostPlatform.isLinux
+, libpulseaudio
+# GUI audio player
+, withQt ? true
+, qt5
+, zip
+}:
+let
+  dlopenBuildInputs = []
+    ++ lib.optional withMp3 lame
+    ++ lib.optional withOgg libvorbis
+    ++ lib.optional withFlac flac
+    ++ lib.optional withOpenal openal
+    ++ lib.optional withSDL SDL
+    ++ lib.optional withAlsa alsa-lib
+    ++ lib.optional withPulse libpulseaudio;
+  supportWayland = (!stdenv.hostPlatform.isDarwin);
+  platformName = "linux";
+  staticBuildInputs = [ boost zlib ]
+    ++ lib.optional withQt (if (supportWayland) then qt5.qtwayland else qt5.qtbase);
+in stdenv.mkDerivation rec {
+  pname = "zxtune";
+  version = "5055";
+
+  outputs = [ "out" ];
+
+  src = fetchFromBitbucket {
+    owner = "zxtune";
+    repo = "zxtune";
+    rev = "r${version}";
+    hash = "sha256-ABXGbzjdsPUuQnwZQOho4s2xRSDGzbZdA6/hCkBb7zE=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex" "r([0-9]+)" ];
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = lib.optionals withQt [ zip qt5.wrapQtAppsHook ];
+
+  buildInputs = staticBuildInputs ++ dlopenBuildInputs;
+
+  patches = [
+    ./disable_updates.patch
+  ];
+
+  # Fix use of old OpenAL header path
+  postPatch = ''
+    substituteInPlace src/sound/backends/gates/openal_api.h \
+      --replace "#include <OpenAL/" "#include <AL/"
+  '';
+
+  buildPhase = let
+    setOptionalSupport = name: var:
+      "support_${name}=" + (if (var) then "1" else "");
+    makeOptsCommon = [
+      ''-j$NIX_BUILD_CORES''
+      ''root.version=${src.rev}''
+      ''system.zlib=1''
+      ''platform=${platformName}''
+      ''includes.dirs.${platformName}="${lib.makeSearchPathOutput "dev" "include" buildInputs}"''
+      ''libraries.dirs.${platformName}="${lib.makeLibraryPath staticBuildInputs}"''
+      ''ld_flags="-Wl,-rpath=\"${lib.makeLibraryPath dlopenBuildInputs}\""''
+      (setOptionalSupport "mp3" withMp3)
+      (setOptionalSupport "ogg" withOgg)
+      (setOptionalSupport "flac" withFlac)
+      (setOptionalSupport "openal" withOpenal)
+      (setOptionalSupport "sdl" withSDL)
+      (setOptionalSupport "oss" withOss)
+      (setOptionalSupport "alsa" withAlsa)
+      (setOptionalSupport "pulseaudio" withPulse)
+    ];
+    makeOptsQt = [
+      ''tools.uic=${qt5.qtbase.dev}/bin/uic''
+      ''tools.moc=${qt5.qtbase.dev}/bin/moc''
+      ''tools.rcc=${qt5.qtbase.dev}/bin/rcc''
+    ];
+  in ''
+    runHook preBuild
+    make ${builtins.toString makeOptsCommon} -C apps/xtractor
+    make ${builtins.toString makeOptsCommon} -C apps/zxtune123
+  '' + lib.optionalString withQt ''
+    make ${builtins.toString (makeOptsCommon ++ makeOptsQt)} -C apps/zxtune-qt
+  '' + ''
+    runHook postBuild
+  '';
+
+  # Libs from dlopenBuildInputs are found with dlopen. Do not shrink rpath. Can
+  # check output of 'out/bin/zxtune123 --list-backends' to verify all plugins
+  # load ("Status: Available" or "Status: Failed to load dynamic library...").
+  dontPatchELF = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/linux/release/xtractor -t $out/bin
+    install -Dm755 bin/linux/release/zxtune123 -t $out/bin
+  '' + lib.optionalString withQt ''
+    install -Dm755 bin/linux/release/zxtune-qt -t $out/bin
+  '' + ''
+    runHook postInstall
+  '';
+
+  # Only wrap the gui
+  dontWrapQtApps = true;
+  preFixup = lib.optionalString withQt ''
+    wrapQtApp "$out/bin/zxtune-qt"
+  '';
+
+  meta = with lib; {
+    description = "Crossplatform chiptunes player";
+    longDescription = ''
+      Chiptune music player with truly extensive format support. Supported
+      formats/chips include AY/YM, ZX Spectrum, PC, Amiga, Atari, Acorn, Philips
+      SAA1099, MOS6581 (Commodore 64), NES, SNES, GameBoy, Atari, TurboGrafX,
+      Nintendo DS, Sega Master System, and more. Powered by vgmstream, OpenMPT,
+      sidplay, and many other libraries.
+    '';
+    homepage = "https://zxtune.bitbucket.io/";
+    license = licenses.gpl3;
+    # zxtune supports mac and windows, but more work will be needed to
+    # integrate with the custom make system (see platformName above)
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ EBADBEEF ];
+    mainProgram = if withQt then "zxtune-qt" else "zxtune123";
+  };
+}


### PR DESCRIPTION
## Description of changes

zxtune is a cross-platform chiptunes music player.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
