### PR TITLE
nixos/acme: do not eat Let's Encrypt's request limits if misconfigured on first try

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -345,6 +345,10 @@ let
       serviceConfig = commonServiceConfig // {
         Group = data.group;
 
+        # Let's Encrypt Failed Validation Limit allows 5 retries per hour, per account, hostname and hour.
+        # This avoids eating them all up if something is misconfigured upon the first try.
+        RestartSec = 15 * 60;
+
         # Keep in mind that these directories will be deleted if the user runs
         # systemctl clean --what=state
         # acme/.lego/${cert} is listed for this reason.


### PR DESCRIPTION
cc @osnyx for review, as you fixed a related issue recently :)

Exactly zero testing performed locally, considering I'm currently banned from Let's Encrypt and it's like the fifth time I think "I'll submit a PR after I add my next certificate" and then forget about it. Ofborg should be a good enough test anyway.

@ofborg build nixosTests.acme