### PR TITLE
texlive.withPackages: respect .outputSpecified even for old style packages

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -40,9 +40,10 @@ lib.fix (self: {
 let
   ### texlive.combine backward compatibility
   # if necessary, convert old style { pkgs = [ ... ]; } packages to attribute sets
-  ensurePkgSets = ps: if ! __fromCombineWrapper && builtins.any (p: p ? pkgs && builtins.all (p: p ? tlType) p.pkgs) ps
-    then let oldStyle = builtins.partition (p: p ? pkgs && builtins.all (p: p ? tlType) p.pkgs) ps;
-      in oldStyle.wrong ++ lib.concatMap toTLPkgSets oldStyle.right
+  isOldPkgList = p: ! p.outputSpecified or false && p ? pkgs && builtins.all (p: p ? tlType) p.pkgs;
+  ensurePkgSets = ps: if ! __fromCombineWrapper && builtins.any isOldPkgList ps
+    then let oldPkgLists = builtins.partition isOldPkgList ps;
+      in oldPkgLists.wrong ++ lib.concatMap toTLPkgSets oldPkgLists.right
     else ps;
 
   pkgList = rec {


### PR DESCRIPTION
## Description of changes
First subtle sharp edge in the backward compatibility code: when detecting `.pkgs = [ ... ]`, we assume that the package is in the old format and convert it. However, if an output was specified, we lose that information.

Since specifying an output only makes sense for new style packages, we can and must disable conversion in those cases.

Example:
```nix
texlive.withPackages (ps: [ perlPackages.LaTeXML.tex ])
```
should install the TeX files of LaTeXML in the environment, and nothing else. Right now LaTeXML gets re-converted to the new style (due to the still present `.pkgs`) and you get both binaries and TeX files.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).