### PR TITLE
haskellPackages.{crypton,SHA}: disable tests on aarch32

### DIFF
--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -124,4 +124,7 @@ self: super: {
   # KAT/ECB/D2 test segfaults on armv7l
   # https://github.com/haskell-crypto/cryptonite/issues/367
   cryptonite = dontCheck super.cryptonite;
+
+  # https://github.com/GaloisInc/SHA/issues/16
+  SHA = dontCheck super.SHA;
 }

--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -125,6 +125,10 @@ self: super: {
   # https://github.com/haskell-crypto/cryptonite/issues/367
   cryptonite = dontCheck super.cryptonite;
 
+  # https://github.com/kazu-yamamoto/crypton/issues/25
+  crypton = dontCheck super.crypton;
+  crypton_0_33 = dontCheck super.crypton_0_33;
+
   # https://github.com/GaloisInc/SHA/issues/16
   SHA = dontCheck super.SHA;
 }


### PR DESCRIPTION
## Description of changes

`crypton` and `SHA` are dependencies of `shellcheck`, which is used by `writeShellApplication`
Upstream issues: https://github.com/kazu-yamamoto/crypton/issues/25 https://github.com/GaloisInc/SHA/issues/16

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] armv7l-linux (native)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
