### PR TITLE
mpvScripts: Add `buildLua` helper

### DIFF
--- a/pkgs/applications/video/mpv/scripts/acompressor.nix
+++ b/pkgs/applications/video/mpv/scripts/acompressor.nix
@@ -1,27 +1,17 @@
-{ stdenvNoCC
+{ lib
+, buildLua
 , mpv-unwrapped
-, lib
 }:
 
-stdenvNoCC.mkDerivation rec {
+buildLua {
+  inherit (mpv-unwrapped) src version;
   pname = "mpv-acompressor";
-  version = mpv-unwrapped.version;
-
-  src = "${mpv-unwrapped.src.outPath}/TOOLS/lua/acompressor.lua";
-
-  dontBuild = true;
-  dontUnpack = true;
-
-  installPhase = ''
-    install -Dm644 ${src} $out/share/mpv/scripts/acompressor.lua
-  '';
-
-  passthru.scriptName = "acompressor.lua";
+  scriptPath = "TOOLS/lua/acompressor.lua";
 
   meta = with lib; {
+    inherit (mpv-unwrapped.meta) license;
     description = "Script to toggle and control ffmpeg's dynamic range compression filter.";
     homepage = "https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/acompressor.lua";
-    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ nicoo ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -1,0 +1,18 @@
+{ lib
+, stdenvNoCC }:
+
+let fileName = pathStr: lib.last (lib.splitString "/" pathStr);
+in
+lib.makeOverridable (
+  { pname, scriptPath ? "${pname}.lua", ... }@args:
+  stdenvNoCC.mkDerivation (lib.attrsets.recursiveUpdate {
+    dontBuild = true;
+    preferLocalBuild = true;
+
+    outputHashMode = "recursive";
+    installPhase = "install -m644 -Dt $out/share/mpv/scripts ${scriptPath}";
+    passthru.scriptName = fileName scriptPath;
+
+    meta.platforms = lib.platforms.all;
+  } args)
+)

--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -10,9 +10,13 @@ lib.makeOverridable (
     preferLocalBuild = true;
 
     outputHashMode = "recursive";
-    installPhase = "install -m644 -Dt $out/share/mpv/scripts ${scriptPath}";
-    passthru.scriptName = fileName scriptPath;
+    installPhase = ''
+      runHook preInstall
+      install -m644 -Dt $out/share/mpv/scripts ${scriptPath}
+      runHook postInstall
+    '';
 
+    passthru.scriptName = fileName scriptPath;
     meta.platforms = lib.platforms.all;
   } args)
 )

--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -1,11 +1,9 @@
 { lib
 , fetchFromGitHub
-, nix-update-script
-, stdenvNoCC }:
+, buildLua }:
 
-stdenvNoCC.mkDerivation {
+buildLua {
   pname = "chapterskip";
-  passthru.scriptName = "chapterskip.lua";
 
   version = "unstable-2022-09-08";
   src = fetchFromGitHub {
@@ -15,17 +13,8 @@ stdenvNoCC.mkDerivation {
     hash  = "sha256-OTrLQE3rYvPQamEX23D6HttNjx3vafWdTMxTiWpDy90=";
   };
 
-  dontBuild = true;
-  preferLocalBuild = true;
-  installPhase = "install -Dt $out/share/mpv/scripts chapterskip.lua";
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=branch" ];
-  };
-
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/po5/chapterskip";
-    platforms = platforms.all;
-    maintainers = with maintainers; [ nicoo ];
+    maintainers = with lib.maintainers; [ nicoo ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -3,13 +3,14 @@
 , config
 }:
 
-lib.recurseIntoAttrs
+let buildLua = callPackage ./buildLua.nix { };
+in lib.recurseIntoAttrs
   ({
-    acompressor = callPackage ./acompressor.nix { };
+    acompressor = callPackage ./acompressor.nix { inherit buildLua; };
     autocrop = callPackage ./autocrop.nix { };
     autodeint = callPackage ./autodeint.nix { };
     autoload = callPackage ./autoload.nix { };
-    chapterskip = callPackage ./chapterskip.nix { };
+    chapterskip = callPackage ./chapterskip.nix { inherit buildLua; };
     convert = callPackage ./convert.nix { };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
@@ -27,7 +28,7 @@ lib.recurseIntoAttrs
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
     cutter = callPackage ./cutter.nix { };
   }
-  // (callPackage ./occivink.nix { }))
+  // (callPackage ./occivink.nix { inherit buildLua; }))
   // lib.optionalAttrs config.allowAliases {
   youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
 }

--- a/pkgs/applications/video/mpv/scripts/occivink.nix
+++ b/pkgs/applications/video/mpv/scripts/occivink.nix
@@ -1,14 +1,11 @@
 { lib
-, stdenvNoCC
 , fetchFromGitHub
+, buildLua
 }:
 
 let
-  script = { n, ... }@p:
-    stdenvNoCC.mkDerivation (lib.attrsets.recursiveUpdate {
-      pname = "mpv_${n}";
-      passthru.scriptName = "${n}.lua";
-
+  script = { pname, ...}@args:
+    buildLua (lib.attrsets.recursiveUpdate {
       src = fetchFromGitHub {
         owner = "occivink";
         repo = "mpv-scripts";
@@ -17,37 +14,28 @@ let
       };
       version = "unstable-2022-10-02";
 
-      dontBuild = true;
-      installPhase = ''
-        mkdir -p $out/share/mpv/scripts
-        cp -r scripts/${n}.lua $out/share/mpv/scripts/
-      '';
+      scriptPath = "scripts/${pname}.lua";
 
       meta = with lib; {
         homepage = "https://github.com/occivink/mpv-scripts";
         license = licenses.unlicense;
-        platforms = platforms.all;
         maintainers = with maintainers; [ nicoo ];
       };
-
-      outputHashAlgo = "sha256";
-      outputHashMode = "recursive";
-    } p);
+    } args);
 
 in
 {
 
   # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.seekTo ]; }`
   seekTo = script {
-    n = "seek-to";
+    pname = "seek-to";
     meta.description = "Mpv script for seeking to a specific position";
     outputHash = "sha256-3RlbtUivmeoR9TZ6rABiZSd5jd2lFv/8p/4irHMLshs=";
   };
 
   blacklistExtensions = script {
-    n = "blacklist-extensions";
+    pname = "blacklist-extensions";
     meta.description = "Automatically remove playlist entries based on their extension.";
     outputHash = "sha256-qw9lz8ofmvvh23F9aWLxiU4YofY+YflRETu+nxMhvVE=";
   };
-
 }

--- a/pkgs/applications/video/mpv/scripts/occivink.nix
+++ b/pkgs/applications/video/mpv/scripts/occivink.nix
@@ -4,8 +4,14 @@
 }:
 
 let
-  script = { pname, ...}@args:
-    buildLua (lib.attrsets.recursiveUpdate {
+  camelToKebab = let
+    inherit (lib.strings) match stringAsChars toLower;
+    isUpper = match "[A-Z]";
+  in stringAsChars (c: if isUpper c != null then "-${toLower c}" else c);
+
+  mkScript = name: args:
+    buildLua (lib.attrsets.recursiveUpdate rec {
+      pname = camelToKebab name;
       src = fetchFromGitHub {
         owner = "occivink";
         repo = "mpv-scripts";
@@ -24,17 +30,15 @@ let
     } args);
 
 in
-{
+lib.mapAttrs (name: lib.makeOverridable (mkScript name)) {
 
   # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.seekTo ]; }`
-  seekTo = script {
-    pname = "seek-to";
+  seekTo = {
     meta.description = "Mpv script for seeking to a specific position";
     outputHash = "sha256-3RlbtUivmeoR9TZ6rABiZSd5jd2lFv/8p/4irHMLshs=";
   };
 
-  blacklistExtensions = script {
-    pname = "blacklist-extensions";
+  blacklistExtensions = {
     meta.description = "Automatically remove playlist entries based on their extension.";
     outputHash = "sha256-qw9lz8ofmvvh23F9aWLxiU4YofY+YflRETu+nxMhvVE=";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33964,7 +33964,7 @@ with pkgs;
     wlroots = wlroots_0_15;
   };
 
-  mpvScripts = import ../applications/video/mpv/scripts { inherit lib callPackage config; };
+  mpvScripts = callPackage ../applications/video/mpv/scripts { };
 
   open-in-mpv = callPackage ../applications/video/open-in-mpv { };
 


### PR DESCRIPTION
## Description of changes

- Added `buildLua` helper in `mpv/scripts/`
- Refactored `mpvScripts.{acompressor, blacklistExtensions, chapterskip, seekTo}` using it
  Those are all drvs I maintain

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
