### PR TITLE
mpv: sign darwin bundle executable

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -19,6 +19,7 @@
 , libuchardet
 , libiconv
 , xcbuild
+, sigtool
 
 , waylandSupport ? stdenv.isLinux
   , wayland
@@ -154,7 +155,7 @@ in stdenv'.mkDerivation (finalAttrs: {
     pkg-config
     python3
   ]
-  ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun ]
+  ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun sigtool ]
   ++ lib.optionals swiftSupport [ swift ]
   ++ lib.optionals waylandSupport [ wayland-scanner ];
 
@@ -203,6 +204,11 @@ in stdenv'.mkDerivation (finalAttrs: {
   postBuild = lib.optionalString stdenv.isDarwin ''
     pushd .. # Must be run from the source dir because it uses relative paths
     python3 TOOLS/osxbundle.py -s build/mpv
+    # Swap binary and bundle symlink to sign bundle executable as symlinks cannot be signed
+    rm build/mpv.app/Contents/MacOS/mpv-bundle
+    mv build/mpv.app/Contents/MacOS/mpv build/mpv.app/Contents/MacOS/mpv-bundle
+    ln -s mpv-bundle build/mpv.app/Contents/MacOS/mpv
+    codesign --force --sign - build/mpv.app/Contents/MacOS/mpv-bundle
     popd
   '';
 

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -97,7 +97,7 @@ let
       '' + lib.optionalString stdenv.isDarwin ''
         # wrapProgram can't operate on symlinks
         rm "$out/Applications/mpv.app/Contents/MacOS/mpv"
-        makeWrapper "${mpv}/Applications/mpv.app/Contents/MacOS/mpv" "$out/Applications/mpv.app/Contents/MacOS/mpv" ${mostMakeWrapperArgs}
+        makeWrapper "${mpv}/Applications/mpv.app/Contents/MacOS/mpv-bundle" "$out/Applications/mpv.app/Contents/MacOS/mpv" ${mostMakeWrapperArgs}
       '';
 
       meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33965,6 +33965,7 @@ with pkgs;
   mpv-unwrapped = darwin.apple_sdk_11_0.callPackage ../applications/video/mpv {
     stdenv = if stdenv.isDarwin then swiftPackages.stdenv else stdenv;
     inherit lua;
+    inherit (darwin) sigtool;
   };
 
   shaka-packager = callPackage ../applications/video/shaka-packager { };


### PR DESCRIPTION
## Description of changes

Sign the application bundle executable on Darwin as is described [here](https://github.com/mpv-player/mpv/wiki/Compiling-distro-releases-for-macOS). This fixes the application exiting immediately after launch via application bundle on macOS 14 (#261072).

## Things done

The application bundle executable is now signed using `sigtool` on darwin.

Before this change, the bundle executable (`mpv-bundle`) was a symlink to `mpv` (inside the bundle). However, as symlinks cannot be signed, the symlink and the binary are now swapped around: i.e. `mpv` is now symlinked to `mpv-bundle`. The wrapper on darwin has been changed to use `mpv-bundle` instead of `mpv`, as `wrapProgram` does not work with symlinks.

The mentioned changes only apply to the application bundle on darwin; other platforms and executables (e.g. `/bin/mpv`) are not affected.

`mpv` and `mpv-bundle` were tested on aarch64-darwin (macOS 14) for, both, wrapped and unwrapped versions.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
  - `hydrus`, `hydrus.doc` and `tomato-c` fail to build, but I'm pretty sure these are not related.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @doronbehar