### PR TITLE
summoning-pixel-dungeon: 1.2.5 -> 1.2.5a

### DIFF
--- a/pkgs/games/shattered-pixel-dungeon/disable-git-version.patch
+++ b/pkgs/games/shattered-pixel-dungeon/disable-git-version.patch
@@ -21,7 +21,7 @@ diff --git a/build.gradle b/build.gradle
          appName = 'Summoning Pixel Dungeon'
          appPackageName = 'com.trashboxbobylev.summoningpixeldungeon'
  
-         appVersionCode = 430
+         appVersionCode = 432
 -        appVersionName = '@version@-' + details.gitHash.substring(0, 7)
 +        appVersionName = '@version@'
  

--- a/pkgs/games/shattered-pixel-dungeon/summoning-pixel-dungeon.nix
+++ b/pkgs/games/shattered-pixel-dungeon/summoning-pixel-dungeon.nix
@@ -6,14 +6,14 @@
 
 callPackage ./generic.nix rec {
   pname = "summoning-pixel-dungeon";
-  version = "1.2.5";
+  version = "1.2.5a";
 
   src = fetchFromGitHub {
     owner = "TrashboxBobylev";
     repo = "Summoning-Pixel-Dungeon";
     # The GH release is named "$version-$hash", but it's actually a mutable "_latest" tag
-    rev = "fc63a89a0f9bdf9cb86a750dfec65bc56d9fddcb";
-    hash = "sha256-n1YR7jYJ8TQFe654aERgmOHRgaPZ82eXxu0K12/5MGw=";
+    rev = "89ff59e7f42abcc88b7a1f24391f95ddc30f9d29";
+    hash = "sha256-VQcWkbGe/0qyt3M5WWgTxczwC5mE3lRHbYidOwRoukI=";
   };
 
   patches = [(substitute {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/TrashboxBobylev/Summoning-Pixel-Dungeon/releases/tag/latest_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
