### PR TITLE
python311Packages.deal: Fixing typeguard version mismatch. 

### DIFF
--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -12,7 +12,7 @@
 , vaa
 , deal-solver
 , pygments
-, typeguard
+, typeguard3
 , urllib3
 , flake8
 }:
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     astroid
     deal-solver
     pygments
-    typeguard
+    typeguard3
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/typeguard3/default.nix
+++ b/pkgs/development/python-modules/typeguard3/default.nix
@@ -1,0 +1,67 @@
+{ buildPythonPackage
+, fetchPypi
+, pythonOlder
+, lib
+, setuptools
+, setuptools-scm
+, pytestCheckHook
+, typing-extensions
+, sphinxHook
+, sphinx-autodoc-typehints
+, sphinx-rtd-theme
+, glibcLocales
+}:
+
+buildPythonPackage rec {
+  pname = "typeguard";
+  version = "3.0.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-/uUpf9so+Onvy4FCte4hngI3VQnNd+qdJwta+CY1jVo=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    glibcLocales
+    setuptools
+    setuptools-scm
+    sphinxHook
+    sphinx-autodoc-typehints
+    sphinx-rtd-theme
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  env.LC_ALL = "en_US.utf-8";
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # mypy tests aren't passing with latest mypy
+    "tests/mypy"
+  ];
+
+  disabledTests = [
+    # not compatible with python3.10
+    "test_typed_dict"
+  ];
+
+  meta = with lib; {
+    description = "This library provides run-time type checking for functions defined with argument type annotations";
+    homepage = "https://github.com/agronholm/typeguard";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14320,6 +14320,8 @@ self: super: with self; {
 
   typeguard = callPackage ../development/python-modules/typeguard { };
 
+  typeguard3 = callPackage ../development/python-modules/typeguard3 { };
+
   typepy = callPackage ../development/python-modules/typepy { };
 
   typer = callPackage ../development/python-modules/typer { };


### PR DESCRIPTION
## Description of changes

The current python deal package fails the check phase. The issue lies within `typeguard` which is too new. I added 
a new package called `typeguard3` and imported it in deal to fix the check phase issue.  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
