### PR TITLE
signaturepdf: init at 1.5.0

### DIFF
--- a/pkgs/by-name/si/signaturepdf/package.nix
+++ b/pkgs/by-name/si/signaturepdf/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, php
+, makeWrapper
+, imagemagick
+, librsvg
+, potrace
+, pdftk
+, ghostscript
+}:
+
+stdenv.mkDerivation rec {
+  pname = "signaturepdf";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "24eme";
+    repo = "${pname}";
+    rev = "v${version}";
+    hash = "sha256-7yhvTxpjxHcmRxTE7avM+dN+yz9iVr8Ea/e2yfkBURA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/signaturepdf $out/bin
+
+    cp --target-directory=$out/share/signaturepdf --recursive \
+      app.php config locale public templates vendor
+
+    makeWrapper ${lib.getExe php} $out/bin/signaturepdf \
+      --inherit-argv0 \
+      --chdir $out/share/signaturepdf \
+      --prefix PATH : ${lib.makeBinPath [ imagemagick librsvg potrace pdftk ghostscript ]} \
+      --run 'port=$1' \
+      --run '[ $# -ge 1 ] || ( echo "Usage $0 <port> -d upload_max_filesize=24M -d post_max_size=24M -d max_file_uploads=201" >&2 && exit 1 )' \
+      --run 'shift' \
+      --run 'echo "You may now open a web browser on http://localhost:$port"' \
+      --add-flags '-S "localhost:$port" -t public'
+
+    runHook preInstall
+  '';
+
+  meta = with lib; {
+    description = "Web software for signing PDFs and also organize pages, edit metadata and compress pdf";
+    homepage = "https://pdf.24eme.fr/";
+    changelog =
+      "https://github.com/24eme/signaturepdf/releases/tag/v${version}";
+    license = licenses.agpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ DamienCassou ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is a web application for filling and signing PDFs and also organize pages, edit metadata and compress pdf.
https://github.com/24eme/signaturepdf/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
