### PR TITLE
python3Packages.pykdl: fix build with Python 3.11

### DIFF
--- a/pkgs/development/python-modules/pykdl/default.nix
+++ b/pkgs/development/python-modules/pykdl/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, toPythonModule, cmake, orocos-kdl, eigen, python }:
+{ lib, stdenv, toPythonModule, fetchpatch, cmake, pybind11, orocos-kdl, eigen
+, python }:
 
 toPythonModule (stdenv.mkDerivation {
   pname = "pykdl";
@@ -6,13 +7,22 @@ toPythonModule (stdenv.mkDerivation {
 
   sourceRoot = "${orocos-kdl.src.name}/python_orocos_kdl";
 
+  patches = [
+    # Support system pybind11; the vendored copy doesn't support Python 3.11
+    (fetchpatch {
+      url = "https://github.com/orocos/orocos_kinematics_dynamics/commit/e25a13fc5820dbca6b23d10506407bca9bcdd25f.patch";
+      hash = "sha256-NGMVGEYsa7hVX+SgRZgeSm93BqxFR1uiyFvzyF5H0Y4=";
+      stripLen = 1;
+    })
+  ];
+
   # Fix hardcoded installation path
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace dist-packages site-packages
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake pybind11 ];
   buildInputs = [ orocos-kdl eigen ];
   propagatedBuildInputs = [ python ];
 


### PR DESCRIPTION
## Description of changes

pykdl 1.5.1 only supports using a vendored copy of pybind11, but this version doesn't support Python 3.11. Therefore, backport an upstream patch that allows using a system pybind11 installation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
