### PR TITLE
unbound: 1.18.0 -> 1.19.0

### DIFF
--- a/nixos/tests/unbound.nix
+++ b/nixos/tests/unbound.nix
@@ -106,8 +106,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
               {
                 name = ".";
                 forward-addr = [
-                  (lib.head nodes.authoritative.config.networking.interfaces.eth1.ipv6.addresses).address
-                  (lib.head nodes.authoritative.config.networking.interfaces.eth1.ipv4.addresses).address
+                  (lib.head nodes.authoritative.networking.interfaces.eth1.ipv6.addresses).address
+                  (lib.head nodes.authoritative.networking.interfaces.eth1.ipv4.addresses).address
                 ];
               }
             ];
@@ -168,8 +168,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
           "unbound-extra1.conf".text = ''
             forward-zone:
             name: "example.local."
-            forward-addr: ${(lib.head nodes.resolver.config.networking.interfaces.eth1.ipv6.addresses).address}
-            forward-addr: ${(lib.head nodes.resolver.config.networking.interfaces.eth1.ipv4.addresses).address}
+            forward-addr: ${(lib.head nodes.resolver.networking.interfaces.eth1.ipv6.addresses).address}
+            forward-addr: ${(lib.head nodes.resolver.networking.interfaces.eth1.ipv4.addresses).address}
           '';
           "unbound-extra2.conf".text = ''
             auth-zone:
@@ -187,8 +187,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       client = { lib, nodes, ... }: {
         imports = [ common ];
         networking.nameservers = [
-          (lib.head nodes.resolver.config.networking.interfaces.eth1.ipv6.addresses).address
-          (lib.head nodes.resolver.config.networking.interfaces.eth1.ipv4.addresses).address
+          (lib.head nodes.resolver.networking.interfaces.eth1.ipv6.addresses).address
+          (lib.head nodes.resolver.networking.interfaces.eth1.ipv4.addresses).address
         ];
         networking.interfaces.eth1.ipv4.addresses = [
           { address = "192.168.0.10"; prefixLength = 24; }
@@ -276,7 +276,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       resolver.wait_for_unit("multi-user.target")
 
       with subtest("client should be able to query the resolver"):
-          test(client, ["${(lib.head nodes.resolver.config.networking.interfaces.eth1.ipv6.addresses).address}", "${(lib.head nodes.resolver.config.networking.interfaces.eth1.ipv4.addresses).address}"], doh=True)
+          test(client, ["${(lib.head nodes.resolver.networking.interfaces.eth1.ipv6.addresses).address}", "${(lib.head nodes.resolver.networking.interfaces.eth1.ipv4.addresses).address}"], doh=True)
 
       # discard the client we do not need anymore
       client.shutdown()
@@ -298,7 +298,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
           ).strip()
 
           # Thank you black! Can't really break this line into a readable version.
-          expected = "example.local. IN forward ${(lib.head nodes.resolver.config.networking.interfaces.eth1.ipv6.addresses).address} ${(lib.head nodes.resolver.config.networking.interfaces.eth1.ipv4.addresses).address}"
+          expected = "example.local. IN forward ${(lib.head nodes.resolver.networking.interfaces.eth1.ipv6.addresses).address} ${(lib.head nodes.resolver.networking.interfaces.eth1.ipv4.addresses).address}"
           assert out == expected, f"Expected `{expected}` but got `{out}` instead."
           local_resolver.fail("sudo -u unauthorizeduser -- unbound-control list_forwards")
 

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -47,23 +47,14 @@
 , gnutls
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "unbound";
-  version = "1.18.0";
+  version = "1.19.0";
 
   src = fetchurl {
-    url = "https://nlnetlabs.nl/downloads/unbound/unbound-${version}.tar.gz";
-    hash = "sha256-PalUkKhc/2Qg8m+uC4Skn1ES3xvxt/w0+HJPAggstxI=";
+    url = "https://nlnetlabs.nl/downloads/unbound/unbound-${finalAttrs.version}.tar.gz";
+    hash = "sha256-qXUyRohUxhwt5IykFw3oVP07yVyAQ7sM+w/iZgWWZiQ=";
   };
-
-  patches = [
-    # Backport: fix libunbound with nettle.
-    (fetchpatch {
-      url = "https://github.com/NLnetLabs/unbound/commit/654a7eab62cbd1844d483cc4a0f2cf2fbcbaf00a.patch";
-      excludes = [ "doc/Changelog" ];
-      hash = "sha256-n3FCeZESFrrn6Wcf28Hb8WZs1eMHWjbsf2WCFOXU3lI=";
-    })
-  ];
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB
 
@@ -157,7 +148,7 @@ stdenv.mkDerivation rec {
   + ''substituteInPlace "$lib/lib/libunbound.la" ''
   + lib.concatMapStrings
     (pkg: lib.optionalString (pkg ? dev) " --replace '-L${pkg.dev}/lib' '-L${pkg.out}/lib' --replace '-R${pkg.dev}/lib' '-R${pkg.out}/lib'")
-    (builtins.filter (p: p != null) buildInputs);
+    (builtins.filter (p: p != null) finalAttrs.buildInputs);
 
   passthru.tests = {
     inherit gnutls;
@@ -172,4 +163,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ajs124 ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

- switch to finalAttrs
- remove the patch from upstream

changelog: https://github.com/NLnetLabs/unbound/releases/tag/release-1.19.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
