### PR TITLE
ocamlPackages.getopt: 20120615 → 20230213

### DIFF
--- a/pkgs/development/ocaml-modules/getopt/default.nix
+++ b/pkgs/development/ocaml-modules/getopt/default.nix
@@ -1,28 +1,22 @@
-{ lib, fetchzip, stdenv, ocaml, findlib, ocamlbuild }:
+{ lib, fetchFromGitHub, buildDunePackage }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-getopt";
-  version = "20120615";
+buildDunePackage rec {
+  pname = "getopt";
+  version = "20230213";
 
-  src = fetchzip {
-    url = "https://download.ocamlcore.org/ocaml-getopt/ocaml-getopt/${version}/ocaml-getopt-${version}.tar.gz";
-    sha256 = "0bng2mmdixpmj23xn8krlnaq66k22iclwz46r8zjrsrq3wcn1xgn";
+  minimalOCamlVersion = "4.07";
+
+  src = fetchFromGitHub {
+    owner = "scemama";
+    repo = "ocaml-getopt";
+    rev = version;
+    hash = "sha256-oYDm945LgjIW+8x7UrO4FlbHywnu8480aiEVvnjBxc8=";
   };
 
-  nativeBuildInputs = [
-    ocaml
-    findlib
-    ocamlbuild
-  ];
-
-  strictDeps = true;
-
   doCheck = true;
-  createFindlibDestdir = true;
 
   meta = {
-    inherit (ocaml.meta) platforms;
-    homepage = "https://github.com/gildor478/ocaml-getopt";
+    homepage = "https://github.com/scemama/ocaml-getopt";
     description = "Parsing of command line arguments (similar to GNU GetOpt) for OCaml";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];


### PR DESCRIPTION
## Description of changes

Support for recent versions of OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
