### PR TITLE
prayer: use html-tidy 5.6

### DIFF
--- a/pkgs/tools/text/html-tidy/5.6.nix
+++ b/pkgs/tools/text/html-tidy/5.6.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, libxslt, html-tidy }:
+
+stdenv.mkDerivation rec {
+  pname = "html-tidy";
+  version = "5.6.0";
+
+  src = fetchFromGitHub {
+    owner = "htacg";
+    repo = "tidy-html5";
+    rev = version;
+    hash = "sha256-M3kOhy/gZn30QQVtVLB/C0dDX+K//R84wEut0AorJ3A=";
+  };
+
+  # https://github.com/htacg/tidy-html5/pull/1036
+  patches = (fetchpatch {
+    url = "https://github.com/htacg/tidy-html5/commit/e9aa038bd06bd8197a0dc049380bc2945ff55b29.diff";
+    sha256 = "sha256-Q2GjinNBWLL+HXUtslzDJ7CJSTflckbjweiSMCnIVwg=";
+  });
+
+  nativeBuildInputs = [ cmake libxslt/*manpage*/ ]
+    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) html-tidy;
+
+  cmakeFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "-DHOST_TIDY=tidy"
+  ];
+
+  # ATM bin/tidy is statically linked, as upstream provides no other option yet.
+  # https://github.com/htacg/tidy-html5/issues/326#issuecomment-160322107
+
+  meta = with lib; {
+    description = "A HTML validator and `tidier'";
+    longDescription = ''
+      HTML Tidy is a command-line tool and C library that can be
+      used to validate and fix HTML data.
+    '';
+    license = licenses.libpng; # very close to it - the 3 clauses are identical
+    homepage = "http://html-tidy.org";
+    platforms = platforms.all;
+    maintainers = with maintainers; [];
+    mainProgram = "tidy";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14673,6 +14673,7 @@ with pkgs;
   html2text = callPackage ../tools/text/html2text { };
 
   html-tidy = callPackage ../tools/text/html-tidy { };
+  html-tidy_5_6 = callPackage ../tools/text/html-tidy/5.6.nix { };
 
   html-xml-utils = callPackage ../tools/text/xml/html-xml-utils { };
 
@@ -28567,7 +28568,13 @@ with pkgs;
 
   pps-tools = callPackage ../os-specific/linux/pps-tools { };
 
-  prayer = callPackage ../servers/prayer { };
+  prayer = callPackage ../servers/prayer {
+    # 2023-07-11: prayer uses internal functions of html-tidy which have become
+    # hidden after version 5.6. There are no public equivalents of all the
+    # internal functions used by pray, so using an older version of html-tidy is
+    # the only way to keep prayer alive.
+    html-tidy = html-tidy_5_6;
+  };
 
   procps = if stdenv.isLinux
     then callPackage ../os-specific/linux/procps-ng { }


### PR DESCRIPTION
## Description of changes

The prayer package requires an older version of html-tidy as dependency due to prayer relying on private library functions of libtidy which have become hidden in versions greater 5.6 of html-tidy.

ZHF: #265948

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
