### PR TITLE
python311Packages.plotnine: 0.12.4 -> 0.13.0, python311Packages.mizani: 0.9.3 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/mizani/default.nix
+++ b/pkgs/development/python-modules/mizani/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "mizani";
-  version = "0.9.3";
+  version = "0.11.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "has2k1";
     repo = "mizani";
     rev = "refs/tags/v${version}";
-    hash = "sha256-gZwM8/9ipcA73m1sPCz9oxD7cndli+qX9+gLILdbq1A=";
+    hash = "sha256-4xk8FCUiNOp5n512asYKcjAS7fsyExyMQiWg14XWwHY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/plotnine/default.nix
+++ b/pkgs/development/python-modules/plotnine/default.nix
@@ -16,16 +16,16 @@
 
 buildPythonPackage rec {
   pname = "plotnine";
-  version = "0.12.4";
+  version = "0.13.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "has2k1";
     repo = "plotnine";
     rev = "refs/tags/v${version}";
-    hash = "sha256-bm7xMCFDFimINlUePqLYw5bZtI5B151QOtltajgSm2U=";
+    hash = "sha256-qhmo1Ckc4OUzWCnjCNQvwsExB98/BCKydMZdB/yfOY0=";
   };
 
   nativeBuildInputs = [
@@ -64,19 +64,24 @@ buildPythonPackage rec {
     # Assertion Errors:
     # Generated plot images do not exactly match the expected files.
     # After manually checking, this is caused by extremely subtle differences in label placement.
+    "tests/test_aes.py"
     "tests/test_annotation_logticks.py"
     "tests/test_coords.py"
-    "tests/test_facets.py"
     "tests/test_facet_labelling.py"
+    "tests/test_facets.py"
     "tests/test_geom_bar_col_histogram.py"
     "tests/test_geom_bin_2d.py"
     "tests/test_geom_boxplot.py"
+    "tests/test_geom_count.py"
+    "tests/test_geom_density_2d.py"
     "tests/test_geom_density.py"
     "tests/test_geom_dotplot.py"
+    "tests/test_geom_freqpoly.py"
     "tests/test_geom_map.py"
     "tests/test_geom_path_line_step.py"
     "tests/test_geom_point.py"
     "tests/test_geom_raster.py"
+    "tests/test_geom_rect_tile.py"
     "tests/test_geom_ribbon_area.py"
     "tests/test_geom_sina.py"
     "tests/test_geom_smooth.py"
@@ -87,6 +92,7 @@ buildPythonPackage rec {
     "tests/test_scale_internals.py"
     "tests/test_scale_labelling.py"
     "tests/test_stat_ecdf.py"
+    "tests/test_stat_function.py"
     "tests/test_stat_summary.py"
     "tests/test_theme.py"
 


### PR DESCRIPTION
## Description of changes

Changelogs:
- plotnine: https://plotnine.readthedocs.io/en/v0.12.4/changelog.html#v0-13-0
- mizani: https://mizani.readthedocs.io/en/stable/changelog.html#v0-11-0

cc @onny @samuela


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
