### PR TITLE
nixos/spice-vdagent: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -739,6 +739,7 @@
   ./services/misc/sonarr.nix
   ./services/misc/sourcehut
   ./services/misc/spice-autorandr.nix
+  ./services/misc/spice-vdagent.nix
   ./services/misc/spice-vdagentd.nix
   ./services/misc/spice-webdavd.nix
   ./services/misc/ssm-agent.nix

--- a/nixos/modules/services/misc/spice-vdagent.nix
+++ b/nixos/modules/services/misc/spice-vdagent.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  cfg = config.services.spice-vdagent;
+in
+{
+  options = {
+    services.spice-vdagent = {
+      enable = mkEnableOption (lib.mdDoc "Spice guest vdagent user daemon");
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.spice-vdagent ];
+
+    systemd.user.services.spice-vdagent = {
+      description = "spice-vdagent user daemon";
+      wantedBy = [ "spice-vdagentd.target" ];
+      after = [ "spice-vdagentd.service" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.spice-vdagent}/bin/spice-vdagent --foreground";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/misc/spice-vdagentd.nix
+++ b/nixos/modules/services/misc/spice-vdagentd.nix
@@ -7,7 +7,7 @@ in
 {
   options = {
     services.spice-vdagentd = {
-      enable = mkEnableOption (lib.mdDoc "Spice guest vdagent daemon");
+      enable = mkEnableOption (lib.mdDoc "Spice guest vdagent system daemon");
     };
   };
 
@@ -16,7 +16,7 @@ in
     environment.systemPackages = [ pkgs.spice-vdagent ];
 
     systemd.services.spice-vdagentd = {
-      description = "spice-vdagent daemon";
+      description = "spice-vdagent system daemon";
       wantedBy = [ "graphical.target" ];
       preStart = ''
         mkdir -p "/run/spice-vdagentd/"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -744,6 +744,7 @@ in {
   sourcehut = handleTest ./sourcehut.nix {};
   spacecookie = handleTest ./spacecookie.nix {};
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark {};
+  spice-vdagent = handleTest ./spice-vdagent.nix {};
   sqlite3-to-mysql = handleTest ./sqlite3-to-mysql.nix {};
   sslh = handleTest ./sslh.nix {};
   sssd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd.nix {};

--- a/nixos/tests/spice-vdagent.nix
+++ b/nixos/tests/spice-vdagent.nix
@@ -1,0 +1,39 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+{
+  name = "spice-vdagent";
+  meta.maintainers = with lib.maintainers; [ dmytrokyrychuk ];
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+
+        services.xserver.enable = true;
+        services.xserver.displayManager.sddm.enable = true;
+        services.xserver.desktopManager.plasma5.enable = true;
+        services.xserver.displayManager.autoLogin = {
+          enable = true;
+          user = "alice";
+        };
+
+        services.spice-vdagentd.enable = true;
+        services.spice-vdagent.enable = true;
+      };
+  };
+
+  testScript = { nodes }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      machine.wait_for_unit("spice-vdagentd")
+
+      # Expecting the service to fail on startup because the test VM is missing
+      # the required virtio channel.
+      machine.wait_until_succeeds("su -c journalctl ${user.name} | grep 'vdagent virtio channel /dev/virtio-ports/com.redhat.spice.0 does not exist, exiting'")
+    '';
+})


### PR DESCRIPTION
This service can be used in place of the autostart .desktop file that comes with spice-vdagent package. Upstream package ships a similar systemd service since 0.22.0.

## Description of changes

Added a spice-vdagent service similar to this: https://gitlab.freedesktop.org/spice/linux/vd_agent/-/blob/aa08162f036840d3e33502dc0a836b03b9cec97c/data/spice-vdagent.service
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
