### PR TITLE
nixos/syncoid: change sshKey options to disallow path-types

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -159,6 +159,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=23.11, `pkgs.nextcloud27` will be installed by default.
   - Please note that an upgrade from v26 (or older) to v28 directly is not possible. Please upgrade to `nextcloud27` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud27;`](options.html#opt-services.nextcloud.package).
 
+- The options `services.syncoid.sshKey` and `services.syncoid.commands.<name>.sshKey` now only accept nulls or strings, not path-types.
+
 - The vendored third party libraries have been mostly removed from `cudaPackages.nsight_systems`, which we now only ship for `cudaPackages_11_8` and later due to outdated dependencies. Users comfortable with the vendored dependencies may use `overrideAttrs` to amend the `postPatch` phase and the `meta.broken` correspondingly. Alternatively, one could package the deprecated `boost170` locally, as required for `cudaPackages_11_4.nsight_systems`.
 
 - The `cudaPackages` package scope has been updated to `cudaPackages_12`.

--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -123,10 +123,10 @@ in
     };
 
     sshKey = mkOption {
-      type = with types; nullOr (coercedTo path toString str);
+      type = types.nullOr types.str;
       default = null;
       description = lib.mdDoc ''
-        SSH private key file to use to login to the remote system. Can be
+        Path to the SSH private key file to use to login to the remote system. Can be
         overridden in individual commands.
       '';
     };
@@ -203,9 +203,9 @@ in
           recursive = mkEnableOption (lib.mdDoc ''the transfer of child datasets'');
 
           sshKey = mkOption {
-            type = with types; nullOr (coercedTo path toString str);
+            type = types.nullOr types.str;
             description = lib.mdDoc ''
-              SSH private key file to use to login to the remote system.
+              Path to the SSH private key file to use to login to the remote system.
               Defaults to {option}`services.syncoid.sshKey` option.
             '';
           };


### PR DESCRIPTION
The previous behavior obfuscates the default behaviors of the nix language with regard to strings and paths. Better to give an error and let them learn the correct way to do what they wanted than to silently fix their mistake and enhance the misunderstanding.

## Description of changes

Limit `sshKey` options to string types rather than using `toString` to prevent path-types from being copied to the store.

Users who try to pass a path type are prevented from making the fairly horrific mistake of copying their ssh keys to the nix store, just as before, but now the mistake is not reinforced as correct code in their minds. Let's not confuse the path/string issue any more than it already is.

Anyone who wants to do something unusual can always use a string antiquote in their own code when setting the option, so no functionality is lost.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
