### PR TITLE
vimix-cursors: init at 2021-09-18

### DIFF
--- a/pkgs/by-name/vi/vimix-cursors/package.nix
+++ b/pkgs/by-name/vi/vimix-cursors/package.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+, inkscape
+, python3Packages
+, xcursorgen
+}:
+stdenvNoCC.mkDerivation {
+  pname = "vimix-cursors";
+  version = "2020-02-24-unstable-2021-09-18";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "vimix-cursors";
+    rev = "9bc292f40904e0a33780eda5c5d92eb9a1154e9c";
+    hash = "sha256-zW7nJjmB3e+tjEwgiCrdEe5yzJuGBNdefDdyWvgYIUU=";
+  };
+
+  nativeBuildInputs = [
+    inkscape
+    python3Packages.cairosvg
+    xcursorgen
+  ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    HOME="$NIX_BUILD_ROOT" ./build.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -dm 755 $out/share/icons
+    for color in "" "-white"; do
+      cp -pr "dist$color/"  "$out/share/icons/Vimix$color-cursors"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An X cursor theme inspired by Materia design";
+    homepage = "https://github.com/vinceliuice/Vimix-cursors";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ambroisie ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

I've had this in an overlay since 2021, time to finally upstream it.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
