### PR TITLE
listenbrainz-mpd: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/applications/audio/listenbrainz-mpd/default.nix
+++ b/pkgs/applications/audio/listenbrainz-mpd/default.nix
@@ -6,25 +6,48 @@
 , openssl
 , libiconv
 , sqlite
-, Security }:
+, Security
+, SystemConfiguration
+, CoreFoundation
+, installShellFiles
+, asciidoctor }:
 
 rustPlatform.buildRustPackage rec {
   pname = "listenbrainz-mpd";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "elomatreb";
     repo = "listenbrainz-mpd";
     rev = "v${version}";
-    hash = "sha256-9o0PsmOkanPcES3y8NvvEOA/lsUU1vtKQAqBQwQtazk=";
+    hash = "sha256-rI6GBDUzI0pHjULoNKWZ4GKlrtpX/4x6Q1Q+DByNqRs=";
   };
 
-  cargoHash = "sha256-z7L6VQmCYo4YoEmwrvNU3u3UxnLkAqPgFBqJv4K1N1k=";
+  cargoHash = "sha256-8/0WkoDxUJz0QoQiDGHTuU7HmiY9nqUNPvztI0xmqvk=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config installShellFiles asciidoctor ];
 
-  buildInputs = [ sqlite ] ++ (if stdenv.isDarwin then [ libiconv Security ] else [ openssl ]);
+  buildInputs = [ sqlite ] ++ (if stdenv.isDarwin then [
+    libiconv
+    Security
+    SystemConfiguration
+    CoreFoundation
+  ] else [
+    openssl
+  ]);
+
+  buildFeatures = [ "shell_completion" ];
+
+  postInstall = ''
+    installShellCompletion \
+      --bash generated_completions/listenbrainz-mpd.bash \
+      --fish generated_completions/listenbrainz-mpd.fish \
+      --zsh generated_completions/_listenbrainz-mpd
+
+    asciidoctor --backend=manpage listenbrainz-mpd.adoc -o listenbrainz-mpd.1
+    installManPage listenbrainz-mpd.1
+  '';
 
   meta = with lib; {
     homepage = "https://codeberg.org/elomatreb/listenbrainz-mpd";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19556,7 +19556,7 @@ with pkgs;
   };
 
   listenbrainz-mpd = callPackage ../applications/audio/listenbrainz-mpd  {
-    inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration CoreFoundation;
   };
 
   lit = with python3Packages; toPythonApplication lit;


### PR DESCRIPTION
## Description of changes
Changes: https://codeberg.org/elomatreb/listenbrainz-mpd/src/tag/v2.3.1/CHANGELOG.md#2-3-1-2023-11-02

Have not tested on Darwin, but hopefully it builds there now.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
