### PR TITLE
JetBrains Runtime Update

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -36,8 +36,8 @@ let
 in
 openjdk17.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk-jcef";
-  javaVersion = "17.0.7";
-  build = "829.16";
+  javaVersion = "17.0.8.1";
+  build = "1080.1";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
@@ -50,7 +50,7 @@ openjdk17.overrideAttrs (oldAttrs: rec {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-b3wW52knkYUeG8h4naTQLGUedhAMiPnUsn3zFAiJCwM=";
+    hash = "sha256-YLW/KX0aGgeWRJDKAv/DqSgtTxyz9xwg+2cGOn6OMnY=";
   };
 
   BOOT_JDK = openjdk17-bootstrap.home;
@@ -64,8 +64,8 @@ openjdk17.overrideAttrs (oldAttrs: rec {
   buildPhase = ''
     runHook preBuild
 
-    mkdir -p jcef_linux_${arch}/jmods
-    cp ${jetbrains.jcef}/* jcef_linux_${arch}/jmods
+    mkdir -p jcef_linux_${arch}/
+    cp -r ${jetbrains.jcef}/* jcef_linux_${arch}/
 
     sed \
         -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -93,11 +93,11 @@ inherit (arches) depsArch projectArch targetArch;
 
 in stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "1ac1c682c497f2b864f86050796461f22935ea64";
+  rev = "3cc44b679366d3a62c2c30fb2ea2c941cfe08bc6";
   # This is the commit number
-  # Currently from the branch: https://github.com/JetBrains/jcef/tree/232
+  # Currently from the branch: https://github.com/JetBrains/jcef/tree/233
   # Run `git rev-list --count HEAD`
-  version = "672";
+  version = "691";
 
   nativeBuildInputs = [ cmake python3 jdk17 git rsync ant ninja ];
   buildInputs = [ libX11 libXdamage nss nspr ];
@@ -106,7 +106,7 @@ in stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-3HuW8upR/bZoK8euVti2KpCZh9xxfqgyHmgoG1NjxOI=";
+    hash = "sha256-2rnK9AjHcaj8J5BiixmvrSRACR/9WA1DYwpidxrw1fs=";
   };
   cef-bin = let
     name = "cef_binary_111.2.1+g870da30+chromium-111.0.5563.64_${platform}_minimal";
@@ -236,12 +236,15 @@ in stdenv.mkDerivation rec {
   dontStrip = debugBuild;
 
   postFixup = ''
+    mkdir $out/jmods
+    # create jcef.version file
+    bash "$JB_TOOLS_DIR"/common/create_version_file.sh $out/
     cd $unpacked/gluegen
-    jmod create --class-path gluegen-rt.jar --libs lib $out/gluegen.rt.jmod
+    jmod create --class-path gluegen-rt.jar --libs lib $out/jmods/gluegen.rt.jmod
     cd ../jogl
-    jmod create --module-path . --class-path jogl-all.jar --libs lib $out/jogl.all.jmod
+    jmod create --module-path . --class-path jogl-all.jar --libs lib $out/jmods/jogl.all.jmod
     cd ../jcef
-    jmod create --module-path . --class-path jcef.jar --libs lib $out/jcef.jmod
+    jmod create --module-path . --class-path jcef.jar --libs lib $out/jmods/jcef.jmod
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates the JetBrains runtime, enabling client-side decorations for JetBrains IDEs among other things.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Updates the JetBrains runtime. A small change had to be made when building JCEF to include its version information as that is now required by the runtime.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
