### PR TITLE
nixos/akkoma: Do not warn under sudo-rs

### DIFF
--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -909,7 +909,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    warnings = optionals (!config.security.sudo.enable) [''
+    warnings = optionals (with config.security; (!sudo.enable) && (!sudo-rs.enable)) [''
       The pleroma_ctl wrapper enabled by the installWrapper option relies on
       sudo, which appears to have been disabled through security.sudo.enable.
     ''];


### PR DESCRIPTION
## Description of changes

Updated the warnings in the `akkoma` module, following #256491 splitting `sudo-rs` support into a separate module.

cc @illdefined

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - NixOS test `akkoma`, ran as-is and modified to use `sudo-rs`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
