### PR TITLE
hare: add onemoresuza as the maintainer

### DIFF
--- a/pkgs/development/compilers/hare/hare/default.nix
+++ b/pkgs/development/compilers/hare/hare/default.nix
@@ -57,15 +57,15 @@ stdenv.mkDerivation (finalAttrs: {
         inherit arch platform hareflags;
       };
     in
-      ''
-        runHook preConfigure
+    ''
+      runHook preConfigure
 
-        export HARECACHE="$NIX_BUILD_TOP/.harecache"
-        export BINOUT="$NIX_BUILD_TOP/.bin"
-        cat ${config-file} > config.mk
+      export HARECACHE="$NIX_BUILD_TOP/.harecache"
+      export BINOUT="$NIX_BUILD_TOP/.bin"
+      cat ${config-file} > config.mk
 
-        runHook postConfigure
-      '';
+      runHook postConfigure
+    '';
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
@@ -81,9 +81,9 @@ stdenv.mkDerivation (finalAttrs: {
         qbe
       ];
     in
-      ''
-        wrapProgram $out/bin/hare --prefix PATH : ${binPath}
-      '';
+    ''
+      wrapProgram $out/bin/hare --prefix PATH : ${binPath}
+    '';
 
   setupHook = ./setup-hook.sh;
 
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     description =
       "A systems programming language designed to be simple, stable, and robust";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ onemoresuza ];
     inherit (harec.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/compilers/hare/harec/default.nix
+++ b/pkgs/development/compilers/hare/harec/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://harelang.org/";
     description = "Bootstrapping Hare compiler written in C for POSIX systems";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ onemoresuza ];
     # The upstream developers do not like proprietary operating systems; see
     # https://harelang.org/platforms/
     # UPDATE: https://github.com/hshq/harelang provides a MacOS port


### PR DESCRIPTION
## Description of changes

Besides adopting hare, since harec is part of its bootstrapping and it's also
orphaned, also adopt it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
