### PR TITLE
python3Packages.wagtail: 5.1.1 -> 5.1.3

### DIFF
--- a/pkgs/development/python-modules/wagtail-localize/default.nix
+++ b/pkgs/development/python-modules/wagtail-localize/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "wagtail-localize";
-  version = "1.5.2";
+  version = "1.6";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     repo = pname;
     owner = "wagtail";
     rev = "refs/tags/v${version}";
-    hash = "sha256-7r2FFfWGqjE3Z7wsdf6KwwbUZ+wXqOscsL/2CepSMLY=";
+    hash = "sha256-OrRR5wLTq3icSBq+9m+MxIvkTvJP7yiGR9yzPt53q+k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "wagtail";
-  version = "5.1.1";
+  version = "5.1.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-IR/wzXBZ+Win/EOFUDsg2AHB5otW9YMeCmpPxgCllD8=";
+    hash = "sha256-RfrHlOTCDH51sBgGnX+XYfJfqjYZ7zDfJAE8okq/mnQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "beautifulsoup4>=4.8,<4.12" "beautifulsoup4>=4.8" \
-      --replace "Pillow>=4.0.0,<10.0.0" "Pillow>=9.1.0,<11.0.0"
+      --replace "draftjs_exporter>=2.1.5,<3.0" "draftjs_exporter>=2.1.5,<6.0"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

The `python3Packages.wagtail` package has been broken by the upgrade of `python3Packages.draftjs_exporter` to version 5.0.0 in 942a15a274de315bc293b24666e87db6e23b9205. For some reason building the `python3Packages.wagtail` directly still worked, but building it as a dependency (eg. by building `python3Packages.wagtail-localize`) failed (see https://gist.github.com/natsukium/fefc90d425bf7fac183b6af18350647d).

The dependency to draftjs_exporter can be safely relaxed. I have [submitted a patch to relax it upstream](https://github.com/wagtail/wagtail/pull/11204), which has been merged. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
