### PR TITLE
nixos/vagrant-guest: Support sudo-rs

### DIFF
--- a/nixos/modules/virtualisation/vagrant-guest.nix
+++ b/nixos/modules/virtualisation/vagrant-guest.nix
@@ -55,4 +55,5 @@ in
   };
 
   security.sudo.wheelNeedsPassword = false;
+  security.sudo-rs.wheelNeedsPassword = false;
 }


### PR DESCRIPTION
## Description of changes

Update the `vagrant-guest` module, following #256491 splitting sudo-rs support into a separate module.

cc @Mic92 @zimbatm (co-authored the module)


## Things done

- No NixOS test found
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
