### PR TITLE
wifi-qr: init at 2023-09-30

### DIFF
--- a/pkgs/by-name/wi/wifi-qr/package.nix
+++ b/pkgs/by-name/wi/wifi-qr/package.nix
@@ -1,0 +1,86 @@
+{ lib
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, gnome
+, ncurses
+, networkmanager
+, patsh
+, procps
+, qrencode
+, stdenvNoCC
+, xdg-utils
+, zbar
+}:
+stdenvNoCC.mkDerivation {
+  pname = "wifi-qr";
+  version = "0.3-unstable-2023-09-30";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitHub {
+    owner = "kokoye2007";
+    repo = "wifi-qr";
+    rev = "821892001f735dc250a549ea36329cdc767db9c9";
+    hash = "sha256-kv0qjO+wn4t//NmKkHB+tZB4eRNm+WRUa5rij+7Syuk=";
+  };
+
+  buildInputs = [
+    gnome.zenity
+    ncurses
+    networkmanager
+    procps
+    qrencode
+    xdg-utils
+    zbar
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    patsh
+  ];
+
+  dontBuild = true;
+
+  dontConfigure = true;
+
+  postPatch = ''
+    substituteInPlace src/wifi-qr.desktop \
+      --replace "Icon=wifi-qr.svg" "Icon=wifi-qr"
+    substituteInPlace src/wifi-qr \
+      --replace "/usr/share/doc/wifi-qr/copyright" "$out/share/doc/wifi-qr/copyright"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/wifi-qr $out/bin/wifi-qr
+
+    install -Dm644 src/wifi-qr.desktop $out/share/applications/wifi-qr.desktop
+    install -Dm644 src/wifi-qr.svg $out/share/icons/hicolor/scalable/apps/wifi-qr.svg
+    install -Dm644 src/LICENSE $out/share/doc/wifi-qr/copyright
+
+    installManPage src/wifi-qr.1
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    patchShebangs $out/bin/wifi-qr
+    patsh -f $out/bin/wifi-qr -s ${builtins.storeDir}
+
+    runHook postFixup
+  '';
+
+  meta = with lib; {
+    description = "WiFi password sharing via QR codes";
+    homepage = "https://github.com/kokoye2007/wifi-qr";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ ambroisie ];
+    mainProgram = "wifi-qr";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

I had this packaged in an overlay for much too long, finally adding it upstream.


## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
