### PR TITLE
wal-lang: init at rev 06498c3f5341ce687a37ad52647f300b72dff52a

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1805,6 +1805,15 @@
       fingerprint = "4AC4 A28D 7208 FC6F 2B51  5EA9 D126 B13A B555 E16F";
     }];
   };
+  avimitin = {
+    email = "dev@avimit.in";
+    github = "avimitin";
+    githubId = 30021675;
+    name = "Jiongjia Lu";
+    keys = [{
+      fingerprint = "6EAE AA25 973B 8863 CDF7  7E25 FF78 83E3 BF68 35DD";
+    }];
+  };
   avitex = {
     email = "theavitex@gmail.com";
     github = "avitex";

--- a/pkgs/development/python-modules/lark-parser/default.nix
+++ b/pkgs/development/python-modules/lark-parser/default.nix
@@ -1,0 +1,18 @@
+{ lib, fetchPypi, buildPythonPackage }:
+ buildPythonPackage rec {
+  pname = "lark-parser";
+  version = "0.12.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-FZZ9sfEhQBPcplsRgHRQR7m+RX1z2iJPzaPZ3U6WoTg=";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/lark-parser/lark";
+    description = "A modern general-purpose parsing library";
+    maintainers = with maintainers; [ avimitin ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pylibfst/default.nix
+++ b/pkgs/development/python-modules/pylibfst/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, setuptools, cmake, zlib, fetchPypi, cffi }:
+buildPythonPackage rec {
+  pname = "pylibfst";
+  version = "0.2.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-/aAEfGuuJgEKQuXgdH67P3mo7wjFBWNRksl0Up0ylSU=";
+  };
+  dontUseCmakeConfigure = true;
+  nativeBuildInputs = [
+    cmake
+    setuptools
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    cffi
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mschlaegl/pylibfst";
+    description = "Handle Fast Signal Traces (fst) in Python";
+    maintainers = with maintainers; [ avimitin ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/wal-lang/default.nix
+++ b/pkgs/development/python-modules/wal-lang/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pip
+, importlib-resources
+, lark-parser
+, pylibfst
+}:
+buildPythonPackage {
+  pname = "wal-lang";
+  version = "unstable-2023-08-12";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "ics-jku";
+    repo = "wal";
+    rev = "06498c3f5341ce687a37ad52647f300b72dff52a";
+    hash = "sha256-gdgaqpbWtc66FEwhTV0AI88TLyfUheBQo4AuZgNyTKY=";
+  };
+
+  nativeBuildInputs = [
+    pip
+  ];
+
+  propagatedBuildInputs = [
+    importlib-resources
+    lark-parser
+    pylibfst
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/ics-jku/wal";
+    description = "Programmable waveform analysis";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ avimitin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41368,6 +41368,8 @@ with pkgs;
 
   wacomtablet = libsForQt5.callPackage ../tools/misc/wacomtablet { };
 
+  wal-lang = with python3Packages; toPythonApplication wal-lang;
+
   wamr = callPackage ../development/interpreters/wamr { };
 
   wasmer = callPackage ../development/interpreters/wasmer {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6018,6 +6018,8 @@ self: super: with self; {
 
   lark = callPackage ../development/python-modules/lark { };
 
+  lark-parser = callPackage ../development/python-modules/lark-parser { };
+
   laspy = callPackage ../development/python-modules/laspy { };
 
   laszip = callPackage ../development/python-modules/laszip {
@@ -10321,6 +10323,8 @@ self: super: with self; {
   pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
 
   pylibdmtx = callPackage ../development/python-modules/pylibdmtx { };
+
+  pylibfst = callPackage ../development/python-modules/pylibfst { };
 
   pylibftdi = callPackage ../development/python-modules/pylibftdi {
     inherit (pkgs) libusb1;
@@ -15501,6 +15505,8 @@ self: super: with self; {
   wallbox = callPackage ../development/python-modules/wallbox { };
 
   walrus = callPackage ../development/python-modules/walrus { };
+
+  wal-lang = callPackage ../development/python-modules/wal-lang { };
 
   wand = callPackage ../development/python-modules/wand { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds three new packages [wal-lang](https://github.com/ics-jku/wal), lark-parser and pylibfst. lark-parser and pylibfst are required by wal-lang, but not presented in python-modules. And we need to use the HEAD revision because the latest release of the wal-lang repository is missing features and has some of the dependencies with security issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
