### PR TITLE
texlive: document new texlive.withPackages interface

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -2,6 +2,46 @@
 
 Since release 15.09 there is a new TeX Live packaging that lives entirely under attribute `texlive`.
 
+## User's guide (experimental new interface) {#sec-language-texlive-user-guide-experimental}
+
+Release 23.11 ships with a new interface that will eventually replace `texlive.combine`.
+
+- For basic usage, use some of the prebuilt environments available at the top level, such as `texliveBasic`, `texliveSmall`. For the full list of prebuilt environments, inspect `texlive.schemes`.
+
+- Packages cannot be used directly but must be assembled in an environment. To create or add packages to an environment, use
+  ```nix
+  texliveSmall.withPackages (ps: with ps; [ collection-langkorean algorithms cm-super ])
+  ```
+  The function `withPackages` can be called multiple times to add more packages.
+
+  - **Note.** Within Nixpkgs, packages should only use prebuilt environments as inputs, such as `texliveSmall` or `texliveInfraOnly`, and should not depend directly on `texlive`. Further dependencies should be added by calling `withPackages`. This is to ensure that there is a consistent and simple way to override the inputs.
+
+- `texlive.withPackages` uses the same logic as `buildEnv`. Only parts of a package are installed in an environment: its 'runtime' files (`tex` output), binaries (`out` output), and support files (`tlpkg` output). Moreover, man and info pages are assembled into separate `man` and `info` outputs. To add only the TeX files of a package, or its documentation (`texdoc` output), just specify the outputs:
+  ```nix
+  texlive.withPackages (ps: with ps; [
+    texdoc # recommended package to navigate the documentation
+    perlPackages.LaTeXML.tex # tex files of LaTeXML, omit binaries
+    cm-super
+    cm-super.texdoc # documentation of cm-super
+  ])
+  ```
+
+- All packages distributed by TeX Live, which contains most of CTAN, are available and can be found under `texlive.pkgs`:
+  ```ShellSession
+  $ nix repl
+  nix-repl> :l <nixpkgs>
+  nix-repl> texlive.pkgs.[TAB]
+  ```
+  Note that the packages in `texlive.pkgs` are only provided for search purposes and must not be used directly.
+
+- **Experimental and subject to change without notice:** to add the documentation for all packages in the environment, use
+  ```nix
+  texliveSmall.__overrideTeXConfig { withDocs = true; }
+  ```
+  This can be applied before or after calling `withPackages`.
+
+  The function currently support the parameters `withDocs`, `withSources`, and `requireTeXPackages`.
+
 ## User's guide {#sec-language-texlive-user-guide}
 
 - For basic usage just pull `texlive.combined.scheme-basic` for an environment with basic LaTeX support.


### PR DESCRIPTION
## Description of changes
Document `texlive.withPackages` as new experimental interface.

**Warning:** do not merge before #265514, #265645!

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).