### PR TITLE
python3Packages.tweepy: Disable failing streaming tests

### DIFF
--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -44,11 +44,34 @@ buildPythonPackage rec {
     "tweepy"
   ];
 
+  # The checks with streaming fail due to (seemingly) not decoding (or unexpectedly sending response in) GZIP
+  # Same issue impacted mastodon-py, see https://github.com/halcy/Mastodon.py/commit/cd86887d88bbc07de462d1e00a8fbc3d956c0151 (who just disabled these)
+  disabledTestPaths = [
+    "tests/test_client.py"
+  ];
+
+  disabledTests = [
+    "test_indicate_direct_message_typing"
+    "testcachedifferentqueryparameters"
+    "testcachedresult"
+    "testcreatedestroyblock"
+    "testcreatedestroyfriendship"
+    "testcreateupdatedestroylist"
+    "testgetfollowerids"
+    "testgetfollowers"
+    "testgetfriendids"
+    "testgetfriends"
+    "testgetuser"
+    "testcursorcursoritems"
+    "testcursorcursorpages"
+    "testcursornext"
+  ];
+
   meta = with lib; {
     description = "Twitter library for Python";
     homepage = "https://github.com/tweepy/tweepy";
     changelog = "https://github.com/tweepy/tweepy/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ marius851000 ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The same issue happened on mastodon-py, which was fixed upstream by just disabling those tests. I did the same thing.
(I don’t have a twitter account to test it. It’s just a dependancy of a software I use, but do not use it as it is not configured)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
