### PR TITLE
 catboost: adding option to build R library 

### DIFF
--- a/pkgs/development/libraries/catboost/default.nix
+++ b/pkgs/development/libraries/catboost/default.nix
@@ -11,13 +11,28 @@
 , ragel
 , yasm
 , zlib
+, R
+, rPackages
 , cudaSupport ? config.cudaSupport
 , cudaPackages ? {}
 , pythonSupport ? false
+, rLibrary ? false
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "catboost";
+stdenv.mkDerivation (finalAttrs: rec {
+  pnameBase = "catboost";
+  pname = lib.optionalString rLibrary "r-" + finalAttrs.pnameBase;
+  # The R package build results in a special catboost.so file
+  # that contains a subset of the .so file use for the CLI
+  # and python version. Catboost is not available from CRAN, so
+  # the rLibrary option follows the same steps as r-modules.
+  # Build with:
+  # nix-build -E "with (import $NIXPKGS{}); \
+  #   let \
+  #     cboost = catboost.override{ rLibrary = true; }; \
+  #   in \
+  #   rWrapper.override{ packages = [ cboost ]; }"
+  # An overlay would also work fine.
   version = "1.2.2";
 
   src = fetchFromGitHub {
@@ -35,6 +50,15 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace cmake/common.cmake \
       --replace  "\''${RAGEL_BIN}" "${ragel}/bin/ragel" \
       --replace "\''${YASM_BIN}" "${yasm}/bin/yasm"
+
+    # catboost caps the number of threads to ensure deterministic
+    # results in tests, but the limit causes the library to fail
+    # on larger machines. Raising the limit seems to have no
+    # adverse effect on smaller machines which are already well
+    # under the limit. See some discussion here:
+    # https://github.com/catboost/catboost/issues/120
+    substituteInPlace catboost/private/libs/options/restrictions.h \
+      --replace "CB_THREAD_LIMIT = 128" "CB_THREAD_LIMIT = 300"
 
     shopt -s globstar
     for cmakelists in **/CMakeLists.*; do
@@ -57,7 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
     yasm
   ] ++ lib.optionals cudaSupport (with cudaPackages; [
     cuda_nvcc
-  ]);
+    autoAddOpenGLRunpathHook
+  ]) ++ lib.optionals rLibrary [ R rPackages.devtools rPackages.withr ];
 
   buildInputs = [
     openssl
@@ -70,6 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
     libcublas
   ]);
 
+  propagatedBuildInputs = lib.optionals rLibrary [
+    rPackages.jsonlite
+  ];
+
   env = {
     CUDAHOSTCXX = lib.optionalString cudaSupport "${stdenv.cc}/bin/cc";
     NIX_CFLAGS_LINK = lib.optionalString stdenv.isLinux "-fuse-ld=lld";
@@ -79,22 +108,43 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DCMAKE_BINARY_DIR=$out"
     "-DCMAKE_POSITION_INDEPENDENT_CODE=on"
-    "-DCATBOOST_COMPONENTS=app;libs${lib.optionalString pythonSupport ";python-package"}"
+    "-DCATBOOST_COMPONENTS=app;libs${lib.optionalString pythonSupport ";python-package"}${lib.optionalString rLibrary ";R-package"}"
   ] ++ lib.optionals cudaSupport [
-    "-DHAVE_CUDA=on"
+    "-DHAVE_CUDA=yes"
   ];
+
+  preConfigure = lib.optionals rLibrary ''
+    export R_LIBS_SITE="$R_LIBS_SITE''${R_LIBS_SITE:+:}$out/library"
+  '';
+
+  postConfigure = lib.optionals rLibrary ''
+    # catboost's configure step deletes the contents of the R-package directory
+    # and this step replaces it from src so it can be build for rLibrary
+    cp -r $src/catboost/R-package/* catboost/R-package
+  '';
 
   installPhase = ''
     runHook preInstall
-
     mkdir $dev
     cp -r catboost $dev
+  '' + lib.optionalString (!rLibrary) ''
     install -Dm555 catboost/app/catboost -t $out/bin
     install -Dm444 catboost/libs/model_interface/static/lib/libmodel_interface-static-lib.a -t $out/lib
     install -Dm444 catboost/libs/model_interface/libcatboostmodel${stdenv.hostPlatform.extensions.sharedLibrary} -t $out/lib
     install -Dm444 catboost/libs/train_interface/libcatboost${stdenv.hostPlatform.extensions.sharedLibrary} -t $out/lib
-
+  '' + lib.optionalString rLibrary ''
+    mkdir $out
+    mkdir $out/library
+    export R_LIBS_SITE="$out/library:$R_LIBS_SITE''${R_LIBS_SITE:+:}"
+    ${R}/bin/R CMD INSTALL -l $out/library catboost/R-package
+  '' + ''
     runHook postInstall
+  '';
+
+  postFixup = lib.optionalString rLibrary ''
+    if test -e $out/nix-support/propagated-build-inputs; then
+        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
+    fi
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/catboost/default.nix
+++ b/pkgs/development/libraries/catboost/default.nix
@@ -19,6 +19,9 @@
 , rLibrary ? false
 }:
 
+assert rLibrary -> !pythonSupport;
+assert pythonSupport -> !rLibrary;
+
 stdenv.mkDerivation (finalAttrs: rec {
   pnameBase = "catboost";
   pname = lib.optionalString rLibrary "r-" + finalAttrs.pnameBase;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adding option to build to build the R library. See included comments for an example of usage.
@natsukium, @jbedo

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
