### PR TITLE
nixVersions.2_3: 2.3.16 -> 2.3.17

### DIFF
--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -1,9 +1,11 @@
-{ lib, fetchFromGitHub
+{ lib
+, fetchFromGitHub
 , version
 , suffix ? ""
 , hash ? null
 , src ? fetchFromGitHub { owner = "NixOS"; repo = "nix"; rev = version; inherit hash; }
 , patches ? [ ]
+, maintainers ? with lib.maintainers; [ eelco lovesegfault artturin ]
 }:
 assert (hash == null) -> (src != null);
 let
@@ -243,7 +245,7 @@ self = stdenv.mkDerivation {
     '';
     homepage = "https://nixos.org/";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ eelco lovesegfault artturin ];
+    inherit maintainers;
     platforms = platforms.unix;
     outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
     mainProgram = "nix";

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -27,6 +27,8 @@ in
 , callPackage
 , coreutils
 , curl
+, docbook_xsl_ns
+, docbook5
 , editline
 , flex
 , gnutar
@@ -37,6 +39,8 @@ in
 , libarchive
 , libcpuid
 , libsodium
+, libxml2
+, libxslt
 , lowdown
 , mdbook
 , mdbook-linkcheck
@@ -86,13 +90,17 @@ self = stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkg-config
-  ] ++ lib.optionals atLeast24 [
     autoconf-archive
     autoreconfHook
     bison
     flex
     jq
-  ] ++ lib.optionals (atLeast24 && enableDocumentation) [
+  ] ++ lib.optionals (enableDocumentation && !atLeast24) [
+    libxslt
+    libxml2
+    docbook_xsl_ns
+    docbook5
+  ] ++ lib.optionals (enableDocumentation && atLeast24) [
     (lib.getBin lowdown)
     mdbook
   ] ++ lib.optionals (atLeast213 && enableDocumentation) [
@@ -111,13 +119,12 @@ self = stdenv.mkDerivation {
     openssl
     sqlite
     xz
-  ] ++ lib.optionals stdenv.isDarwin [
-    Security
-  ] ++ lib.optionals atLeast24 [
     gtest
     libarchive
     lowdown
-  ] ++ lib.optionals (atLeast24 && stdenv.isx86_64) [
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+  ] ++ lib.optionals (stdenv.isx86_64) [
     libcpuid
   ] ++ lib.optionals atLeast214 [
     rapidcheck
@@ -131,13 +138,6 @@ self = stdenv.mkDerivation {
     boehmgc
   ] ++ lib.optionals (atLeast27) [
     nlohmann_json
-  ];
-
-  NIX_LDFLAGS = lib.optionals (!atLeast24) [
-    # https://github.com/NixOS/nix/commit/3e85c57a6cbf46d5f0fe8a89b368a43abd26daba
-    (lib.optionalString enableStatic "-lssl -lbrotlicommon -lssh2 -lz -lnghttp2 -lcrypto")
-    # https://github.com/NixOS/nix/commits/74b4737d8f0e1922ef5314a158271acf81cd79f8
-    (lib.optionalString (stdenv.hostPlatform.system == "armv5tel-linux" || stdenv.hostPlatform.system == "armv6l-linux") "-latomic")
   ];
 
   postPatch = ''
@@ -180,9 +180,6 @@ self = stdenv.mkDerivation {
     "--enable-gc"
   ] ++ lib.optionals (!enableDocumentation) [
     "--disable-doc-gen"
-  ] ++ lib.optionals (!atLeast24) [
-    # option was removed in 2.4
-    "--disable-init-state"
   ] ++ lib.optionals atLeast214 [
     "CXXFLAGS=-I${lib.getDev rapidcheck}/extras/gtest/include"
   ] ++ lib.optionals stdenv.isLinux [

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -145,12 +145,9 @@ let
     pkg;
 
 in lib.makeExtensible (self: ({
-  nix_2_3 = (common rec {
-    version = "2.3.16";
-    src = fetchurl {
-      url = "https://nixos.org/releases/nix/nix-${version}/nix-${version}.tar.xz";
-      hash = "sha256-fuaBtp8FtSVJLSAsO+3Nne4ZYLuBj2JpD2xEk7fCqrw=";
-    };
+  nix_2_3 = (common {
+    version = "2.3.17";
+    hash = "sha256-EK0pgHDekJFqr0oMj+8ANIjq96WPjICe2s0m4xkUdH4=";
     patches = [
       patch-monitorfdhup
     ];

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -151,6 +151,7 @@ in lib.makeExtensible (self: ({
     patches = [
       patch-monitorfdhup
     ];
+    maintainers = with lib.maintainers; [ flokli raitobezarius ];
   }).override { boehmgc = boehmgc-nix_2_3; };
 
   nix_2_10 = common {


### PR DESCRIPTION
## Description of changes

2.3.17 became a bit more like 2.4, this is reflected in the common expression.

TODO:

- [x] Fix documentation build.
- [x] Add separated maintenance fields, defaulting to prior maintainers of Nix core team?
- [x] Add maintainers for 2.3 series.

Fixes #265916.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
