### PR TITLE
freeradius: add option to compile with postgres

### DIFF
--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -10,14 +10,14 @@ let
     after = ["network.target"];
     wants = ["network.target"];
     preStart = ''
-      ${pkgs.freeradius}/bin/radiusd -C -d ${cfg.configDir} -l stdout
+      ${cfg.package}/bin/radiusd -C -d ${cfg.configDir} -l stdout
     '';
 
     serviceConfig = {
-        ExecStart = "${pkgs.freeradius}/bin/radiusd -f -d ${cfg.configDir} -l stdout" +
+        ExecStart = "${cfg.package}/bin/radiusd -f -d ${cfg.configDir} -l stdout" +
                     lib.optionalString cfg.debug " -xx";
         ExecReload = [
-          "${pkgs.freeradius}/bin/radiusd -C -d ${cfg.configDir} -l stdout"
+          "${cfg.package}/bin/radiusd -C -d ${cfg.configDir} -l stdout"
           "${pkgs.coreutils}/bin/kill -HUP $MAINPID"
         ];
         User = "radius";
@@ -31,6 +31,8 @@ let
 
   freeradiusConfig = {
     enable = lib.mkEnableOption "the freeradius server";
+
+    package = lib.mkPackageOption pkgs "freeradius" { };
 
     configDir = lib.mkOption {
       type = lib.types.path;

--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -74,7 +74,9 @@ in
         /*uid = config.ids.uids.radius;*/
         description = "Radius daemon user";
         isSystemUser = true;
+        groups = "radius";
       };
+      groups.radius = {};
     };
 
     systemd.services.freeradius = freeradiusService cfg;

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -12,6 +12,7 @@
 , withLdap ? true, openldap
 , withMemcached ? false, libmemcached
 , withMysql ? false, libmysqlclient
+, withPostgresql ? false, postgresql
 , withPcap ? true, libpcap
 , withRedis ? false, hiredis
 , withRest ? false, curl
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withLdap openldap
     ++ lib.optional withMemcached libmemcached
     ++ lib.optional withMysql libmysqlclient
+    ++ lib.optional withPostgresql postgresql
     ++ lib.optional withPcap libpcap
     ++ lib.optional withRedis hiredis
     ++ lib.optional withRest curl


### PR DESCRIPTION
## Description of changes

There are 3 commits in this PR:
- An option to compile freeradius with postgresql enabled.
- An option to use arbitrary package for freeradius service (so the overriden package can be used)
- A fix to make freeradius service actually usable -- it's currently missing group for the user

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The option is off-by-default so doing a normal test build is pointless. I did a test build to confirm that postgres plugin is usable with `freeradius.override { withPostgresql = true; }`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
