### PR TITLE
Add NixOS test for `security.pam.enableSSHAgentAuth`

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -782,6 +782,7 @@ in {
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark {};
   sqlite3-to-mysql = handleTest ./sqlite3-to-mysql.nix {};
   sslh = handleTest ./sslh.nix {};
+  ssh-agent-auth = handleTest ./ssh-agent-auth.nix {};
   ssh-audit = handleTest ./ssh-audit.nix {};
   sssd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd.nix {};
   sssd-ldap = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-ldap.nix {};

--- a/nixos/tests/ssh-agent-auth.nix
+++ b/nixos/tests/ssh-agent-auth.nix
@@ -1,0 +1,48 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+  let
+    inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+  in {
+    name = "ssh-agent-auth";
+    meta.maintainers = with lib.maintainers; [ nicoo ];
+
+    nodes.sudoVM = { lib, ... }: {
+      users.users = {
+        admin = {
+          isNormalUser = true;
+          extraGroups = [ "wheel" ];
+          openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+        };
+        foo.isNormalUser = true;
+      };
+
+      security.pam.enableSSHAgentAuth = true;
+      security.sudo = {
+        enable = true;
+        wheelNeedsPassword = true;  # We are checking `pam_ssh_agent_auth(8)` works for a sudoer
+      };
+
+      # Necessary for pam_ssh_agent_auth  >_>'
+      services.openssh.enable = true;
+    };
+
+    testScript = let
+      privateKeyPath = "/home/admin/.ssh/id_ecdsa";
+      userScript = pkgs.writeShellScript "test-script" ''
+        set -e
+        ssh-add -q ${privateKeyPath}
+
+        # faketty needed to ensure `sudo` doesn't write to the controlling PTY,
+        #  which would break the test-driver's line-oriented protocol.
+        ${lib.getExe pkgs.faketty} sudo -u foo -- id -un
+      '';
+    in ''
+      sudoVM.copy_from_host("${snakeOilPrivateKey}", "${privateKeyPath}")
+      sudoVM.succeed("chmod -R 0700 /home/admin")
+      sudoVM.succeed("chown -R admin:users /home/admin")
+
+      with subtest("sudoer can auth through pam_ssh_agent_auth(8)"):
+          # Run `userScript` in an environment with an SSH-agent available
+          assert sudoVM.succeed("sudo -u admin -- ssh-agent ${userScript} 2>&1").strip() == "foo"
+    '';
+  }
+)

--- a/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
+++ b/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchpatch, fetchFromGitHub, pam, openssl, perl }:
+{ lib, stdenv, nixosTests, fetchpatch, fetchFromGitHub, pam, openssl, perl }:
 
 stdenv.mkDerivation rec {
   pname = "pam_ssh_agent_auth";
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
   prePatch = "cp -r ${ed25519-donna}/. ed25519-donna/.";
 
   enableParallelBuilding = true;
+
+  passthru.tests.sudo = nixosTests.ssh-agent-auth;
 
   meta = {
     homepage = "https://github.com/jbeverly/pam_ssh_agent_auth";


### PR DESCRIPTION
## Description of changes
Add a new NixOS test, for `pam_ssh_agent_auth(8)` support  

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - `nixosTests.ssh-agent-auth`
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
