### PR TITLE
open-english-wordnet: init at 2022

### DIFF
--- a/pkgs/by-name/op/open-english-wordnet/package.nix
+++ b/pkgs/by-name/op/open-english-wordnet/package.nix
@@ -42,14 +42,14 @@ stdenvNoCC.mkDerivation (self: {
     python scripts/merge.py
 
     echo Compressing
-    gzip --best --no-name ./wn.xml
+    gzip --best --no-name --stdout ./wn.xml > 'oewn:${self.version}.xml.gz'
 
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    install -Dt $out/share/wordnet wn.xml.gz
+    install -Dt $out/share/wordnet 'oewn:${self.version}.xml.gz'
     runHook postInstall
   '';
 

--- a/pkgs/by-name/op/open-english-wordnet/package.nix
+++ b/pkgs/by-name/op/open-english-wordnet/package.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , gzip
 , python3
 , stdenvNoCC
@@ -14,6 +15,16 @@ stdenvNoCC.mkDerivation (self: {
     repo = "english-wordnet";
     rev = "${self.version}-edition";
     hash = "sha256-a1fWIp39uuJZL1aFX/r+ttLB1+kwh/XPHwphgENTQ5M=";
+  };
+
+  patches = lib.mapAttrsToList (rev: hash: fetchpatch {
+    url = "https://github.com/globalwordnet/english-wordnet/commit/${rev}.patch";
+    inherit hash;
+  }) {
+    # Upstream commit bumping the version number, accidentally ommited from the tagged release
+    "bc07902f8995b62c70f01a282b23f40f30630540" = "sha256-1e4MG/k86g3OFUhiShCCbNXnvDKrYFr1KlGVsGl++KI=";
+    # PR #982, “merge.py: Make result independent of filesystem order”
+    "6da46a48dd76a48ad9ff563e6c807b8271fc83cd" = "sha256-QkkJH7NVGy/IbeSWkotU80IGF4esz0b8mIL9soHdQtQ=";
   };
 
   # TODO(nicoo): make compression optional?

--- a/pkgs/by-name/op/open-english-wordnet/package.nix
+++ b/pkgs/by-name/op/open-english-wordnet/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, fetchFromGitHub
+, gzip
+, python3
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation (self: {
+  pname = "open-english-wordnet";
+  version = "2022";
+
+  src = fetchFromGitHub {
+    owner = "globalwordnet";
+    repo = "english-wordnet";
+    rev = "${self.version}-edition";
+    hash = "sha256-a1fWIp39uuJZL1aFX/r+ttLB1+kwh/XPHwphgENTQ5M=";
+  };
+
+  # TODO(nicoo): make compression optional?
+  nativeBuildInputs = [
+    gzip
+    (python3.withPackages (p: with p; [ pyyaml ]))
+  ];
+
+  # TODO(nicoo): generate LMF and WNDB versions with separate outputs
+  buildPhase = ''
+    runHook preBuild
+
+    echo Generating wn.xml
+    python scripts/from-yaml.py
+    python scripts/merge.py
+
+    echo Compressing
+    gzip --best --no-name ./wn.xml
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/share/wordnet wn.xml.gz
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lexical network of the English language";
+    longDescription = ''
+      Open English WordNet is a lexical network of the English language grouping
+      words into synsets and linking them according to relationships such as
+      hypernymy, antonymy and meronymy. It is intended to be used in natural
+      language processing applications and provides deep lexical information
+      about the English language as a graph.
+
+      Open English WordNet is a fork of the Princeton Wordnet developed under an
+      open source methodology.
+    '';
+    homepage = "https://en-word.net/";
+    license = licenses.cc-by-40;
+    maintainers = with maintainers; [ nicoo ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

- Packaged [Open English WordNet](https://en-word.net/)
- Wrote a patch for reproducibility issues, submitted it upstream.

Having WordNet in nixpkgs would allow improving tools like `wordbook` which use that data, but currently download it at runtime (in the user's homedir)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
