### PR TITLE
sudachi-rs: init at 0.6.7; python311Packages.sudachipy: init at 0.6.7; sudachidict: init at 20230927

### DIFF
--- a/pkgs/by-name/su/sudachi-rs/package.nix
+++ b/pkgs/by-name/su/sudachi-rs/package.nix
@@ -1,0 +1,49 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, sudachidict
+, runCommand
+, sudachi-rs
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sudachi-rs";
+  version = "0.6.7";
+
+  src = fetchFromGitHub {
+    owner = "WorksApplications";
+    repo = "sudachi.rs";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-VzNOI6PP9sKBsNfB5yIxAI8jI8TEdM4tD49Jl/2tkSE=";
+  };
+
+  postPatch = ''
+    substituteInPlace sudachi/src/config.rs \
+      --replace '"resources"' '"${placeholder "out"}/share/resources"'
+  '';
+
+  cargoHash = "sha256-b2NtgHcMkimzFFuqohAo9KdSaIq6oi3qo/k8/VugyFs=";
+
+  # prepare the resources before the build so that the binary can find sudachidict
+  preBuild = ''
+    install -Dm644 ${sudachidict}/share/system.dic resources/system.dic
+    install -Dm644 resources/* -t $out/share/resources
+  '';
+
+  passthru.tests = {
+    # detects an error that sudachidict is not found
+    cli = runCommand "${pname}-cli-test" { } ''
+      mkdir $out
+      echo "高輪ゲートウェイ駅" | ${lib.getExe sudachi-rs} > $out/result
+    '';
+  };
+
+  meta = with lib; {
+    description = "A Japanese morphological analyzer";
+    homepage = "https://github.com/WorksApplications/sudachi.rs";
+    changelog = "https://github.com/WorksApplications/sudachi.rs/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ natsukium ];
+    mainProgram = "sudachi";
+  };
+}

--- a/pkgs/by-name/su/sudachidict/package.nix
+++ b/pkgs/by-name/su/sudachidict/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+, dict-type ? "core"
+}:
+
+let
+  pname = "sudachidict";
+  version = "20230927";
+
+  srcs = {
+    core = fetchzip {
+      url = "https://github.com/WorksApplications/SudachiDict/releases/download/v${version}/sudachi-dictionary-${version}-core.zip";
+      hash = "sha256-c88FfC03AU8eP37RVu9M3BAIlwFlTJqQJ60PK94mHOc=";
+    };
+    small = fetchzip {
+      url = "https://github.com/WorksApplications/SudachiDict/releases/download/v${version}/sudachi-dictionary-${version}-small.zip";
+      hash = "sha256-eaYD2C/qPeZJvmOeqH307a6OXtYfuksf6VZt+9kM7eM=";
+    };
+    full = fetchzip {
+      url = "https://github.com/WorksApplications/SudachiDict/releases/download/v${version}/sudachi-dictionary-${version}-full.zip";
+      hash = "sha256-yiO33UUQHcf6LvHJ1Is4MJtI5GSHuIP/tsE9m/KZ01o=";
+    };
+  };
+in
+
+lib.checkListOfEnum "${pname}: dict-type" [ "core" "full" "small" ] [ dict-type ]
+
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+
+  src = srcs.${dict-type};
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 system_${dict-type}.dic $out/share/system.dic
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    dict-type = dict-type;
+  };
+
+  meta = with lib; {
+    description = "A lexicon for Sudachi";
+    homepage = "https://github.com/WorksApplications/SudachiDict";
+    changelog = "https://github.com/WorksApplications/SudachiDict/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ natsukium ];
+    platforms = platforms.all;
+    # it is a waste of space and time to build this package in hydra since it is just data
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/development/python-modules/sudachidict/default.nix
+++ b/pkgs/development/python-modules/sudachidict/default.nix
@@ -1,0 +1,42 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, sudachidict
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "sudachidict-${sudachidict.dict-type}";
+  inherit (sudachidict) version meta;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "WorksApplications";
+    repo = "SudachiDict";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-xJ/iPywOZA2kzHaVU43Bc8TUboj3OpDg1kLFMIc/T90=";
+  };
+
+  sourceRoot = "source/python";
+
+  # setup script tries to get data from the network but we use the nixpkgs' one
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'ZIP_NAME = urlparse(ZIP_URL).path.split("/")[-1]' "" \
+      --replace "not os.path.exists(RESOURCE_DIR)" "False"
+    substituteInPlace INFO.json \
+      --replace "%%VERSION%%" ${version} \
+      --replace "%%DICT_VERSION%%" ${version} \
+      --replace "%%DICT_TYPE%%" ${sudachidict.dict-type}
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  # we need to prepare some files before the build
+  # https://github.com/WorksApplications/SudachiDict/blob/develop/package_python.sh
+  preBuild = ''
+    install -Dm644 ${sudachidict}/share/system.dic -t sudachidict_${sudachidict.dict-type}/resources
+    touch sudachidict_${sudachidict.dict-type}/__init__.py
+  '';
+}

--- a/pkgs/development/python-modules/sudachipy/default.nix
+++ b/pkgs/development/python-modules/sudachipy/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, cargo
+, libiconv
+, rustPlatform
+, rustc
+, sudachi-rs
+, setuptools-rust
+, pytestCheckHook
+, sudachidict-core
+, tokenizers
+}:
+
+buildPythonPackage rec {
+  pname = "sudachipy";
+  inherit (sudachi-rs) src version;
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-Am+ae2lgnndSDzf0GF8R1i6OPLdIlm2dLThqYqXbscA=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    setuptools-rust
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
+
+  preBuild = ''
+    cd python
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    sudachidict-core
+    tokenizers
+  ];
+
+  pythonImportsCheck = [
+    "sudachipy"
+  ];
+
+  meta = sudachi-rs.meta // {
+    homepage = "https://github.com/WorksApplications/sudachi.rs/tree/develop/python";
+    mainProgram = "sudachipy";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13516,6 +13516,16 @@ self: super: with self; {
 
   succulent = callPackage ../development/python-modules/succulent { };
 
+  sudachidict-core = callPackage ../development/python-modules/sudachidict { };
+
+  sudachidict-full = callPackage ../development/python-modules/sudachidict {
+    sudachidict = pkgs.sudachidict.override { dict-type = "full"; };
+  };
+
+  sudachidict-small = callPackage ../development/python-modules/sudachidict {
+    sudachidict = pkgs.sudachidict.override { dict-type = "small"; };
+  };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   sumtypes = callPackage ../development/python-modules/sumtypes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13526,6 +13526,8 @@ self: super: with self; {
     sudachidict = pkgs.sudachidict.override { dict-type = "small"; };
   };
 
+  sudachipy = callPackage ../development/python-modules/sudachipy { };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   sumtypes = callPackage ../development/python-modules/sumtypes { };


### PR DESCRIPTION
## Description of changes

sudachi-rs
- sudachi.rs is a Rust implementation of [Sudachi](https://github.com/WorksApplications/Sudachi), a Japanese morphological analyzer.
- https://github.com/WorksApplications/sudachi.rs

sudachidict
- A lexicon for Sudachi
- https://github.com/WorksApplications/SudachiDict

sudachipy
- SudachiPy is a Python version of [Sudachi](https://github.com/WorksApplications/Sudachi), a Japanese morphological analyzer.
- https://github.com/WorksApplications/sudachi.rs/tree/develop/python

sudachidict-{core,small,full}
- Sudachi Dictionary for SudachiPy
- https://github.com/WorksApplications/SudachiDict/tree/develop/python


cc @teto if you are interested.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
