### PR TITLE
WIP: nixos/luks: Allow for many key files

### DIFF
--- a/nixos/modules/system/boot/luks/keys.nix
+++ b/nixos/modules/system/boot/luks/keys.nix
@@ -1,0 +1,56 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+    file = mkOption {
+      default = null;
+      example = "/dev/sdb1";
+      type = types.nullOr (types.listOf types.str);
+      description = lib.mdDoc ''
+        The name of the file (can be a raw device or a partition) that
+        should be used as the decryption key for the encrypted device. If
+        not specified, you will be prompted for a passphrase instead.
+      '';
+    };
+
+    fileSize = mkOption {
+      default = null;
+      example = 4096;
+      type = types.nullOr types.int;
+      description = lib.mdDoc ''
+        The size of the key file. Use this if only the beginning of the
+        key file should be used as a key (often the case if a raw device
+        or partition is used as key file). If not specified, the whole
+        `keyFile` will be used decryption, instead of just
+        the first `keyFileSize` bytes.
+      '';
+    };
+
+    fileOffset = mkOption {
+      default = null;
+      example = 4096;
+      type = types.nullOr types.int;
+      description = lib.mdDoc ''
+        The offset of the key file. Use this in combination with
+        `size` to use part of a file as key file
+        (often the case if a raw device or partition is used as a key file).
+        If not specified, the key begins at the first byte of
+        `file`.
+      '';
+    };
+
+    priority = mkOption {
+      type = types.int;
+      default = 1000;
+      description = lib.mdDoc ''
+        Order of this location block in relation to the others in keys.
+        The semantics are the same as with `lib.mkOrder`. Smaller values have
+        a greater priority.
+      '';
+    };
+
+  };
+}
+


### PR DESCRIPTION
## Description of changes

Would be great to have a series of key files available to try for a device.

TODO: get `nixosTests.luks` to not hang (not sure if this was related to my changes)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

