### PR TITLE
qt5.qtwebengine: pin clang version to clang 15

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -306,7 +306,6 @@ qtModule ({
         isAarch64
         (patternLogicalAnd isMips isLittleEndian)
       ]);
-    broken = stdenv.isDarwin && stdenv.isx86_64;
 
     # This build takes a long time; particularly on slow architectures
     timeout = 24 * 3600;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24694,6 +24694,7 @@ with pkgs;
       inherit (__splicedPackages)
         makeScopeWithSplicing' generateSplicesForMkScope lib fetchurl fetchpatch fetchgit fetchFromGitHub makeSetupHook makeWrapper
         bison cups dconf harfbuzz libGL perl gtk3 python3
+        llvmPackages_15 overrideSDK overrideLibcxx
         darwin;
       inherit (__splicedPackages.gst_all_1) gstreamer gst-plugins-base;
       inherit config;


### PR DESCRIPTION
## Description of changes

Fixes Qt WebEngine build in staging-next #263535. https://hydra.nixos.org/build/239868952

The version of Chromium used by Qt WebEngine 5.15.x does not build with clang 16 due to the following errors:

* -Wenum-constexpr-conversion: This is a downgradable error in clang 16, but it is planned to be made into a hard error in a future version of clang. Patches are not available for the version of v8 used by Chromium in Qt WebEngine, and fixing the code is non-trivial.
* -Wincompatible-function-pointer-types: This is also a downgradable error generated starting with clang 16. Patches are available upstream that can be backported.

Because the first error is non-trivial to fix and suppressing it risks future breakage, clang is pinned to clang 15, which also makes fixing the incompatible function pointer conversion errors unnecessary.

The derivation is also updated to use the `overrideLibcxx` adapter. Using it links qt5.qtwebengine against the same versions of libc++ and libc++abi as qt5.qtbase even though they are built with different versions of clang, avoiding the compatibility problems that can cause.

Also, reenable x86_64-darwin because it builds successfully too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
