### PR TITLE
python3Packages.{shiboken6,pyside6}: 6.5.2 -> 6.6.0

### DIFF
--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -1,12 +1,10 @@
 { lib
 , stdenv
-, fetchpatch2
 , cmake
 , ninja
 , python
 , moveBuildTree
 , shiboken6
-, libxcrypt
 }:
 
 stdenv.mkDerivation rec {
@@ -14,16 +12,7 @@ stdenv.mkDerivation rec {
 
   inherit (shiboken6) version src;
 
-  sourceRoot = "pyside-setup-everywhere-src-${version}/sources/${pname}";
-
-  patches = [
-    # Needed to build against qt 6.5.3, until pyside 6.5.3 is released
-    (fetchpatch2 {
-      url = "https://code.qt.io/cgit/pyside/pyside-setup.git/patch/sources/pyside6?id=63ef7628091c8827e3d0d688220d3ae165587eb2";
-      hash = "sha256-TN1xdBkrzZhNontShMC1SKyJK6a8fOk/Di3zX3kv5+I=";
-      stripLen = 2;
-    })
-  ];
+  sourceRoot = "pyside-setup-everywhere-src-${lib.removeSuffix ".0" version}/sources/${pname}";
 
   # FIXME: cmake/Macros/PySideModules.cmake supposes that all Qt frameworks on macOS
   # reside in the same directory as QtCore.framework, which is not true for Nix.

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -1,11 +1,11 @@
 { lib
 , fetchurl
+, fetchpatch
 , llvmPackages
 , python
 , cmake
 , autoPatchelfHook
 , stdenv
-, libxcrypt
 }:
 
 let
@@ -13,23 +13,30 @@ let
 in
 stdenv'.mkDerivation rec {
   pname = "shiboken6";
-  version = "6.5.2";
+  version = "6.6.0";
 
   src = fetchurl {
     # https://download.qt.io/official_releases/QtForPython/shiboken6/
     url = "https://download.qt.io/official_releases/QtForPython/shiboken6/PySide6-${version}-src/pyside-setup-everywhere-src-${version}.tar.xz";
-    sha256 = "sha256-kNvx0U/NQcmKfL6kS4pJUeENC3mOFUdJdW5JRmVNG6g";
+    sha256 = "sha256-LdAC24hRqHFzNU84qoxuxC0P8frJnqQisp4t/OUtFjg=";
   };
 
-  sourceRoot = "pyside-setup-everywhere-src-${version}/sources/${pname}";
+  sourceRoot = "pyside-setup-everywhere-src-${lib.removeSuffix ".0" version}/sources/${pname}";
 
   patches = [
     ./fix-include-qt-headers.patch
+    # TODO: remove after bumping above 6.6.0
+    (fetchpatch {
+      name = "shiboken6-improve-api-extractor-argument-parsing.patch";
+      url = "https://code.qt.io/cgit/pyside/pyside-setup.git/patch/?id=6abde77c3df60ccac25089660df5797de7f6e68c";
+      hash = "sha256-uctp5rjY16X37BYzsZzg9AAgM2hwNVkcNxT1bCobb0I=";
+      stripLen = 2;
+    })
   ];
 
   nativeBuildInputs = [
     cmake
-    python
+    (python.pythonOnBuildForHost.withPackages (ps: [ ps.setuptools ]))
   ] ++ lib.optionals stdenv.isLinux [
     autoPatchelfHook
   ];
@@ -47,14 +54,20 @@ stdenv'.mkDerivation rec {
     "-DBUILD_TESTS=OFF"
   ];
 
-  # Due to Shiboken.abi3.so being linked to libshiboken6.abi3.so.6.5 in the build tree,
+  # We intentionally use single quotes around `${BASH}` since it expands from a CMake
+  # variable available in this file.
+  postPatch = ''
+    substituteInPlace cmake/ShibokenHelpers.cmake --replace '#!/bin/bash' '#!''${BASH}'
+  '';
+
+  # Due to Shiboken.abi3.so being linked to libshiboken6.abi3.so.6.6 in the build tree,
   # we need to remove the build tree reference from the RPATH and then add the correct
   # directory to the RPATH. On Linux, the second part is handled by autoPatchelfHook.
   # https://bugreports.qt.io/browse/PYSIDE-2233
   preFixup = ''
     echo "fixing RPATH of Shiboken.abi3.so"
   '' + lib.optionalString stdenv.isDarwin ''
-    install_name_tool -change {@rpath,$out/lib}/libshiboken6.abi3.6.5.dylib $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so
+    install_name_tool -change {@rpath,$out/lib}/libshiboken6.abi3.6.6.dylib $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so
   '' + lib.optionalString stdenv.isLinux ''
     patchelf $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir}
   '';


### PR DESCRIPTION
## Description of changes

Upstream started hardcoding `/bin/bash` in [`4685aca4f`](https://code.qt.io/cgit/pyside/pyside-setup.git/commit/sources/shiboken6/cmake/ShibokenHelpers.cmake?h=6.6&id=4685aca4fc09db54b21814c7e70b62d4689bdccb) so this rewrites that in a `postPatch`

Upstream also requires setuptools now in [`709c3f0b8`](https://code.qt.io/cgit/pyside/pyside-setup.git/commit/build_scripts/utils.py?id=709c3f0b8a7a597e531506d6024ead26b3a8f08a) and no longer falls back on distutils, so this adds the `setuptools` package to the python interpreter used for build

This also pulls in [`6abde77c3`](https://code.qt.io/cgit/pyside/pyside-setup.git/commit/?h=6.6&id=6abde77c3df60ccac25089660df5797de7f6e68c) since it seems to fix a regression in `--include-paths` argument parsing in shiboken6 that some dependents need

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## nixpkgs-review

Result of `nixpkgs-review pr 265987` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>comic-mandown</li>
    <li>comic-mandown.dist</li>
    <li>normcap</li>
    <li>normcap.dist</li>
    <li>onedrivegui</li>
    <li>onedrivegui.dist</li>
    <li>python310Packages.pyside6</li>
    <li>python310Packages.shiboken6</li>
    <li>python311Packages.pyside6</li>
    <li>python311Packages.shiboken6</li>
    <li>retool</li>
    <li>retool.dist</li>
    <li>smb3-foundry</li>
    <li>streamdeck-ui</li>
    <li>streamdeck-ui.dist</li>
    <li>syncplay</li>
  </ul>
</details>

Result of `nixpkgs-review pr 265987` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>comic-mandown</li>
    <li>comic-mandown.dist</li>
    <li>normcap</li>
    <li>normcap.dist</li>
    <li>onedrivegui</li>
    <li>onedrivegui.dist</li>
    <li>python310Packages.pyside6</li>
    <li>python310Packages.shiboken6</li>
    <li>python311Packages.pyside6</li>
    <li>python311Packages.shiboken6</li>
    <li>retool</li>
    <li>retool.dist</li>
    <li>smb3-foundry</li>
    <li>streamdeck-ui</li>
    <li>streamdeck-ui.dist</li>
    <li>syncplay</li>
  </ul>
</details>

Result of `nixpkgs-review pr 265987` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>comic-mandown</li>
    <li>comic-mandown.dist</li>
    <li>normcap</li>
    <li>normcap.dist</li>
    <li>python310Packages.pyside6</li>
    <li>python310Packages.shiboken6</li>
    <li>python311Packages.pyside6</li>
    <li>python311Packages.shiboken6</li>
    <li>retool</li>
    <li>retool.dist</li>
    <li>smb3-foundry</li>
    <li>syncplay</li>
  </ul>
</details>

Result of `nixpkgs-review pr 265987` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>comic-mandown</li>
    <li>comic-mandown.dist</li>
    <li>normcap</li>
    <li>normcap.dist</li>
    <li>python310Packages.pyside6</li>
    <li>python310Packages.shiboken6</li>
    <li>python311Packages.pyside6</li>
    <li>python311Packages.shiboken6</li>
    <li>retool</li>
    <li>retool.dist</li>
    <li>smb3-foundry</li>
    <li>syncplay</li>
  </ul>
</details>