### PR TITLE
ocamlPackages: small fixes for OCaml ≥ 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 if lib.versionOlder ocaml.version "4.02"
+|| lib.versionAtLeast ocaml.version "5.0"
 then throw "erm_xml is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/fontconfig/default.nix
+++ b/pkgs/development/ocaml-modules/fontconfig/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, pkg-config, fontconfig, ocaml }:
 
 stdenv.mkDerivation {
-  pname = "ocaml-fontconfig";
+  pname = "ocaml${ocaml.version}-fontconfig";
   version = "unstable-2013-11-03";
 
   src = fetchFromGitHub {
@@ -10,6 +10,12 @@ stdenv.mkDerivation {
     rev = "42daf1697ffcee9c89ee4be3103b6427f7a7b7e5";
     sha256 = "1fw6bzydmnyh2g4x35mcbg0hypnxqhynivk4nakcsx7prr8zr3yh";
   };
+
+  postPatch = lib.optionalString (lib.versionAtLeast ocaml.version "4.03") ''
+    substituteInPlace extract_consts.ml \
+      --replace String.lowercase String.lowercase_ascii \
+      --replace String.capitalize String.capitalize_ascii
+  '';
 
   nativeBuildInputs = [ pkg-config ocaml ];
   buildInputs = [ fontconfig ];
@@ -24,7 +30,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Fontconfig bindings for OCaml";
     license = lib.licenses.gpl2Plus;
-    platforms = ocaml.meta.platforms or [ ];
+    platforms = ocaml.meta.platforms;
     maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, ocaml, findlib }:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "3.11";
-
 let param =
   if lib.versionAtLeast ocaml.version "4.02" then {
     version = "0.6";
@@ -11,6 +9,9 @@ let param =
     sha256 = "1j17rhifdjv1z262dma148ywg34x0zjn8vczdrnkwajsm4qg1hw3";
   };
 in
+
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "functory is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation {
   pname = "ocaml${ocaml.version}-functory";

--- a/pkgs/development/ocaml-modules/gd4o/default.nix
+++ b/pkgs/development/ocaml-modules/gd4o/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchurl, ocaml, gd, freetype, findlib, zlib, libpng, libjpeg }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "gd4o is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-gd4o";
   version = "1.0a5";

--- a/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
@@ -1,6 +1,9 @@
 { lib, buildDunePackage, ocaml, ocaml_gettext, dune-configurator, ounit }:
 
-buildDunePackage rec {
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "gettext-stub is not available for OCaml ${ocaml.version}"
+
+buildDunePackage {
 
   pname = "gettext-stub";
 


### PR DESCRIPTION
## Description of changes

Disable or fix a few legacy packages.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
