### PR TITLE
python311Packages.img2pdf: fix evaluation on darwin

### DIFF
--- a/pkgs/development/python-modules/img2pdf/default-icc-profile.patch
+++ b/pkgs/development/python-modules/img2pdf/default-icc-profile.patch
@@ -14,7 +14,7 @@ index 036232b..d2e7829 100755
 -        if os.path.exists(profile):
 -            return profile
 -    return "/usr/share/color/icc/sRGB.icc"
-+    return "@colord@/share/color/icc/colord/sRGB.icc"
++    return "@srgbProfile@"
  
  
  def get_main_parser():

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -38,7 +38,10 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./default-icc-profile.patch;
-      inherit colord;
+      srgbProfile = if stdenv.isDarwin then
+        "/System/Library/ColorSync/Profiles/sRGB Profile.icc"
+      else
+        "${colord}/share/color/icc/colord/sRGB.icc";
     })
     (fetchpatch {
       # https://gitlab.mister-muffin.de/josch/img2pdf/issues/178
@@ -55,6 +58,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pikepdf
     pillow
+  ];
+
+  # FIXME: Only add "sRGB Profile.icc" to __impureHostDeps once
+  # https://github.com/NixOS/nix/issues/9301 is fixed.
+  __impureHostDeps = lib.optionals stdenv.isDarwin [
+    "/System/Library/ColorSync/Profiles"
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The img2pdf derivation uses the sRGB ICC profile provided by colord starting with #264119. colord and several of its dependencies only support Linux, so this broke evaluation on Darwin. This change drops the use of colord on Darwin to fix the derivation; the system-provided sRGB profile is used instead.

`__impureHostDeps` should be updated to only include `/System/Library/ColorSync/Profiles/sRGB Profile.icc` once https://github.com/NixOS/nix/issues/9301 is fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
