### PR TITLE
darwin.text_cmds,inetutils: fix build with clang 16

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/text_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/text_cmds/default.nix
@@ -20,7 +20,12 @@ appleDerivation {
     done
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=format-security" ]; # hardeningDisable doesn't cut it
+  env.NIX_CFLAGS_COMPILE = toString [
+    # hardeningDisable doesn't cut it
+    "-Wno-error=format-security"
+    # Required to build with clang 16
+    "-Wno-error=deprecated-non-prototype"
+  ];
 
   meta = {
     platforms = lib.platforms.darwin;

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -34,6 +34,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ help2man perl /* for `whois' */ ];
   buildInputs = [ ncurses /* for `talk' */ libxcrypt ];
 
+  env = lib.optionalAttrs stdenv.isDarwin {
+    # This is a temporary workaround for missing headers in the 10.12 SDK to avoid a mass rebuild.
+    # A commit to revert this change will be included in the fix PR targeting staging.
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
   # Don't use help2man if cross-compiling
   # https://lists.gnu.org/archive/html/bug-sed/2017-01/msg00001.html
   # https://git.congatec.com/yocto/meta-openembedded/blob/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3/meta-networking/recipes-connectivity/inetutils/inetutils_1.9.1.bb#L44


### PR DESCRIPTION
## Description of changes

Fixes build failures in staging-next #263535.

* darwin.text_cmds: https://hydra.nixos.org/build/239554497
* inetutils: https://hydra.nixos.org/build/239485276

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
