### PR TITLE
slimserver: fix broken package

### DIFF
--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -54,7 +54,7 @@ in {
       serviceConfig = {
         User = "slimserver";
         # Issue 40589: Disable broken image/video support (audio still works!)
-        ExecStart = "${cfg.package}/slimserver.pl --logdir ${cfg.dataDir}/logs --prefsdir ${cfg.dataDir}/prefs --cachedir ${cfg.dataDir}/cache --noimage --novideo";
+        ExecStart = "${lib.getExe cfg.package} --logdir ${cfg.dataDir}/logs --prefsdir ${cfg.dataDir}/prefs --cachedir ${cfg.dataDir}/cache --noimage --novideo";
       };
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -750,6 +750,7 @@ in {
   signal-desktop = handleTest ./signal-desktop.nix {};
   simple = handleTest ./simple.nix {};
   sing-box = handleTest ./sing-box.nix {};
+  slimserver = handleTest ./slimserver.nix {};
   slurm = handleTest ./slurm.nix {};
   smokeping = handleTest ./smokeping.nix {};
   snapcast = handleTest ./snapcast.nix {};

--- a/nixos/tests/slimserver.nix
+++ b/nixos/tests/slimserver.nix
@@ -1,0 +1,16 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "slimserver";
+  meta.maintainers = with pkgs.lib.maintainers; [ adamcstephens ];
+
+  nodes.machine = { ... }: {
+    services.slimserver.enable = true;
+  };
+
+  testScript =
+    ''
+      machine.wait_for_unit("slimserver.service")
+      machine.wait_for_open_port(9000)
+      machine.succeed("curl http://localhost:9000")
+      machine.wait_until_succeeds("journalctl -eu slimserver.service | grep 'Completed dbOptimize Scan'")
+    '';
+})

--- a/nixos/tests/slimserver.nix
+++ b/nixos/tests/slimserver.nix
@@ -4,13 +4,44 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
   nodes.machine = { ... }: {
     services.slimserver.enable = true;
+    services.squeezelite = {
+      enable = true;
+      extraArguments = "-s 127.0.0.1 -d slimproto=info";
+    };
+    sound.enable = true;
+    boot.initrd.kernelModules = ["snd-dummy"];
   };
 
   testScript =
     ''
-      machine.wait_for_unit("slimserver.service")
-      machine.wait_for_open_port(9000)
-      machine.succeed("curl http://localhost:9000")
-      machine.wait_until_succeeds("journalctl -eu slimserver.service | grep 'Completed dbOptimize Scan'")
+      import json
+      rpc_get_player = {
+          "id": 1,
+          "method": "slim.request",
+          "params":[0,["player", "id", "0", "?"]]
+      }
+
+      with subtest("slimserver is started"):
+          machine.wait_for_unit("slimserver.service")
+          # give slimserver a moment to report errors
+          machine.sleep(2)
+
+      with subtest('slimserver module errors are not reported'):
+          machine.fail("journalctl -u slimserver.service | grep 'throw_exception'")
+          machine.fail("journalctl -u slimserver.service | grep 'not installed'")
+          machine.fail("journalctl -u slimserver.service | grep 'not found'")
+          machine.fail("journalctl -u slimserver.service | grep 'The following CPAN modules were found but cannot work with Logitech Media Server'")
+          machine.fail("journalctl -u slimserver.service | grep 'please use the buildme.sh'")
+
+      with subtest('slimserver is ready'):
+          machine.wait_for_open_port(9000)
+          machine.wait_until_succeeds("journalctl -u slimserver.service | grep 'Completed dbOptimize Scan'")
+
+      with subtest("squeezelite player successfully connects to slimserver"):
+          machine.wait_for_unit("squeezelite.service")
+          machine.wait_until_succeeds("journalctl -u squeezelite.service | grep 'slimproto:937 connected'")
+          player_mac = machine.wait_until_succeeds("journalctl -eu squeezelite.service | grep 'sendHELO:148 mac:'").strip().split(" ")[-1]
+          player_id = machine.succeed(f"curl http://localhost:9000/jsonrpc.js -g -X POST -d '{json.dumps(rpc_get_player)}'")
+          assert player_mac == json.loads(player_id)["result"]["_id"], "squeezelite player not found"
     '';
 })

--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -22,6 +22,7 @@
 , openssl
 , portaudioSupport ? stdenv.isDarwin
 , portaudio
+, slimserver
 , AudioToolbox
 , AudioUnit
 , Carbon
@@ -95,7 +96,10 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    inherit (slimserver) tests;
+    updateScript = ./update.sh;
+  };
 
   meta = with lib; {
     description = "Lightweight headless squeezebox client emulator";

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -10,6 +10,7 @@
 , stdenv
 , wavpack
 , zlib
+, enableUnfreeFirmware ? false
 }:
 
 let
@@ -32,6 +33,12 @@ perlPackages.buildPerlPackage rec {
 
   prePatch = ''
     rm -rf Bin
+
+    ${lib.optionalString (!enableUnfreeFirmware) ''
+      # remove unfree firmware
+      rm -rf Firmware
+    ''}
+
     touch Makefile.PL
   '';
 
@@ -49,9 +56,9 @@ perlPackages.buildPerlPackage rec {
   meta = with lib; {
     homepage = "https://github.com/Logitech/slimserver";
     description = "Server for Logitech Squeezebox players. This server is also called Logitech Media Server";
-    # the firmware is not under a free license!
+    # the firmware is not under a free license, but not included in the default package
     # https://github.com/Logitech/slimserver/blob/public/8.3/License.txt
-    license = licenses.unfree;
+    license = if enableUnfreeFirmware then licenses.unfree else licenses.gpl2Only;
     maintainers = with maintainers; [ adamcstephens jecaro ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -59,6 +59,8 @@ perlPackages.buildPerlPackage rec {
     wrapProgram $out/slimserver.pl \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib stdenv.cc.cc.lib ]}" \
       --prefix PATH : "${lib.makeBinPath [ lame flac faad2 sox monkeysAudio wavpack ]}"
+    mkdir $out/bin
+    ln -s $out/slimserver.pl $out/bin/slimserver
   '';
 
   outputs = [ "out" ];
@@ -73,6 +75,7 @@ perlPackages.buildPerlPackage rec {
     # the firmware is not under a free license, but not included in the default package
     # https://github.com/Logitech/slimserver/blob/public/8.3/License.txt
     license = if enableUnfreeFirmware then licenses.unfree else licenses.gpl2Only;
+    mainProgram = "slimserver";
     maintainers = with maintainers; [ adamcstephens jecaro ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -58,7 +58,7 @@ perlPackages.buildPerlPackage rec {
     cp -r . $out
     wrapProgram $out/slimserver.pl \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib stdenv.cc.cc.lib ]}" \
-      --prefix PATH : "${lib.makeBinPath [ lame flac faad2 sox monkeysAudio wavpack ]}"
+      --prefix PATH : "${lib.makeBinPath ([ lame flac faad2 sox wavpack ] ++ (lib.optional stdenv.isLinux monkeysAudio))}"
     mkdir $out/bin
     ln -s $out/slimserver.pl $out/bin/slimserver
   '';
@@ -78,5 +78,6 @@ perlPackages.buildPerlPackage rec {
     mainProgram = "slimserver";
     maintainers = with maintainers; [ adamcstephens jecaro ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -5,6 +5,7 @@
 , lib
 , makeWrapper
 , monkeysAudio
+, nixosTests
 , perl536Packages
 , sox
 , stdenv
@@ -52,6 +53,10 @@ perlPackages.buildPerlPackage rec {
   '';
 
   outputs = [ "out" ];
+
+  passthru.tests = {
+    inherit (nixosTests) slimserver;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/Logitech/slimserver";

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -5,13 +5,16 @@
 , lib
 , makeWrapper
 , monkeysAudio
-, perlPackages
+, perl536Packages
 , sox
 , stdenv
 , wavpack
 , zlib
 }:
 
+let
+  perlPackages = perl536Packages;
+in
 perlPackages.buildPerlPackage rec {
   pname = "slimserver";
   version = "8.3.1";

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,5 +1,6 @@
 { faad2
 , fetchFromGitHub
+, fetchurl
 , flac
 , lame
 , lib
@@ -33,7 +34,15 @@ perlPackages.buildPerlPackage rec {
   buildInputs = [ perlPackages.CryptOpenSSLRSA perlPackages.IOSocketSSL ];
 
   prePatch = ''
+    # remove vendored binaries
     rm -rf Bin
+
+    # remove modules for other versions of perl
+    for x in $(ls CPAN/arch); do
+      if [ "$x" != "${lib.versions.majorMinor perlPackages.perl.version}" ]; then
+        rm -rf "CPAN/arch/$x"
+      fi
+    done
 
     ${lib.optionalString (!enableUnfreeFirmware) ''
       # remove unfree firmware

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1169,6 +1169,20 @@ with self; {
     };
   };
 
+  AsyncUtil = buildPerlPackage {
+    pname = "Async-Util";
+    version = "0.01";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/W/WH/WHITNEY/Async-Util-0.01.tar.gz";
+      hash = "sha256-jzKxHKvFD2Xjh79W8mWBV6IsNah5Nmbhtfis/hMQkQY=";
+    };
+    buildInputs = [ AnyEvent ListMoreUtils ];
+    meta = {
+      description = "Utilities for doing common async operations";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ArchiveCpio = buildPerlPackage {
     pname = "Archive-Cpio";
     version = "0.10";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12751,6 +12751,19 @@ with self; {
     };
   };
 
+  IOInterface = buildPerlModule {
+    pname = "IO-Interface";
+    version = "1.09";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LD/LDS/IO-Interface-1.09.tar.gz";
+      hash = "sha256-5j6BxS6x4OYOwtmD9VUtJJPhFxeZJclnV/I8S9n6cTo=";
+    };
+    meta = {
+      description = "Access and modify network interface card configuration";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   IOInteractive = buildPerlPackage {
     pname = "IO-Interactive";
     version = "1.025";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3628,6 +3628,19 @@ with self; {
     };
   };
 
+  ClassMember = buildPerlPackage {
+    pname = "Class-Member";
+    version = "1.6";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/O/OP/OPI/Class-Member-1.6.tar.gz";
+      hash = "sha256-p1KK8in6OhIF3NJakd59dKxvp9lSgbmTtV6Lb0+HuZE=";
+    };
+    meta = {
+      description = "A set of modules to make the module developement easier";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ClassMethodMaker = buildPerlPackage {
     pname = "Class-MethodMaker";
     version = "2.24";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1267,6 +1267,18 @@ with self; {
     };
   };
 
+  AudioCuefileParser = buildPerlPackage {
+    pname = "Audio-Cuefile-Parser";
+    version = "0.02";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MATTK/Audio-Cuefile-Parser-0.02.tar.gz";
+      hash = "sha256-ulbQcMhz2WxoatmoH99P6JuETkPrSd/gAL+c70PFtmk=";
+    };
+    meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   AudioFLACHeader = buildPerlPackage {
     pname = "Audio-FLAC-Header";
     version = "2.4";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17985,6 +17985,20 @@ with self; {
     };
   };
 
+  MP3CutGapless = buildPerlPackage {
+    pname = "MP3-Cut-Gapless";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/MP3-Cut-Gapless-0.03.tar.gz";
+      hash = "sha256-PoS3OdHx4902FvhR3GV14WXTKEZ/AySGB5UOWVH+pPM=";
+    };
+    propagatedBuildInputs = [ AudioCuefileParser ];
+    meta = {
+      description = "Split an MP3 file without gaps (based on pcutmp3)";
+      license = with lib.licenses; [ artistic1 ];
+    };
+  };
+
   MP3Info = buildPerlPackage {
     pname = "MP3-Info";
     version = "1.26";


### PR DESCRIPTION
## Description of changes

As reported in https://github.com/NixOS/nixpkgs/issues/265488 , the slimserver package is broken. Probably related to perl 5.38, which is not yet supported by slimserver. I resolved this by first downgrading to 5.36, but after switching back to using nixpkgs provided perl dependencies I was able to upgrade to 5.38.

By changing unfree firmware to disabled by default, I was able to package slimserver as free software and allow us to start testing it. The last firmware update in this repo was 12 years ago, so I suspect most devices will be updated now. Users can override the package if they need the firmware. I do not have any physical squeezeboxes to verify this change.

Since the default package is now freely licensed, I was able to add testing infrastructure which will allow us to better validate this works moving forward. Combined with a simple end-to-end test with squeezelite, we can verify both components are able to successfully communicate.

Closes https://github.com/NixOS/nixpkgs/issues/265488
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
