### PR TITLE
tplay: init at 0.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4245,6 +4245,12 @@
     githubId = 5503422;
     name = "Dmitriy Demin";
   };
+  demine = {
+    email = "riches_tweaks0o@icloud.com";
+    github = "demine0";
+    githubId = 51992962;
+    name = "Nikita Demin";
+  };
   demize = {
     email = "johannes@kyriasis.com";
     github = "kyrias";

--- a/pkgs/by-name/tp/tplay/cargo.diff
+++ b/pkgs/by-name/tp/tplay/cargo.diff
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 0eb70e4..8d81ba0 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2069,7 +2069,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+ 
+ [[package]]
+ name = "tplay"
+-version = "0.4.4"
++version = "0.4.5"
+ dependencies = [
+  "clap",
+  "crossbeam-channel",

--- a/pkgs/by-name/tp/tplay/package.nix
+++ b/pkgs/by-name/tp/tplay/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, clang
+, ffmpeg
+, openssl
+, alsa-lib
+, libclang
+, opencv
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "tplay";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "maxcurzi";
+    repo = "tplay";
+    rev =  "v${version}";
+    hash = "sha256-qt5I5rel88NWJZ6dYLCp063PfVmGTzkUUKgF3JkhLQk=";
+  };
+
+  cargoHash = "sha256-0kHh7Wb9Dp+t2G9/Kz/3K43bQdFCl+q2Vc3W32koc2I=";
+  cargoPatches = [ ./cargo.diff ];
+  checkFlags = [
+        # requires network access
+    "--skip=pipeline::image_pipeline::tests::test_process"
+    "--skip=pipeline::image_pipeline::tests::test_to_ascii"
+    "--skip=pipeline::image_pipeline::tests::test_to_ascii_ext"
+    "--skip=pipeline::runner::tests::test_time_to_send_next_frame"
+  ];
+
+  nativeBuildInputs = [ pkg-config clang ffmpeg ];
+  buildInputs = [
+    openssl.dev
+    alsa-lib.dev
+    libclang.lib
+    ffmpeg.dev
+    opencv
+  ];
+
+  env.LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  meta = {
+    description = "Terminal Media Player";
+    homepage = "https://github.com/maxcurzi/tplay";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ demine ];
+  };
+}


### PR DESCRIPTION
## tplay: init at 0.4.5
Terminal Media Player
homepage: https://github.com/maxcurzi/tplay#terminal-media-player
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
