### PR TITLE
vxl: enable tests

### DIFF
--- a/pkgs/development/libraries/vxl/default.nix
+++ b/pkgs/development/libraries/vxl/default.nix
@@ -1,25 +1,50 @@
-{ lib, stdenv, fetchFromGitHub, unzip, cmake, libtiff, expat, zlib, libpng, libjpeg }:
-stdenv.mkDerivation rec {
+{ lib
+, stdenv
+, fetchFromGitHub
+, unzip
+, cmake
+, libtiff
+, expat
+, zlib
+, libpng
+, libjpeg
+}:
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "vxl";
   version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "vxl";
     repo = "vxl";
-    rev = "v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     sha256 = "sha256-4kMpIrywEZzt0JH95LHeDLrDneii0R/Uw9GsWkvED+E=";
   };
 
-  nativeBuildInputs = [ cmake unzip ];
-  buildInputs = [ libtiff expat zlib libpng libjpeg ];
+  nativeBuildInputs = [
+    cmake
+    unzip
+  ];
+  buildInputs = [
+    libtiff
+    expat
+    zlib
+    libpng
+    libjpeg
+  ];
+
+  # test failure on aarch64-linux; unknown reason:
+  cmakeFlags = lib.optionals stdenv.isAarch64 [ "-DCMAKE_CTEST_ARGUMENTS='-E vgl_test_frustum_3d'" ];
+
+  doCheck = true;
 
   meta = {
     description = "C++ Libraries for Computer Vision Research and Implementation";
-    homepage = "https://vxl.sourceforge.net/";
+    homepage = "https://vxl.sourceforge.net";
     # license appears contradictory; see https://github.com/vxl/vxl/issues/752
     # (and see https://github.com/InsightSoftwareConsortium/ITK/pull/1920/files for potential patch)
     license = [ lib.licenses.unfree ];
-    maintainers = with lib.maintainers; [viric];
+    maintainers = with lib.maintainers; [ viric ];
     platforms = with lib.platforms; linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Enable tests; minor cleanup.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
