### PR TITLE
ant: build from source

### DIFF
--- a/pkgs/development/tools/build-managers/apache-ant/default.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/default.nix
@@ -1,111 +1,161 @@
-{ fetchurl, lib, stdenv, coreutils, makeWrapper }:
+{ fetchzip
+, lib
+, stdenv
+, coreutils
+, makeWrapper
+, jdk
+, symlinkJoin
+}:
 
-stdenv.mkDerivation rec {
-  pname = "ant";
-  version = "1.10.11";
+rec {
+  ant = stdenv.mkDerivation rec {
+    pname = "ant";
+    version = "1.10.14";
 
-  nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ makeWrapper jdk ];
 
-  src = fetchurl {
-    url = "mirror://apache/ant/binaries/apache-ant-${version}-bin.tar.bz2";
-    sha256 = "19m8xb7h6xm4jykzb79kakbx1pa4awaglw6z31pbfg8m5pmwkipz";
-  };
+    src = fetchzip {
+      url = "mirror://apache/ant/source/apache-ant-${version}-src.tar.xz";
+      hash = "sha256-U/tFnXzbkVqnkMYQp9Mv90wYW+I5GkeDhefN04LUAcE=";
+    };
 
-  contrib = fetchurl {
-    url = "mirror://sourceforge/ant-contrib/ant-contrib-1.0b3-bin.tar.bz2";
-    sha256 = "1l8say86bz9gxp4yy777z7nm4j6m905pg342li1aphc14p5grvwn";
-  };
-
-  installPhase =
-    ''
-      mkdir -p $out/bin $out/lib/ant
-      mv * $out/lib/ant/
-
-      # Get rid of the manual (35 MiB).  Maybe we should put this in a
-      # separate output.  Keep the antRun script since it's vanilla sh
-      # and needed for the <exec/> task (but since we set ANT_HOME to
-      # a weird value, we have to move antRun to a weird location).
-      # Get rid of the other Ant scripts since we provide our own.
-      mv $out/lib/ant/bin/antRun $out/bin/
-      rm -rf $out/lib/ant/{manual,bin,WHATSNEW}
-      mkdir $out/lib/ant/bin
-      mv $out/bin/antRun $out/lib/ant/bin/
-
-      # Install ant-contrib.
-      unpackFile $contrib
-      cp -p ant-contrib/ant-contrib-*.jar $out/lib/ant/lib/
-
-      cat >> $out/bin/ant <<EOF
-      #! ${stdenv.shell} -e
-
-      ANT_HOME=$out/lib/ant
-
-      # Find the JDK by looking for javac.  As a fall-back, find the
-      # JRE by looking for java.  The latter allows just the JRE to be
-      # used with (say) ECJ as the compiler.  Finally, allow the GNU
-      # JVM.
-      if [ -z "\''${JAVA_HOME-}" ]; then
-          for i in javac java gij; do
-              if p="\$(type -p \$i)"; then
-                  export JAVA_HOME="\$(${coreutils}/bin/dirname \$(${coreutils}/bin/dirname \$(${coreutils}/bin/readlink -f \$p)))"
-                  break
-              fi
-          done
-          if [ -z "\''${JAVA_HOME-}" ]; then
-              echo "\$0: cannot find the JDK or JRE" >&2
-              exit 1
-          fi
-      fi
-
-      if [ -z \$NIX_JVM ]; then
-          if [ -e \$JAVA_HOME/bin/java ]; then
-              NIX_JVM=\$JAVA_HOME/bin/java
-          elif [ -e \$JAVA_HOME/bin/gij ]; then
-              NIX_JVM=\$JAVA_HOME/bin/gij
-          else
-              NIX_JVM=java
-          fi
-      fi
-
-      LOCALCLASSPATH="\$ANT_HOME/lib/ant-launcher.jar\''${LOCALCLASSPATH:+:}\$LOCALCLASSPATH"
-
-      exec \$NIX_JVM \$NIX_ANT_OPTS \$ANT_OPTS -classpath "\$LOCALCLASSPATH" \
-          -Dant.home=\$ANT_HOME -Dant.library.dir="\$ANT_LIB" \
-          org.apache.tools.ant.launch.Launcher \$NIX_ANT_ARGS \$ANT_ARGS \
-          -cp "\$CLASSPATH" "\$@"
-      EOF
-
-      chmod +x $out/bin/ant
-    ''; # */
-
-  meta = {
-    homepage = "https://ant.apache.org/";
-    description = "A Java-based build tool";
-
-    longDescription = ''
-      Apache Ant is a Java-based build tool.  In theory, it is kind of like
-      Make, but without Make's wrinkles.
-
-      Why another build tool when there is already make, gnumake, nmake, jam,
-      and others? Because all those tools have limitations that Ant's
-      original author couldn't live with when developing software across
-      multiple platforms.  Make-like tools are inherently shell-based -- they
-      evaluate a set of dependencies, then execute commands not unlike what
-      you would issue in a shell.  This means that you can easily extend
-      these tools by using or writing any program for the OS that you are
-      working on.  However, this also means that you limit yourself to the
-      OS, or at least the OS type such as Unix, that you are working on.
-
-      Ant is different.  Instead of a model where it is extended with
-      shell-based commands, Ant is extended using Java classes.  Instead of
-      writing shell commands, the configuration files are XML-based, calling
-      out a target tree where various tasks get executed.  Each task is run
-      by an object that implements a particular Task interface.
+    buildPhase = ''
+      export SOURCE_DATE_EPOCH=0
+      ./build.sh
     '';
 
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.eelco ];
-    platforms = lib.platforms.all;
+    installPhase =
+      ''
+        mkdir -p $out/bin $out/lib
+        mv dist $out/lib/ant
+
+        # Get rid of the manual (35 MiB).  Maybe we should put this in a
+        # separate output.  Keep the antRun script since it's vanilla sh
+        # and needed for the <exec/> task (but since we set ANT_HOME to
+        # a weird value, we have to move antRun to a weird location).
+        # Get rid of the other Ant scripts since we provide our own.
+        mv $out/lib/ant/bin/antRun $out/bin/
+        rm -rf $out/lib/ant/{manual,bin,WHATSNEW}
+        mkdir $out/lib/ant/bin
+        mv $out/bin/antRun $out/lib/ant/bin/
+
+        cat >> $out/bin/ant <<EOF
+        #! ${stdenv.shell} -e
+
+        ANT_HOME=$out/lib/ant
+
+        # Find the JDK by looking for javac.  As a fall-back, find the
+        # JRE by looking for java.  The latter allows just the JRE to be
+        # used with (say) ECJ as the compiler.  Finally, allow the GNU
+        # JVM.
+        if [ -z "\''${JAVA_HOME-}" ]; then
+            for i in javac java gij; do
+                if p="\$(type -p \$i)"; then
+                    export JAVA_HOME="\$(${coreutils}/bin/dirname \$(${coreutils}/bin/dirname \$(${coreutils}/bin/readlink -f \$p)))"
+                    break
+                fi
+            done
+            if [ -z "\''${JAVA_HOME-}" ]; then
+                echo "\$0: cannot find the JDK or JRE" >&2
+                exit 1
+            fi
+        fi
+
+        if [ -z \$NIX_JVM ]; then
+            if [ -e \$JAVA_HOME/bin/java ]; then
+                NIX_JVM=\$JAVA_HOME/bin/java
+            elif [ -e \$JAVA_HOME/bin/gij ]; then
+                NIX_JVM=\$JAVA_HOME/bin/gij
+            else
+                NIX_JVM=java
+            fi
+        fi
+
+        LOCALCLASSPATH="\$ANT_HOME/lib/ant-launcher.jar\''${LOCALCLASSPATH:+:}\$LOCALCLASSPATH"
+
+        exec \$NIX_JVM \$NIX_ANT_OPTS \$ANT_OPTS -classpath "\$LOCALCLASSPATH" \
+            -Dant.home=\$ANT_HOME -Dant.library.dir="\$ANT_LIB" \
+            org.apache.tools.ant.launch.Launcher \$NIX_ANT_ARGS \$ANT_ARGS \
+            -cp "\$CLASSPATH" "\$@"
+        EOF
+
+        chmod +x $out/bin/ant
+      '';
+
+    meta = {
+      homepage = "https://ant.apache.org/";
+      description = "A Java-based build tool";
+
+      longDescription = ''
+        Apache Ant is a Java-based build tool.  In theory, it is kind of like
+        Make, but without Make's wrinkles.
+
+        Why another build tool when there is already make, gnumake, nmake, jam,
+        and others? Because all those tools have limitations that Ant's
+        original author couldn't live with when developing software across
+        multiple platforms.  Make-like tools are inherently shell-based -- they
+        evaluate a set of dependencies, then execute commands not unlike what
+        you would issue in a shell.  This means that you can easily extend
+        these tools by using or writing any program for the OS that you are
+        working on.  However, this also means that you limit yourself to the
+        OS, or at least the OS type such as Unix, that you are working on.
+
+        Ant is different.  Instead of a model where it is extended with
+        shell-based commands, Ant is extended using Java classes.  Instead of
+        writing shell commands, the configuration files are XML-based, calling
+        out a target tree where various tasks get executed.  Each task is run
+        by an object that implements a particular Task interface.
+      '';
+
+      license = lib.licenses.asl20;
+      maintainers = [ lib.maintainers.eelco ];
+      platforms = lib.platforms.all;
+    };
+  };
+
+  ant-contrib = stdenv.mkDerivation rec {
+    pname = "ant-contrib";
+    version = "1.0b3";
+
+    nativeBuildInputs = [ makeWrapper jdk ant ];
+
+    src = fetchzip {
+      url = "mirror://sourceforge/ant-contrib/ant-contrib-${version}-src.tar.bz2";
+      hash = "sha256-WCHIFcrVvUpiizM+VhE1R6DDpB0VxmD/seLpgfSG9Kg=";
+    };
+
+    postPatch = ''
+      substituteInPlace build.properties --replace "1.4" "8"
+    '';
+
+    buildPhase = ''
+      export SOURCE_DATE_EPOCH=0
+      ant -f build.xml jar
+    '';
+
+    checkPhase = ''
+      ant -f build.xml test
+    '';
+
+    installPhase = ''
+      mkdir -p $out/lib/ant/lib/
+      cp -p target/ant-contrib.jar $out/lib/ant/lib/
+    '';
+
+    meta = {
+      homepage = "https://ant-contrib.sourceforge.net/";
+      description = "A collection of tasks for Apache Ant";
+      sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+      license = lib.licenses.asl20;
+      maintainers = [ lib.maintainers.eelco ];
+      platforms = lib.platforms.all;
+    };
+  };
+
+  ant-with-contrib = symlinkJoin {
+    name = "ant-with-contrib";
+    paths = [ ant ant-contrib ];
+
+    inherit (ant) meta;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18448,8 +18448,9 @@ with pkgs;
 
   antlr = antlr4;
 
-  apacheAnt = callPackage ../development/tools/build-managers/apache-ant { };
-  ant = apacheAnt;
+  inherit (callPackages ../development/tools/build-managers/apache-ant { })
+    ant ant-contrib ant-with-contrib;
+  apacheAnt = ant;
 
   apacheKafka = apacheKafka_3_5;
   apacheKafka_2_8 = callPackage ../servers/apache-kafka { majorVersion = "2.8"; };


### PR DESCRIPTION
## Description of changes

Looks like apacheAnt_1_9 is not used. Maybe we can remove it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
