### PR TITLE
libcamera-apps: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8775,6 +8775,11 @@
     githubId = 1918771;
     name = "Joe Doyle";
   };
+  jpds = {
+    github = "jpds";
+    githubId = 29158971;
+    name = "Jonathan Davies";
+  };
   jpentland = {
     email = "joe.pentland@gmail.com";
     github = "jpentland";

--- a/pkgs/applications/misc/libcamera-apps/default.nix
+++ b/pkgs/applications/misc/libcamera-apps/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, meson
+, ninja
+, pkg-config
+, boost
+, ffmpeg
+, libcamera
+, libdrm
+, libexif
+, libjpeg
+, libpng
+, libtiff
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcamera-apps";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IRHCM8RpszSDH44Ztkf0J1LUwvX8D3qxQ/4KLiL/fn0=";
+  };
+
+  buildInputs = [
+    boost
+    ffmpeg
+    libcamera
+    libdrm
+    libexif
+    libjpeg
+    libpng
+    libtiff
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  # Meson is no longer able to pick up Boost automatically.
+  # https://github.com/NixOS/nixpkgs/issues/86131
+  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
+  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
+
+  meta = with lib; {
+    description = "Small suite of libcamera-based apps that aim to copy the functionality of the existing 'raspicam' apps.";
+    homepage = "https://github.com/raspberrypi/libcamera-apps";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ jpds ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32475,6 +32475,8 @@ with pkgs;
 
   levant = callPackage ../applications/networking/cluster/levant { };
 
+  libcamera-apps = callPackage ../applications/misc/libcamera-apps/default.nix { };
+
   lwm = callPackage ../applications/window-managers/lwm { };
 
   marker = callPackage ../applications/editors/marker { };


### PR DESCRIPTION
## Description of changes

Adds https://github.com/raspberrypi/libcamera-apps for ease of NixOS Raspberry Pi camera enablement.

Fixes: #231147.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).