### PR TITLE
feat(bats): bats-libs add pre/postinstall hook and use finalAttrs, update bats-file to 0.4.0 and add bats-detik

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2605,6 +2605,13 @@
     githubId = 1071610;
     name = "Gunnar Nitsche";
   };
+  brokenpip3 = {
+    email = "brokenpip3@gmail.com";
+    matrix = "@brokenpip3:matrix.org";
+    github = "brokenpip3";
+    githubId = 40476330;
+    name = "brokenpip3";
+  };
   bryanasdev000 = {
     email = "bryanasdev000@gmail.com";
     matrix = "@bryanasdev000:matrix.org";

--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -140,6 +140,7 @@ resholve.mkDerivation rec {
         bats_load_library bats-support
         bats_load_library bats-assert
         bats_load_library bats-file
+        bats_load_library bats-detik/detik.bash
 
         bats_require_minimum_version 1.5.0
 
@@ -170,7 +171,7 @@ resholve.mkDerivation rec {
     '';
     passAsFile = [ "testScript" ];
   } ''
-    ${bats.withLibraries (p: [ p.bats-support p.bats-assert p.bats-file ])}/bin/bats "$testScriptPath"
+    ${bats.withLibraries (p: [ p.bats-support p.bats-assert p.bats-file p.bats-detik ])}/bin/bats "$testScriptPath"
     touch "$out"
   '';
 

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -1,18 +1,20 @@
 { lib, stdenv, fetchFromGitHub }: {
-  bats-assert = stdenv.mkDerivation rec {
+  bats-assert = stdenv.mkDerivation (finalAttrs: {
     pname = "bats-assert";
     version = "2.1.0";
     src = fetchFromGitHub {
       owner = "bats-core";
       repo = "bats-assert";
-      rev = "v${version}";
-      sha256 = "sha256-opgyrkqTwtnn/lUjMebbLfS/3sbI2axSusWd5i/5wm4=";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-opgyrkqTwtnn/lUjMebbLfS/3sbI2axSusWd5i/5wm4=";
     };
     dontBuild = true;
     installPhase = ''
+      runHook preInstall
       mkdir -p "$out/share/bats/bats-assert"
       cp load.bash "$out/share/bats/bats-assert"
       cp -r src "$out/share/bats/bats-assert"
+      runHook postInstall
     '';
     meta = {
       description = "Common assertions for Bats";
@@ -21,22 +23,24 @@
       license = lib.licenses.cc0;
       maintainers = with lib.maintainers; [ infinisil ];
     };
-  };
+  });
 
-  bats-file = stdenv.mkDerivation rec {
+  bats-file = stdenv.mkDerivation (finalAttrs: {
     pname = "bats-file";
     version = "0.4.0";
     src = fetchFromGitHub {
       owner = "bats-core";
       repo = "bats-file";
-      rev = "v${version}";
-      sha256 = "sha256-NJzpu1fGAw8zxRKFU2awiFM2Z3Va5WONAD2Nusgrf4o=";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-NJzpu1fGAw8zxRKFU2awiFM2Z3Va5WONAD2Nusgrf4o=";
     };
     dontBuild = true;
     installPhase = ''
+      runHook preInstall
       mkdir -p "$out/share/bats/bats-file"
       cp load.bash "$out/share/bats/bats-file"
       cp -r src "$out/share/bats/bats-file"
+      runHook postInstall
     '';
     meta = {
       description = "Common filesystem assertions for Bats";
@@ -45,7 +49,7 @@
       license = lib.licenses.cc0;
       maintainers = with lib.maintainers; [ infinisil ];
     };
-  };
+  });
 
   bats-detik = stdenv.mkDerivation (finalAttrs: {
     pname = "bats-detik";
@@ -72,20 +76,22 @@
     };
   });
 
-  bats-support = stdenv.mkDerivation rec {
+  bats-support = stdenv.mkDerivation (finalAttrs: {
     pname = "bats-support";
     version = "0.3.0";
     src = fetchFromGitHub {
       owner = "bats-core";
       repo = "bats-support";
-      rev = "v${version}";
-      sha256 = "sha256-4N7XJS5XOKxMCXNC7ef9halhRpg79kUqDuRnKcrxoeo=";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-4N7XJS5XOKxMCXNC7ef9halhRpg79kUqDuRnKcrxoeo=";
     };
     dontBuild = true;
     installPhase = ''
+      runHook preInstall
       mkdir -p "$out/share/bats/bats-support"
       cp load.bash "$out/share/bats/bats-support"
       cp -r src "$out/share/bats/bats-support"
+      runHook postInstall
     '';
     meta = {
       description = "Supporting library for Bats test helpers";
@@ -94,5 +100,5 @@
       license = lib.licenses.cc0;
       maintainers = with lib.maintainers; [ infinisil ];
     };
-  };
+  });
 }

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -47,6 +47,31 @@
     };
   };
 
+  bats-detik = stdenv.mkDerivation (finalAttrs: {
+    pname = "bats-detik";
+    version = "1.2.1";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-detik";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-2BEIqRSc21oPjd9BgTLg5mGyAdNJYA2b7gZe7Nj2dks=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/share/bats/bats-detik"
+      cp -r lib/* "$out/share/bats/bats-detik"
+      runHook postInstall
+    '';
+    meta = {
+      description = "Library to ease e2e tests of applications in K8s environments";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-detik";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ brokenpip3 ];
+    };
+  });
+
   bats-support = stdenv.mkDerivation rec {
     pname = "bats-support";
     version = "0.3.0";

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -25,12 +25,12 @@
 
   bats-file = stdenv.mkDerivation rec {
     pname = "bats-file";
-    version = "0.3.0";
+    version = "0.4.0";
     src = fetchFromGitHub {
       owner = "bats-core";
       repo = "bats-file";
       rev = "v${version}";
-      sha256 = "sha256-3xevy0QpwNZrEe+2IJq58tKyxQzYx8cz6dD2nz7fYUM=";
+      sha256 = "sha256-NJzpu1fGAw8zxRKFU2awiFM2Z3Va5WONAD2Nusgrf4o=";
     };
     dontBuild = true;
     installPhase = ''


### PR DESCRIPTION
## Description of changes

The Bats organization has another useful library called [bats-detik](https://github.com/bats-core/bats-detik) under its umbrella. This library is used for Kubernetes end-to-end tests. This PR will add bats-detik to the list of supported libraries for Bats.

Please note the following:
1. Bats-detik is widely used and packaged like the other libraries.
2. It is normal to use `bats_load_library bats-detik/detik.bash` in the tests because detik does not have load.bash.
3. I have appointed myself as the maintainer for this library, as I am already responsible for maintaining some other bats libraries under other package/ci systems. However, I must clarify that I am not an expert in nix or nixos so If someone else prefer to become the maintainer I'm happy to switch the usernames :) 
4. I would like to apologize in advance for any potential mistakes, as this is my first pull request in the Nix world.

Additionally, a new version of bats-file has been released and updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
