### PR TITLE
python311Packages.zlib-ng: init at 0.2.0; python311Packages.aiohttp-zlib-ng: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/aiohttp-zlib-ng/default.nix
+++ b/pkgs/development/python-modules/aiohttp-zlib-ng/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, aiohttp
+, zlib-ng
+}:
+
+buildPythonPackage rec {
+  pname = "aiohttp-zlib-ng";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = "aiohttp-zlib-ng";
+    rev = "v${version}";
+    hash = "sha256-dTNwt4eX6ZQ8ySK2/9ziVbc3KFg2aL/EsiBWaJRC4x8=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    zlib-ng
+  ];
+
+  pythonImportsCheck = [ "aiohttp_zlib_ng" ];
+
+  meta = with lib; {
+    description = "Enable zlib_ng on aiohttp";
+    homepage = "https://github.com/bdraco/aiohttp-zlib-ng";
+    changelog = "https://github.com/bdraco/aiohttp-zlib-ng/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/zlib-ng/default.nix
+++ b/pkgs/development/python-modules/zlib-ng/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build-system
+, cmake
+, setuptools
+
+# native dependencies
+, zlib-ng
+
+# tests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "zlib-ng";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pycompression";
+    repo = "python-zlib-ng";
+    rev = "v${version}";
+    hash = "sha256-dZnX94SOuV1/zTYUecnRe6DDKf5nAvydHn7gESVQ6hs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    setuptools
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  env.PYTHON_ZLIB_NG_LINK_DYNAMIC = true;
+
+  buildInputs = [
+    zlib-ng
+  ];
+
+  pythonImportsCheck = [
+    "zlib_ng"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    rm -rf src
+  '';
+
+  meta = with lib; {
+    description = "A drop-in replacement for Python's zlib and gzip modules using zlib-ng";
+    homepage = "https://github.com/pycompression/python-zlib-ng";
+    changelog = "https://github.com/pycompression/python-zlib-ng/blob/${src.rev}/CHANGELOG.rst";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/zlib-ng/default.nix
+++ b/pkgs/development/python-modules/zlib-ng/default.nix
@@ -50,6 +50,16 @@ buildPythonPackage rec {
     rm -rf src
   '';
 
+  disabledTests = [
+    # commandline tests fail to find the built module
+    "test_compress_fast_best_are_exclusive"
+    "test_compress_infile_outfile"
+    "test_compress_infile_outfile_default"
+    "test_decompress_cannot_have_flags_compression"
+    "test_decompress_infile_outfile"
+    "test_decompress_infile_outfile_error"
+  ];
+
   meta = with lib; {
     description = "A drop-in replacement for Python's zlib and gzip modules using zlib-ng";
     homepage = "https://github.com/pycompression/python-zlib-ng";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -250,6 +250,8 @@ self: super: with self; {
 
   aiohttp-wsgi = callPackage ../development/python-modules/aiohttp-wsgi { };
 
+  aiohttp-zlib-ng = callPackage ../development/python-modules/aiohttp-zlib-ng { };
+
   aioitertools = callPackage ../development/python-modules/aioitertools { };
 
   aiobiketrax = callPackage ../development/python-modules/aiobiketrax { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16273,6 +16273,10 @@ self: super: with self; {
 
   zipstream-ng = callPackage ../development/python-modules/zipstream-ng { };
 
+  zlib-ng = callPackage ../development/python-modules/zlib-ng {
+    inherit (pkgs) zlib-ng;
+  };
+
   zm-py = callPackage ../development/python-modules/zm-py { };
 
   zodb = callPackage ../development/python-modules/zodb { };


### PR DESCRIPTION
## Description of changes

WIP for upcoming home-assistant release in December.

Currently failing tests on `python311.pkgs.zlib-ng`.

```
zlib-ng> FAILED tests/test_gzip_compliance.py::TestCommandLine::test_compress_fast_best_are_exclusive - AssertionError: b'error: argument -9/--best: not allowed with argument -1/-...
zlib-ng> FAILED tests/test_gzip_compliance.py::TestCommandLine::test_compress_infile_outfile - AssertionError: Process return code is 1
zlib-ng> FAILED tests/test_gzip_compliance.py::TestCommandLine::test_compress_infile_outfile_default - AssertionError: Process return code is 1
zlib-ng> FAILED tests/test_gzip_compliance.py::TestCommandLine::test_decompress_cannot_have_flags_compression - AssertionError: b'error: argument -d/--decompress: not allowed with argumen...
zlib-ng> FAILED tests/test_gzip_compliance.py::TestCommandLine::test_decompress_infile_outfile - AssertionError: Process return code is 1
zlib-ng> FAILED tests/test_gzip_compliance.py::TestCommandLine::test_decompress_infile_outfile_error - AssertionError: b"filename doesn't end in .gz: 'thisisatest.out'" not found...
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
