### PR TITLE
sshx: init at unstable-2023-11-04

### DIFF
--- a/pkgs/by-name/ss/sshx/package.nix
+++ b/pkgs/by-name/ss/sshx/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, protobuf
+, zstd
+, stdenv
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sshx";
+  version = "unstable-2023-11-04";
+
+  src = fetchFromGitHub {
+    owner = "ekzhang";
+    repo = "sshx";
+    rev = "91c82d46cde4d1ffa0ae34e2a9a49911e2e53baa";
+    hash = "sha256-X9c7ZKIpWI5EsbkgB8FJWlwQQXHAcPjLKp2Bvo0fo/w=";
+  };
+
+  cargoHash = "sha256-mOK5gpPuUKzN5xnJs5nFyslxr9IIHtiCylMP53ObDqg=";
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    zstd
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  outputs = [ "out" "server" ];
+
+  postInstall = ''
+    moveToOutput 'bin/sshx' "$out"
+    moveToOutput 'bin/sshx-server' "$server"
+  '';
+
+  meta = with lib; {
+    description = "Fast, collaborative live terminal sharing over the web";
+    homepage = "https://github.com/ekzhang/sshx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pinpox ];
+    mainProgram = "sshx";
+  };
+}


### PR DESCRIPTION
## Description of changes

Init sshx, A secure web-based, collaborative terminal

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
