### PR TITLE
feather: init at 2.5.2

### DIFF
--- a/pkgs/by-name/fe/feather/package.nix
+++ b/pkgs/by-name/fe/feather/package.nix
@@ -1,0 +1,84 @@
+{ boost
+, cmake
+, fetchFromGitHub
+, hidapi
+, lib
+, libsodium
+, libusb1
+, openssl
+, pkg-config
+, protobuf
+, qrencode
+, qt6
+, readline
+, stdenv
+, testers
+, tor
+, unbound
+, zxing-cpp
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "feather";
+  version = "2.5.2";
+
+  src = fetchFromGitHub {
+    owner = "feather-wallet";
+    repo = "feather";
+    rev = finalAttrs.version;
+    hash = "sha256-OSBG2W35GYlViwz5eXokpScrMTtPSaWAgEUNw2urm6w=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost
+    hidapi
+    libsodium
+    libusb1
+    openssl
+    protobuf
+    qrencode
+    unbound
+    zxing-cpp
+  ] ++ (with qt6; [
+    qtbase
+    qtmultimedia
+    qtsvg
+    qttools
+    qtwayland
+    qtwebsockets
+  ]);
+
+  cmakeFlags = [
+    "-DProtobuf_INCLUDE_DIR=${lib.getDev protobuf}/include"
+    "-DProtobuf_PROTOC_EXECUTABLE=${lib.getExe protobuf}"
+    "-DReadline_INCLUDE_DIR=${lib.getDev readline}/include/readline"
+    "-DReadline_LIBRARY=${lib.getLib readline}/lib/libreadline.so"
+    "-DReadline_ROOT_DIR=${lib.getDev readline}"
+    "-DTOR_DIR=${lib.makeBinPath [ tor ]}"
+    "-DTOR_VERSION=${tor.version}"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = ''
+      QT_QPA_PLATFORM=minimal ${finalAttrs.finalPackage.meta.mainProgram} --version
+    '';
+  };
+
+  meta = with lib; {
+    description = "A free Monero desktop wallet";
+    homepage = "https://featherwallet.org/";
+    changelog = "https://featherwallet.org/changelog/#${finalAttrs.version}%20changelog";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    mainProgram = "feather";
+    maintainers = with maintainers; [ surfaceflinger ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Added a package for [Feather Wallet](https://featherwallet.org/). Based on #186382 which seems stale now.

 - [x] Works with my Ledger
 - [x] Tested with my own Monero node
 - [x] Tested embedded TOR and connected to a remote onion node
 - [x] Made a churn transaction

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
