### PR TITLE
nixos/amazon-ssm-agent: Support sudo-rs

### DIFF
--- a/nixos/modules/services/misc/amazon-ssm-agent.nix
+++ b/nixos/modules/services/misc/amazon-ssm-agent.nix
@@ -15,6 +15,11 @@ let
       -r) echo "${config.system.nixos.version}";;
     esac
   '';
+
+  sudoRule = {
+    users = [ "ssm-user" ];
+    commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
+  };
 in {
   imports = [
     (mkRenamedOptionModule [ "services" "ssm-agent" "enable" ] [ "services" "amazon-ssm-agent" "enable" ])
@@ -51,17 +56,9 @@ in {
 
     # Add user that Session Manager needs, and give it sudo.
     # This is consistent with Amazon Linux 2 images.
-    security.sudo.extraRules = [
-      {
-        users = [ "ssm-user" ];
-        commands = [
-          {
-            command = "ALL";
-            options = [ "NOPASSWD" ];
-          }
-        ];
-      }
-    ];
+    security.sudo.extraRules = [ sudoRule ];
+    security.sudo-rs.extraRules = [ sudoRule ];
+
     # On Amazon Linux 2 images, the ssm-user user is pretty much a
     # normal user with its own group. We do the same.
     users.groups.ssm-user = {};


### PR DESCRIPTION
## Description of changes

Update the `amazon-ssm-agent` module, following #256491 splitting sudo-rs support into a separate module.

cc @copumpkin


## Things done

- No NixOS test found
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
