### PR TITLE
itk: unvendor some of the dependencies

### DIFF
--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation rec {
     "TestSCUValidation"
     # errors because 3 classes not wrapped:
     "TestWrapPython"
+  ] ++ lib.optionals (stdenv.isAarch64 && stdenv.isLinux) [
+    "TestRescaler2"
   ];
 
   checkPhase = ''

--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -1,7 +1,8 @@
 { version, rev, sourceSha256 }:
 
-{ lib, stdenv, fetchFromGitHub, cmake, makeWrapper
-, pkg-config, libX11, libuuid, xz, vtk, Cocoa }:
+{ lib, stdenv, fetchFromGitHub, cmake
+, expat, fftw, gdcm, hdf5-cpp, libjpeg, libminc, libtiff, libpng
+, libX11, libuuid, xz, vtk, zlib, Cocoa }:
 
 let
   itkGenericLabelInterpolatorSrc = fetchFromGitHub {
@@ -41,8 +42,6 @@ stdenv.mkDerivation {
     substituteInPlace CMake/ITKSetStandardCompilerFlags.cmake  \
       --replace "-march=corei7" ""  \
       --replace "-mtune=native" ""
-    substituteInPlace Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/src/lib/openjp2/libopenjp2.pc.cmake.in  \
-      --replace "@OPENJPEG_INSTALL_LIB_DIR@" "@OPENJPEG_INSTALL_FULL_LIB_DIR@"
     ln -sr ${itkGenericLabelInterpolatorSrc} Modules/External/ITKGenericLabelInterpolator
     ln -sr ${itkAdaptiveDenoisingSrc} Modules/External/ITKAdaptiveDenoising
     ln -sr ${itkSimpleITKFiltersSrc} Modules/External/ITKSimpleITKFilters
@@ -52,6 +51,15 @@ stdenv.mkDerivation {
     "-DBUILD_EXAMPLES=OFF"
     "-DBUILD_SHARED_LIBS=ON"
     "-DITK_FORBID_DOWNLOADS=ON"
+    "-DITK_USE_SYSTEM_LIBRARIES=ON"  # finds common libraries e.g. hdf5, libpng, libtiff, zlib, but not GDCM, NIFTI, MINC, etc.
+    # note ITK_USE_SYSTEM_EIGEN, part of ITK_USE_SYSTEM_LIBRARIES,
+    # causes "...-itk-5.2.1/include/ITK-5.2/itkSymmetricEigenAnalysis.h:23:31: fatal error: Eigen/Eigenvalues: No such file or directory"
+    # when compiling c3d, but maybe an ITK 5.2/eigen version issue:
+    "-DITK_USE_SYSTEM_EIGEN=OFF"
+    "-DITK_USE_SYSTEM_GOOGLETEST=OFF"  # ANTs build failure due to https://github.com/ANTsX/ANTs/issues/1489
+    "-DITK_USE_SYSTEM_GDCM=ON"
+    "-DITK_USE_SYSTEM_MINC=ON"
+    "-DLIBMINC_DIR=${libminc}/lib/cmake"
     "-DModule_ITKMINC=ON"
     "-DModule_ITKIOMINC=ON"
     "-DModule_ITKIOTransformMINC=ON"
@@ -63,8 +71,12 @@ stdenv.mkDerivation {
     "-DModule_GenericLabelInterpolator=ON"
   ];
 
-  nativeBuildInputs = [ cmake xz makeWrapper ];
-  buildInputs = [ libX11 libuuid vtk ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+  nativeBuildInputs = [ cmake xz ];
+  buildInputs = [
+    libX11
+    libuuid
+    vtk
+  ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
   # Due to ITKVtkGlue=ON and the additional dependencies needed to configure VTK 9
   # (specifically libGL and libX11 on Linux),
   # it's now seemingly necessary for packages that configure ITK to
@@ -72,11 +84,20 @@ stdenv.mkDerivation {
   # These deps were propagated from VTK 9 in https://github.com/NixOS/nixpkgs/pull/206935,
   # so we simply propagate them again from ITK.
   # This admittedly is a hack and seems like an issue with VTK 9's CMake configuration.
-  propagatedBuildInputs = vtk.propagatedBuildInputs;
-
-  postInstall = ''
-    wrapProgram "$out/bin/h5c++" --prefix PATH ":" "${pkg-config}/bin"
-  '';
+  propagatedBuildInputs = [
+    # The dependencies we've un-vendored from ITK, such as GDCM, must be propagated,
+    # otherwise other software built against ITK fails to configure since ITK headers
+    # refer to these previously vendored libraries:
+    expat
+    fftw
+    gdcm
+    hdf5-cpp
+    libjpeg
+    libminc
+    libpng
+    libtiff
+    zlib
+  ] ++ vtk.propagatedBuildInputs;
 
   meta = {
     description = "Insight Segmentation and Registration Toolkit";


### PR DESCRIPTION
## Description of changes

Unvendored GDCM, MINC, and several common libraries (under the omnibus but incomplete ITK_USE_SYSTEM_LIBRARIES).
We didn't unvendor Eigen, Gtest, or VXL due to downstream compilation errors (in e.g. c3d, ants, simpleitk), but at least the first two of these are less of an issue security-wise. Some other libraries such as NIfTI, GIfTI, etc., seemingly can't be unvendored via ITK_USE_SYSTEM_<...>, and others such as TBB aren't enabled by default.

Results of `nixpkgs-review` on x86_64-Linux:

```
1 package marked as broken and skipped:
ezminc

32 packages built:
ants c3d elastix intensity-normalization intensity-normalization.dist itk itk_5_2 mirtk mrtrix python310Packages.intensity-normalization python310Packages.intensity-normalization.dist python310Packages.pydicom-seg python310Packages.pydicom-seg.dist python310Packages.pymedio python310Packages.pymedio.dist python310Packages.pyradiomics python310Packages.pyradiomics.dist python310Packages.simpleitk python310Packages.simpleitk.dist python310Packages.torchio python310Packages.torchio.dist python311Packages.pydicom-seg python311Packages.pydicom-seg.dist python311Packages.pymedio python311Packages.pymedio.dist python311Packages.pyradiomics python311Packages.pyradiomics.dist python311Packages.simpleitk python311Packages.simpleitk.dist python311Packages.torchio python311Packages.torchio.dist simpleitk
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).