### PR TITLE
openrefine: init at 3.7.7

### DIFF
--- a/pkgs/applications/science/misc/openrefine/default.nix
+++ b/pkgs/applications/science/misc/openrefine/default.nix
@@ -1,0 +1,136 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildNpmPackage
+, curl
+, jdk
+, jq
+, makeWrapper
+, maven
+, writeText
+}:
+
+let
+  maven' = maven.override {
+    inherit jdk;
+  };
+
+  version = "3.7.7";
+  src = fetchFromGitHub {
+    owner = "openrefine";
+    repo = "openrefine";
+    rev = version;
+    hash = "sha256-/Txx+r+eFizxaTV5u/nOJwum8nJW6jsR6kYA0YbRsJs=";
+  };
+
+  npmPkg = buildNpmPackage {
+    inherit src version;
+
+    pname = "openrefine-npm";
+    sourceRoot = "source/main/webapp";
+
+    npmDepsHash = "sha256-8GhcL4tohQ5u2HeYN6JyTMMobUOqAL8ETCLiP1SoDSk=";
+
+    # package.json doesn't supply a version, which npm doesn't like - fix this.
+    # directly referencing jq because buildNpmPackage doesn't pass
+    # nativeBuildInputs through to fetchNpmDeps
+    postPatch = ''
+      NEW_PACKAGE_JSON=$(mktemp)
+      ${jq}/bin/jq '. + {version: $ENV.version}' package.json > $NEW_PACKAGE_JSON
+      cp $NEW_PACKAGE_JSON package.json
+    '';
+
+    dontNpmBuild = true;
+    installPhase = ''
+      mkdir -p $out
+      cp -r modules/core/3rdparty/* $out/
+    '';
+  };
+
+in maven'.buildMavenPackage {
+  inherit src version;
+
+  pname = "openrefine";
+
+  postPatch = ''
+    cp -r ${npmPkg} main/webapp/modules/core/3rdparty
+  '';
+  mvnParameters = "-DskipTests=true -pl !packaging";
+  mvnHash = "sha256-MqE+iloqzBav6E3/rf1LP5BlKhW/FBIt6+6U+S8UJWA=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = let
+    gitProperties = writeText "git.properties" (builtins.toJSON {
+      "git.build.version" = version;
+      "git.branch" = "none";
+      "git.build.time" = "1970-01-01T00:00:00+0000";
+      "git.commit.id.abbrev" = "none";
+      "git.commit.id.describe" = "none";
+    });
+  in ''
+    mkdir -p $out/lib/server/target/lib
+    cp -r server/target/lib/* $out/lib/server/target/lib/
+    cp server/target/openrefine-*-server.jar $out/lib/server/target/lib/
+
+    mkdir -p $out/lib/webapp
+    cp -r main/webapp/{WEB-INF,modules} $out/lib/webapp/
+    (
+      cd extensions
+      for ext in * ; do
+        if [ -d "$ext/module" ] ; then
+          mkdir -p "$out/lib/webapp/extensions/$ext"
+          cp -r "$ext/module" "$out/lib/webapp/extensions/$ext/"
+        fi
+      done
+    )
+
+    cp ${gitProperties} $out/lib/webapp/WEB-INF/classes/git.properties
+
+    mkdir -p $out/etc
+    cp refine.ini $out/etc/
+
+    mkdir -p $out/bin
+    cp refine $out/bin/
+  '';
+
+  preFixup = ''
+    find $out -name '*.java' -delete
+    sed -i -E 's|^(butterfly\.modules\.path =).*extensions.*$|\1 '"$out/lib/webapp/extensions|" \
+      $out/lib/webapp/WEB-INF/butterfly.properties
+
+    sed -i 's|^cd `dirname \$0`$|cd '"$out/lib|" $out/bin/refine
+
+    cat >> $out/etc/refine.ini <<EOF
+    REFINE_WEBAPP='$out/lib/webapp'
+    REFINE_LIB_DIR='$out/lib/server/target/lib'
+
+    JAVA_HOME='${jdk.home}'
+
+    # non-headless mode tries to launch a browser, causing a
+    # number of purity problems
+    JAVA_OPTIONS='-Drefine.headless=true'
+    EOF
+
+    wrapProgram $out/bin/refine \
+      --prefix PATH : '${lib.makeBinPath [ jdk curl ]}' \
+      --set-default REFINE_INI_PATH "$out/etc/refine.ini"
+  '';
+
+  passthru = {
+    inherit npmPkg;
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "Power tool for working with messy data and improving it";
+    homepage = "https://openrefine.org";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ris ];
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # maven dependencies
+    ];
+    broken = stdenv.isDarwin;  # builds, doesn't run
+  };
+}

--- a/pkgs/applications/science/misc/openrefine/update.sh
+++ b/pkgs/applications/science/misc/openrefine/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix nix-update
+
+set -euxo pipefail
+
+nix-update "${UPDATE_NIX_ATTR_PATH}"
+nix-update "${UPDATE_NIX_ATTR_PATH}.npmPkg" --version=skip
+
+FILE="$(nix-instantiate --eval -E 'with import ./. {}; (builtins.unsafeGetAttrPos "version" '"${UPDATE_NIX_ATTR_PATH}"').file' | tr -d '"')"
+
+MVNHASH_OLD=$(nix-instantiate --eval . -A "${UPDATE_NIX_ATTR_PATH}.mvnHash" | tr -d '"')
+MVNHASH_OLD_ESCAPED=$(echo "${MVNHASH_OLD}" | sed -re 's|[+]|\\&|g')
+FAKEHASH=$(nix-instantiate --eval . -A "lib.fakeHash" | tr -d '"')
+FAKEHASH_ESCAPED=$(echo "${FAKEHASH}" | sed -re 's|[+]|\\&|g')
+
+sed -E -i "s|${MVNHASH_OLD_ESCAPED}|${FAKEHASH}|g" "${FILE}"
+
+MVNHASH_NEW="$(nix-build . -A "${UPDATE_NIX_ATTR_PATH}" 2>&1 | tail -n10 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+
+sed -E -i "s|${FAKEHASH_ESCAPED}|${MVNHASH_NEW}|g" "${FILE}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11605,6 +11605,8 @@ with pkgs;
 
   openresolv = callPackage ../tools/networking/openresolv { };
 
+  openrefine = callPackage ../applications/science/misc/openrefine { jdk = jdk17; };
+
   openrgb = libsForQt5.callPackage ../applications/misc/openrgb { };
 
   openrgb-with-all-plugins = openrgb.withPlugins [


### PR DESCRIPTION
## Description of changes
Addresses #214080. This tool deserves a package, as quirky and non-ideal as it is.

Built "from source" but inevitably depends on binary bytecode from maven :(

Can't get it working properly on darwin, but I don't think I've ever got anything java-y from nix running properly on macos.

cc @hervyqa

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
