### PR TITLE
govulncheck: fix version information

### DIFF
--- a/pkgs/tools/security/govulncheck/default.nix
+++ b/pkgs/tools/security/govulncheck/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, substituteAll
 }:
 
 buildGoModule rec {
@@ -13,6 +14,14 @@ buildGoModule rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-cewQ03dK/k3mXevE09M01Yox/3ZWP6IrG0H4QsZMzy8=";
   };
+
+  patches = [
+    # patch in version information
+    (substituteAll {
+      src = ./version.patch;
+      inherit version;
+    })
+  ];
 
   vendorHash = "sha256-r9XshbgVA5rppJF46SFYPad344ZHMLWTHTnL6vbIFH8=";
 

--- a/pkgs/tools/security/govulncheck/version.patch
+++ b/pkgs/tools/security/govulncheck/version.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/scan/run.go b/internal/scan/run.go
+index fa7fe37..216ca43 100644
+--- a/internal/scan/run.go
++++ b/internal/scan/run.go
+@@ -99,8 +99,8 @@ func scannerVersion(cfg *config, bi *debug.BuildInfo) {
+ 	if bi.Path != "" {
+ 		cfg.ScannerName = path.Base(bi.Path)
+ 	}
+-	if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+-		cfg.ScannerVersion = bi.Main.Version
++	if true {
++		cfg.ScannerVersion = "@version@"
+ 		return
+ 	}
+ 


### PR DESCRIPTION
## Description of changes

now it looks like:

```
Using go1.21.3 and govulncheck@1.0.1 with vulnerability data from https://vuln.go.dev (last modified 2023-11-02 22:04:24 +0000 UTC).
```

instead of displaying ``govulncheck@0.0.0``

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
