### PR TITLE
dependabot-cli: init at 1.39.0

### DIFF
--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -1,0 +1,62 @@
+{ buildGoModule
+, dependabot-cli
+, fetchFromGitHub
+, fetchpatch
+, installShellFiles
+, lib
+, testers
+}:
+let
+  pname = "dependabot-cli";
+  version = "1.39.0";
+in
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "dependabot";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-QuhgFWF97B72KTX/QKSXNl/4RDAKUMDga7vLYiZw4SM=";
+  };
+
+  vendorHash = "sha256-mNpNp/zeQGgcljj2VhGl4IN1HG1R8CJSTWKzrgC0z44=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/dependabot/cli/cmd/dependabot/internal/cmd.version=v${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd dependabot \
+      --bash <($out/bin/dependabot completion bash) \
+      --fish <($out/bin/dependabot completion fish) \
+      --zsh <($out/bin/dependabot completion zsh)
+  '';
+
+  checkFlags = [
+    "-skip=TestIntegration|TestNewProxy_customCert|TestRun"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/dependabot --help
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = dependabot-cli;
+    command = "dependabot --version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/dependabot/cli/releases/tag/v${version}";
+    description = "A tool for testing and debugging Dependabot update jobs";
+    homepage = "https://github.com/dependabot/cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ l0b0 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Motivation: #266156

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).