### PR TITLE
emacsPackages.lspce: init at unstable-2023-10-30

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -57,6 +57,8 @@ in
     inherit (pkgs) python3 git go gopls pyright;
   };
 
+  lspce = callPackage ./manual-packages/lspce { };
+
   matrix-client = callPackage ./manual-packages/matrix-client {
     _map = self.map;
   };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, emacs
+, f
+, fetchFromGitHub
+, markdown-mode
+, rustPlatform
+, trivialBuild
+, yasnippet
+}:
+
+let
+  version = "unstable-2023-10-30";
+
+  src = fetchFromGitHub {
+    owner = "zbelial";
+    repo = "lspce";
+    rev = "34c59787bcdbf414c92d9b3bf0a0f5306cb98d64";
+    hash = "sha256-kUHGdeJo2zXA410FqXGclgXmgWrll30Zv8fSprcmnIo=";
+  };
+
+  meta = {
+    homepage = "https://github.com/zbelial/lspce";
+    description = "LSP Client for Emacs implemented as a module using rust";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.marsam ];
+    inherit (emacs.meta) platforms;
+  };
+
+  lspce-module = rustPlatform.buildRustPackage {
+    inherit version src meta;
+    pname = "lspce-module";
+
+    cargoHash = "sha256-eqSromwJrFhtJWedDVJivfbKpAtSFEtuCP098qOxFgI=";
+
+    checkFlags = [
+      # flaky test
+      "--skip=msg::tests::serialize_request_with_null_params"
+    ];
+
+    postFixup = ''
+      for f in $out/lib/*; do
+        mv $f $out/lib/lspce-module.''${f##*.}
+      done
+    '';
+  };
+in
+trivialBuild rec {
+  inherit version src meta;
+  pname = "lspce";
+
+  preBuild = ''
+    ln -s ${lspce-module}/lib/lspce-module* .
+
+    # Fix byte-compilation
+    substituteInPlace lspce-util.el \
+      --replace "(require 'yasnippet)" "(require 'yasnippet)(require 'url-util)"
+    substituteInPlace lspce-calltree.el \
+      --replace "(require 'compile)" "(require 'compile)(require 'cl-lib)"
+  '';
+
+  buildInputs = propagatedUserEnvPkgs;
+
+  propagatedUserEnvPkgs = [
+    f
+    markdown-mode
+    yasnippet
+  ];
+
+  postInstall = ''
+    install lspce-module* $LISPDIR
+  '';
+}


### PR DESCRIPTION
## Description of changes
Add https://github.com/zbelial/lspce

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
