### PR TITLE
persepolis: ZHF: fix build and runtime errors on darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7486,6 +7486,13 @@
     githubId = 1550265;
     name = "Dominic Steinitz";
   };
+  iFreilicht = {
+    github = "iFreilicht";
+    githubId = 9742635;
+    matrix = "@ifreilicht:matrix.org";
+    email = "nixpkgs@mail.felix-uhl.de";
+    name = "Felix Uhl";
+  };
   ifurther = {
     github = "ifurther";
     githubId = 55025025;

--- a/pkgs/tools/networking/persepolis/0001-Allow-building-on-darwin.patch
+++ b/pkgs/tools/networking/persepolis/0001-Allow-building-on-darwin.patch
@@ -1,0 +1,45 @@
+---
+ setup.py | 13 +++++--------
+ 1 file changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 985d28d..933f3df 100755
+--- a/setup.py
++++ b/setup.py
+@@ -24,13 +24,9 @@ import shutil
+ # finding os platform
+ os_type = platform.system()
+ 
+-if os_type == 'Linux' or os_type == 'FreeBSD' or os_type == 'OpenBSD':
+-    from setuptools import setup, Command, find_packages
+-    setuptools_available = True
+-    print(os_type + " detected!")
+-else:
+-    print('This script is only work for GNU/Linux or BSD!')
+-    sys.exit(1)
++from setuptools import setup, Command, find_packages
++setuptools_available = True
++print(os_type + " detected!")
+ 
+ # Checking dependencies!
+ not_installed = ''
+@@ -100,6 +96,7 @@ else:
+     print('paplay is found!')
+ 
+ # sound-theme-freedesktop
++notifications_path = ''
+ if os_type == 'Linux':
+     notifications_path = '/usr/share/sounds/freedesktop/stereo/'
+ elif os_type == 'FreeBSD' or os_type == 'OpenBSD':
+@@ -139,7 +136,7 @@ if sys.argv[1] == "test":
+ 
+ DESCRIPTION = 'Persepolis Download Manager'
+ 
+-if os_type == 'Linux':
++if os_type in ['Linux', 'Darwin']:
+     DATA_FILES = [
+         ('/usr/share/man/man1/', ['man/persepolis.1.gz']),
+         ('/usr/share/applications/', ['xdg/com.github.persepolisdm.persepolis.desktop']),
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/tools/networking/persepolis/0002-Fix-startup-crash-on-darwin.patch
+++ b/pkgs/tools/networking/persepolis/0002-Fix-startup-crash-on-darwin.patch
@@ -1,0 +1,41 @@
+---
+ persepolis/scripts/mac_notification.py | 25 +++++++++----------------
+ 1 file changed, 9 insertions(+), 16 deletions(-)
+
+diff --git a/persepolis/scripts/mac_notification.py b/persepolis/scripts/mac_notification.py
+index 4d69929..9a9a7cf 100644
+--- a/persepolis/scripts/mac_notification.py
++++ b/persepolis/scripts/mac_notification.py
+@@ -15,20 +15,13 @@
+ 
+ # native notification on mac! needs Xcode (latest version) installed and pyobjc
+ # library from pip
+-import Foundation
+-import AppKit
+-import objc
+-
+-NSUserNotification = objc.lookUpClass('NSUserNotification')
+-NSUserNotificationCenter = objc.lookUpClass('NSUserNotificationCenter')
+-
+-
+ def notifyMac(title, subtitle, info_text, delay=0):
+-    notification = NSUserNotification.alloc().init()
+-    notification.setTitle_(title)
+-    notification.setSubtitle_(subtitle)
+-    notification.setInformativeText_(info_text)
+-    notification.setDeliveryDate_(Foundation.NSDate.dateWithTimeInterval_sinceDate_(
+-        delay, Foundation.NSDate.date()))
+-    NSUserNotificationCenter.defaultUserNotificationCenter(
+-    ).scheduleNotification_(notification)
++    print(f"""
++Warning: Persepolis was installed from nixpkgs, which currently breaks notifications
++         on macOS. Until https://github.com/NixOS/nixpkgs/issues/105156 is resolved,
++         this cannot be fixed. The notification that should've been displayed was:
++
++         title: {title}
++         subtitle: {subtitle}
++         info_text: {info_text}
++ """)
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/tools/networking/persepolis/0003-Search-PATH-for-aria2c-on-darwin.patch
+++ b/pkgs/tools/networking/persepolis/0003-Search-PATH-for-aria2c-on-darwin.patch
@@ -1,0 +1,29 @@
+---
+ persepolis/scripts/download.py | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/persepolis/scripts/download.py b/persepolis/scripts/download.py
+index aaabb35..69676d3 100644
+--- a/persepolis/scripts/download.py
++++ b/persepolis/scripts/download.py
+@@ -72,16 +72,8 @@ def startAria():
+ 
+     # in macintosh
+     elif os_type == 'Darwin':
+-        if aria2_path == "" or aria2_path == None or os.path.isfile(str(aria2_path)) == False:
+-
+-            cwd = sys.argv[0]
+-            current_directory = os.path.dirname(cwd)
+-            aria2d = os.path.join(current_directory, 'aria2c')
+ 
+-        else:
+-            aria2d = aria2_path
+-
+-        subprocess.Popen([aria2d, '--no-conf',
++        subprocess.Popen(['aria2c', '--no-conf',
+                           '--enable-rpc', '--rpc-listen-port=' + str(port),
+                           '--rpc-max-request-size=2M',
+                           '--rpc-listen-all', '--quiet=true'],
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/tools/networking/persepolis/0004-Search-PATH-for-ffmpeg-on-darwin.patch
+++ b/pkgs/tools/networking/persepolis/0004-Search-PATH-for-ffmpeg-on-darwin.patch
@@ -1,0 +1,34 @@
+---
+ persepolis/scripts/mainwindow.py   | 2 +-
+ persepolis/scripts/useful_tools.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/persepolis/scripts/mainwindow.py b/persepolis/scripts/mainwindow.py
+index d21f3f4..a0e3674 100644
+--- a/persepolis/scripts/mainwindow.py
++++ b/persepolis/scripts/mainwindow.py
+@@ -161,7 +161,7 @@ class CheckVersionsThread(QThread):
+ 
+             else:
+                 pipe = subprocess.Popen(
+-                    [ffmpeg_path, '-version'],
++                    ['ffmpeg', '-version'],
+                     stdout=subprocess.PIPE,
+                     stdin=subprocess.PIPE,
+                     stderr=subprocess.PIPE,
+diff --git a/persepolis/scripts/useful_tools.py b/persepolis/scripts/useful_tools.py
+index b780967..31733eb 100644
+--- a/persepolis/scripts/useful_tools.py
++++ b/persepolis/scripts/useful_tools.py
+@@ -342,7 +342,7 @@ def muxer(parent, video_finder_dictionary):
+                 current_directory = os.path.dirname(cwd)
+                 ffmpeg_path = os.path.join(current_directory, 'ffmpeg')
+ 
+-                pipe = subprocess.Popen([ffmpeg_path, '-i', video_file_path,
++                pipe = subprocess.Popen(['ffmpeg', '-i', video_file_path,
+                                          '-i', audio_file_path,
+                                          '-c', 'copy',
+                                          '-shortest',
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, buildPythonApplication, fetchFromGitHub
+{ lib
+, stdenv
+, buildPythonApplication
+, fetchFromGitHub
 , aria
 , libnotify
 , pulseaudio
@@ -30,6 +33,12 @@ buildPythonApplication rec {
     substituteInPlace setup.py --replace "answer = input(" "answer = 'y'#"
   '';
 
+  patches = lib.optionals stdenv.isDarwin [
+    ./0001-Allow-building-on-darwin.patch
+    ./0002-Fix-startup-crash-on-darwin.patch
+    ./0003-Search-PATH-for-aria2c-on-darwin.patch
+  ];
+
   postPatch = ''
     sed -i 's|/usr/share/sounds/freedesktop/stereo/|${sound-theme-freedesktop}/share/sounds/freedesktop/stereo/|' setup.py
     sed -i "s|'persepolis = persepolis.__main__'|'persepolis = persepolis.scripts.persepolis:main'|" setup.py
@@ -46,7 +55,7 @@ buildPythonApplication rec {
 
   # feed args to wrapPythonApp
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [aria libnotify ]}"
+    "--prefix PATH : ${lib.makeBinPath [ aria libnotify ]}"
     "\${qtWrapperArgs[@]}"
   ];
 
@@ -64,7 +73,6 @@ buildPythonApplication rec {
   meta = with lib; {
     description = "Persepolis Download Manager is a GUI for aria2";
     homepage = "https://persepolisdm.github.io/";
-    broken = stdenv.isDarwin; # Upstream’s build scripts check and fail on Darwin.
     license = licenses.gpl3;
     maintainers = [ ];
   };

--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -3,6 +3,7 @@
 , buildPythonApplication
 , fetchFromGitHub
 , aria
+, ffmpeg
 , libnotify
 , pulseaudio
 , psutil
@@ -37,6 +38,7 @@ buildPythonApplication rec {
     ./0001-Allow-building-on-darwin.patch
     ./0002-Fix-startup-crash-on-darwin.patch
     ./0003-Search-PATH-for-aria2c-on-darwin.patch
+    ./0004-Search-PATH-for-ffmpeg-on-darwin.patch
   ];
 
   postPatch = ''
@@ -55,7 +57,7 @@ buildPythonApplication rec {
 
   # feed args to wrapPythonApp
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [ aria libnotify ]}"
+    "--prefix PATH : ${lib.makeBinPath [ aria ffmpeg libnotify ]}"
     "\${qtWrapperArgs[@]}"
   ];
 

--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -13,7 +13,7 @@
 , setuptools
 , sound-theme-freedesktop
 , wrapQtAppsHook
-, youtube-dl
+, yt-dlp
 }:
 
 buildPythonApplication rec {
@@ -30,11 +30,21 @@ buildPythonApplication rec {
   # see: https://github.com/persepolisdm/persepolis/blob/3.2.0/setup.py#L130
   doCheck = false;
 
-  preBuild=''
+  preBuild=
+  # Make setup automatic
+  ''
     substituteInPlace setup.py --replace "answer = input(" "answer = 'y'#"
+  '' +
+  # Replace abandoned youtube-dl with maintained fork yt-dlp. Fixes https://github.com/persepolisdm/persepolis/issues/930,
+  # can be removed if that issue is fixed and/or https://github.com/persepolisdm/persepolis/pull/936 is merged
+  ''
+    substituteInPlace setup.py ./persepolis/scripts/video_finder_addlink.py --replace \
+        "import youtube_dl" "import yt_dlp as youtube_dl"
   '';
 
   patches = lib.optionals stdenv.isDarwin [
+    # Upstream is abandonware, the last commit to master was on 2021-08-26.
+    # If it is forked or picked up again, consider upstreaming these patches.
     ./0001-Allow-building-on-darwin.patch
     ./0002-Fix-startup-crash-on-darwin.patch
     ./0003-Search-PATH-for-aria2c-on-darwin.patch
@@ -69,7 +79,7 @@ buildPythonApplication rec {
     setproctitle
     setuptools
     sound-theme-freedesktop
-    youtube-dl
+    yt-dlp
   ];
 
   meta = with lib; {

--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -76,6 +76,6 @@ buildPythonApplication rec {
     description = "Persepolis Download Manager is a GUI for aria2";
     homepage = "https://persepolisdm.github.io/";
     license = licenses.gpl3;
-    maintainers = [ ];
+    maintainers = with maintainers; [ iFreilicht ];
   };
 }


### PR DESCRIPTION
## Description of changes
This fixes the build and runtime errors on darwin as part of #265948.

## Things done
* Fixed the build of the package on darwin
* Tried to start the binary, this failed at first
* Fixed the startup with additional patches
   * Disabled notifications on darwin as they relied on [pyobjc, which is not currently in nixpkgs](https://github.com/NixOS/nixpkgs/issues/105156)
* Tested basic functionality, found the package has an implicit dependency on ffmpeg
* Added ffmpeg as well
* Added myself to the maintainers list
* Added myself as the maintainer as this package is currently orphaned and I know a little bit about how it works and is built now
* Replaced abandoned `youtube-dl` with maintained fork `yt-dlp` to restore video finder functionality (this was broken on Linux and Darwin)
* Tested everything once more;
   * Downloaded a small video successfully as well as random files off of github and wikipedia

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
