### PR TITLE
treewide: replace `<command> | systemd-cat` with `systemd-cat <command>`

### DIFF
--- a/nixos/tests/castopod.nix
+++ b/nixos/tests/castopod.nix
@@ -82,6 +82,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
     castopod.succeed("curl -s http://localhost/cp-install | grep 'Create your Super Admin account' > /dev/null")
 
     with subtest("Create superadmin and log in"):
-        castopod.succeed("PYTHONUNBUFFERED=1 test-runner | systemd-cat -t test-runner")
+        castopod.succeed("PYTHONUNBUFFERED=1 systemd-cat -t test-runner test-runner")
   '';
 })

--- a/nixos/tests/hadoop/hadoop.nix
+++ b/nixos/tests/hadoop/hadoop.nix
@@ -176,22 +176,22 @@ import ../make-test-python.nix ({ package, ... }: {
     nn2.succeed("systemctl stop hdfs-zkfc")
 
     # Initialize zookeeper for failover controller
-    nn1.succeed("sudo -u hdfs hdfs zkfc -formatZK 2>&1 | systemd-cat")
+    nn1.succeed("sudo -u hdfs systemd-cat hdfs zkfc -formatZK")
 
     # Format NN1 and start it
-    nn1.succeed("sudo -u hdfs hadoop namenode -format 2>&1 | systemd-cat")
+    nn1.succeed("sudo -u hdfs systemd-cat hadoop namenode -format")
     nn1.succeed("systemctl start hdfs-namenode")
     nn1.wait_for_open_port(9870)
     nn1.wait_for_open_port(8022)
     nn1.wait_for_open_port(8020)
 
     # Bootstrap NN2 from NN1 and start it
-    nn2.succeed("sudo -u hdfs hdfs namenode -bootstrapStandby 2>&1 | systemd-cat")
+    nn2.succeed("sudo -u hdfs systemd-cat hdfs namenode -bootstrapStandby")
     nn2.succeed("systemctl start hdfs-namenode")
     nn2.wait_for_open_port(9870)
     nn2.wait_for_open_port(8022)
     nn2.wait_for_open_port(8020)
-    nn1.succeed("netstat -tulpne | systemd-cat")
+    nn1.succeed("systemd-cat netstat -tulpne")
 
     # Start failover controllers
     nn1.succeed("systemctl start hdfs-zkfc")
@@ -200,10 +200,10 @@ import ../make-test-python.nix ({ package, ... }: {
     # DN should have started by now, but confirm anyway
     dn1.wait_for_unit("hdfs-datanode")
     # Print states of namenodes
-    client.succeed("sudo -u hdfs hdfs haadmin -getAllServiceState | systemd-cat")
+    client.succeed("sudo -u hdfs systemd-cat hdfs haadmin -getAllServiceState")
     # Wait for cluster to exit safemode
     client.succeed("sudo -u hdfs hdfs dfsadmin -safemode wait")
-    client.succeed("sudo -u hdfs hdfs haadmin -getAllServiceState | systemd-cat")
+    client.succeed("sudo -u hdfs systemd-cat hdfs haadmin -getAllServiceState")
     # test R/W
     client.succeed("echo testfilecontents | sudo -u hdfs hdfs dfs -put - /testfile")
     assert "testfilecontents" in client.succeed("sudo -u hdfs hdfs dfs -cat /testfile")
@@ -211,7 +211,7 @@ import ../make-test-python.nix ({ package, ... }: {
     # Test NN failover
     nn1.succeed("systemctl stop hdfs-namenode")
     assert "active" in client.succeed("sudo -u hdfs hdfs haadmin -getAllServiceState")
-    client.succeed("sudo -u hdfs hdfs haadmin -getAllServiceState | systemd-cat")
+    client.succeed("sudo -u hdfs systemd-cat hdfs haadmin -getAllServiceState")
     assert "testfilecontents" in client.succeed("sudo -u hdfs hdfs dfs -cat /testfile")
 
     nn1.succeed("systemctl start hdfs-namenode")
@@ -219,7 +219,7 @@ import ../make-test-python.nix ({ package, ... }: {
     nn1.wait_for_open_port(8022)
     nn1.wait_for_open_port(8020)
     assert "standby" in client.succeed("sudo -u hdfs hdfs haadmin -getAllServiceState")
-    client.succeed("sudo -u hdfs hdfs haadmin -getAllServiceState | systemd-cat")
+    client.succeed("sudo -u hdfs systemd-cat hdfs haadmin -getAllServiceState")
 
     #### YARN tests ####
 
@@ -236,18 +236,18 @@ import ../make-test-python.nix ({ package, ... }: {
     nm1.wait_for_open_port(8042)
     nm1.wait_for_open_port(8040)
     client.wait_until_succeeds("yarn node -list | grep Nodes:1")
-    client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState | systemd-cat")
-    client.succeed("sudo -u yarn yarn node -list | systemd-cat")
+    client.succeed("sudo -u yarn systemd-cat yarn rmadmin -getAllServiceState")
+    client.succeed("sudo -u yarn systemd-cat yarn node -list")
 
     # Test RM failover
     rm1.succeed("systemctl stop yarn-resourcemanager")
     assert "standby" not in client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState")
-    client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState | systemd-cat")
+    client.succeed("sudo -u yarn systemd-cat yarn rmadmin -getAllServiceState")
     rm1.succeed("systemctl start yarn-resourcemanager")
     rm1.wait_for_unit("yarn-resourcemanager")
     rm1.wait_for_open_port(8088)
     assert "standby" in client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState")
-    client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState | systemd-cat")
+    client.succeed("sudo -u yarn systemd-cat yarn rmadmin -getAllServiceState")
 
     assert "Estimated value of Pi is" in client.succeed("HADOOP_USER_NAME=hdfs yarn jar $(readlink $(which yarn) | sed -r 's~bin/yarn~share/hadoop/mapreduce/hadoop-mapreduce-examples-*.jar~g') pi 2 10")
     assert "SUCCEEDED" in client.succeed("yarn application -list -appStates FINISHED")

--- a/nixos/tests/hadoop/hdfs.nix
+++ b/nixos/tests/hadoop/hdfs.nix
@@ -50,8 +50,8 @@ import ../make-test-python.nix ({ package, lib, ... }:
     namenode.wait_for_unit("hdfs-namenode")
     namenode.wait_for_unit("network.target")
     namenode.wait_for_open_port(8020)
-    namenode.succeed("ss -tulpne | systemd-cat")
-    namenode.succeed("cat /etc/hadoop*/hdfs-site.xml | systemd-cat")
+    namenode.succeed("systemd-cat ss -tulpne")
+    namenode.succeed("systemd-cat cat /etc/hadoop*/hdfs-site.xml")
     namenode.wait_for_open_port(9870)
 
     datanode.wait_for_unit("hdfs-datanode")

--- a/nixos/tests/iscsi-multipath-root.nix
+++ b/nixos/tests/iscsi-multipath-root.nix
@@ -202,7 +202,7 @@ import ./make-test-python.nix (
       initiatorAuto.succeed("umount /mnt")
 
       initiatorAuto.succeed("systemctl restart multipathd")
-      initiatorAuto.succeed("multipath -ll | systemd-cat")
+      initiatorAuto.succeed("systemd-cat multipath -ll")
 
       # Install our RootDisk machine to 123456, the alias to the device that multipath is now managing
       initiatorAuto.succeed("mount /dev/mapper/123456 /mnt")
@@ -223,7 +223,7 @@ import ./make-test-python.nix (
       initiatorRootDisk.fail("iscsiadm -m discovery -o update -t sendtargets -p 192.168.1.3 --login")
       initiatorRootDisk.fail("iscsiadm -m discovery -o update -t sendtargets -p 192.168.2.3 --login")
       initiatorRootDisk.succeed("systemctl restart multipathd")
-      initiatorRootDisk.succeed("multipath -ll | systemd-cat")
+      initiatorRootDisk.succeed("systemd-cat multipath -ll")
 
       # Verify we can write and sync the root disk
       initiatorRootDisk.succeed("mkdir /scratch")

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -174,7 +174,7 @@ let
           )
 
       with subtest("use the web interface to sign up, log in, and save a password"):
-          server.succeed("PYTHONUNBUFFERED=1 test-runner | systemd-cat -t test-runner")
+          server.succeed("PYTHONUNBUFFERED=1 systemd-cat -t test-runner test-runner")
 
       with subtest("log in with the cli"):
           key = client.succeed(


### PR DESCRIPTION
The former swallows exit codes, the latter doesn't.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
