### PR TITLE
rsync: fix regression with _FORTIFY_SOURCE=2

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
+  patches = [
+    # https://github.com/WayneD/rsync/issues/511#issuecomment-1774612577
+    # original source: https://build.opensuse.org/package/view_file/network/rsync/rsync-fortified-strlcpy-fix.patch?expand=1&rev=3f8dd2f4a404c96c0f69176e60893714
+    ./rsync-fortified-strlcpy-fix.patch
+  ];
+
   buildInputs = [ libiconv zlib popt ]
     ++ lib.optional enableACLs acl
     ++ lib.optional enableZstd zstd

--- a/pkgs/applications/networking/sync/rsync/rsync-fortified-strlcpy-fix.patch
+++ b/pkgs/applications/networking/sync/rsync/rsync-fortified-strlcpy-fix.patch
@@ -1,0 +1,49 @@
+From 1f83963f59960150e8c46112daa8411324c1f209 Mon Sep 17 00:00:00 2001
+From: Jiri Slaby <jslaby@suse.cz>
+Date: Fri, 18 Aug 2023 08:26:20 +0200
+Subject: [PATCH] exclude: fix crashes with fortified strlcpy()
+
+Fortified (-D_FORTIFY_SOURCE=2 for gcc) builds make strlcpy() crash when
+its third parameter (size) is larger than the buffer:
+  $ rsync -FFXHav '--filter=merge global-rsync-filter' Align-37-43/ xxx
+  sending incremental file list
+  *** buffer overflow detected ***: terminated
+
+It's in the exclude code in setup_merge_file():
+  strlcpy(y, save, MAXPATHLEN);
+
+Note the 'y' pointer was incremented, so it no longer points to memory
+with MAXPATHLEN "owned" bytes.
+
+Fix it by remembering the number of copied bytes into the 'save' buffer
+and use that instead of MAXPATHLEN which is clearly incorrect.
+
+Fixes #511.
+---
+ exclude.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/exclude.c b/exclude.c
+index ffe55b167..1a5de3b9e 100644
+--- a/exclude.c
++++ b/exclude.c
+@@ -720,7 +720,8 @@ static BOOL setup_merge_file(int mergelist_num, filter_rule *ex,
+ 	parent_dirscan = True;
+ 	while (*y) {
+ 		char save[MAXPATHLEN];
+-		strlcpy(save, y, MAXPATHLEN);
++		/* copylen is strlen(y) which is < MAXPATHLEN. +1 for \0 */
++		size_t copylen = strlcpy(save, y, MAXPATHLEN) + 1;
+ 		*y = '\0';
+ 		dirbuf_len = y - dirbuf;
+ 		strlcpy(x, ex->pattern, MAXPATHLEN - (x - buf));
+@@ -734,7 +735,7 @@ static BOOL setup_merge_file(int mergelist_num, filter_rule *ex,
+ 			lp->head = NULL;
+ 		}
+ 		lp->tail = NULL;
+-		strlcpy(y, save, MAXPATHLEN);
++		strlcpy(y, save, copylen);
+ 		while ((*x++ = *y++) != '/') {}
+ 	}
+ 	parent_dirscan = False;
+


### PR DESCRIPTION
See https://github.com/WayneD/rsync/issues/511 for details. Not using fetchpatch, because I didn't found a raw link for opensuse's repository

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
