### PR TITLE
vulkan-cts: 1.3.7.0 -> 1.3.7.1

### DIFF
--- a/pkgs/tools/graphics/vulkan-cts/default.nix
+++ b/pkgs/tools/graphics/vulkan-cts/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv
+, callPackage
 , fetchFromGitHub
 , fetchurl
 , cmake
@@ -37,13 +38,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vulkan-cts";
-  version = "1.3.7.0";
+  version = "1.3.7.1";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "VK-GL-CTS";
     rev = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-f7i7gytk3cKeFQD0FR+nrUR2o0FWaJWKG7OpDz9u42E=";
+    hash = "sha256-V9QwWIIEALEsAhFzjloV6nUDomIpQGy+CImrLwJVZcI=";
   };
 
   prePatch = ''
@@ -104,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.updateScript = ./update.sh;
+  passthru.impureTests = { vulkan-cts = callPackage ./test.nix {}; };
 
   meta = with lib; {
     description = "Khronos Vulkan Conformance Tests";

--- a/pkgs/tools/graphics/vulkan-cts/test.nix
+++ b/pkgs/tools/graphics/vulkan-cts/test.nix
@@ -1,0 +1,22 @@
+{ lib, makeImpureTest, vulkan-cts, mesa }:
+makeImpureTest {
+  name = "vulkan-cts";
+  testedPackage = "vulkan-cts";
+
+  sandboxPaths = [ "/sys" "/dev/dri" ];
+
+  nativeBuildInputs = [ vulkan-cts ];
+
+  # Make mesa drivers available, they should support most common GPUs
+  testScript = ''
+    icds=(${mesa.drivers}/share/vulkan/icd.d/*.json)
+    IFS=: eval 'export VK_ICD_FILENAMES=''${icds[*]}'
+    echo VK_ICD_FILENAMES="$VK_ICD_FILENAMES"
+
+    deqp-vk -n dEQP-VK.api.smoke.triangle
+  '';
+
+  meta = with lib.maintainers; {
+    maintainers = [ Flakebi ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/KhronosGroup/VK-GL-CTS/releases/tag/vulkan-cts-1.3.7.1

Also add an impureTest that runs a test on the GPU.
Use `$(nix-build -A vulkan-cts.impureTests)` to run the test.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
