### PR TITLE
heroic: 2.9.2 -> 2.10.0

### DIFF
--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -45,6 +45,9 @@ in stdenv.mkDerivation rec {
     ./remove-drm-support.patch
     # Make Heroic create Steam shortcuts (to non-steam games) with the correct path to heroic.
     ./fix-non-steam-shortcuts.patch
+    # Fix reg add infinite loop
+    # Submitted upstream: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3210
+    ./fix-infinite-loop.patch
   ];
 
   postPatch = ''

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -17,18 +17,18 @@
 let appName = "heroic";
 in stdenv.mkDerivation rec {
   pname = "heroic-unwrapped";
-  version = "2.9.2";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     rev = "v${version}";
-    hash = "sha256-kCvMUhN1kjGb5rV+lkKm1FFYBJUSQGOKTY1DQdiAWLU=";
+    hash = "sha256-umPQIxwIahjbO4QbkKEoeSSeYT2UatsTGRPrLgw5KW8=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-kHZL7TENVK58dvr8PBFtWYZ2PSKEYESX4e1xYmMA5+Y=";
+    hash = "sha256-o5ztk4okH21Op1jqHZfranR12M8B1Y/K95aWb10tf5o=";
   };
 
   nativeBuildInputs = [
@@ -46,6 +46,13 @@ in stdenv.mkDerivation rec {
     # Make Heroic create Steam shortcuts (to non-steam games) with the correct path to heroic.
     ./fix-non-steam-shortcuts.patch
   ];
+
+  postPatch = ''
+    # We are not packaging this as an Electron application bundle, so Electron
+    # reports to the application that is is not "packaged", which causes Heroic
+    # to take some incorrect codepaths meant for development environments.
+    substituteInPlace src/**/*.ts --replace 'app.isPackaged' 'true'
+  '';
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -29,6 +29,7 @@ buildFHSEnv {
     perl
     psmisc
     python3
+    unzip
     which
     xorg.xrandr
     zstd

--- a/pkgs/games/heroic/fix-infinite-loop.patch
+++ b/pkgs/games/heroic/fix-infinite-loop.patch
@@ -1,0 +1,23 @@
+From b698779053b7ba31bd8e69b230e86515e3019bf6 Mon Sep 17 00:00:00 2001
+From: K900 <me@0upti.me>
+Date: Sun, 5 Nov 2023 22:04:32 +0300
+Subject: [PATCH] Force add the registry entry
+
+Otherwise, newer Wine versions will prompt to overwrite it and loop there forever.
+---
+ src/backend/storeManagers/legendary/setup.ts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/backend/storeManagers/legendary/setup.ts b/src/backend/storeManagers/legendary/setup.ts
+index 1837106621..b5c2432435 100644
+--- a/src/backend/storeManagers/legendary/setup.ts
++++ b/src/backend/storeManagers/legendary/setup.ts
+@@ -20,7 +20,7 @@ export const legendarySetup = async (appName: string) => {
+ 
+   // Fixes games like Fallout New Vegas and Dishonored: Death of the Outsider
+   await runWineCommandOnGame(appName, {
+-    commandParts: ['reg', 'add', 'HKEY_CLASSES_ROOT\\com.epicgames.launcher'],
++    commandParts: ['reg', 'add', 'HKEY_CLASSES_ROOT\\com.epicgames.launcher', '/f'],
+     wait: true,
+     protonVerb: 'waitforexitandrun'
+   })

--- a/pkgs/games/heroic/remove-drm-support.patch
+++ b/pkgs/games/heroic/remove-drm-support.patch
@@ -1,22 +1,26 @@
 diff --git a/src/backend/main.ts b/src/backend/main.ts
-index 2cd1a28f..a60e04d0 100644
+index 83b58bb2..f61656fa 100644
 --- a/src/backend/main.ts
 +++ b/src/backend/main.ts
-@@ -19,8 +19,7 @@ import {
-   powerSaveBlocker,
+@@ -19,7 +19,6 @@ import {
    protocol,
    screen,
--  clipboard,
--  components
-+  clipboard
+   clipboard,
+-  components,
+   session
  } from 'electron'
  import 'backend/updater'
- import { autoUpdater } from 'electron-updater'
-@@ -286,8 +285,7 @@ if (!gotTheLock) {
-     initImagesCache()
+@@ -310,14 +309,7 @@ if (!gotTheLock) {
+     }
  
      if (!process.env.CI) {
--      await components.whenReady()
+-      await components.whenReady().catch((e) => {
+-        logError([
+-          'Failed to download / update DRM components.',
+-          'Make sure you do not block update.googleapis.com domain if you want to use WideVine in Browser sideloaded apps',
+-          e
+-        ])
+-      })
 -      logInfo(['DRM module staus', components.status()])
 +      logInfo('DRM modules disabled for nixpkgs')
      }

--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonApplication rec {
   pname = "legendary-gl"; # Name in pypi
-  version = "0.20.33";
+  version = "unstable-2023-10-14";
 
   src = fetchFromGitHub {
     owner = "derrod";
     repo = "legendary";
-    rev = "refs/tags/${version}";
-    sha256 = "sha256-fEQUChkxrKV2IkFGORUolZE2qTzA10Xxogjl5Va4TcE=";
+    rev = "450784283dd49152dda6322db2fb2ef33e7c382e";
+    sha256 = "sha256-iwIaxD35tkOX6NX1SVNmN2OQACwaX/C4xnfgT5YcUvg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/games/nile/default.nix
+++ b/pkgs/games/nile/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonApplication rec {
   pname = "nile";
-  version = "1.0.0";
+  version = "unstable-2023-10-03";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "imLinguin";
     repo = "nile";
-    rev = "f5f3b96f6483c59cfc646afbda6e97cb0bd94778";
-    hash = "sha256-HibY3U9/MibEDwHY+YiErW/pz6qwtps8wwjhznTISgA=";
+    rev = "8f7ab2650fc730efc8960b5fcd71421d724a4108";
+    hash = "sha256-Vhjp9JX8VX0PWsvEh5eOhz7vsIEaiCyPNPOjibE8GXo=";
   };
 
   disabled = pythonOlder "3.8";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37341,7 +37341,7 @@ with pkgs;
 
   heroic-unwrapped = callPackage ../games/heroic {
     # Match the version used by the upstream package.
-    electron = electron_24;
+    electron = electron_27;
   };
 
   heroic = callPackage ../games/heroic/fhsenv.nix { };


### PR DESCRIPTION
## Description of changes
- Update Heroic Games Launcher to latest stable release (fixes #264156).
- Update Nile Amazon Games client, used by Heroic.
- Heroic FHS env fix (closes #262299).

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).