### PR TITLE
pynitrokey: 0.4.40 -> 0.4.42

### DIFF
--- a/pkgs/development/python-modules/nethsm/default.nix
+++ b/pkgs/development/python-modules/nethsm/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonRelaxDepsHook
+, flit-core
+, certifi
+, cryptography
+, python-dateutil
+, typing-extensions
+, urllib3
+}:
+
+let
+  pname = "nethsm";
+  version = "1.0.0";
+in
+
+buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-sENuSdA4pYt8v2w2RvDkcQLYCP9V0vZOdWOlkNBi3/o=";
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    cryptography
+    python-dateutil
+    typing-extensions
+    urllib3
+  ];
+
+  nativeBuildInputs = [
+    flit-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = true;
+
+  pythonImportsCheck = [ "nethsm" ];
+
+  meta = with lib; {
+    description = "Client-side Python SDK for NetHSM";
+    homepage = "https://github.com/Nitrokey/nethsm-sdk-py";
+    changelog = "https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v${version}";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ frogamic ];
+  };
+}

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -1,63 +1,82 @@
 { lib
-, python3Packages
+, buildPythonApplication
 , fetchPypi
-, nrfutil
+, pythonRelaxDepsHook
+, installShellFiles
 , libnitrokey
-, nix-update-script
+, flit-core
+, certifi
+, cffi
+, click
+, cryptography
+, ecdsa
+, fido2
+, intelhex
+, nkdfu
+, python-dateutil
+, pyusb
+, requests
+, spsdk
+, tqdm
+, tlv8
+, typing-extensions
+, pyserial
+, protobuf
+, click-aliases
+, semver
+, nethsm
+, importlib-metadata
 }:
 
-with python3Packages;
-
-buildPythonApplication rec {
+let
   pname = "pynitrokey";
-  version = "0.4.40";
-  format = "pyproject";
+  version = "0.4.42";
+  mainProgram = "nitropy";
+in
+
+buildPythonApplication {
+  inherit pname version;
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Hu+8UooDzv4GhkWt0sCckQQyHjWn4V/zt2ADlVCoHmk=";
+    hash = "sha256-KLUuMTGiPqm2C3+TWS7nBNZAq+rGxAL/mMaT94SkYWY=";
   };
 
   propagatedBuildInputs = [
     certifi
     cffi
     click
-    click-aliases
     cryptography
     ecdsa
-    frozendict
     fido2
     intelhex
     nkdfu
-    nrfutil
     python-dateutil
     pyusb
     requests
-    semver
     spsdk
     tqdm
-    urllib3
     tlv8
     typing-extensions
+    pyserial
+    protobuf
+    click-aliases
+    semver
+    nethsm
     importlib-metadata
   ];
 
   nativeBuildInputs = [
     flit-core
+    installShellFiles
     pythonRelaxDepsHook
   ];
 
-  # FIXME: does pythonRelaxDepsHook not work for pypaBuildHook + flit-core?
-  pypaBuildFlags = [ "--skip-dependency-check" ];
+  pythonRelaxDeps = true;
 
-  pythonRelaxDeps = [
-    "click"
-    "cryptography"
-    "protobuf"
-    "python-dateutil"
-    "spsdk"
-    "typing_extensions"
-  ];
+  # pythonRelaxDepsHook runs in postBuild so cannot be used
+  pypaBuildFlags = [ "--skip-dependency-check" ];
 
   # libnitrokey is not propagated to users of the pynitrokey Python package.
   # It is only usable from the wrapped bin/nitropy
@@ -70,13 +89,19 @@ buildPythonApplication rec {
 
   pythonImportsCheck = [ "pynitrokey" ];
 
-  passthru.updateScript = nix-update-script { };
+  postInstall = ''
+    installShellCompletion --cmd ${mainProgram} \
+      --bash <(_NITROPY_COMPLETE=bash_source $out/bin/${mainProgram}) \
+      --zsh <(_NITROPY_COMPLETE=zsh_source $out/bin/${mainProgram}) \
+      --fish <(_NITROPY_COMPLETE=fish_source $out/bin/${mainProgram})
+  '';
 
   meta = with lib; {
     description = "Python client for Nitrokey devices";
     homepage = "https://github.com/Nitrokey/pynitrokey";
+    changelog = "https://github.com/Nitrokey/pynitrokey/releases/tag/v${version}";
     license = with licenses; [ asl20 mit ];
     maintainers = with maintainers; [ frogamic ];
-    mainProgram = "nitropy";
+    inherit mainProgram;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41726,7 +41726,7 @@ with pkgs;
 
   xrq = callPackage ../applications/misc/xrq { };
 
-  pynitrokey = callPackage ../tools/security/pynitrokey { };
+  pynitrokey = python3Packages.callPackage ../tools/security/pynitrokey { };
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8088,6 +8088,8 @@ self: super: with self; {
 
   netdisco = callPackage ../development/python-modules/netdisco { };
 
+  nethsm = callPackage ../development/python-modules/nethsm { };
+
   netifaces = callPackage ../development/python-modules/netifaces { };
 
   netmiko = callPackage ../development/python-modules/netmiko { };


### PR DESCRIPTION
## Description of changes

* Update pynitrokey to [0.4.42](https://github.com/Nitrokey/pynitrokey/releases/tag/v0.4.42)
* Add shell completion to nitropy
* Remove excess `with` and `rec` usage in pynitrokey
* Add new dependency: [nethsm at 1.0.0](https://github.com/Nitrokey/nethsm-sdk-py/)
* Closes #265314

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
