### PR TITLE
python311Packages.dash: 2.13.0 -> 2.14.1

### DIFF
--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -1,27 +1,43 @@
 { lib
 , buildPythonPackage
-, celery
-, dash-core-components
-, dash-html-components
-, dash-table
-, diskcache
-, fetchFromGitHub
-, flask
-, flask-compress
-, mock
-, multiprocess
-, plotly
-, psutil
-, pytest-mock
-, pytestCheckHook
 , pythonOlder
-, pyyaml
+, fetchFromGitHub
+
+, nodejs
+, yarn
+, fixup_yarn_lock
+, fetchYarnDeps
+
+, setuptools
+, flask
+, werkzeug
+, plotly
+, dash-html-components
+, dash-core-components
+, dash-table
+, importlib-metadata
+, typing-extensions
+, requests
+, retrying
+, ansi2html
+, nest-asyncio
+
+, celery
 , redis
+, diskcache
+, multiprocess
+, psutil
+, flask-compress
+
+, pytestCheckHook
+, pytest-mock
+, mock
+, pyyaml
 }:
 
 buildPythonPackage rec {
   pname = "dash";
-  version = "2.13.0";
+  version = "2.14.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -30,16 +46,52 @@ buildPythonPackage rec {
     owner = "plotly";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-+pTxEPuXtcu+ZekphqXD/k2tQ5werH/1ueGJOxA8pZw=";
+    hash = "sha256-vQOfX9RCIbr5lfUyT2knwrO374/vm7jH+/1+BeqmRjI=";
   };
 
+  nativeBuildInputs = [
+    nodejs
+    yarn
+    fixup_yarn_lock
+  ];
+
+  yarnDeps = fetchYarnDeps {
+    yarnLock = src + "/@plotly/dash-jupyterlab/yarn.lock";
+    hash = "sha256-mkiyrA0jGiP0zbabSjgHFLEUX3f+LZdJ8eARI5QA8CU=";
+  };
+
+  preBuild = ''
+    pushd @plotly/dash-jupyterlab
+
+    export HOME=$(mktemp -d)
+
+    yarn config --offline set yarn-offline-mirror ${yarnDeps}
+    fixup_yarn_lock yarn.lock
+
+    substituteInPlace package.json --replace jlpm yarn
+    yarn install --offline --frozen-lockfile --ignore-engines --ignore-scripts
+    patchShebangs .
+
+    # Generates the jupyterlab extension files
+    yarn run build:pack
+
+    popd
+  '';
+
   propagatedBuildInputs = [
-    dash-core-components
-    dash-html-components
-    dash-table
+    setuptools # for importing pkg_resources
     flask
-    flask-compress
+    werkzeug
     plotly
+    dash-html-components
+    dash-core-components
+    dash-table
+    importlib-metadata
+    typing-extensions
+    requests
+    retrying
+    ansi2html
+    nest-asyncio
   ];
 
   passthru.optional-dependencies = {
@@ -52,35 +104,31 @@ buildPythonPackage rec {
       multiprocess
       psutil
     ];
+    compress = [
+      flask-compress
+    ];
   };
 
   nativeCheckInputs = [
-    mock
-    pytest-mock
     pytestCheckHook
+    pytest-mock
+    mock
     pyyaml
   ];
 
   disabledTestPaths = [
     "tests/unit/test_browser.py"
-    "tests/unit/test_app_runners.py" # Use selenium
+    "tests/unit/test_app_runners.py" # Uses selenium
     "tests/integration"
   ];
 
-  disabledTests = [
-    # Failed: DID NOT RAISE <class 'ImportError'>
-    "test_missing_flask_compress_raises"
-  ];
+  pythonImportsCheck = [ "dash" ];
 
-  pythonImportsCheck = [
-    "dash"
-  ];
-
-  meta = with lib; {
+  meta = {
     description = "Python framework for building analytical web applications";
     homepage = "https://dash.plot.ly/";
-    changelog = "https://github.com/plotly/dash/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ antoinerg ];
+    changelog = "https://github.com/plotly/dash/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ antoinerg tomasajt ];
   };
 }


### PR DESCRIPTION
## Description of changes

Supersedes https://github.com/NixOS/nixpkgs/pull/244072

This PR fixes the build, as the automatic update didn't consider the breaking change in the build-step.
This PR also further bumps the version.

The merging of the JupyterDash module into the main repo caused the build faliure. Sadly, the jupyter extension was not pushed to the repo already build (the Pypi source does have it though, but I tried to stay with the GitHub source)

To build the Jupyter extension I had to use yarn and prefetch the deps.

I grouped the used python packages by usage area and ordered them by how they appear in the requirements.txt list.

I put flask-compress into optional-dependencies.compress which fixed the broken test.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
