### PR TITLE
automatix: init at 1.12.1

### DIFF
--- a/pkgs/development/python-modules/automatix/default.nix
+++ b/pkgs/development/python-modules/automatix/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, pyyaml
+, importlib-metadata
+, withBundlewrap ? true, bundlewrap
+, withBundlewrapTeamvault ? withBundlewrap, bundlewrap-teamvault
+, pytest
+}:
+
+assert withBundlewrapTeamvault -> withBundlewrap;
+
+buildPythonPackage rec {
+  pname = "automatix";
+  version = "1.12.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Lgft8lUUu8kKpoSutw7VxRz6Ktws2HG+0H7KfSoSFrA=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [ pyyaml importlib-metadata ]
+    ++ lib.optional withBundlewrap bundlewrap
+    ++ lib.optional withBundlewrapTeamvault bundlewrap-teamvault;
+
+  buildInputs = [ pytest ];
+
+  # Tests are currently broken
+  # Also, there's only integration tests requiring a docker setup
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "automatix"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/seibert-media/automatix";
+    description = "Automation wrapper for bash and python commands";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexchen ];
+  };
+}

--- a/pkgs/development/python-modules/bundlewrap-teamvault/default.nix
+++ b/pkgs/development/python-modules/bundlewrap-teamvault/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, bundlewrap
+, passlib
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "bundlewrap-teamvault";
+  version = "3.1.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ePGt+XbhTcTrh0bkZHrfM4Uur3oNL7uW78kQHkjXhQ8=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [ bundlewrap passlib requests ];
+
+  # upstream has no checks
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "bwtv"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/trehn/bundlewrap-teamvault";
+    description = "Pull secrets from TeamVault into your BundleWrap repo";
+    license = [ licenses.gpl3 ] ;
+    maintainers = with maintainers; [ hexchen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18301,6 +18301,8 @@ with pkgs;
 
   autoadb = callPackage ../misc/autoadb { };
 
+  automatix = python3Packages.toPythonApplication python3Packages.automatix;
+
   ansible = ansible_2_15;
   ansible_2_15 = python3Packages.toPythonApplication python3Packages.ansible-core;
   ansible_2_14 = python3Packages.toPythonApplication (python3Packages.ansible-core.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -922,6 +922,8 @@ self: super: with self; {
 
   automate-home = callPackage ../development/python-modules/automate-home { };
 
+  automatix = callPackage ../development/python-modules/automatix { };
+
   automx2 = callPackage ../development/python-modules/automx2 { };
 
   autopage = callPackage ../development/python-modules/autopage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1699,6 +1699,8 @@ self: super: with self; {
 
   bundlewrap = callPackage ../development/python-modules/bundlewrap { };
 
+  bundlewrap-teamvault = callPackage ../development/python-modules/bundlewrap-teamvault { };
+
   busypie = callPackage ../development/python-modules/busypie { };
 
   bx-py-utils = callPackage ../development/python-modules/bx-py-utils { };


### PR DESCRIPTION
## Description of changes

Introduced automatix, a automation utility using python and bash, which is also able to interact with bundlewrap.

I have cherry-picked the commit that introduces bundlewrap-teamvault from https://github.com/NixOS/nixpkgs/pull/266258, since automatix depends on it (despite the dependency not being declared in the setup.py).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
