### PR TITLE
dvb-apps: init at 1.1.1-unstable-2014-03-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18845,6 +18845,12 @@
     githubId = 7038383;
     name = "Vojta Káně";
   };
+  volfyd = {
+    email = "lb.nix@lisbethmail.com";
+    github = "volfyd";
+    githubId = 3578382;
+    name = "Leif Huhn";
+  };
   volhovm = {
     email = "volhovm.cs@gmail.com";
     github = "volhovm";

--- a/pkgs/by-name/dv/dvb-apps/package.nix
+++ b/pkgs/by-name/dv/dvb-apps/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchurl
+, perl
+, fetchpatch
+}:
+stdenv.mkDerivation {
+  pname = "dvb-apps";
+  version = "1.1.1-unstable-2014-03-21";
+
+  src = fetchurl {
+    url = "https://www.linuxtv.org/hg/dvb-apps/archive/3d43b280298c.tar.bz2";
+    hash = "sha256-854vDr7X4yvOg1IgYq1NQU9n/M1d8bZHYYUkSX4V4Fc=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-glibc-2.31.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-zSbbKSJgW4L983DR0GVXtgAHK6ILOQC3Gz2iGnmWOp8=";
+    })
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-no-ca_set_pid.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-GZunNYlhktalPOZ4ZST1MwooBvdDGA6ckscx/7mx8ok=";
+    })
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-1.1.1.20100223-alevt.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-+j+tP8O3mho+gcsDPzQUJaE39ZAgimMAJoRP1J1HrBk=";
+    })
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-1.1.1.20100223-ldflags.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-jrRE1yySLbQWbF+SaugFN8VuEIfveSvjR0nKpmKffpQ=";
+    })
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-1.1.1.20100223-perl526.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-zIROx0HEvtZqvNBLlKp3aI3S2CihuS6l/OWf6WFFCrY=";
+    })
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-1.1.1.20140321-dvbdate.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-dLPlscdDOd7Kq+2sEhgJ/PBY1zN/0/fh3TU6JOELaYw=";
+    })
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-1.1.1.20140321-gcc10.patch?id=ec6d38022bd905cb5460d4812e52434fd1f9663c";
+      hash = "sha256-034TYxH1qHcdkwVxuAcNHORfBWhw/k8P+11QAc3jp74=";
+    })
+    (fetchpatch {
+      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=779520;filename=bug779520.patch;msg=17";
+      hash = "sha256-UL5lKDfloXvngsabnslpVXbe/dmt4dzVK5W8JkIieps=";
+    })
+  ];
+
+  buildInputs = [ perl ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  dontConfigure = true; # skip configure
+
+  meta = {
+    description = "Linux DVB API applications and utilities";
+    homepage = "https://linuxtv.org/";
+    maintainers = with lib.maintainers; [ volfyd ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
+  };
+}


### PR DESCRIPTION

## Description of changes

The wiki describing dvb_apps is https://www.linuxtv.org/wiki/index.php/LinuxTV_dvb-apps

dvb_apps was marked broken in 2018 and removed in 2020. Re-add dvb_apps with the same version and patches used in this working AUR package: https://aur.archlinux.org/packages/linuxtv-dvb-apps

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
