### PR TITLE
qbe: 1.1 -> 1.1-unstable-2023-08-18

### DIFF
--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv
-, fetchzip
+{ lib
+, stdenv
 , callPackage
+, fetchgit
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "qbe";
-  version = "1.1";
+  version = "1.1-unstable-2023-08-18";
 
-  src = fetchzip {
-    url = "https://c9x.me/compile/release/qbe-${version}.tar.xz";
-    sha256 = "sha256-yFZ3cpp7eLjf7ythKFTY1YEJYyfeg2en4/D8+9oM1B4=";
+  src = fetchgit {
+    url = "git://c9x.me/qbe.git";
+    rev = "0d929287d77ccc3fb52ca8bd072678b5ae2c81c8";
+    hash = "sha256-4pwkMUDnOI11P+priMowf9HE/Dva8FKQIrk0rEDa1NE=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -17,13 +19,13 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   passthru = {
-    tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};
+    tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix { };
   };
 
   meta = with lib; {
     homepage = "https://c9x.me/compile/";
     description = "A small compiler backend written in C";
-    maintainers = with maintainers; [ fgaz ];
+    maintainers = with maintainers; [ fgaz onemoresuza ];
     license = licenses.mit;
     platforms = platforms.all;
   };


### PR DESCRIPTION
## Description of changes

The changes implemented up to [36946a51][1] (dbgfile and dbgloc) are
needed for more recent versions of Hare.

[1]: https://c9x.me/git/qbe.git/commit/?id=36946a5142c40b733d25ea5ca469f7949ee03439

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
