### PR TITLE
electrs: 0.9.13 -> 0.10.1

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -3,25 +3,25 @@
 , rustPlatform
 , fetchFromGitHub
 , llvmPackages
-, rocksdb_6_23
+, rocksdb_7_10
 , Security
 }:
 
 let
-  rocksdb = rocksdb_6_23;
+  rocksdb = rocksdb_7_10;
 in
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
-  version = "0.9.13";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "romanz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-GV/cwFdYpXJXRTgdVfuzJpmwNhe0kVJnYAJe+DPmRV8=";
+    hash = "sha256-cRnCo/N0k5poiOh308Djw6bySFQFIY3GiD2qjRyMjLM=";
   };
 
-  cargoHash = "sha256-eQAizO26oQRosbMGJLwMmepBN3pocmnbc0qsHsAJysg=";
+  cargoHash = "sha256-fsYJ+80se5VsIaRkFgwJaPPgRw/WdsecRTt6EIjoQTQ=";
 
   # needed for librocksdb-sys
   nativeBuildInputs = [ rustPlatform.bindgenHook ];


### PR DESCRIPTION
This pkg now uses rocksdb 7.10.2, the latest 7.x release.
The [electrs dev docs](https://github.com/romanz/electrs/blob/master/doc/install.md) recommend using version 7.8.3, probably because this was the latest version of the rocksdb Debian package at the time of writing.

But rocksdb 7.10.2 works fine:
- All electrs unit tests succeed
- Per the release notes, 7.10.2 contains no breaking changes
- I've updated the electrs instance on https://nixbitcoin.org to this pkg, with no issues

## Things done
- [x] built on `x86_64-linux`
- [x] manually tested on `x86_64-linux`