### PR TITLE
skkDictionaries: split up skk-dicts

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -297,6 +297,12 @@
 
 - `tests.overriding` has its `passthru.tests` restructured as an attribute set instead of a list, making individual tests accessible by their names.
 
+- Package `skk-dict` was split into multiple packages under `skkDictionaries`.
+  If in doubt, try `skkDictionaries.l`. As part of this change, the dictionaries
+  were moved from `$out/share` to `$out/share/skk`. Also, the dictionaries won't
+  be converted to UTF-8 unless the `useUtf8` package option is enabled. UTF-8
+  converted dictionaries will have the .utf8 suffix appended to its filename.
+
 - `vaultwarden` lost the capability to bind to privileged ports. If you rely on
    this behavior, override the systemd unit to allow `CAP_NET_BIND_SERVICE` in
    your local configuration.

--- a/pkgs/development/libraries/libskk/default.nix
+++ b/pkgs/development/libraries/libskk/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub,
   libtool, gettext, pkg-config,
   vala, gnome-common, gobject-introspection,
-  libgee, json-glib, skk-dicts, libxkbcommon }:
+  libgee, json-glib, skkDictionaries, libxkbcommon }:
 
 stdenv.mkDerivation rec {
   pname = "libskk";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0y279pcgs3jrsi9vzx086xhz9jbz23dqqijp4agygc9ackp9sxy5";
   };
 
-  buildInputs = [ skk-dicts libxkbcommon ];
+  buildInputs = [ libxkbcommon ];
   nativeBuildInputs = [ vala gnome-common gobject-introspection libtool gettext pkg-config ];
   propagatedBuildInputs = [ libgee json-glib ];
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   preInstall = ''
     dictDir=$out/share/skk
     mkdir -p $dictDir
-    ln -s ${skk-dicts}/share/SKK-JISYO.L $dictDir/
+    ln -s ${skkDictionaries.l}/share/skk/SKK-JISYO.L $dictDir/
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-skk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-skk.nix
@@ -9,7 +9,7 @@
 , fcitx5-qt
 , libskk
 , qtbase
-, skk-dicts
+, skkDictionaries
 , enableQt ? false
 }:
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_QT" enableQt)
     (lib.cmakeBool "USE_QT6" (lib.versions.major qtbase.version == "6"))
-    "-DSKK_DEFAULT_PATH=${skk-dicts}/share/SKK-JISYO.L"
+    "-DSKK_DEFAULT_PATH=${skkDictionaries.l}/share/skk/SKK-JISYO.L"
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-kkc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-kkc/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl
 , vala, intltool, pkg-config
-, libkkc, ibus, skk-dicts
+, libkkc, ibus, skkDictionaries
 , gtk3
 }:
 
@@ -17,10 +17,10 @@ stdenv.mkDerivation rec {
     vala intltool pkg-config
   ];
 
-  buildInputs = [ libkkc ibus skk-dicts gtk3 ];
+  buildInputs = [ libkkc ibus gtk3 ];
 
   postInstall = ''
-    ln -s ${skk-dicts}/share $out/share/skk
+    ln -s ${skkDictionaries.l}/share/skk $out/share/skk
   '';
 
   meta = with lib; {

--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -74,7 +74,7 @@ let
             SKK Japanese input method.
           '';
           homepage = "https://github.com/skk-dev/dict";
-          maintainers = with maintainers; [ yuriaisaka ];
+          maintainers = with maintainers; [ yuriaisaka midchildan ];
           platforms = platforms.all;
         };
       };

--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -1,77 +1,202 @@
-{ lib, stdenv, fetchurl, iconv, skktools }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, nix-update-script
+, nkf
+, skktools
+, useUtf8 ? false
+}:
 
 let
-  # kana to kanji
-  small = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.S";
-    sha256 = "11cjrc8m99hj4xpl2nvzxanlswpapi92vmgk9d6yimdz0jidb6cq";
-  };
-  medium = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.M";
-    sha256 = "0pwjp9qjmn9sq6zc0k6632l7dc2dbjn45585ibckvvl9iwfqqxdp";
-  };
-  large = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.L";
-    sha256 = "0ps0a7sbkryd6hxvphq14i7g5wci4gvr0vraac8ia2ww67a2xbyc";
-  };
+  suffix = lib.optionalString useUtf8 ".utf8";
 
-  # english to japanese
-  edict = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.edict";
-    sha256 = "1vrwnq0vvjn61nijbln6wfinqg93802d2a8d4ad82n692v83b1li";
-  };
-  # misc
-  assoc = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.assoc";
-    sha256 = "1smcbyv6srrhnpl7ic9nqds9nz3g2dgqngmhzkrdlwmvcpvakp1v";
-  };
+  mkDictNameValue =
+    { name
+    , description
+    , license # it's written in the beginning of each file
+    , files ? [ "SKK-JISYO.${name}" ]
+    }: {
+      name = lib.toLower (builtins.replaceStrings [ "." ] [ "_" ] name);
+      value = stdenvNoCC.mkDerivation {
+        pname = "skk-jisyo-" + lib.toLower name;
+        version = "0-unstable-2024-08-28";
+
+        src = fetchFromGitHub {
+          owner = "skk-dev";
+          repo = "dict";
+          rev = "4eb91a3bbfef70bde940668ec60f3beae291e971";
+          sha256 = "sha256-sWz85Q6Bu2WoKsckSp5SlcuPUQN2mcq+BHMqNXQ/aho=";
+        };
+
+        nativeBuildInputs = lib.optionals useUtf8 [ nkf ];
+
+        strictDeps = true;
+
+        buildPhase = ''
+          runHook preBuild
+        '' + lib.concatMapStrings
+          (file: ''
+            nkf -w ${file} \
+              | LC_ALL=C sed 's/coding: [^ ]\{1,\}/coding: utf-8/' \
+              > ${file + suffix}
+          '')
+          (lib.optionals useUtf8 (map lib.escapeShellArg files)) + ''
+          runHook postBuild
+        '';
+
+        installPhase = ''
+          runHook preInstall
+        '' + lib.concatMapStrings
+          (file: ''
+            install -Dm644 \
+              ${lib.escapeShellArg file} \
+              $out/share/skk/${lib.escapeShellArg (baseNameOf file)}
+          '')
+          (map (file: file + suffix) files) + ''
+          runHook postInstall
+        '';
+
+        doInstallCheck = true;
+        installCheckPhase = ''
+          emptydict=': 0 candidates$'
+          ${skktools}/bin/skkdic-count /dev/null | grep "$emptydict"
+          ${skktools}/bin/skkdic-count $out/share/skk/* | grep -v "$emptydict"
+        '';
+
+        passthru.updateScript = nix-update-script {
+          extraArgs = ["--version" "branch"];
+        };
+
+        meta = with lib; {
+          inherit description license;
+          longDescription = ''
+            This package provides a kana-to-kanji conversion dictionary for the
+            SKK Japanese input method.
+          '';
+          homepage = "https://github.com/skk-dev/dict";
+          maintainers = with maintainers; [ yuriaisaka ];
+          platforms = platforms.all;
+        };
+      };
+    };
 in
-
-stdenv.mkDerivation {
-  pname = "skk-dicts-unstable";
-  version = "2020-03-24";
-  srcs = [ small medium large edict assoc ];
-  nativeBuildInputs = [ iconv skktools ];
-
-  strictDeps = true;
-
-  dontUnpack = true;
-
-  installPhase = ''
-    function dictname() {
-      src=$1
-      name=$(basename $src)          # remove dir name
-      dict=$(echo $name | cut -b34-) # remove sha256 prefix
-      echo $dict
-    }
-    mkdir -p $out/share
-
-    for src in $srcs; do
-      dst=$out/share/$(dictname $src)
-      echo ";;; -*- coding: utf-8 -*-" > $dst  # libskk requires this on the first line
-      iconv -f EUC-JP -t UTF-8 $src | skkdic-expr2 >> $dst
-    done
-
-    # combine .L .edict and .assoc for convenience
-    dst=$out/share/SKK-JISYO.combined
-    echo ";;; -*- coding: utf-8 -*-" > $dst
-    skkdic-expr2 \
-      $out/share/$(dictname ${large}) + \
-      $out/share/$(dictname ${edict}) + \
-      $out/share/$(dictname ${assoc}) >> $dst
-  '';
-
-  enableParallelBuilding = true;
-
-  meta = with lib; {
-    description = "Collection of standard SKK dictionaries";
-    longDescription = ''
-      This package provides a collection of standard kana-to-kanji
-      dictionaries for the SKK Japanese input method.
+lib.listToAttrs (map mkDictNameValue [
+  {
+    name = "L";
+    description = "The standard SKK dictionary";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "S";
+    description = "Small SKK dictionary";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "M";
+    description = "Medium sized SKK dictionary";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "ML";
+    description = "Medium to large sized SKK dictionary";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "jinmei";
+    description = "SKK dictionary for names";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "fullname";
+    description = "SKK dictionary for celebrities";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "geo";
+    description = "SKK dictionary for locations";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "propernoun";
+    description = "SKK dictionary for proper nouns";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "station";
+    description = "SKK dictionary for stations";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "law";
+    description = "SKK dictionary for legal terms";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "okinawa";
+    description = "SKK dictionary for the Okinawan language";
+    license = lib.licenses.publicDomain;
+  }
+  {
+    name = "china_taiwan";
+    description = "SKK dictionary for Chinese & Taiwanese locations";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "assoc";
+    description = "SKK dictionary for abbreviated input";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "edict";
+    description = "SKK dictionary for English to Japanese translation";
+    license = lib.licenses.cc-by-sa-30;
+  }
+  {
+    name = "zipcode";
+    description = "SKK dictionary for Japanese zipcodes";
+    files = [ "zipcode/SKK-JISYO.zipcode" "zipcode/SKK-JISYO.office.zipcode" ];
+    license = lib.licenses.publicDomain;
+  }
+  {
+    name = "JIS2";
+    description = "SKK dictionary for JIS level 2 kanjis";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "JIS3_4";
+    description = "SKK dictionary for JIS level 3 and 4 kanjis";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "JIS2004";
+    description = ''
+      A complementary SKK dictionary for JIS3_4 with JIS X 0213:2004 additions"
     '';
-    homepage = "https://github.com/skk-dev/dict";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ yuriaisaka ];
-    platforms = platforms.all;
-  };
-}
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "itaiji";
+    description = "SKK dictionary for variant kanjis";
+    license = lib.licenses.publicDomain;
+  }
+  {
+    name = "itaiji.JIS3_4";
+    description = "SKK dictionary for JIS level 3 and 4 variant kanjis";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "mazegaki";
+    description = "SKK dictionary for mazegaki";
+    license = lib.licenses.gpl2Plus;
+  }
+  {
+    name = "emoji";
+    description = "SKK dictionary for emojis";
+    license = lib.licenses.unicode-dfs-2016;
+  }
+  {
+    name = "pinyin";
+    description = "SKK dictionary for pinyin to simplified Chinese input";
+    license = lib.licenses.gpl1Plus;
+  }
+])

--- a/pkgs/tools/text/cmigemo/default.nix
+++ b/pkgs/tools/text/cmigemo/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub
 , iconv, nkf, perl, which
-, skk-dicts
+, skkDictionaries
 }:
 
 stdenv.mkDerivation {
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ iconv nkf perl which ];
 
   postUnpack = ''
-    cp ${skk-dicts}/share/SKK-JISYO.L source/dict/
+    cp ${skkDictionaries.l}/share/skk/SKK-JISYO.L source/dict/
   '';
 
   patches = [ ./no-http-tool-check.patch ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1449,6 +1449,7 @@ mapAliases {
   shipyard = jumppad; # Added 2023-06-06
   signumone-ks = throw "signumone-ks has been removed from nixpkgs because the developers stopped offering the binaries"; # Added 2023-08-17
   simplenote = throw "'simplenote' has been removed because it is no longer maintained and insecure"; # Added 2023-10-09
+  skk-dicts = throw "'skk-dicts' has been split into multiple packages under 'skkDictionaries'"; # Added 2023-11-08
   sky = throw "'sky' has been removed because its upstream website disappeared"; # Added 2024-07-21
   SkypeExport = skypeexport; # Added 2024-06-12
   slack-dark = slack; # Added 2020-03-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6502,7 +6502,7 @@ with pkgs;
   netplan = callPackage ../tools/admin/netplan { };
 
   skktools = callPackage ../tools/inputmethods/skk/skktools { };
-  skk-dicts = callPackage ../tools/inputmethods/skk/skk-dicts { };
+  skkDictionaries = callPackages ../tools/inputmethods/skk/skk-dicts { };
 
   libkkc-data = callPackage ../data/misc/libkkc-data { };
 


### PR DESCRIPTION
## Description of changes
skk-dicts contain dictionary files that aid writing Japanese text with SKK-style input method editors. It offers multiple different dictionary files that users are supposed to combine based on their style of writing. Exactly which comibination of those dictionaries a user should install is purely based on personal preference. However, the current skk-dicts package lumps the dictionaries into a single package and is opionated in which dictionaries it includes and which of them it doesn't.

This PR offers users the required flexibility by splitting skk-dicts into multiple packages under the `skkDictionaries` attribute.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
