### PR TITLE
bk: init at 0.6.0

### DIFF
--- a/pkgs/by-name/bk/bk/package.nix
+++ b/pkgs/by-name/bk/bk/package.nix
@@ -1,0 +1,38 @@
+{ fetchCrate
+, go-md2man
+, installShellFiles
+, lib
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bk";
+  version = "0.6.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-rSMvx/zUZqRRgj48TVVG7RwQT8e70m0kertRJysDY4Y=";
+  };
+
+  cargoHash = "sha256-pE5loMwNMdHL3GODiw3kVVHj374hf3+vIDEYTqvx5WI=";
+
+  nativeBuildInputs = [ go-md2man installShellFiles ];
+
+  postBuild = ''
+    sed -i '$ a # Source and further info' README.md
+    sed -i '$ a https://github.com/aeosynth/bk' README.md
+    go-md2man -in README.md -out bk.1
+  '';
+
+  postInstall = ''
+    installManPage bk.?
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/aeosynth/bk";
+    description = "A terminal epub reader written in rust";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vuimuich ];
+    mainProgram = "bk";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
bk is a terminal EPUB reader, written in Rust.
https://github.com/aeosynth/bk

In a discord discussion with the upstream maintainer `bk-ereader` was suggested as a potential alternative package name, as `bk` like the executable itself might be a bit to short or undescriptive.
Let me know if you'd prefer to change it up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
