### PR TITLE
cudaPackages.cuda-samples: misc bumps and fixups

### DIFF
--- a/pkgs/test/cuda/cuda-samples/extension.nix
+++ b/pkgs/test/cuda/cuda-samples/extension.nix
@@ -14,6 +14,7 @@ final: prev: let
     "11.7" = throw "The tag 11.7 of cuda-samples does not exist";
     "11.8" = "sha256-7+1P8+wqTKUGbCUBXGMDO9PkxYr2+PLDx9W2hXtXbuc=";
     "12.0" = "sha256-Lj2kbdVFrJo5xPYPMiE4BS7Z8gpU5JLKXVJhZABUe/g=";
+    "12.1" = "sha256-xE0luOMq46zVsIEWwK4xjLs7NorcTIi9gbfZPVjIlqo=";
   }.${prev.cudaVersion};
 
 in {

--- a/pkgs/test/cuda/cuda-samples/extension.nix
+++ b/pkgs/test/cuda/cuda-samples/extension.nix
@@ -15,6 +15,7 @@ final: prev: let
     "11.8" = "sha256-7+1P8+wqTKUGbCUBXGMDO9PkxYr2+PLDx9W2hXtXbuc=";
     "12.0" = "sha256-Lj2kbdVFrJo5xPYPMiE4BS7Z8gpU5JLKXVJhZABUe/g=";
     "12.1" = "sha256-xE0luOMq46zVsIEWwK4xjLs7NorcTIi9gbfZPVjIlqo=";
+    "12.2" = "sha256-pOy0qfDjA/Nr0T9PNKKefK/63gQnJV2MQsN2g3S2yng=";
   }.${prev.cudaVersion};
 
 in {

--- a/pkgs/test/cuda/cuda-samples/extension.nix
+++ b/pkgs/test/cuda/cuda-samples/extension.nix
@@ -11,15 +11,15 @@ final: prev: let
     "11.4" = "082dkk5y34wyvjgj2p5j1d00rk8xaxb9z0mhvz16bd469r1bw2qk";
     "11.5" = "sha256-AKRZbke0K59lakhTi8dX2cR2aBuWPZkiQxyKaZTvHrI=";
     "11.6" = "sha256-AsLNmAplfuQbXg9zt09tXAuFJ524EtTYsQuUlV1tPkE=";
-    "11.7" = throw "The tag 11.7 of cuda-samples does not exist";
+    # The tag 11.7 of cuda-samples does not exist
     "11.8" = "sha256-7+1P8+wqTKUGbCUBXGMDO9PkxYr2+PLDx9W2hXtXbuc=";
     "12.0" = "sha256-Lj2kbdVFrJo5xPYPMiE4BS7Z8gpU5JLKXVJhZABUe/g=";
     "12.1" = "sha256-xE0luOMq46zVsIEWwK4xjLs7NorcTIi9gbfZPVjIlqo=";
     "12.2" = "sha256-pOy0qfDjA/Nr0T9PNKKefK/63gQnJV2MQsN2g3S2yng=";
-  }.${prev.cudaVersion};
+  };
 
-in {
+in prev.lib.attrsets.optionalAttrs (builtins.hasAttr prev.cudaVersion sha256) {
   cuda-samples = final.callPackage ./generic.nix {
-    inherit sha256;
+    sha256 = sha256.${prev.cudaVersion};
   };
 }

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,15 +1,15 @@
-{ lib
+{ autoAddOpenGLRunpathHook
 , backendStdenv
 , cmake
-, fetchFromGitHub
-, fetchpatch
-, autoAddOpenGLRunpathHook
 , cudatoolkit
 , cudaVersion
+, fetchFromGitHub
+, fetchpatch
+, freeimage
+, glfw3
+, lib
 , pkg-config
 , sha256
-, glfw3
-, freeimage
 }:
 backendStdenv.mkDerivation (finalAttrs: {
   pname = "cuda-samples";

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,17 +1,18 @@
 { lib
-, cudaPackages
+, backendStdenv
 , fetchFromGitHub
 , fetchpatch
 , autoAddOpenGLRunpathHook
 , cudatoolkit
+, cudaVersion
 , pkg-config
 , sha256
 , glfw3
 , freeimage
 }:
-cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
+backendStdenv.mkDerivation (finalAttrs: {
   pname = "cuda-samples";
-  version = lib.versions.majorMinor cudatoolkit.version;
+  version = cudaVersion;
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
@@ -41,7 +42,7 @@ cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin bin/${cudaPackages.backendStdenv.hostPlatform.parsed.cpu.name}/${cudaPackages.backendStdenv.hostPlatform.parsed.kernel.name}/release/*
+    install -Dm755 -t $out/bin bin/${backendStdenv.hostPlatform.parsed.cpu.name}/${backendStdenv.hostPlatform.parsed.kernel.name}/release/*
 
     runHook postInstall
   '';

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -2,7 +2,7 @@
 , cudaPackages
 , fetchFromGitHub
 , fetchpatch
-, addOpenGLRunpath
+, autoAddOpenGLRunpathHook
 , cudatoolkit
 , pkg-config
 , sha256
@@ -20,7 +20,7 @@ cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ pkg-config addOpenGLRunpath glfw3 freeimage ];
+  nativeBuildInputs = [ pkg-config autoAddOpenGLRunpathHook glfw3 freeimage ];
 
   buildInputs = [ cudatoolkit ];
 
@@ -44,12 +44,6 @@ cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
     install -Dm755 -t $out/bin bin/${cudaPackages.backendStdenv.hostPlatform.parsed.cpu.name}/${cudaPackages.backendStdenv.hostPlatform.parsed.kernel.name}/release/*
 
     runHook postInstall
-  '';
-
-  postFixup = ''
-    for exe in $out/bin/*; do
-      addOpenGLRunpath $exe
-    done
   '';
 
   meta = {

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -56,6 +56,6 @@ cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
     description = "Samples for CUDA Developers which demonstrates features in CUDA Toolkit";
     # CUDA itself is proprietary, but these sample apps are not.
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ obsidian-systems-maintenance ];
+    maintainers = with lib.maintainers; [ obsidian-systems-maintenance ] ++ lib.teams.cuda.members;
   };
 })

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -9,14 +9,14 @@
 , glfw3
 , freeimage
 }:
-cudaPackages.backendStdenv.mkDerivation rec {
+cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
   pname = "cuda-samples";
   version = lib.versions.majorMinor cudatoolkit.version;
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
     inherit sha256;
   };
 
@@ -25,7 +25,7 @@ cudaPackages.backendStdenv.mkDerivation rec {
   buildInputs = [ cudatoolkit ];
 
   # See https://github.com/NVIDIA/cuda-samples/issues/75.
-  patches = lib.optionals (version == "11.3") [
+  patches = lib.optionals (finalAttrs.version == "11.3") [
     (fetchpatch {
       url = "https://github.com/NVIDIA/cuda-samples/commit/5c3ec60faeb7a3c4ad9372c99114d7bb922fda8d.patch";
       sha256 = "sha256-0XxdmNK9MPpHwv8+qECJTvXGlFxc+fIbta4ynYprfpU=";
@@ -58,4 +58,4 @@ cudaPackages.backendStdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ obsidian-systems-maintenance ];
   };
-}
+})

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,5 +1,6 @@
 { lib
 , backendStdenv
+, cmake
 , fetchFromGitHub
 , fetchpatch
 , autoAddOpenGLRunpathHook
@@ -21,7 +22,20 @@ backendStdenv.mkDerivation (finalAttrs: {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ pkg-config autoAddOpenGLRunpathHook glfw3 freeimage ];
+  nativeBuildInputs = [
+    pkg-config
+    autoAddOpenGLRunpathHook
+    glfw3
+    freeimage
+  ]
+  # CMake has to run as a native, build-time dependency for libNVVM samples.
+  ++ lib.lists.optionals (lib.strings.versionAtLeast finalAttrs.version "12.2") [
+    cmake
+  ];
+
+  # CMake is not the primary build tool -- that's still make.
+  # As such, we disable CMake's build system.
+  dontUseCmakeConfigure = true;
 
   buildInputs = [ cudatoolkit ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Don't include `cuda-samples` in `cudaPackages_11_7` because there isn't a compatible release.
  - Better to have it absent than to throw and break evaluation in a way that can't easily be overridden.
- Fixes a bug where `backendStdenv` was always taken from the default `cudaPackages`, regardless of which version of `cudaPackages` was trying to build `cuda-samples`.
- Refactors to use `finalAttrs` instead of the `rec` keyword.
- Fixes CMake-related build failure for CUDA Packages 12.2+.
  - NOTE: This does not fix 12.0+ builds; see below.
- Adds CUDA team as maintainers.
- Switches to `autoAddOpenGLRunpathHook`.

> [!WARNING]
> Builds with CUDA Packages 12+ are currently failing with the following:
>
> ```console
> cuda-samples> /nix/store/x1254667lvjd1d760lhz0irxr9q40338-cudatoolkit-12.1.1/bin/nvcc -ccbin g++ -m64 -gencode arch=compute_50,code=compute_50 -o memMapIPCDrv helper_multiprocess.o memMapIpc.o -L/nix/store/x1254667lvjd1d760lhz0irxr9q40338-cudatoolkit-12.1.1/lib64/stubs -lcuda
> cuda-samples> /nix/store/x1254667lvjd1d760lhz0irxr9q40338-cudatoolkit-12.1.1/include/cuda/std/barrier(144): error: function "operator new" cannot be called with the given argument list
> cuda-samples>             argument types are: (unsigned long, cuda::std::__4::__barrier_base<cuda::std::__4::__empty_completion, 2> *)
> cuda-samples>           { new (&__b->__barrier) __barrier_base(__expected); }
> cuda-samples>             ^
> cuda-samples> 1 error detected in the compilation of "tf32TensorCoreGemm.cu".
> cuda-samples> make[1]: *** [Makefile:367: tf32TensorCoreGemm.o] Error 255
> ```
>
> I imagine this is unrelated to this PR -- the only reason it appears now is because this PR allows compilation with newer versions of CUDA. Prior to this PR, the version used was fixed to the version of `cudaPackages` defined at the top level in Nixpkgs, regardless of which `cudaPackages_*_*` was used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
