### PR TITLE
mmj2: init at 2.5.2-unstable-2023-06-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9593,6 +9593,11 @@
     githubId = 88038050;
     name = "Souvik Sen";
   };
+  io12 = {
+    github = "io12";
+    githubId = 7348004;
+    name = "Benjamin Levy";
+  };
   iogamaster = {
     email = "iogamastercode+nixpkgs@gmail.com";
     name = "IogaMaster";

--- a/pkgs/by-name/mm/mmj2/package.nix
+++ b/pkgs/by-name/mm/mmj2/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  maven,
+  fetchFromGitHub,
+  jre,
+  makeWrapper,
+}:
+
+let
+  lastVersion = "2.5.2";
+
+in
+maven.buildMavenPackage {
+  pname = "mmj2";
+
+  # The latest stable version is from 2017 and doesn't include the mmj2jar/mmj2
+  # wrapper script, so use the unstable one for now
+  version = "${lastVersion}-unstable-2023-06-27";
+
+  src = fetchFromGitHub {
+    owner = "digama0";
+    repo = "mmj2";
+    fetchSubmodules = true;
+    rev = "1cd95c1fe4435899c8575644fccb412dd77d79e4";
+    hash = "sha256-WYBrLY04+bJGzjRMs8LgHnI6lMRhQKyz15DIoLeiE2s=";
+  };
+
+  mvnHash = "sha256-fu/q6CTvSllrfgnKNX6aIuPO65H/q0IPCHFuWmOFOvM=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    local jar=$out/share/$pname/$pname.jar
+    local bin=$out/bin/$pname
+    install -Dm644 target/$pname-${lastVersion}-SNAPSHOT-jar-with-dependencies.jar $jar
+    install -Dm744 mmj2jar/$pname $bin
+    wrapProgram $bin \
+      --set MMJ2_JAR $jar \
+      --set JAVA ${jre}/bin/java
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "GUI Proof Assistant for the Metamath project";
+    longDescription = ''
+      mmj2 is a proof assistant for the Metamath language. Metamath is a
+      language that lets you express mathematical axioms and theorems. The proof
+      assistant includes a GUI for creating proofs, proof verification tools,
+      and grammatical/syntax analysis.
+    '';
+    homepage = "https://github.com/digama0/mmj2";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ io12 ];
+    platforms = platforms.linux;
+    mainProgram = "mmj2";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [mmj2](https://github.com/digama0/mmj2/) package. This can be run with `./result/bin/mmj2 -d set.mm`, where `set.mm` is the file https://github.com/metamath/set.mm/blob/develop/set.mm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
