### PR TITLE
mbedtls: 3.4.1 -> 3.5.0

### DIFF
--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "3.4.1";
-  hash = "sha256-NIjyRcVbg6lT6+RlTz5Jt6V9T85mvta5grOSLIAK9Ts=";
+  version = "3.5.0";
+  hash = "sha256-uHHQmaAmFS8Vd7PrAfRpK+aNi3pJ76XBC7rFWcd16NU=";
 }


### PR DESCRIPTION
## Description of changes

https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.5.0

```
1 package marked as broken and skipped:
obs-studio-plugins.obs-hyperion

1 package failed to build:
obs-studio-plugins.obs-replay-source

44 packages built:
gauche gaucheBootstrap hyperion-ng imhex librist mbedtls nanomq nng obs-studio obs-studio-plugins.advanced-scene-switcher obs-studio-plugins.droidcam-obs obs-studio-plugins.input-overlay obs-studio-plugins.looking-glass-obs obs-studio-plugins.obs-3d-effect obs-studio-plugins.obs-backgroundremoval obs-studio-plugins.obs-command-source obs-studio-plugins.obs-freeze-filter obs-studio-plugins.obs-gradient-source obs-studio-plugins.obs-gstreamer obs-studio-plugins.obs-livesplit-one obs-studio-plugins.obs-move-transition obs-studio-plugins.obs-multi-rtmp obs-studio-plugins.obs-mute-filter obs-studio-plugins.obs-nvfbc obs-studio-plugins.obs-pipewire-audio-capture obs-studio-plugins.obs-rgb-levels-filter obs-studio-plugins.obs-scale-to-sound obs-studio-plugins.obs-shaderfilter obs-studio-plugins.obs-source-clone obs-studio-plugins.obs-source-record obs-studio-plugins.obs-source-switcher obs-studio-plugins.obs-teleport obs-studio-plugins.obs-text-pthread obs-studio-plugins.obs-transition-table obs-studio-plugins.obs-tuna obs-studio-plugins.obs-vaapi obs-studio-plugins.obs-vertical-canvas obs-studio-plugins.obs-vintage-filter obs-studio-plugins.obs-vkcapture obs-studio-plugins.obs-websocket obs-studio-plugins.waveform obs-studio-plugins.wlrobs ps3netsrv srsran
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
