### PR TITLE
gcc: fix build Darwin builds on staging-next

### DIFF
--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -33,6 +33,7 @@
 , nukeReferences
 , callPackage
 , majorMinorVersion
+, darwin
 
 # only for gcc<=6.x
 , langJava ? false
@@ -412,6 +413,11 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   };
 } // optionalAttrs is7 {
   env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument";
+} // lib.optionalAttrs (!atLeast10 && stdenv.hostPlatform.isDarwin) {
+  # GCC <10 requires default cctools `strip` instead of `llvm-strip` used by Darwin bintools.
+  preBuild = ''
+    makeFlagsArray+=('STRIP=${lib.getBin darwin.cctools-port}/bin/${stdenv.cc.targetPrefix}strip')
+  '';
 } // optionalAttrs (!atLeast7) {
   env.langJava = langJava;
 } // optionalAttrs atLeast6 {

--- a/pkgs/development/compilers/gcc/patches/11/libgcc-aarch64-darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/patches/11/libgcc-aarch64-darwin-detection.patch
@@ -1,0 +1,21 @@
+diff -u a/libgcc/config.host b/libgcc/config.host
+--- a/libgcc/config.host	2023-11-05 11:01:55.778638446 -0500
++++ b/libgcc/config.host	2023-11-05 11:07:29.405103979 -0500
+@@ -227,7 +227,7 @@
+   tmake_file="$tmake_file t-slibgcc-darwin"
+   # newer toolsets produce warnings when building for unsupported versions.
+   case ${host} in
+-    *-*-darwin1[89]* | *-*-darwin2* )
++    *-*-darwin1[89]* | *-*-darwin2* | aarch64*-*-darwin*)
+       tmake_file="t-darwin-min-8 $tmake_file"
+       ;;
+     *-*-darwin9* | *-*-darwin1[0-7]*)
+diff -ur a/libgcc/config/t-darwin-rpath b/libgcc/config/t-darwin-rpath
+--- a/libgcc/config/t-darwin-rpath	2023-11-05 11:34:18.691150009 -0500
++++ b/libgcc/config/t-darwin-rpath	2023-11-05 11:50:36.968920904 -0500
+@@ -2,4 +2,4 @@
+ SHLIB_RPATH = @rpath
+
+ # Which does not work for Darwin < 9
+-HOST_LIBGCC2_CFLAGS += -mmacosx-version-min=10.5
++SHLIB_LOADER_PATH = -Wl,-rpath,@loader_path

--- a/pkgs/development/compilers/gcc/patches/4.9/darwin-clang-as.patch
+++ b/pkgs/development/compilers/gcc/patches/4.9/darwin-clang-as.patch
@@ -1,0 +1,16 @@
+diff -ur a/libgcc/config/t-darwin b/libgcc/config/t-darwin
+--- a/libgcc/config/t-darwin	2012-07-14 09:50:59.000000000 -0400
++++ b/libgcc/config/t-darwin	2023-11-05 21:26:11.696825584 -0500
+@@ -7,12 +7,6 @@
+ crttme.o: $(srcdir)/config/darwin-crt-tm.c
+ 	$(crt_compile) $(DARWIN_EXTRA_CRT_BUILD_CFLAGS) -DEND -c $<
+ 
+-# -pipe because there's an assembler bug, 4077127, which causes
+-# it to not properly process the first # directive, causing temporary
+-# file names to appear in stabs, causing the bootstrap to fail.  Using -pipe
+-# works around this by not having any temporary file names.
+-HOST_LIBGCC2_CFLAGS += -pipe
+-
+ # Use unwind-dw2-fde-darwin
+ LIB2ADDEH = $(srcdir)/unwind-dw2.c $(srcdir)/config/unwind-dw2-fde-darwin.c \
+   $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c

--- a/pkgs/development/compilers/gcc/patches/8/gcc8-darwin-as-gstabs.patch
+++ b/pkgs/development/compilers/gcc/patches/8/gcc8-darwin-as-gstabs.patch
@@ -1,0 +1,96 @@
+Backported from https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b2cee5e1e89c8f939bc36fe9756befcb93d96982
+
+diff -ur a/gcc/config/darwin.h b/gcc/config/darwin.h
+--- a/gcc/config/darwin.h	2021-05-14 04:42:08.000000000 -0400
++++ b/gcc/config/darwin.h	2023-11-06 08:53:27.629155053 -0500
+@@ -233,12 +233,18 @@
+ 
+ #define DSYMUTIL "\ndsymutil"
+ 
++/* Spec that controls whether the debug linker is run automatically for
++   a link step.  This needs to be done if there is a source file on the
++   command line which will result in a temporary object (and debug is
++   enabled).  */
++
+ #define DSYMUTIL_SPEC \
+    "%{!fdump=*:%{!fsyntax-only:%{!c:%{!M:%{!MM:%{!E:%{!S:\
+     %{v} \
+-    %{gdwarf-2:%{!gstabs*:%{%:debug-level-gt(0): -idsym}}}\
+-    %{.c|.cc|.C|.cpp|.cp|.c++|.cxx|.CPP|.m|.mm: \
+-    %{gdwarf-2:%{!gstabs*:%{%:debug-level-gt(0): -dsym}}}}}}}}}}}"
++    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -idsym}}}\
++    %{.c|.cc|.C|.cpp|.cp|.c++|.cxx|.CPP|.m|.mm|.s|.f|.f90|\
++      .f95|.f03|.f77|.for|.F|.F90|.F95|.F03: \
++    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -dsym}}}}}}}}}}}"
+ 
+ #define LINK_COMMAND_SPEC LINK_COMMAND_SPEC_A DSYMUTIL_SPEC
+ 
+@@ -469,18 +475,31 @@
+ /* Default ASM_DEBUG_SPEC.  Darwin's as cannot currently produce dwarf
+    debugging data.  */
+ 
++#ifdef HAS_AS_STABS_DIRECTIVE
++/* We only pass a debug option to the assembler if that supports stabs, since
++   dwarf is not uniformly supported in the assemblers.  */
+ #define ASM_DEBUG_SPEC  "%{g*:%{%:debug-level-gt(0):%{!gdwarf*:--gstabs}}}"
++#else
++#define ASM_DEBUG_SPEC ""
++#endif
++
++#undef  ASM_DEBUG_OPTION_SPEC
++#define ASM_DEBUG_OPTION_SPEC  ""
++
+ #define ASM_FINAL_SPEC \
+   "%{gsplit-dwarf:%ngsplit-dwarf is not supported on this platform } %<gsplit-dwarf"
+ 
+-/* We still allow output of STABS if the assembler supports it.  */
++/* We now require C++11 to bootstrap and newer tools than those based on
++   stabs, so require DWARF-2, even if stabs is supported by the assembler.  */
++
++#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
++#define DARWIN_PREFER_DWARF
++#define DWARF2_DEBUGGING_INFO 1
++
+ #ifdef HAVE_AS_STABS_DIRECTIVE
+ #define DBX_DEBUGGING_INFO 1
+-#define PREFERRED_DEBUGGING_TYPE DBX_DEBUG
+ #endif
+ 
+-#define DWARF2_DEBUGGING_INFO 1
+-
+ #define DEBUG_FRAME_SECTION	  "__DWARF,__debug_frame,regular,debug"
+ #define DEBUG_INFO_SECTION	  "__DWARF,__debug_info,regular,debug"
+ #define DEBUG_ABBREV_SECTION	  "__DWARF,__debug_abbrev,regular,debug"
+diff -ur a/gcc/config/darwin9.h b/gcc/config/darwin9.h
+--- a/gcc/config/darwin9.h	2021-05-14 04:42:08.000000000 -0400
++++ b/gcc/config/darwin9.h	2023-11-06 08:54:02.663945206 -0500
+@@ -18,29 +18,6 @@
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-/* Prefer DWARF2.  */
+-#undef PREFERRED_DEBUGGING_TYPE
+-#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
+-#define DARWIN_PREFER_DWARF
+-
+-/* Since DWARF2 is default, conditions for running dsymutil are different.  */
+-#undef DSYMUTIL_SPEC
+-#define DSYMUTIL_SPEC \
+-   "%{!fdump=*:%{!fsyntax-only:%{!c:%{!M:%{!MM:%{!E:%{!S:\
+-    %{v} \
+-    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -idsym}}}\
+-    %{.c|.cc|.C|.cpp|.cp|.c++|.cxx|.CPP|.m|.mm|.s|.f|.f90|.f95|.f03|.f77|.for|.F|.F90|.F95|.F03: \
+-    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -dsym}}}}}}}}}}}"
+-
+-/* Tell collect2 to run dsymutil for us as necessary.  */
+-#define COLLECT_RUN_DSYMUTIL 1
+-
+-/* Only ask as for debug data if the debug style is stabs (since as doesn't
+-   yet generate dwarf.)  */
+-
+-#undef  ASM_DEBUG_SPEC
+-#define ASM_DEBUG_SPEC  "%{g*:%{%:debug-level-gt(0):%{gstabs:--gstabs}}}"
+-
+ #undef  ASM_OUTPUT_ALIGNED_COMMON
+ #define ASM_OUTPUT_ALIGNED_COMMON(FILE, NAME, SIZE, ALIGN)		\
+   do {									\

--- a/pkgs/development/compilers/gcc/patches/9/gcc9-darwin-as-gstabs.patch
+++ b/pkgs/development/compilers/gcc/patches/9/gcc9-darwin-as-gstabs.patch
@@ -1,0 +1,99 @@
+Backported from https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b2cee5e1e89c8f939bc36fe9756befcb93d96982
+
+diff -ur a/gcc/config/darwin.h b/gcc/config/darwin.h
+--- a/gcc/config/darwin.h	2022-05-27 03:21:10.947379000 -0400
++++ b/gcc/config/darwin.h	2023-11-06 12:18:27.209236423 -0500
+@@ -230,12 +230,18 @@
+ 
+ #define DSYMUTIL "\ndsymutil"
+ 
++/* Spec that controls whether the debug linker is run automatically for
++   a link step.  This needs to be done if there is a source file on the
++   command line which will result in a temporary object (and debug is
++   enabled).  */
++
+ #define DSYMUTIL_SPEC \
+    "%{!fdump=*:%{!fsyntax-only:%{!c:%{!M:%{!MM:%{!E:%{!S:\
+     %{v} \
+-    %{gdwarf-2:%{!gstabs*:%{%:debug-level-gt(0): -idsym}}}\
+-    %{.c|.cc|.C|.cpp|.cp|.c++|.cxx|.CPP|.m|.mm: \
+-    %{gdwarf-2:%{!gstabs*:%{%:debug-level-gt(0): -dsym}}}}}}}}}}}"
++    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -idsym}}}\
++    %{.c|.cc|.C|.cpp|.cp|.c++|.cxx|.CPP|.m|.mm|.s|.f|.f90|\
++      .f95|.f03|.f77|.for|.F|.F90|.F95|.F03: \
++    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -dsym}}}}}}}}}}}"
+ 
+ #define LINK_COMMAND_SPEC LINK_COMMAND_SPEC_A DSYMUTIL_SPEC
+ 
+@@ -463,21 +469,31 @@
+   %{Zforce_cpusubtype_ALL:-force_cpusubtype_ALL} \
+   %{static}" ASM_MMACOSX_VERSION_MIN_SPEC
+ 
+-/* Default ASM_DEBUG_SPEC.  Darwin's as cannot currently produce dwarf
+-   debugging data.  */
+-
++#ifdef HAS_AS_STABS_DIRECTIVE
++/* We only pass a debug option to the assembler if that supports stabs, since
++   dwarf is not uniformly supported in the assemblers.  */
+ #define ASM_DEBUG_SPEC  "%{g*:%{%:debug-level-gt(0):%{!gdwarf*:--gstabs}}}"
++#else
++#define ASM_DEBUG_SPEC ""
++#endif
++
++#undef  ASM_DEBUG_OPTION_SPEC
++#define ASM_DEBUG_OPTION_SPEC  ""
++
+ #define ASM_FINAL_SPEC \
+   "%{gsplit-dwarf:%ngsplit-dwarf is not supported on this platform} %<gsplit-dwarf"
+ 
+-/* We still allow output of STABS if the assembler supports it.  */
++/* We now require C++11 to bootstrap and newer tools than those based on
++   stabs, so require DWARF-2, even if stabs is supported by the assembler.  */
++
++#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
++#define DARWIN_PREFER_DWARF
++#define DWARF2_DEBUGGING_INFO 1
++
+ #ifdef HAVE_AS_STABS_DIRECTIVE
+ #define DBX_DEBUGGING_INFO 1
+-#define PREFERRED_DEBUGGING_TYPE DBX_DEBUG
+ #endif
+ 
+-#define DWARF2_DEBUGGING_INFO 1
+-
+ #define DEBUG_FRAME_SECTION	  "__DWARF,__debug_frame,regular,debug"
+ #define DEBUG_INFO_SECTION	  "__DWARF,__debug_info,regular,debug"
+ #define DEBUG_ABBREV_SECTION	  "__DWARF,__debug_abbrev,regular,debug"
+diff -ur a/gcc/config/darwin9.h b/gcc/config/darwin9.h
+--- a/gcc/config/darwin9.h	2022-05-27 03:21:10.947379000 -0400
++++ b/gcc/config/darwin9.h	2023-11-06 12:18:48.325260590 -0500
+@@ -18,29 +18,6 @@
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-/* Prefer DWARF2.  */
+-#undef PREFERRED_DEBUGGING_TYPE
+-#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
+-#define DARWIN_PREFER_DWARF
+-
+-/* Since DWARF2 is default, conditions for running dsymutil are different.  */
+-#undef DSYMUTIL_SPEC
+-#define DSYMUTIL_SPEC \
+-   "%{!fdump=*:%{!fsyntax-only:%{!c:%{!M:%{!MM:%{!E:%{!S:\
+-    %{v} \
+-    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -idsym}}}\
+-    %{.c|.cc|.C|.cpp|.cp|.c++|.cxx|.CPP|.m|.mm|.s|.f|.f90|.f95|.f03|.f77|.for|.F|.F90|.F95|.F03: \
+-    %{g*:%{!gstabs*:%{%:debug-level-gt(0): -dsym}}}}}}}}}}}"
+-
+-/* Tell collect2 to run dsymutil for us as necessary.  */
+-#define COLLECT_RUN_DSYMUTIL 1
+-
+-/* Only ask as for debug data if the debug style is stabs (since as doesn't
+-   yet generate dwarf.)  */
+-
+-#undef  ASM_DEBUG_SPEC
+-#define ASM_DEBUG_SPEC  "%{g*:%{%:debug-level-gt(0):%{gstabs:--gstabs}}}"
+-
+ #undef  ASM_OUTPUT_ALIGNED_COMMON
+ #define ASM_OUTPUT_ALIGNED_COMMON(FILE, NAME, SIZE, ALIGN)		\
+   do {									\

--- a/pkgs/development/compilers/gcc/patches/clang-genconditions.patch
+++ b/pkgs/development/compilers/gcc/patches/clang-genconditions.patch
@@ -1,0 +1,34 @@
+From https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92061#c5
+
+--- a/gcc/genconditions.c	2019-01-01 12:37:19.064943662 +0100
++++ b/gcc/genconditions.c	2019-10-11 10:57:11.464595789 +0200
+@@ -57,8 +57,9 @@ write_header (void)
+ \n\
+ /* It is necessary, but not entirely safe, to include the headers below\n\
+    in a generator program.  As a defensive measure, don't do so when the\n\
+-   table isn't going to have anything in it.  */\n\
+-#if GCC_VERSION >= 3001\n\
++   table isn't going to have anything in it.\n\
++   Clang 9 is buggy and doesn't handle __builtin_constant_p correctly.  */\n\
++#if GCC_VERSION >= 3001 && __clang_major__ < 9\n\
+ \n\
+ /* Do not allow checking to confuse the issue.  */\n\
+ #undef CHECKING_P\n\
+@@ -170,7 +171,7 @@ struct c_test\n\
+    vary at run time.  It works in 3.0.1 and later; 3.0 only when not\n\
+    optimizing.  */\n\
+ \n\
+-#if GCC_VERSION >= 3001\n\
++#if GCC_VERSION >= 3001 && __clang_major__ < 9\n\
+ static const struct c_test insn_conditions[] = {\n");
+ 
+   traverse_c_tests (write_one_condition, 0);
+@@ -191,7 +192,7 @@ write_writer (void)
+ 	"  unsigned int i;\n"
+         "  const char *p;\n"
+         "  puts (\"(define_conditions [\");\n"
+-	"#if GCC_VERSION >= 3001\n"
++	"#if GCC_VERSION >= 3001 && __clang_major__ < 9\n"
+ 	"  for (i = 0; i < ARRAY_SIZE (insn_conditions); i++)\n"
+ 	"    {\n"
+ 	"      printf (\"  (%d \\\"\", insn_conditions[i].value);\n"

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -194,6 +194,9 @@ in
   sha256 = "sha256-XtykrPd5h/tsnjY1wGjzSOJ+AyyNLsfnjuOZ5Ryq9vA=";
 })
 
+# Fix undefined symbol errors when building older versions with clang
+++ optional (!atLeast11 && stdenv.cc.isClang) ./clang-genconditions.patch
+
 
 ## gcc 9.0 and older ##############################################################################
 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -200,12 +200,20 @@ in
 ++ optional (majorVersion == "9") ./9/fix-struct-redefinition-on-glibc-2.36.patch
 ++ optional (atLeast7 && !atLeast10 && targetPlatform.isNetBSD) ./libstdc++-netbsd-ctypes.patch
 
+# Make Darwin bootstrap respect whether the assembler supports `--gstabs`,
+# which is not supported by the clang integrated assembler used by default on Darwin.
+++ optional (is9 && hostPlatform.isDarwin) ./9/gcc9-darwin-as-gstabs.patch
+
 
 ## gcc 8.0 and older ##############################################################################
 
 # for 49 this is applied later
 ++ optional (atLeast49 && !is49 && !atLeast9) ./libsanitizer-no-cyclades-9.patch
 ++ optional (is7 || is8) ./9/fix-struct-redefinition-on-glibc-2.36.patch
+
+# Make Darwin bootstrap respect whether the assembler supports `--gstabs`,
+# which is not supported by the clang integrated assembler used by default on Darwin.
+++ optional (is8 && hostPlatform.isDarwin) ./8/gcc8-darwin-as-gstabs.patch
 
 
 ## gcc 7.0 and older ##############################################################################

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -178,6 +178,9 @@ in
 # https://github.com/osx-cross/homebrew-avr/issues/280#issuecomment-1272381808
 ++ optional (is11 && stdenv.isDarwin && targetPlatform.isAvr) ./avr-gcc-11.3-darwin.patch
 
+# libgcc’s `configure` script misdetects aarch64-darwin, resulting in an invalid deployment target.
+++ optional (is11 && stdenv.isDarwin && stdenv.isAarch64) ./11/libgcc-aarch64-darwin-detection.patch
+
 # openjdk build fails without this on -march=opteron; is upstream in gcc12
 ++ optionals (is11) [ ./11/gcc-issue-103910.patch ]
 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -243,6 +243,12 @@ in
   ./6/gnat-glibc234.patch
 ]
 
+# The clang-based assembler used in darwin.cctools-llvm (LLVM >11) does not support piping input.
+# Fortunately, it does not exhibit the problem GCC has with the cctools assembler.
+# This patch can be dropped should darwin.cctools-llvm ever implement support.
+++ optional (!atLeast7 && hostPlatform.isDarwin && lib.versionAtLeast (lib.getVersion stdenv.cc) "12") ./4.9/darwin-clang-as.patch
+
+
 ## gcc 4.9 and older ##############################################################################
 
 ++ optional (!atLeast6) ./parallel-bconfig.patch

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -195,7 +195,7 @@ in
 })
 
 # Fix undefined symbol errors when building older versions with clang
-++ optional (!atLeast11 && stdenv.cc.isClang) ./clang-genconditions.patch
+++ optional (!atLeast11 && stdenv.cc.isClang && stdenv.hostPlatform.isDarwin) ./clang-genconditions.patch
 
 
 ## gcc 9.0 and older ##############################################################################


### PR DESCRIPTION
## Description of changes

This PR fixes the build of all versions of GCC on Darwin in staging-next #263535 except for GCC 4.8. GCC 4.8 hasn’t built successfully for almost a decade, so the PR just disables it.

### aarch64-darwin
* GCC 11: https://hydra.nixos.org/build/239466277

### x86_64-darwin
* GCC 10: https://hydra.nixos.org/build/239551156
* GCC 9: https://hydra.nixos.org/build/239612904
* GCC 8: https://hydra.nixos.org/build/239628060
* GCC 7: https://hydra.nixos.org/build/239554679
* GCC 6: https://hydra.nixos.org/build/239525116

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
