### PR TITLE
python3Packages.taskw: support relative paths in taskrc

### DIFF
--- a/pkgs/development/python-modules/taskw/default.nix
+++ b/pkgs/development/python-modules/taskw/default.nix
@@ -20,7 +20,11 @@ buildPythonPackage rec {
     hash = "sha256-EQm9+b3nqbMqUAejAsh4MD/2UYi2QiWsdKMomkxUi90=";
   };
 
-  patches = [ ./use-template-for-taskwarrior-install-path.patch ];
+  patches = [
+    ./use-template-for-taskwarrior-install-path.patch
+    # Remove when https://github.com/ralphbean/taskw/pull/151 is merged.
+    ./support-relative-path-in-taskrc.patch
+  ];
   postPatch = ''
     substituteInPlace taskw/warrior.py \
       --replace '@@taskwarrior@@' '${pkgs.taskwarrior}'

--- a/pkgs/development/python-modules/taskw/support-relative-path-in-taskrc.patch
+++ b/pkgs/development/python-modules/taskw/support-relative-path-in-taskrc.patch
@@ -1,0 +1,79 @@
+From 958b63ceec02b179482141cfb846ddbcae711a1b Mon Sep 17 00:00:00 2001
+From: Scott Mcdermott <scott@smemsh.net>
+Date: Sat, 28 Aug 2021 21:12:38 -0700
+Subject: [PATCH] RcFile: _read: try taskrc directory when trying to load
+ includes
+
+Taskwarrior itself tries includes as absolute path, then cwd, then
+relative to rcfile, then in various search paths (see
+GothenburgBitFactory/libshared -> src/Configuration.cpp ->
+Configuration::parse()).
+
+We won't try to duplicate that whole arrangement here, but at least look
+relative to the rcfile in addition to cwd/absolute, like taskwarrior
+does.  This will allow specification as relative path in most cases.
+Otherwise, we'd have to chdir anyways because includes are always tried
+as-is by taskw.  They would only work if specified as absolute paths or
+if in cwd
+
+We use a TaskRc() class variable to store the rcdir because there could
+be an include chain and all the instances will need to know the same
+one, but will be processing different paths, so we have to capture the
+directory of the first one processed, ie the base rcfile.
+
+Fixes #150
+
+Co-authored-by: Raito Bezarius <masterancpp@gmail.com>
+---
+ taskw/taskrc.py | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/taskw/taskrc.py b/taskw/taskrc.py
+index 1b6f8e5..b72dee6 100644
+--- a/taskw/taskrc.py
++++ b/taskw/taskrc.py
+@@ -1,5 +1,6 @@
+ import logging
+ import os
++import os.path
+ 
+ from taskw.fields import (
+     ChoiceField,
+@@ -39,6 +40,7 @@ class TaskRc(dict):
+ 
+     """
+ 
++    rcdir = None
+     UDA_TYPE_MAP = {
+         'date': DateField,
+         'duration': DurationField,
+@@ -54,6 +56,8 @@ class TaskRc(dict):
+                     path
+                 )
+             )
++            if not self.rcdir:
++                TaskRc.rcdir = os.path.dirname(os.path.realpath(self.path))
+             config = self._read(self.path)
+         else:
+             self.path = None
+@@ -92,6 +96,17 @@ class TaskRc(dict):
+ 
+     def _read(self, path):
+         config = {}
++        if not os.path.exists(path) and TaskRc.rcdir is not None:
++            # include path may be given relative to dir of rcfile
++            oldpath = path
++            path = os.path.join(TaskRc.rcdir, oldpath)
++            if not os.path.exists(path):
++                logger.error(
++                    "rcfile does not exist, tried %s and %s",
++                    oldpath, path
++                )
++                raise FileNotFoundError
++
+         with open(path, 'r') as config_file:
+             for raw_line in config_file.readlines():
+                 line = sanitize(raw_line)
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

Since TaskWarrior 2.6.0, relative paths are now supported (`include ./xyz`), but many libraries are still not supporting them properly.

We apply a patch downstream as the author is unresponsive for the time being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
