### PR TITLE
graphite-gtk-theme: fix wallpapers

### DIFF
--- a/pkgs/data/themes/graphite-gtk-theme/default.nix
+++ b/pkgs/data/themes/graphite-gtk-theme/default.nix
@@ -63,7 +63,7 @@ stdenvNoCC.mkDerivation rec {
 
     ${lib.optionalString wallpapers ''
       mkdir -p $out/share/backgrounds
-      cp -a wallpaper/Graphite-normal/*.png $out/share/backgrounds/
+      cp -a wallpaper/Graphite/*.png $out/share/backgrounds/
       ${lib.optionalString (builtins.elem "nord" tweaks) ''
         cp -a wallpaper/Graphite-nord/*.png $out/share/backgrounds/
       ''}


### PR DESCRIPTION
## Description of changes

`wallpaper/Graphite-normal` directory had been moved to `wallpaper/Graphite` in upstream vinceliuice/Graphite-gtk-theme@d1c8ec940964582f934feaff1346e73084ab4ddd.

```
❯ nix-build -E 'with (import ./. {}); graphite-gtk-theme.override { wallpapers = true; }'
this derivation will be built:
  /nix/store/v2ic8iidns36wzhnrja95xs16h8xhvza-graphite-gtk-theme-2023-05-17.drv
building '/nix/store/v2ic8iidns36wzhnrja95xs16h8xhvza-graphite-gtk-theme-2023-05-17.drv'...
unpacking sources
unpacking source archive /nix/store/d1v0dl6i77ygk8s83p0cb6zdxwihaws8-source
source root is source
patching sources
updateAutotoolsGnuConfigScriptsPhase
configuring
no configure script, doing nothing
building
no Makefile or custom buildPhase, doing nothing
installing
patching script interpreter paths in install.sh
install.sh: interpreter directive changed from "#! /usr/bin/env bash" to "/nix/store/lf0wpjrj8yx4gsmw2s3xfl58ixmqk8qa-bash-5.2-p15/bin/bash"
'gnome-shell' not found, using styles for last gnome-shell version available.
Destination directory does not exist. Let's make a new one...
Installing '/nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17/share/themes/Graphite'...
Installing '/nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17/share/themes/Graphite-Light'...
Installing '/nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17/share/themes/Graphite-Dark'...

Done.
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17
checking for references to /build/ in /nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17...
patching script interpreter paths in /nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17
/nix/store/8hc2xf49q6nq35lysa54l84npfs3xxdg-graphite-gtk-theme-2023-05-17
```

```
❯ ls -la result/share/backgrounds/
.r--r--r-- 129k root  1 Jan  1970 wave-color.png
.r--r--r-- 254k root  1 Jan  1970 wave-Dark-arch.png
.r--r--r-- 258k root  1 Jan  1970 wave-Dark-debian.png
.r--r--r-- 251k root  1 Jan  1970 wave-Dark-fedora.png
.r--r--r-- 244k root  1 Jan  1970 wave-Dark-manjaro.png
.r--r--r-- 260k root  1 Jan  1970 wave-Dark-ubuntu.png
.r--r--r-- 237k root  1 Jan  1970 wave-Dark.png
.r--r--r-- 247k root  1 Jan  1970 wave-Light-arch.png
.r--r--r-- 251k root  1 Jan  1970 wave-Light-debian.png
.r--r--r-- 244k root  1 Jan  1970 wave-Light-fedora.png
.r--r--r-- 237k root  1 Jan  1970 wave-Light-manjaro.png
.r--r--r-- 253k root  1 Jan  1970 wave-Light-ubuntu.png
.r--r--r-- 230k root  1 Jan  1970 wave-Light.png
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Sorry, somehow `nixpkgs-review` wouldn't work.

```
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
these 2 paths will be fetched (0.11 MiB download, 0.62 MiB unpacked):
  /nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3
  /nix/store/1ljzhl5vnr7bynm06h8nay38lbjd6937-python3.11-argcomplete-3.1.2
copying path '/nix/store/1ljzhl5vnr7bynm06h8nay38lbjd6937-python3.11-argcomplete-3.1.2' from 'https://cache.nixos.org'...
copying path '/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   ae24e3e528c9..5eda4619591b  master     -> refs/nixpkgs-review/0
$ git worktree add /home/sei40kr/.cache/nixpkgs-review/rev-ce4a4e651e020d9fe58b4c59cc09bef86d268bdd/nixpkgs 5eda4619591bc659942cd03d1bb3b04925bb1435
Preparing worktree (detached HEAD 5eda4619591b)
Updating files: 100% (37898/37898), done.
HEAD is now at 5eda4619591b Merge pull request #265605 from r-ryantm/auto-update/python310Packages.cx-freeze
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/sei40kr/.cache/nixpkgs-review/rev-ce4a4e651e020d9fe58b4c59cc09bef86d268bdd/nixpkgs nixpkgs-overlays=/run/user/1000/tmp8ek4w3by -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git worktree remove -f /home/sei40kr/.cache/nixpkgs-review/rev-ce4a4e651e020d9fe58b4c59cc09bef86d268bdd/nixpkgs
Traceback (most recent call last):
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/bin/.nixpkgs-review-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/__init__.py", line 10, in main
    cli.main(command, args)
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/cli/__init__.py", line 334, in main
    return cast(str, args.func(args))
                     ^^^^^^^^^^^^^^^
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/cli/rev.py", line 14, in rev_command
    return review_local_revision(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 582, in review_local_revision
    review.review_commit(builddir.path, args.branch, commit, staged, print_result)
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 310, in review_commit
    self.build_commit(branch_rev, reviewed_commit, staged),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 161, in build_commit
    base_packages = list_packages(
                    ^^^^^^^^^^^^^^
  File "/nix/store/v9hbnssw96kk49sjhvwisqzkns894l2f-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 398, in list_packages
    raise NixpkgsReviewError(
nixpkgs_review.errors.NixpkgsReviewError: Failed to list packages: nix-env failed with exit code -9
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
