### PR TITLE
PoC: NixOS `apply` script refactor

### DIFF
--- a/nixos/modules/system/apply/nixos-apply.sh
+++ b/nixos/modules/system/apply/nixos-apply.sh
@@ -1,0 +1,97 @@
+# This shell library is used by both
+#   - The nixos-rebuild package: for applying configurations that pre-date the toplevel/bin/apply script
+#   - toplevel/bin/apply: the normal script for applying configurations
+#   - system.build.apply: same script but not incorporated into toplevel (it's a tradeoff)
+#
+# Relevant tests:
+#   - nixos-rebuild.tests
+#   - TBD
+
+# TODO: Test deploying a legacy config in a NixOS test. Remove `bin/apply` using override? Or add an internal option to avoid adding `apply`?
+# TODO: Move the documentation to the manual
+# TODO: Is it ok for action=test not to produce a result symlink? It's undocumented and might have been a mistake that's been cautiously preserved.
+#       I would consider it to be a bug. A surprise result symlink will be a GC root that the user is unaware of, taking up space.
+# TODO: Canonicalize pathToConfig with readlink for consistency? Currently rollbacks make them point to the profile symlink instead.
+# TODO: Test --target-host
+
+# Run $action
+#
+# Prerequisites:
+#  - $action: The switch-to-configuration subcommand (ie boot|switch|boot|dry-activate)
+#  - $pathToConfig: The toplevel, or the special string "rollback"
+#  - $profile: The profile location
+#  - targetHostCmd: A function that runs a command on the target host. This is
+#    an artefact of legacy configuration support, where we can't just invoke bin/apply
+#    New deployment methods should just ssh once and invoke bin/apply directly.
+#      - e.g. for local execution: targetHostCmd(){ "$@"; }
+#      - see nixos-rebuild
+nixos_apply_run_action() {
+
+    if [[ "$pathToConfig" == rollback ]]; then
+        if [[ "$action" == switch || "$action" == test ]]; then
+            targetHostCmd nix-env -p "$profile" --rollback
+            pathToConfig="$profile"
+        else
+            systemNumber=$(
+                targetHostCmd nix-env -p "$profile" --list-generations |
+                sed -n '/current/ {g; p;}; s/ *\([0-9]*\).*/\1/; h'
+            )
+            pathToConfig="$profile"-${systemNumber}-link
+        fi
+
+    else # [[ -n "$rollback" ]]
+        targetHostCmd nix-env -p "$profile" --set "$pathToConfig"
+    fi
+
+    # Using systemd-run here to protect against PTY failures/network
+    # disconnections during rebuild.
+    # See: https://github.com/NixOS/nixpkgs/issues/39118
+    cmd=(
+        "systemd-run"
+        "-E" "LOCALE_ARCHIVE" # Will be set to new value early in switch-to-configuration script, but interpreter starts out with old value
+        "-E" "NIXOS_INSTALL_BOOTLOADER"
+        "--collect"
+        "--no-ask-password"
+        "--pty"
+        "--quiet"
+        "--same-dir"
+        "--service-type=exec"
+        "--unit=nixos-rebuild-switch-to-configuration"
+        "--wait"
+    )
+    # Check if we have a working systemd-run. In chroot environments we may have
+    # a non-working systemd, so we fallback to not using systemd-run.
+    # You may also want to explicitly set NIXOS_SWITCH_USE_DIRTY_ENV environment
+    # variable, since systemd-run runs inside an isolated environment and
+    # this may break some post-switch scripts. However keep in mind that this
+    # may be dangerous in remote access (e.g. SSH).
+    if [[ -n "$NIXOS_SWITCH_USE_DIRTY_ENV" ]]; then
+        log "warning: skipping systemd-run since NIXOS_SWITCH_USE_DIRTY_ENV is set. This environment variable will be ignored in the future"
+        cmd=()
+    elif ! targetHostCmd "${cmd[@]}" true &>/dev/null; then
+        logVerbose "Skipping systemd-run to switch configuration since it is not working in target host."
+        cmd=(
+            "env"
+            "-i"
+            "LOCALE_ARCHIVE=$LOCALE_ARCHIVE"
+            "NIXOS_INSTALL_BOOTLOADER=$NIXOS_INSTALL_BOOTLOADER"
+        )
+    else
+        logVerbose "Using systemd-run to switch configuration."
+    fi
+    if [[ -z "$specialisation" ]]; then
+        cmd+=("$pathToConfig/bin/switch-to-configuration")
+    else
+        cmd+=("$pathToConfig/specialisation/$specialisation/bin/switch-to-configuration")
+
+        if [[ ! -f "${cmd[-1]}" ]]; then
+            log "error: specialisation not found: $specialisation"
+            exit 1
+        fi
+    fi
+
+    if ! targetHostCmd "${cmd[@]}" "$action"; then
+        log "warning: error(s) occurred while switching to the new configuration"
+        exit 1
+    fi
+}

--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -16,6 +16,7 @@ in
 substituteAll {
   name = "nixos-rebuild";
   src = ./nixos-rebuild.sh;
+  nixos_apply_sh = ./../../../../nixos/modules/system/apply/nixos-apply.sh;
   dir = "bin";
   isExecutable = true;
   inherit runtimeShell nix;


### PR DESCRIPTION
## Motivation

This explores a small part of what's proposed in

- https://github.com/NixOS/nixpkgs/issues/266290

Refer to that issue for design and discussion.

## Description of changes

Factor out a script from nixos-rebuild, to illustrate which operations' implementations are made available in the new script.

This does not yet include a stand-alone apply script, which would have to supply its own implementation of the prerequisites documented at the `nixos_apply_run_action` function.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
