### PR TITLE
nvidia-vaapi-driver: 0.0.10 -> 0.0.11

### DIFF
--- a/pkgs/development/libraries/nvidia-vaapi-driver/0001-hardcode-install_dir.patch
+++ b/pkgs/development/libraries/nvidia-vaapi-driver/0001-hardcode-install_dir.patch
@@ -1,0 +1,34 @@
+From 4e8bd61c216969615a492043092bd8298dcd1410 Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Mon, 6 Nov 2023 09:33:45 -0500
+Subject: [PATCH] hardcode install_dir
+
+partially revert https://github.com/elFarto/nvidia-vaapi-driver/commit/60ab79608ae35bd929d3e1387d226547d18e6bed
+---
+ meson.build | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 990c2b2..f5e63d7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -71,7 +71,6 @@ if gst_codecs_deps.found()
+ endif
+ 
+ nvidia_incdir = include_directories('nvidia-include')
+-nvidia_install_dir = libva_deps.get_variable(pkgconfig: 'driverdir')
+ 
+ shared_library(
+     'nvidia_drv_video',
+@@ -80,7 +79,7 @@ shared_library(
+     dependencies: deps,
+     include_directories: nvidia_incdir,
+     install: true,
+-    install_dir: nvidia_install_dir,
++    install_dir: get_option('libdir') / 'dri',
+     gnu_symbol_visibility: 'hidden',
+ )
+ 
+-- 
+2.42.0
+

--- a/pkgs/development/libraries/nvidia-vaapi-driver/default.nix
+++ b/pkgs/development/libraries/nvidia-vaapi-driver/default.nix
@@ -14,14 +14,18 @@
 
 stdenv.mkDerivation rec {
   pname = "nvidia-vaapi-driver";
-  version = "0.0.10";
+  version = "0.0.11";
 
   src = fetchFromGitHub {
     owner = "elFarto";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-j6AIleVZCgV7CD7nP/dKz5we3sUW9pldy0QKi8xwXB0=";
+    sha256 = "sha256-mVVRpCyT374P1Vql0yPY0e5tNktHNJ8XHoixvxp3b20=";
   };
+
+  patches = [
+    ./0001-hardcode-install_dir.patch
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
Diff: https://github.com/elFarto/nvidia-vaapi-driver/compare/v0.0.10...v0.0.11

Changelog: https://github.com/elFarto/nvidia-vaapi-driver/releases/tag/v0.0.11

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
