### PR TITLE
glaxnimate: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/applications/video/glaxnimate/default.nix
+++ b/pkgs/applications/video/glaxnimate/default.nix
@@ -37,13 +37,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "glaxnimate";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitLab {
     owner = "mattbas";
     repo = "${pname}";
     rev = version;
-    sha256 = "G4ykcOvXXnVIQZUYpRIrALtDSsGqxMvDtcmobjjtlKw=";
+    sha256 = "ueZSyKvYPArDdrQSKtYWEd0uoXXDOWqhpJZu8ZY1IUk=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This updates the version of glaxnimate to a later version that builds. 0.5.4 is latest, but there's a build error. 0.5.3 is the same. 0.5.2 builds fine.