### PR TITLE
cudaPackages.nccl-tests: 2.13.6 -> 2.13.8

### DIFF
--- a/pkgs/development/libraries/science/math/nccl/tests.nix
+++ b/pkgs/development/libraries/science/math/nccl/tests.nix
@@ -1,41 +1,47 @@
 { config
-, cudaPackages
+, cuda_cccl
+, cuda_cudart
+, cuda_nvcc
+, cudaVersion
+, backendStdenv
 , fetchFromGitHub
 , lib
 , mpiSupport ? false
 , mpi
-, stdenv
+, nccl
 , which
 , gitUpdater
 }:
 
-cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
+backendStdenv.mkDerivation (finalAttrs: {
 
   pname = "nccl-tests";
-  version = "2.13.6";
+  version = "2.13.8";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3gSBQ0g6mnQ/MFXGflE+BqqrIUoiBgp8+fWRQOvLVkw=";
+    hash = "sha256-dxLoflsTHDBnZRTzoXdm30OyKpLlRa73b784YWALBHg=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    cudaPackages.cuda_nvcc
+    cuda_nvcc
     which
   ];
 
   buildInputs = [
-    cudaPackages.cuda_cudart
-    cudaPackages.nccl
+    cuda_cudart
+    nccl
+  ] ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [
+    cuda_cccl.dev # <nv/target>
   ] ++ lib.optional mpiSupport mpi;
 
   makeFlags = [
-    "CUDA_HOME=${cudaPackages.cuda_nvcc}"
-    "NCCL_HOME=${cudaPackages.nccl}"
+    "CUDA_HOME=${cuda_nvcc}"
+    "NCCL_HOME=${nccl}"
   ] ++ lib.optionals mpiSupport [
     "MPI=1"
   ];

--- a/pkgs/development/libraries/science/math/nccl/tests.nix
+++ b/pkgs/development/libraries/science/math/nccl/tests.nix
@@ -49,7 +49,7 @@ cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations";
     homepage = "https://github.com/NVIDIA/nccl-tests";
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
     license = licenses.bsd3;
     broken = !config.cudaSupport || (mpiSupport && mpi == null);
     maintainers = with maintainers; [ jmillerpdt ];

--- a/pkgs/development/libraries/science/math/nccl/tests.nix
+++ b/pkgs/development/libraries/science/math/nccl/tests.nix
@@ -1,16 +1,16 @@
-{ config
+{ backendStdenv
+, config
 , cuda_cccl
 , cuda_cudart
 , cuda_nvcc
 , cudaVersion
-, backendStdenv
 , fetchFromGitHub
+, gitUpdater
 , lib
-, mpiSupport ? false
 , mpi
+, mpiSupport ? false
 , nccl
 , which
-, gitUpdater
 }:
 
 backendStdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/libraries/science/math/nccl/tests.nix
+++ b/pkgs/development/libraries/science/math/nccl/tests.nix
@@ -6,6 +6,7 @@
 , mpi
 , stdenv
 , which
+, gitUpdater
 }:
 
 cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
@@ -46,12 +47,17 @@ cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
     cp -r build/* $out/bin/
   '';
 
+  passthru.updateScript = gitUpdater {
+    inherit (finalAttrs) pname version;
+    rev-prefix = "v";
+  };
+
   meta = with lib; {
     description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations";
     homepage = "https://github.com/NVIDIA/nccl-tests";
     platforms = platforms.linux;
     license = licenses.bsd3;
     broken = !config.cudaSupport || (mpiSupport && mpi == null);
-    maintainers = with maintainers; [ jmillerpdt ];
+    maintainers = with maintainers; [ jmillerpdt ] ++ teams.cuda.members;
   };
 })


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Version bump: 2.13.6 -> 2.13.8
- Add `updateScript`
- Add CUDA team as maintainers
- Enable building on all linux platforms
- Fixes a possible error by which `nccl-tests` is provided `cudaPackages` from the top-level `pkgs` definition, and not from the `cudaPackages` of the enclosing scope.
  - As an example, if `cudaPackages` is the default version of CUDA packages in Nixpkgs and you tried to build `cudaPackages_12_2.nccl-tests`, `nccl-tests` wouldn't receive `cudaPackages_12_2` -- no, instead it would get `cudaPackages` from the top level scope!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
