### PR TITLE
dorion: 5.0.1 → 6.7.1; dorion: build from source

### DIFF
--- a/pkgs/by-name/do/dorion/no-cargo-patch.patch
+++ b/pkgs/by-name/do/dorion/no-cargo-patch.patch
@@ -1,0 +1,31 @@
+diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
+index 13a6b54..f6bd9d6 100644
+--- a/src-tauri/Cargo.lock
++++ b/src-tauri/Cargo.lock
+@@ -5049,6 +5049,8 @@ dependencies = [
+ [[package]]
+ name = "tauri-plugin-shell"
+ version = "2.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "69d5eb3368b959937ad2aeaf6ef9a8f5d11e01ffe03629d3530707bbcb27ff5d"
+ dependencies = [
+  "encoding_rs",
+  "log",
+diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
+index 4dcaa86..daef086 100644
+--- a/src-tauri/Cargo.toml
++++ b/src-tauri/Cargo.toml
+@@ -12,13 +12,6 @@ rust-version = "1.84.1"
+ strip = "debuginfo"
+ lto = false
+ 
+-# Patches
+-[package.metadata.patch]
+-crates = ["tauri-plugin-shell"]
+-
+-[patch.crates-io]
+-tauri-plugin-shell = { path="./target/patch/tauri-plugin-shell-2.2.1" }
+-
+ [build-dependencies]
+ tauri-build = { version = "2.0.0", features = [] }
+ 

--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -1,66 +1,193 @@
 {
   lib,
-  stdenv,
+  fetchFromGitHub,
   fetchurl,
-  autoPatchelfHook,
-  dpkg,
+  rustPlatform,
+  cmake,
+  ninja,
+  wrapGAppsHook4,
   glib-networking,
   gst_all_1,
-  libappindicator,
+  libsysprof-capture,
   libayatana-appindicator,
-  webkitgtk_4_0,
-  wrapGAppsHook3,
+  nodejs,
+  openssl,
+  pkg-config,
+  yq-go,
+  pnpm_9,
+  webkitgtk_4_1,
+  cargo-tauri,
+  desktop-file-utils,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "dorion";
-  version = "5.0.1";
-
-  src = fetchurl {
-    url = "https://github.com/SpikeHD/Dorion/releases/download/v${finalAttrs.version}/Dorion_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-cCZikTZ+IU3mq/FkJfeggXLyWIsWG+a2qu1GbgW93WQ=";
+let
+  webkitgtk_4_1' = webkitgtk_4_1.override {
+    enableExperimental = true;
   };
 
-  unpackCmd = ''
-    dpkg -X $curSrc .
-  '';
+  shelter = fetchurl {
+    url = "https://raw.githubusercontent.com/uwu/shelter-builds/fab6f100bd0ab8583d67f792f66722a7d2a14bd1/shelter.js";
+    hash = "sha256-d9vaKLrl8RYNcHnE1iGN49ov6U/Y+9XpEsio+c1Sguc=";
+    meta = {
+      homepage = "https://github.com/uwu/shelter";
+      sourceProvenance = [ lib.sourceTypes.binaryBytecode ]; # actually, minified JS
+      license = lib.licenses.cc0;
+    };
+  };
+in
 
-  runtimeDependencies = [
-    glib-networking
-    libappindicator
-    libayatana-appindicator
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dorion";
+  version = "6.7.1";
+
+  src = fetchFromGitHub {
+    owner = "SpikeHD";
+    repo = "Dorion";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-d4G3royqhz+te5wPWVLNqqG/w0qOvTd7dKcWSzxUMUo=";
+  };
+
+  cargoPatches = [
+    ./no-cargo-patch.patch
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-1xpAJkS31DjrZCY5WJ4/Z1t1ALED5gz7xYLhVR1Qzww=";
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-xBonUzA4+1zbViEsKap6CaG6ZRldW1LjNYIB+FmVRFs=";
+  };
+
+  # CMake (webkit extension)
+  cmakeDir = ".";
+  cmakeBuildDir = "src-tauri/extension_webkit";
+  dontUseCmakeConfigure = true;
+  dontUseNinjaBuild = true;
+  dontUseNinjaCheck = true;
+  dontUseNinjaInstall = true;
+  # cmake's supposed to set this automatically
+  # ... but the detection is based on the presence of ninja build hook
+  cmakeFlags = [
+    "-GNinja"
   ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
-    wrapGAppsHook3
+    pnpm_9.configHook
+    cargo-tauri.hook
+    nodejs
+    pkg-config
+    wrapGAppsHook4
+    yq-go
+    desktop-file-utils
+    cmake
+    ninja
   ];
 
   buildInputs = [
-    glib-networking
-    gst_all_1.gst-plugins-bad
+    openssl
+    webkitgtk_4_1'
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-good
-    webkitgtk_4_0
+    gst_all_1.gst-plugins-rs
+    glib-networking
+    libsysprof-capture
+    libayatana-appindicator
   ];
 
-  installPhase = ''
-    runHook preInstall
+  postPatch = ''
+    # remove updater
+    rm -rf updater
 
-    mkdir -pv $out
-    mv -v {bin,lib,share} $out
+    # patch cargo-deps
+    pushd $cargoDepsCopy/tauri-plugin-shell-*
+    patch -p1 < /build/source/src-tauri/patches/tauri-plugin-shell+*.patch
+    popd
 
-    runHook postInstall
+    substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+
+    # disable pre-build script and disable auto-updater
+    yq -iPo=json '
+      .bundle.resources = (.bundle.resources | map(select(. != "updater*")))
+    ' src-tauri/tauri.conf.json
+
+    # link shelter injection
+    ln -s ${shelter} src-tauri/injection/shelter.js
+
+    # link html/frontend data
+    ln -s /build/source/src /build/source/src-tauri/html
   '';
 
+  configurePhase = ''
+    cmakeConfigurePhase
+    pnpmConfigHook
+  '';
+
+  buildPhase = ''
+    ninjaBuildPhase
+    cd /build/source
+    tauriBuildHook
+  '';
+
+  postInstall = ''
+    # Set up the resource directories
+    mkdir -p $out/lib/Dorion
+    ln -s $out/lib/Dorion $out/lib/dorion
+    rm -rf $out/lib/Dorion/injection
+    cp -r src-tauri/injection $out/lib/Dorion
+    cp -r src $out/lib/Dorion
+
+    # Modify the desktop file
+    desktop-file-edit \
+      --set-comment "Tiny alternative Discord client" \
+      --set-key="Exec" --set-value="Dorion %U" \
+      --set-key="TryExec" --set-value="Dorion" \
+      --set-key="StartupWMClass" --set-value="Dorion" \
+      --set-key="StartupNotify" --set-value="true" \
+      --set-key="Categories" --set-value="Network;InstantMessaging;Chat;" \
+      --set-key="Keywords" --set-value="dorion;discord;vencord;chat;im;vc;ds;dc;dsc;tauri;" \
+      --set-key="Terminal" --set-value="false" \
+      --set-key="MimeType" --set-value="x-scheme-handler/discord" \
+      $out/share/applications/Dorion.desktop
+  '';
+
+  # error: failed to run custom build command for `Dorion v6.5.3 (/build/source/src-tauri)`
+  # Permission denied (os error 13)
+  doCheck = false;
+
+  env = {
+    TAURI_RESOURCE_DIR = "${placeholder "out"}/lib";
+  };
+
   meta = {
-    homepage = "https://github.com/SpikeHD/Dorion";
+    homepage = "https://spikehd.github.io/projects/dorion/";
     description = "Tiny alternative Discord client";
-    license = lib.licenses.gpl3Only;
-    mainProgram = "dorion";
-    maintainers = with lib.maintainers; [ aleksana ];
-    platforms = lib.intersectLists (lib.platforms.linux) (lib.platforms.x86_64);
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    longDescription = ''
+      Dorion is an alternative Discord client aimed towards lower-spec or
+      storage-sensitive PCs that supports themes, plugins, and more!
+    '';
+    changelog = "https://github.com/SpikeHD/Dorion/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/SpikeHD/Dorion/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      gpl3Only
+      cc0 # Shelter
+    ];
+    mainProgram = "Dorion";
+    maintainers = with lib.maintainers; [
+      nyabinary
+      aleksana
+      griffi-gh
+      getchoo
+    ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = [
+      lib.sourceTypes.binaryBytecode # actually, minified JS
+      lib.sourceTypes.fromSource
+    ];
   };
 })


### PR DESCRIPTION
## Description of changes
Build from source
Enable WebkitGTK Experimental toggle for WebRTC (To make VCs work)
Added myself to maintainer
Depends on #280554
Depends on #398783 (Currently in staging-next)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/360644

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Huge thanks to @lilyinstarlight this PR wouldn't be possible without her.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
