### PR TITLE
lib.applyToOverridable: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -114,6 +114,7 @@ let
     inherit (self.stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (self.customisation) overrideDerivation makeOverridable
+      applyToOverridable
       callPackageWith callPackagesWith extendDerivation hydraJob
       makeScope makeScopeWithSplicing makeScopeWithSplicing';
     inherit (self.derivations) lazyDerivation;

--- a/pkgs/development/compilers/cudatoolkit/stdenv.nix
+++ b/pkgs/development/compilers/cudatoolkit/stdenv.nix
@@ -26,8 +26,10 @@ let
   };
   assertCondition = true;
 in
-lib.extendDerivation
-  assertCondition
-  passthruExtra
+lib.applyToOverridable
+  (lib.extendDerivation
+    assertCondition
+    passthruExtra
+  )
   cudaStdenv
 


### PR DESCRIPTION
## Description of changes

This PR defines a function `lib.applyToOverridable` that make sure that an overridable (an attribute set one can override) behaves when updating its attributes directly (i.e. not by overriding).

Without it, the updating will be lost once the overridable is overridden. For example, `((lib.extendDerivation true { ans = 42; } pkgs.hello).override { }).ans` throws `error: attribute 'ans' missing`. This is relevant when applying `extendDerivation` to a package produced by `stdenv.mkDerivation`.

Packages produced by many language-specific build helpers suffers from such `overrideAttrs` misbehave. For example, `pkgs.python3Packages.six.updateScript` evaluates successfully, but `(pkgs.python311Packages.six.overrideAttrs { }).updateScript` throws `error: attribute 'updateScript' missing`. I'm not planning to fix them here, as they can be improved through `lib.extendMkDerivationModified` in the future, which internally calls `lib.applyToOverridable`. It sounds awkward to change them twice.

This is split from #234651

This depends on #265710 for `lib.mirrorFunctionArgs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
