### PR TITLE
cargo-outdated: add missing CoreServices dep to fix build on darwin

### DIFF
--- a/pkgs/development/tools/rust/cargo-outdated/default.nix
+++ b/pkgs/development/tools/rust/cargo-outdated/default.nix
@@ -6,6 +6,7 @@
 , stdenv
 , curl
 , CoreFoundation
+, CoreServices
 , Security
 , SystemConfiguration
 }:
@@ -26,6 +27,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [
     curl
     CoreFoundation
+    CoreServices
     Security
     SystemConfiguration
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17071,7 +17071,7 @@ with pkgs;
   cargo-lock = callPackage ../development/tools/rust/cargo-lock { };
   cargo-machete = callPackage ../development/tools/rust/cargo-machete { };
   cargo-outdated = callPackage ../development/tools/rust/cargo-outdated {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices Security SystemConfiguration;
   };
   cargo-pgx_0_6_1 = callPackage ../development/tools/rust/cargo-pgx/0_6_1.nix {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
## Description of changes

`cargo-outdated` fails to build on darwin (at least, on my macOS 14.2 beta system) due to a link failure looking for `CoreServices`.

<details>
<summary>error output</summary>

```
   Compiling cargo-outdated v0.14.0 (/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz)
error: linking with `/nix/store/2ldr4s30zvv1lnf95g88nr9y14w7nm6h-clang-wrapper-11.1.0/bin/cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/nix/store/khislvcrbgv3xm5i9f9nmmvrmrw73rjz-rustc-1.72.1/lib/rustlib/x86_64-apple-darwin/bin:/nix/store/80ky4iqiwxiw6sicd3cmv08rwsnf34al-cargo-1.72.1/bin:/nix/store/zpapgw7ibixlz5zsfh2ms110wppdy97x-cargo-auditable-0.6.1/bin:/nix/store/apryar00qyvvzika07xvkhk91vc5wqwk-pkg-config-wrapper-0.29.2/bin:/nix/store/gwdv583zx056kvr64x4cvksbfv3vpcjx-auditable-cargo-1.72.1/bin:/nix/store/80ky4iqiwxiw6sicd3cmv08rwsnf34al-cargo-1.72.1/bin:/nix/store/khislvcrbgv3xm5i9f9nmmvrmrw73rjz-rustc-1.72.1/bin:/nix/store/2ldr4s30zvv1lnf95g88nr9y14w7nm6h-clang-wrapper-11.1.0/bin:/nix/store/m9ss04fbwfd8544pdk6aan7k8sk85zgm-clang-11.1.0/bin:/nix/store/hcil3fgcjav0y458ff4m98zgcqky00gk-coreutils-9.3/bin:/nix/store/zr335yx742gfrkankw5dnndh96wmni55-cctools-binutils-darwin-wrapper-11.1.0-973.0.1/bin:/nix/store/nshpjjndkd8x0nkjpl8p2pljjfplz1h7-cctools-binutils-darwin-11.1.0-973.0.1/bin:/nix/store/hcil3fgcjav0y458ff4m98zgcqky00gk-coreutils-9.3/bin:/nix/store/xyaf13n6x0q7m5wvvlqjvsqyqjpw10b0-findutils-4.9.0/bin:/nix/store/x9h23ixd3x35n0sm244qc3b64ppg67dp-diffutils-3.10/bin:/nix/store/4qm1gw0w2zpdg16jya88r82f8bxl33np-gnused-4.9/bin:/nix/store/hfjfxp1x0rc6d7vizwrhsx4y6dhf9pda-gnugrep-3.11/bin:/nix/store/4pvhzm0pd1skad8wkszdc0g77zy70vh7-gawk-5.2.2/bin:/nix/store/4ifdvs7fjczlvyssp1h91139n4yb57d3-gnutar-1.35/bin:/nix/store/7mq4n3fjyg42qsaxd8yk4w0z4x8yrhms-gzip-1.13/bin:/nix/store/n66a4pzpv5lqrvd3xi6v2gy947bcgb9v-bzip2-1.0.8-bin/bin:/nix/store/x5yxhfzpj4vwb42pxbvyxvijwz88gfiz-gnumake-4.4.1/bin:/nix/store/v2s6lw54klm8qvff4209125bhf99yifk-bash-5.2-p15/bin:/nix/store/z81njmbg6db5011g4hgi8m5r0yh81lpl-patch-2.7.6/bin:/nix/store/1595k4ndj99y757yf4rfssds357nypqz-xz-5.4.4-bin/bin:/nix/store/162rzwan1c3s1czwdjf8mxb4hafr1wih-file-5.45/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/2ldr4s30zvv1lnf95g88nr9y14w7nm6h-clang-wrapper-11.1.0/bin/cc" "-arch" "x86_64" "-m64" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/rustco0oVXb/symbols.o" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/deps/cargo_outdated-376103bd52324c3d.cargo_outdated.ebf37e819ca328a-cgu.05.rcgu.o" "-L" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/release/deps" "-L" "/nix/store/2ldr4s30zvv1lnf95g88nr9y14w7nm6h-clang-wrapper-11.1.0/resource-root/lib/darwin" "-L" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/build/curl-sys-81ed6947e09a2482/out/build" "-L" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/build/libnghttp2-sys-a5ce86388e27286b/out/i/lib" "-L" "/nix/store/qhvhxknspl6lsvbnyw99rbrriwgpry77-zlib-1.3/lib" "-L" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/build/libgit2-sys-a76e2ec647b6bfeb/out/build" "-L" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/build/libssh2-sys-8b7a34967c1de059/out/build" "-L" "/nix/store/dk68nml2i0x9x4dhcz6halr8fff710ny-openssl-3.0.11/lib" "-L" "/nix/store/khislvcrbgv3xm5i9f9nmmvrmrw73rjz-rustc-1.72.1/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/rustco0oVXb/liblibgit2_sys-8c16854d3ddae8ac.rlib" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/rustco0oVXb/liblibssh2_sys-ee1c97adb9b2b24b.rlib" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/rustco0oVXb/libcurl_sys-e796053d15423ce8.rlib" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/rustco0oVXb/liblibnghttp2_sys-0feccc35ec7fc448.rlib" "/nix/store/khislvcrbgv3xm5i9f9nmmvrmrw73rjz-rustc-1.72.1/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-fbf04098a808021a.rlib" "-liconv" "-framework" "Security" "-framework" "CoreFoundation" "-lssl" "-lcrypto" "-lclang_rt.osx" "-framework" "Security" "-framework" "CoreFoundation" "-framework" "CoreServices" "-framework" "SystemConfiguration" "-lz" "-framework" "CoreFoundation" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/khislvcrbgv3xm5i9f9nmmvrmrw73rjz-rustc-1.72.1/lib/rustlib/x86_64-apple-darwin/lib" "-o" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/deps/cargo_outdated-376103bd52324c3d" "-Wl,-dead_strip" "-nodefaultlibs" "/private/tmp/nix-build-cargo-outdated-0.14.0.drv-6/cargo-outdated-0.14.0.tar.gz/target/x86_64-apple-darwin/release/deps/cargo_outdated_audit_data.o" "-Wl,-u,_AUDITABLE_VERSION_INFO"
  = note: ld: framework not found CoreServices
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `cargo-outdated` (bin "cargo-outdated") due to previous error
```
</details>

Fix this by adding `CoreServices` to `buildInputs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
