### PR TITLE
cargo-readme: 3.2.0 -> 3.3.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-readme/default.nix
+++ b/pkgs/development/tools/rust/cargo-readme/default.nix
@@ -2,27 +2,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-readme";
-  version = "3.2.0";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
-    owner = "livioribeiro";
+    owner = "webern";
     repo = pname;
-    # Git tag is missing, see upstream issue:
-    # https://github.com/livioribeiro/cargo-readme/issues/61
-    rev = "cf66017c0120ae198210ebaf58a0be6a78372974";
-    sha256 = "sha256-/ufHHM13L83M3UYi6mjdhIjgXx7bZgzvR/X02Zsx7Fw=";
+    rev = "v${version}";
+    sha256 = "sha256-FFWHADATEfvZvxGwdkj+eTVoq7pnPuoUAhMGTokUkMs=";
   };
 
-  cargoSha256 = "sha256-Isd05qOuVBNfXOI5qsaDOhjF7QIKAG5xrZsBFK2PpQQ=";
+  cargoSha256 = "sha256-OEArMqOiT+PZ+zMRt9h0EzeP7ikFuOYR8mFGtm+xCkQ=";
 
-  patches = [
-    (fetchpatch {
-      # Fixup warning thrown at build when running test-suite
-      # unused return, see upstream PR:
-      # https://github.com/livioribeiro/cargo-readme/pull/62
-      url = "https://github.com/livioribeiro/cargo-readme/commit/060f2daaa2b2cf981bf490dc36bcc6527545ea03.patch";
-      sha256 = "sha256-wlAIgTI9OqtA/Jnswoqp7iOj+1zjrUZA7JpHUiF/n+s=";
-    })
+  # disable doc tests
+  cargoTestFlags = [
+    "--bins" "--lib"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Release notes:

   - https://github.com/webern/cargo-readme/releases/tag/v3.3.1
   - https://github.com/webern/cargo-readme/releases/tag/v3.3.0

diff: https://github.com/webern/cargo-readme/compare/v3.2.0...v3.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
