### PR TITLE
poetry: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -12,12 +12,12 @@ let
       # We keep the override around even when the versions match, as
       # it's likely to become relevant again after the next Poetry update.
       poetry-core = super.poetry-core.overridePythonAttrs (old: rec {
-        version = poetry.version;
+        version = "1.8.1";
         src = fetchFromGitHub {
           owner = "python-poetry";
           repo = "poetry-core";
           rev = version;
-          hash = "sha256-OfY2zc+5CgOrgbiPVnvMdT4h1S7Aek8S7iThl6azmsk=";
+          hash = "sha256-RnCJ67jaL2knwv+Uo7p0zOejHAT73f40weaJnfqOYoM=";
         };
       });
     } // (plugins self);

--- a/pkgs/tools/package-management/poetry/plugins/poetry-plugin-export.nix
+++ b/pkgs/tools/package-management/poetry/plugins/poetry-plugin-export.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "poetry-plugin-export";
-  version = "1.5.0";
+  version = "1.6.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-bX7Mqpe7SYQQVrPNVOl8Bwmeiq7owIiUhw0sp5+Gwck=";
+    hash = "sha256-6U96O0mCQpviBr4I67ZfHytsooXG4oCNTx8YqrrIzYo=";
   };
 
   postPatch = ''

--- a/pkgs/tools/package-management/poetry/unwrapped.nix
+++ b/pkgs/tools/package-management/poetry/unwrapped.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
 , installShellFiles
 , pythonRelaxDepsHook
 , build
@@ -42,7 +41,7 @@
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "1.6.1";
+  version = "1.7.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -51,17 +50,8 @@ buildPythonPackage rec {
     owner = "python-poetry";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-/OvYT4Vix1t5Yx/Tx0z3E9L9qJ4OdI4maQqUVl8H524=";
+    hash = "sha256-au+4TOh/sA1+XZqXvWkKxfSdurusBR4l8jsPg6acUM8=";
   };
-
-  patches = [
-    # Backport patch to fix pypa/build 1.0 incompatibility
-    # FIXME: remove in next release
-    (fetchpatch {
-      url = "https://github.com/python-poetry/poetry/commit/a16863d1a448ff91a7cc4e48042d3a8669b78b34.patch";
-      hash = "sha256-dWa5W1jFS7h5cTgoFy89o1Rbtmyddvme4sus+lld058=";
-    })
-  ];
 
   nativeBuildInputs = [
     installShellFiles
@@ -132,6 +122,8 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
+    "test_env_system_packages_are_relative_to_lib"
+    "test_install_warning_corrupt_root"
     "test_installer_with_pypi_repository"
     # touches network
     "git"
@@ -148,6 +140,7 @@ buildPythonPackage rec {
     # fs permission errors
     "test_builder_should_execute_build_scripts"
     # poetry.installation.chef.ChefBuildError: Backend 'poetry.core.masonry.api' is not available.
+    "test_isolated_env_install_success"
     "test_prepare_sdist"
     "test_prepare_directory"
     "test_prepare_directory_with_extensions"


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/python-poetry/poetry/compare/refs/tags/1.6.1...1.7.0

Changelog: https://github.com/python-poetry/poetry/blob/refs/tags/1.7.0/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
