### PR TITLE
nixos/caddy: optional formatting of Caddyfile

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -511,6 +511,8 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `services.bitcoind` now properly respects the `enable` option.
 
+- The Caddy module gained a new option named `services.caddy.formatCaddyfile` which is enabled by default, to match existing behaviour. When disabled, `caddy fmt` will no longer run on the generated caddyfile. This is useful where the caddyfile is not supported by `caddy fmt`, for example [for heredocs](https://github.com/caddyserver/caddy/issues/5930).
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - The use of `sourceRoot = "source";`, `sourceRoot = "source/subdir";`, and similar lines in package derivations using the default `unpackPhase` is deprecated as it requires `unpackPhase` to always produce a directory named "source". Use `sourceRoot = src.name`, `sourceRoot = "${src.name}/subdir";`, or `setSourceRoot = "sourceRoot=$(echo */subdir)";` or similar instead.

--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -45,7 +45,8 @@ let
           caddy fmt --overwrite $out/Caddyfile
         '';
       in
-      "${if pkgs.stdenv.buildPlatform == pkgs.stdenv.hostPlatform then Caddyfile-formatted else Caddyfile}/Caddyfile";
+      "${if cfg.formatCaddyfile && pkgs.stdenv.buildPlatform == pkgs.stdenv.hostPlatform
+         then Caddyfile-formatted else Caddyfile}/Caddyfile";
 
   etcConfigFile = "caddy/caddy_config";
 
@@ -146,6 +147,20 @@ in
         Configuration for the default logger. See
         <https://caddyserver.com/docs/caddyfile/options#log>
         for details.
+      '';
+    };
+
+    formatCaddyfile = mkOption {
+      default = true;
+      type = types.bool;
+      description = lib.mdDoc ''
+        Format the generated caddyfile using `caddy fmt` if `caddy` is available
+        (i.e. if buildPlatform = hostPlatform) (defaults to true to match behaviour
+        in earlier versions of this module).
+
+        Caddy fmt does not handle all valid Caddyfiles. For example, see
+        <https://github.com/caddyserver/caddy/issues/5930> for the lack of heredoc
+        support.
       '';
     };
 


### PR DESCRIPTION
## Description of changes

As explained in
https://github.com/caddyserver/caddy/issues/5930#issuecomment-1797709061, `caddy fmt` doesn’t handle heredocs. The existing module always runs `caddy fmt` on native builds, and thus for a configuration containing a heredoc, the service fails at runtime.

This change is simple, and backwards compatible. Alternatives I considered include only using the output of `caddy fmt` if `caddy adapt` also succeeds, removing the formatting and adding an option defaulting to false. Adding an option that defaults to true allows users to disable `caddy fmt` for other reasons, thoguh.

I figured the PR was quicker than raising an issue.

Testing will require a little time, as I get back to the test platform suitable test. I've confirmed that running without `caddy fmt` fixes the issue in a vendored module.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).