### PR TITLE
netcdfcxx4: fix build, add patch for cmake

### DIFF
--- a/pkgs/development/libraries/netcdf-cxx4/cmake-h5free.patch
+++ b/pkgs/development/libraries/netcdf-cxx4/cmake-h5free.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 60c699d..606b972 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -402,7 +402,7 @@ ELSE(MSVC)
+   FIND_PACKAGE(HDF5 COMPONENTS C HL REQUIRED)
+ ENDIF(MSVC)
+ 
+-CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5free_memory "" HAVE_H5FREE_MEMORY)
++CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARIES} H5free_memory "" HAVE_H5FREE_MEMORY)
+ IF(NOT HAVE_H5FREE_MEMORY)
+   MESSAGE(STATUS "Plugin support requires libhdf5 with H5Free support. Your libhdf5 install does not provide H5Free.  Please install a newer version of libhdf5 if you require plugin compression support.")
+   SET(NC_HAS_DEF_VAR_FILTER "")

--- a/pkgs/development/libraries/netcdf-cxx4/default.nix
+++ b/pkgs/development/libraries/netcdf-cxx4/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.unidata.ucar.edu/software/netcdf/";
     license = lib.licenses.free;
     platforms = lib.platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/netcdf-cxx4/default.nix
+++ b/pkgs/development/libraries/netcdf-cxx4/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-GZ6n7dW3l8Kqrk2Xp2mxRTUWWQj0XEd2LDTG9EtrfhY=";
   };
 
+  patches = [
+    # This fix is included upstream, remove with next upgrade
+    ./cmake-h5free.patch
+  ];
+
   preConfigure = ''
     cmakeFlags+="-Dabs_top_srcdir=$(readlink -f ./)"
   '';


### PR DESCRIPTION
The fix in the patch is picked from upstream.
Can be removed with next release.
(Upstream commit does not apply; contains more changes)

ZHF https://github.com/NixOS/nixpkgs/issues/265948

EDIT: mark broken on Darwin. I am not able to fix Darwin build failures.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
