### PR TITLE
stdenv: run patchShebangs on the configure script when it's a file

### DIFF
--- a/pkgs/applications/editors/vis/default.nix
+++ b/pkgs/applications/editors/vis/default.nix
@@ -30,10 +30,6 @@ stdenv.mkDerivation rec {
     libselinux
   ];
 
-  postPatch = ''
-    patchShebangs ./configure
-  '';
-
   postInstall = ''
     wrapProgram $out/bin/vis \
       --prefix LUA_CPATH ';' "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \

--- a/pkgs/by-name/ze/zesarux/package.nix
+++ b/pkgs/by-name/ze/zesarux/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   sourceRoot = "${finalAttrs.src.name}/src";
 
   postPatch = ''
-    patchShebangs ./configure *.sh
+    patchShebangs *.sh
   '';
 
   configureFlags = [

--- a/pkgs/data/documentation/stdman/default.nix
+++ b/pkgs/data/documentation/stdman/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   outputDevdoc = "out";
 
   preConfigure = "
-    patchShebangs ./configure
     patchShebangs ./do_install
   ";
 

--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -14,9 +14,4 @@ mkCoqDerivation {
   release."20200201".sha256 = "1h55s6lk47bk0lv5ralh81z55h799jbl9mhizmqwqzy57y8wqgs1";
 
   propagatedBuildInputs = [ StructTact ];
-  preConfigure = ''
-    if [ -f ./configure ]; then
-      patchShebangs ./configure
-    fi
-  '';
 }

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -12,9 +12,4 @@ mkCoqDerivation {
   release."20230107".sha256 = "sha256-YMBzVIsLkIC+w2TeyHrKe29eWLIxrH3wIMZqhik8p9I=";
   release."20200131".rev    = "203d4c20211d6b17741f1fdca46dbc091f5e961a";
   release."20200131".sha256 = "0xylkdmb2dqnnqinf3pigz4mf4zmczcbpjnn59g5g76m7f2cqxl0";
-  preConfigure = ''
-    if [ -f ./configure ]; then
-      patchShebangs ./configure
-    fi
-  '';
 }

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -15,9 +15,4 @@ mkCoqDerivation {
   release."20210328".sha256 = "sha256:1y5r1zm3hli10ah6lnj7n8hxad6rb6rgldd0g7m2fjibzvwqzhdg";
   release."20181102".rev =    "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
   release."20181102".sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
-  preConfigure = ''
-    if [ -f ./configure ]; then
-      patchShebangs ./configure
-    fi
-  '';
 }

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -24,9 +24,4 @@ mkCoqDerivation {
   release."20181102".sha256 = "1vw47c37k5vaa8vbr6ryqy8riagngwcrfmb3rai37yi9xhdqg55z";
 
   propagatedBuildInputs = [ Cheerios InfSeqExt ssreflect ];
-  preConfigure = ''
-    if [ -f ./configure ]; then
-      patchShebangs ./configure
-    fi
-  '';
 }

--- a/pkgs/development/coq-modules/corn/default.nix
+++ b/pkgs/development/coq-modules/corn/default.nix
@@ -17,7 +17,6 @@ mkCoqDerivation rec {
     "8.18.0".sha256 = "sha256-ow3mfarZ1PvBGf5WLnI8LdF3E+8A6fN7cOcXHrZJLo0=";
   };
 
-  preConfigure = "patchShebangs ./configure.sh";
   configureScript = "./configure.sh";
   dontAddPrefix = true;
 

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -48,7 +48,6 @@ let
         propagatedBuildInputs = [ equations coq.ocamlPackages.zarith ] ++ metacoq-deps;
 
         patchPhase =  ''
-          patchShebangs ./configure.sh
           patchShebangs ./template-coq/update_plugin.sh
           patchShebangs ./template-coq/gen-src/to-lower.sh
           patchShebangs ./pcuic/clean_extraction.sh

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -31,9 +31,6 @@ stdenv.mkDerivation rec {
     sha256 = "005d993xcac8236fpvd1iawkz4wqjybkpn8dbwaliqz5jfkidlyn";
   };
 
-  # make: *** No rule to make target 'build/*.lo', needed by 'build/libSDL.la'.  Stop.
-  postPatch = "patchShebangs ./configure";
-
   outputs = [ "out" "dev" ];
   outputBin = "dev"; # sdl-config
 

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   doCheck = true; # not cross;
 
   preCheck = ''
-    patchShebangs ./configure ./run.sh ./test-driver-wrapper.sh
+    patchShebangs ./run.sh ./test-driver-wrapper.sh
   '';
 
   # CMake files incorrectly calculate library path from dev prefix

--- a/pkgs/development/libraries/physics/fastjet-contrib/default.nix
+++ b/pkgs/development/libraries/physics/fastjet-contrib/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     for f in Makefile.in */Makefile; do
       substituteInPlace "$f" --replace "CXX=g++" ""
     done
-    patchShebangs ./configure ./utils/check.sh ./utils/install-sh
+    patchShebangs ./utils/check.sh ./utils/install-sh
   '';
 
   # Written in shell manually, does not support autoconf-style

--- a/pkgs/development/libraries/physics/pythia/default.nix
+++ b/pkgs/development/libraries/physics/pythia/default.nix
@@ -13,10 +13,6 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
   buildInputs = [ boost fastjet hepmc zlib lhapdf ];
 
-  preConfigure = ''
-    patchShebangs ./configure
-  '';
-
   configureFlags = [
     "--enable-shared"
     "--with-lhapdf6=${lhapdf}"

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  preConfigure = "patchShebangs ./configure.sh";
-
   configureScript = "./configure.sh";
   dontAddPrefix = "true";
   dontAddStaticConfigureFlags = true;

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
-  preConfigure = "patchShebangs ./configure.sh";
-
   configureScript = "./configure.sh";
   dontAddPrefix = "true";
   dontAddStaticConfigureFlags = true;

--- a/pkgs/development/tools/kcat/default.nix
+++ b/pkgs/development/tools/kcat/default.nix
@@ -16,10 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib rdkafka yajl avro-c libserdes ];
 
-  preConfigure = ''
-    patchShebangs ./configure
-  '';
-
   meta = with lib; {
     description = "A generic non-JVM producer and consumer for Apache Kafka";
     homepage = "https://github.com/edenhill/kcat";

--- a/pkgs/development/tools/pyenv/default.nix
+++ b/pkgs/development/tools/pyenv/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-liDm8lcHSdn9f/tNISRlnqEIcBtmusMplH0N4tW5Lgo=";
   };
 
-  postPatch = ''
-    patchShebangs --build src/configure
-  '';
-
   nativeBuildInputs = [
     installShellFiles
   ];

--- a/pkgs/games/eboard/default.nix
+++ b/pkgs/games/eboard/default.nix
@@ -16,10 +16,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  preConfigure = ''
-    patchShebangs ./configure
-  '';
-
   env.NIX_CFLAGS_COMPILE = "-fpermissive";
 
   meta = {

--- a/pkgs/os-specific/linux/dracut/default.nix
+++ b/pkgs/os-specific/linux/dracut/default.nix
@@ -61,10 +61,6 @@ stdenv.mkDerivation rec {
     echo 'DRACUT_VERSION=${version}' >dracut-version.sh
   '';
 
-  preConfigure = ''
-    patchShebangs ./configure
-  '';
-
   postFixup = ''
     wrapProgram $out/bin/dracut --prefix PATH : ${lib.makeBinPath [
       coreutils

--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -11,10 +11,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-RvjYd8iD6JkGhh6TDy/Qo+UzLxbhPvIJvhl/Rw14lbk=";
   };
 
-  postPatch = ''
-    patchShebangs ./configure
-  '';
-
   configureFlags = [ "--datadir=${placeholder "out"}/share" ];
 
   doCheck = false; # this does build machine-specific checks (e.g. enumerates PCI bus)

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -102,8 +102,6 @@ in stdenv.mkDerivation {
   ];
 
   preConfigure = ''
-    patchShebangs ./configure
-
     substituteInPlace src/config.c \
       --replace /usr/bin/tar ${gnutar}/bin/tar
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1273,6 +1273,10 @@ configurePhase() {
                 prependToVar configureFlags --disable-static
             fi
         fi
+
+        if [ -z "${dontPatchShebangsInConfigure:-}" ]; then
+            patchShebangs --build "$configureScript"
+        fi
     fi
 
     if [ -n "$configureScript" ]; then

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -40,8 +40,6 @@ stdenv.mkDerivation rec {
     substituteInPlace hooks/dhcpcd-run-hooks.in --replace /bin/sh ${runtimeShell}
   '';
 
-  preConfigure = "patchShebangs ./configure";
-
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"


### PR DESCRIPTION
if the configure script has a `/usr/bin/env` or some other shebang which is not in the sandbox then there will be errors such as

`...-stdenv-linux/setup: line 1299: ./configure: cannot execute: required file not found`

There are 250 files which `patchShebangs` `./configure`

https://github.com/search?q=NOT+is%3Afork+lang%3Anix+%2FpatchShebangs+.%5C%2Fconfigure%2F&type=code

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
