### PR TITLE
nixos/btrbk: Support sudo-rs

### DIFF
--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -47,8 +47,21 @@ let
     then [ "${name} ${value}" ]
     else concatLists (mapAttrsToList (genSection name) value);
 
+  sudoRule = {
+    users = [ "btrbk" ];
+    commands = [
+      { command = "${pkgs.btrfs-progs}/bin/btrfs"; options = [ "NOPASSWD" ]; }
+      { command = "${pkgs.coreutils}/bin/mkdir"; options = [ "NOPASSWD" ]; }
+      { command = "${pkgs.coreutils}/bin/readlink"; options = [ "NOPASSWD" ]; }
+      # for ssh, they are not the same than the one hard coded in ${pkgs.btrbk}
+      { command = "/run/current-system/sw/bin/btrfs"; options = [ "NOPASSWD" ]; }
+      { command = "/run/current-system/sw/bin/mkdir"; options = [ "NOPASSWD" ]; }
+      { command = "/run/current-system/sw/bin/readlink"; options = [ "NOPASSWD" ]; }
+    ];
+  };
+
   sudo_doas =
-    if config.security.sudo.enable then "sudo"
+    if config.security.sudo.enable || config.security.sudo-rs.enable then "sudo"
     else if config.security.doas.enable then "doas"
     else throw "The btrbk nixos module needs either sudo or doas enabled in the configuration";
 
@@ -157,22 +170,10 @@ in
   };
   config = mkIf (sshEnabled || serviceEnabled) {
     environment.systemPackages = [ pkgs.btrbk ] ++ cfg.extraPackages;
-    security.sudo = mkIf (sudo_doas == "sudo") {
-      extraRules = [
-        {
-            users = [ "btrbk" ];
-            commands = [
-            { command = "${pkgs.btrfs-progs}/bin/btrfs"; options = [ "NOPASSWD" ]; }
-            { command = "${pkgs.coreutils}/bin/mkdir"; options = [ "NOPASSWD" ]; }
-            { command = "${pkgs.coreutils}/bin/readlink"; options = [ "NOPASSWD" ]; }
-            # for ssh, they are not the same than the one hard coded in ${pkgs.btrbk}
-            { command = "/run/current-system/sw/bin/btrfs"; options = [ "NOPASSWD" ]; }
-            { command = "/run/current-system/sw/bin/mkdir"; options = [ "NOPASSWD" ]; }
-            { command = "/run/current-system/sw/bin/readlink"; options = [ "NOPASSWD" ]; }
-            ];
-        }
-      ];
-    };
+
+    security.sudo.extraRules = mkIf (sudo_doas == "sudo") [ sudoRule ];
+    security.sudo-rs.extraRules = mkIf (sudo_doas == "sudo") [ sudoRule ];
+
     security.doas = mkIf (sudo_doas == "doas") {
       extraRules = let
         doasCmdNoPass = cmd: { users = [ "btrbk" ]; cmd = cmd; noPass = true; };


### PR DESCRIPTION
## Description of changes

- Updated the `btrbk` NixOS module to support `sudo-rs`, following #256491 splitting sudo-rs support into a separate module.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) `btrbk{, -no-timer, -section-order}`
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
