### PR TITLE
aba: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/by-name/ab/aba/package.nix
+++ b/pkgs/by-name/ab/aba/package.nix
@@ -6,7 +6,7 @@
 , scdoc
 }:
 let
-  version = "0.7.1";
+  version = "0.8.0";
 in
 rustPlatform.buildRustPackage {
   pname = "aba";
@@ -16,11 +16,10 @@ rustPlatform.buildRustPackage {
     owner = "~onemoresuza";
     repo = "aba";
     rev = version;
-    hash = "sha256-Sz9I1Dw7wmoUPpTBNfbYbehfNO8FK6r/ubofx+FGb04=";
-    domain = "sr.ht";
+    hash = "sha256-2zVQNchL4DFh2v2/kwupJTBSmXiKqlxzUMrP9TbfCMs=";
   };
 
-  cargoSha256 = "sha256-Ihoh+yp12qN74JHvJbEDoYz+eoMwPOQar+yBEy+bqb0=";
+  cargoHash = "sha256-YhSzbfcEIJjKWlyYq1lK70qt4f/Z71n7hgaaZ/D/U80=";
 
   nativeBuildInputs = [
     just
@@ -28,9 +27,8 @@ rustPlatform.buildRustPackage {
   ];
 
   postPatch = ''
-    # Suppress messages of command not found. jq is not needed for the build, but just calls it anyway.
-    sed -i '/[[:space:]]*|[[:space:]]*jq -r/s/jq -r .*/: \\/' ./justfile
-    # Let only nix strip the binary by disabling cargo's `strip = true`, like buildRustPackage does.
+    # Let only nix strip the binary by disabling cargo's `strip = true`, like
+    # buildRustPackage does when not using just's setup hooks.
     sed -i '/strip[[:space:]]*=[[:space:]]*true/s/true/false/' ./Cargo.toml
   '';
 
@@ -38,7 +36,7 @@ rustPlatform.buildRustPackage {
     justFlagsArray+=(
       PREFIX=${builtins.placeholder "out"}
       MANIFEST_OPTS="--frozen --locked --profile=release"
-      INSTALL_OPTS=--no-track
+      INSTALL_OPTS="--no-track"
     )
   '';
 


### PR DESCRIPTION
## Description of changes
The [Changelog](https://git.sr.ht/~onemoresuza/aba/tree/main/item/CHANGELOG.md#a-hrefhttpsgitsrhtonemoresuzaabarefs080080a---2023-11-27).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
