### PR TITLE
qrtool: init at 0.8.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13919,6 +13919,12 @@
     githubId = 9267430;
     name = "Philipp Mildenberger";
   };
+  philiptaron = {
+    email = "philip.taron@gmail.com";
+    github = "philiptaron";
+    githubId = 43863;
+    name = "Philip Taron";
+  };
   phip1611 = {
     email = "phip1611@gmail.com";
     github = "phip1611";

--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "qrtool";
+  version = "0.8.4";
+
+  src = fetchFromGitHub {
+    owner = "sorairolake";
+    repo = "qrtool";
+    rev = "v${version}";
+    sha256 = "sha256-FoWUGhNfVILpYxmsnSzRIM1+R9/xFxCF7W1sdiHaAiA=";
+  };
+
+  cargoSha256 = "sha256-mtejnHCkN2krgFAneyyBpvbv5PZO3GigM2DJqrbHim4=";
+
+  meta = with lib; {
+    maintainers = with maintainers; [ philiptaron ];
+    description = "An utility for encoding or decoding QR code";
+    license = licenses.asl20;
+    homepage = "https://sorairolake.github.io/qrtool/book/index.html";
+    changelog = "https://sorairolake.github.io/qrtool/book/changelog.html";
+    mainProgram = "qrtool";
+  };
+}


### PR DESCRIPTION
## Description of changes

qrtool is a command-line utility for encoding or decoding QR code.

![Demonstration of qrtool](https://sorairolake.github.io/qrtool/book/_images/demo.gif)

I added myself as maintainer, but I'm just a drive-by packager.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).