### PR TITLE
nixos/stalwart-mail: small fixes for systemd settings

### DIFF
--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -57,8 +57,6 @@ in {
         KillSignal = "SIGINT";
         Restart = "on-failure";
         RestartSec = 5;
-        StandardOutput = "syslog";
-        StandardError = "syslog";
         SyslogIdentifier = "stalwart-mail";
 
         DynamicUser = true;


### PR DESCRIPTION
## Description of changes

### removal of obsolete settings

Journal shows deprecation warnings:
```console
$ sudo journalctl -b -f -u stalwart-mail.service 
Nov 07 20:44:27 pc980 systemd[1]: stalwart-mail.service: Failed with result 'exit-code'.
Nov 07 20:44:28 pc980 systemd[1]: Stopped stalwart-mail.service.
Nov 07 20:45:21 pc980 systemd[1]: /etc/systemd/system/stalwart-mail.service:42: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
Nov 07 20:45:21 pc980 systemd[1]: /etc/systemd/system/stalwart-mail.service:43: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
Nov 07 20:45:21 pc980 systemd[1]: Starting stalwart-mail.service...
Nov 07 20:45:21 pc980 systemd[1]: Started stalwart-mail.service.
```

```nix
StandardOutput = "syslog";
StandardError = "syslog";
``` 

Because they are obsolete according to systemd/systemd/pull/15812. [Manual](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#StandardOutput=) also states that these settings usually default to `"journal"`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
