### PR TITLE
mpifileutils: init at 0.11.1

### DIFF
--- a/pkgs/by-name/dt/dtcmp/package.nix
+++ b/pkgs/by-name/dt/dtcmp/package.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, mpi, lwgrp }:
+
+stdenv.mkDerivation rec {
+  pname = "dtcmp";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo = "dtcmp";
+    rev = "v${version}";
+    hash = "sha256-Dc+c8JCc5D23CtpwiWkHCqngywEZXw7cYsRiSYiQdWk=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ lwgrp ];
+
+  configureFlags = [ "--with-lwgrp=${lib.getDev lwgrp}" ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  meta = with lib; {
+    description = "MPI datatype comparison library";
+    homepage = "https://github.com/LLNL/dtcmp";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}

--- a/pkgs/by-name/li/libcircle/package.nix
+++ b/pkgs/by-name/li/libcircle/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, mpi
+, lwgrp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcircle";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "hpc";
+    repo = "libcircle";
+    rev = "v${version}";
+    hash = "sha256-EfnoNL6wo6qQES6XzMtpTpYcsJ8V2gy32i26wiTldH0=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  meta = with lib; {
+    description = "API for distributing embarrassingly parallel workloads using self-stabilization";
+    homepage = "http://hpc.github.io/libcircle/";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}

--- a/pkgs/by-name/lw/lwgrp/package.nix
+++ b/pkgs/by-name/lw/lwgrp/package.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, mpi, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "lwgrp";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo = "lwgrp";
+    rev = "v${version}";
+    hash = "sha256-f0tYn9FbrOz8iMoG8Is8vYDNfYHTfxLKNnyxJA+Msdk=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  meta = with lib; {
+    description = "Data structures and operations to group MPI processes as an ordered set";
+    homepage = "https://github.com/LLNL/lwgrp";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}

--- a/pkgs/by-name/mp/mpifileutils/package.nix
+++ b/pkgs/by-name/mp/mpifileutils/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, mpi
+, attr
+, dtcmp
+, libarchive
+, libcircle
+, bzip2
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mpifileutils";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "hpc";
+    repo = "mpifileutils";
+    rev = "v${version}";
+    hash = "sha256-3nls82awMMCwlfafsOy3AY8OvT9sE+BvvsDOY14YvQc=";
+  };
+
+  outputs = [ "out" "dev" "man" ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    attr
+    dtcmp
+    libarchive
+    libcircle
+    bzip2
+    openssl
+  ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  meta = with lib; {
+    description = "Suite of MPI-based tools to manage large datasets";
+    homepage = "https://hpc.github.io/mpifileutils";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Suite of MPI-based tools to manage large datasets

New dependencies:
* lwgrp
* libcircle
* dtcmp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
