### PR TITLE
make `setBuildTargets` work in more cases

### DIFF
--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -209,7 +209,8 @@ rec {
    *   > setBuildTarget "server" (callCabal2nix "thePackageName" thePackageSrc {})
    *
    */
-  setBuildTargets = xs: overrideCabal (drv: { buildTarget = lib.concatStringsSep " " xs; });
+  setBuildTargets = xs: justStaticExecutables
+     (dontCheck (overrideCabal (drv: { buildTarget = lib.concatStringsSep " " xs; })));
   setBuildTarget = x: setBuildTargets [x];
 
   doHyperlinkSource = overrideCabal (drv: { hyperlinkSource = true; });

--- a/pkgs/test/haskell/setBuildTarget/Test.hs
+++ b/pkgs/test/haskell/setBuildTarget/Test.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "PASS!"

--- a/pkgs/test/haskell/setBuildTarget/haskell-setBuildTarget.cabal
+++ b/pkgs/test/haskell/setBuildTarget/haskell-setBuildTarget.cabal
@@ -14,3 +14,8 @@ executable bar
   main-is:             Bar.hs
   build-depends:       base
   default-language:    Haskell2010
+
+test-suite tests
+  main-is:             Test.hs
+  build-depends:       base
+  default-language:    Haskell2010


### PR DESCRIPTION
## Description of changes

This modifies the `setBuildTargets` function in `haskell.lib` to remove profiling and checks. These create extra compiles that differ from the spirit of specifying targets. Removing them also allows projects with tests to build executables without having to manually call `dontCheck`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
