### PR TITLE
lib.types.anything: Add functionArgs

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -513,6 +513,10 @@ checkConfigOutput '^{}$' config.value.mkmerge ./types-anything/mk-mods.nix
 checkConfigOutput '^true$' config.value.mkbefore ./types-anything/mk-mods.nix
 checkConfigOutput '^1$' config.value.nested.foo ./types-anything/mk-mods.nix
 checkConfigOutput '^"baz"$' config.value.nested.bar.baz ./types-anything/mk-mods.nix
+# Function reflection works
+checkConfigOutput '^{"p":1,"q":2}$' 'config.applied.merging-args.value' ./types-anything/functions.nix
+checkConfigOutput '^{"a":false,"b":false}$' 'config.applied.merging-args.args' ./types-anything/functions.nix
+
 
 ## types.functionTo
 checkConfigOutput '^"input is input"$' config.result ./functionTo/trivial.nix

--- a/lib/tests/modules/types-anything/functions.nix
+++ b/lib/tests/modules/types-anything/functions.nix
@@ -10,7 +10,19 @@
   };
 
   options.applied = lib.mkOption {
-    default = lib.mapAttrs (name: fun: fun null) config.value;
+    default = lib.mapAttrs (name: fun:
+      if name == "merging-args"
+      then
+        {
+          args =
+            let x = lib.functionArgs fun;
+            in builtins.deepSeq x x;
+          value =
+            let x = fun { a = 1; b = 2; };
+            # can't pass --strict easily
+            in builtins.deepSeq x x;
+        }
+      else fun null) config.value;
   };
 
   config = lib.mkMerge [
@@ -18,10 +30,12 @@
       value.single-lambda = x: x;
       value.multiple-lambdas = x: { inherit x; };
       value.merging-lambdas = x: { inherit x; };
+      value.merging-args = args@{ a, ... }: { p = a; };
     }
     {
       value.multiple-lambdas = x: [ x ];
       value.merging-lambdas = y: { inherit y; };
+      value.merging-args = args@{ b, ... }: { q = b; };
     }
   ];
 


### PR DESCRIPTION

## Description of changes

Make function reflection work even when `types.anything` mediates the value.

I'm not a big fan of function reflection, or types.anything, because both are broken concepts, but this at least fixes the use case where a function is expected and passed to, say, `callPackage` or `evalModules`, etc.

I have chosen not to apply this change to `functionTo`, because this solution has a performance cost, and perhaps usages of `functionTo` are better - by not using reflection.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
