### PR TITLE
p4v: 2022.2.2336701 -> 2023.3.2495381, fix Qt-related crashes

### DIFF
--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -2,28 +2,32 @@
 , fetchurl
 , lib
 , callPackage
-, libsForQt5
 }:
 
 let
   # Upstream replaces minor versions, so use archived URLs.
   srcs = {
     "x86_64-linux" = fetchurl {
-      url = "https://web.archive.org/web/20220902181457id_/https://ftp.perforce.com/perforce/r22.2/bin.linux26x86_64/p4v.tgz";
-      sha256 = "8fdade4aafe25f568a61cfd80823aa90599c2a404b7c6b4a0862c84b07a9f8d2";
+      url = "https://web.archive.org/web/20231108005633id_/https://ftp.perforce.com/perforce/r23.3/bin.linux26x86_64/p4v.tgz";
+      sha256 = "18b275c2d96fb90cc94bb55b132e69f85fb2f4f3f34794d0c5ef7ed63271402a";
     };
     "x86_64-darwin" = fetchurl {
-      url = "https://web.archive.org/web/20220902194716id_/https://ftp.perforce.com/perforce/r22.2/bin.macosx1015x86_64/P4V.dmg";
-      sha256 = "c4a9460c0f849be193c68496c500f8a785c740f5bea5b5e7f617969c20be3cd7";
+      url = "https://web.archive.org/web/20231108010205id_/https://ftp.perforce.com/perforce/r23.3/bin.macosx12u/P4V.dmg";
+      sha256 = "2f846b6a2db71f44292f2137c4289f1294ab0c4ba55ab2f2495befd78b6a85c0";
+    };
+    "aarch64-darwin" = fetchurl {
+      url = "https://web.archive.org/web/20231108010205id_/https://ftp.perforce.com/perforce/r23.3/bin.macosx12u/P4V.dmg";
+      sha256 = "2f846b6a2db71f44292f2137c4289f1294ab0c4ba55ab2f2495befd78b6a85c0";
     };
   };
 
   mkDerivation =
     if stdenv.isDarwin then callPackage ./darwin.nix { }
-    else libsForQt5.callPackage ./linux.nix { };
-in mkDerivation {
+    else callPackage ./linux.nix { };
+in
+mkDerivation {
   pname = "p4v";
-  version = "2022.2.2336701";
+  version = "2023.3.2495381";
 
   src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 


### PR DESCRIPTION
## Description of changes

Updates P4V and related tools from release 2022.2 to 2023.3.

This unfortunately switches P4V to a `buildFHSEnv` approach. It really did not like running with just patchelf'd libraries: lots of segfaults. I spent some time investigating them and it all seems to have to do with Qt library incompatibilities but it isn't clear where they're coming from exactly. It runs really smoothly under FHS so I'm inclined to roll with it.

On the upside, I added some nice icons for Linux users and new releases are universal macOS binaries so they should support aarch64-darwin too.

Release notes: https://www.perforce.com/perforce/doc.current/user/p4vnotes.txt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
