### PR TITLE
telegram-desktop: make libXcursor hack optional

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
@@ -9,8 +9,6 @@
 , ninja
 , python3
 , gobject-introspection
-, wrapGAppsHook
-, wrapQtAppsHook
 , extra-cmake-modules
 , qtbase
 , qtwayland
@@ -52,8 +50,6 @@
 , libXtst
 , libthai
 , libdatrie
-, xdg-utils
-, xorg
 , libsysprof-capture
 , libpsl
 , brotli
@@ -103,7 +99,7 @@ let
   });
 in
 stdenv.mkDerivation rec {
-  pname = "telegram-desktop";
+  pname = "telegram-desktop-unwrapped";
   version = "4.11.3";
 
   src = fetchFromGitHub {
@@ -135,8 +131,7 @@ stdenv.mkDerivation rec {
       --replace '"libwebkitgtk-6.0.so.4"' '"${webkitgtk_6_0}/lib/libwebkitgtk-6.0.so.4"'
   '';
 
-  # We want to run wrapProgram manually (with additional parameters)
-  dontWrapGApps = true;
+  # This is an unwrapped package
   dontWrapQtApps = true;
 
   nativeBuildInputs = [
@@ -145,8 +140,6 @@ stdenv.mkDerivation rec {
     ninja
     python3
     gobject-introspection
-    wrapGAppsHook
-    wrapQtAppsHook
     extra-cmake-modules
   ];
 
@@ -209,16 +202,6 @@ stdenv.mkDerivation rec {
   preBuild = ''
     # for cppgir to locate gir files
     export GI_GIR_PATH="$XDG_DATA_DIRS"
-  '';
-
-  postFixup = ''
-    # This is necessary to run Telegram in a pure environment.
-    # We also use gappsWrapperArgs from wrapGAppsHook.
-    wrapProgram $out/bin/telegram-desktop \
-      "''${gappsWrapperArgs[@]}" \
-      "''${qtWrapperArgs[@]}" \
-      --prefix LD_LIBRARY_PATH : "${xorg.libXcursor}/lib" \
-      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
   '';
 
   passthru = {

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/wrapper.nix
@@ -1,0 +1,43 @@
+{ lib
+, telegram-desktop-unwrapped
+, wrapGAppsHook
+, wrapQtAppsHook
+, xdg-utils
+, xorg
+, symlinkJoin
+}:
+
+let
+  telegram = telegram-desktop-unwrapped;
+in symlinkJoin {
+  name = "telegram-desktop-${telegram.version}";
+
+  paths = [ telegram ];
+
+  # We want to run wrapProgram manually (with additional parameters)
+  dontWrapGApps = true;
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    wrapQtAppsHook
+  ];
+
+  inherit (telegram) buildInputs;
+
+  postBuild = ''
+    # This is necessary to run Telegram in a pure environment.
+    # We also use gappsWrapperArgs from wrapGAppsHook.
+    wrapProgram $out/bin/telegram-desktop \
+      "''${gappsWrapperArgs[@]}" \
+      "''${qtWrapperArgs[@]}" \
+      --prefix LD_LIBRARY_PATH : "${xorg.libXcursor}/lib" \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+  '';
+
+  passthru = {
+    inherit (telegram) tg_owt;
+  };
+
+  inherit (telegram) meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35735,7 +35735,8 @@ with pkgs;
 
   taskopen = callPackage ../applications/misc/taskopen { };
 
-  telegram-desktop = qt6Packages.callPackage ../applications/networking/instant-messengers/telegram/telegram-desktop { };
+  telegram-desktop-unwrapped = qt6Packages.callPackage ../applications/networking/instant-messengers/telegram/telegram-desktop { };
+  telegram-desktop = qt6Packages.callPackage ../applications/networking/instant-messengers/telegram/telegram-desktop/wrapper.nix { };
 
   telegram-bot-api = callPackage ../servers/telegram-bot-api { };
 


### PR DESCRIPTION
## Description of changes

I use nixos stable, but I pull tdesktop from unstable. Lately, I've been unable to open links. The following output shows up when running in a terminal:

```
XPCOMGlueLoad error for file /nix/store/25rzm9fz1qljrws497xqcwl9pjd3nq6d-firefox-nightly-bin-unwrapped-121.0a1/lib/firefox-bin-121.0a1/libmozgtk.so:
/nix/store/whypqfa83z4bsn43n4byvmw80n4mg3r8-glibc-2.37-45/lib/libc.so.6: version `GLIBC_2.38' not found (required by /nix/store/ncx0rw8c2b8bvbxfqnsvs70vqw35a28k-libXcursor-1.2.1/lib/libXcursor.so.1)
Couldn't load XPCOM.
```

Clearly it's trying to load a newer libXcursor than it should, and fails because that's built against a newer version of glibc.
I've tracked this down to  #196269.

To keep everyone happy, and avoid unnecessary rebuilds or carrying custom wrappers outside of nixpkgs, this PR splits the telegram-desktop derivation into a new -unwrapped package, and the wrapper on its own, as is common for various other packages.
It then adds an extra parameter to the package to control the inclusion of the xcursor hack (on by default).

For what it's worth, on my setup (sway), I don't have any problems with the cursor theme, but regardless being unable to open links is a more breaking issue than the cursor theme not applying.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
