### PR TITLE
hdl_checker: init at 0.7.5-devel

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12809,6 +12809,12 @@
     githubId = 4368690;
     name = "Ratko Mladic";
   };
+  nikp123 = {
+    email = "nikp123@e.email";
+    github = "nikp123";
+    githubId = 4696350;
+    name = "nikp123";
+  };
   nikstur = {
     email = "nikstur@outlook.com";
     name = "nikstur";

--- a/pkgs/development/tools/language-servers/hdl_checker/default.nix
+++ b/pkgs/development/tools/language-servers/hdl_checker/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, pkgs
+, python3Packages
+, fetchFromGitHub
+, fetchpatch
+, argparse
+}: let
+  pname = "hdl_checker";
+  # Version is a development commit because the release version
+  # won't compile on NixOS
+  version = "0.7.5-develop";
+in python3Packages.buildPythonPackage {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "suoto";
+    repo  = "hdl_checker";
+    rev   = "12983254962ca2d221d5e755726528aedeca27e2";
+    hash  = "sha256-2vvJEEjptKxfIc6bOiUXDh70wEdK4YppWXSPxeazE40=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/suoto/hdl_checker/pull/101.patch";
+      hash = "sha256-cQ9RJt2H3yD19i9ya4vyC1IHuc/7gbl1c+5+GiJbtSA=";
+    })
+    ./remove_argparse_from_pip.diff
+  ];
+
+  propagatedBuildInputs = (with python3Packages; [
+    future
+    argcomplete
+    prettytable
+    waitress
+    pygls
+    bottle
+    six
+    tabulate
+    requests
+    mock
+
+    typing-extensions
+  ]) ++ [
+    argparse
+  ];
+
+  # Depends on 'unittest2' which is DEPRECATED AND BROKEN
+  # See: https://github.com/NixOS/nixpkgs/pull/203986
+  doCheck = false;
+
+  meta = with lib; {
+    description = "HDL code checker";
+    homepage    = "https://github.com/suoto/hdl_checker";
+    license     = licenses.gpl3Only;
+    maintainers = [ maintainers.nikp123 ];
+  };
+}
+

--- a/pkgs/development/tools/language-servers/hdl_checker/remove_argparse_from_pip.diff
+++ b/pkgs/development/tools/language-servers/hdl_checker/remove_argparse_from_pip.diff
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index d7a37b3..491fcfe 100755
+--- a/setup.py
++++ b/setup.py
+@@ -52,7 +52,6 @@ setuptools.setup(
+     platforms                     = 'any',
+     packages                      = setuptools.find_packages(),
+     install_requires              = ['argcomplete',
+-                                     'argparse',
+                                      'backports.functools_lru_cache; python_version<"3.2"',
+                                      'bottle>=0.12.9',
+                                      'enum34>=1.1.6; python_version<"3.3"',

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18360,6 +18360,8 @@ with pkgs;
 
   gopls = callPackage ../development/tools/language-servers/gopls { };
 
+  hdl_checker = callPackage ../development/tools/language-servers/hdl_checker { };
+
   helm-ls = callPackage ../development/tools/language-servers/helm-ls { };
 
   javascript-typescript-langserver = callPackage ../development/tools/language-servers/javascript-typescript-langserver { };


### PR DESCRIPTION
Version tag is a development build from 'master' because the current release tag (0.7.4) won't compile.

## Description of changes

https://github.com/suoto/hdl_checker

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ? ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I've tested compiling on both ``nixos-23.05`` and ``nixpkgs-unstable``. Both work fine when ran from the command-line. Tests were disabled however due to reliance on deprecated packages.

I am in no hurry to package this for ``23.11``, this can be left for later. I just wanted to make the package available to whoever needs it.
