### PR TITLE
exiv2: 0.28.0 -> 0.28.1

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, config, lib, fetchurl, cmake, doxygen, extra-cmake-modules, wrapGAppsHook
+{ mkDerivation, config, lib, fetchpatch, fetchurl, cmake, doxygen, extra-cmake-modules, wrapGAppsHook
 
 # For `digitaglinktree`
 , perl, sqlite
@@ -66,6 +66,14 @@ mkDerivation rec {
     url = "mirror://kde/stable/${pname}/${version}/digiKam-${version}.tar.xz";
     hash = "sha256-BQPANORF/0JPGKZxXAp6eb5KXgyCs+vEYaIc7DdFpbM=";
   };
+
+  # Fix build against exiv2 0.28.1
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/graphics/digikam/-/commit/f5ea91a7f6c1926815ec68f3e0176d6c15b83051.patch";
+      hash = "sha256-5g2NaKKNKVfgW3dTO/IP/H/nZ0YAIOmdPAumy3NEaNg=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/graphics/kphotoalbum/default.nix
+++ b/pkgs/applications/graphics/kphotoalbum/default.nix
@@ -1,4 +1,5 @@
 { mkDerivation
+, fetchpatch
 , fetchurl
 , lib
 , extra-cmake-modules
@@ -24,6 +25,14 @@ mkDerivation rec {
     url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
     hash = "sha256-NWtOIHJXtc8PlltYbbp2YwDf/3QI3MdHNDX7WVQMig4=";
   };
+
+  # Fix build against exiv2 0.28.1
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/graphics/kphotoalbum/-/commit/1ceb1ae37f3f95aa290b0846969af4b26f616760.patch";
+      hash = "sha256-SfBJHyJZcysvemc/F09GPczBjcofxGomgjJ814PSU+c=";
+    })
+  ];
 
   # not sure if we really need phonon when we have vlc, but on KDE it's bound to
   # be on the system anyway, so there is no real harm including it

--- a/pkgs/applications/graphics/photoqt/default.nix
+++ b/pkgs/applications/graphics/photoqt/default.nix
@@ -30,8 +30,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-kVf9+zI9rtEMmS0N4qrN673T/1fnqfcV3hQPnMXMLas=";
   };
 
+  postPatch = ''
+    # exiv2 0.28.1
+    substituteInPlace CMakeLists.txt \
+      --replace "exiv2lib" "exiv2"
+  ''
   # error: no member named 'setlocale' in namespace 'std'; did you mean simply 'setlocale'?
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.isDarwin ''
     substituteInPlace cplusplus/main.cpp \
       --replace "std::setlocale" "setlocale"
   '';

--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , doxygen
 , gettext
@@ -19,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "exiv2";
-  version = "0.28.0";
+  version = "0.28.1";
 
   outputs = [ "out" "lib" "dev" "doc" "man" ];
 
@@ -27,8 +28,15 @@ stdenv.mkDerivation rec {
     owner = "exiv2";
     repo = "exiv2";
     rev = "v${version}";
-    hash = "sha256-nEoLJWxSJmAonCbW/iZKjLrKMj09mwEaSUXUcUu8GxU=";
+    hash = "sha256-Jim8vYWyCa16LAJ1GuP8cCzhXIc2ouo6hVsHg3UQbdg=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Exiv2/exiv2/commit/c351c7cce317571934abf693055779a59df30d6e.patch";
+      hash = "sha256-fWJT4IUBrAELl6ku0M1iTzGFX74le8Z0UzTJLU/gYls=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -67,8 +75,7 @@ stdenv.mkDerivation rec {
     "doc"
   ];
 
-  # https://github.com/Exiv2/exiv2/issues/2762
-  doCheck = lib.versionOlder brotli.version "1.1.0";
+  doCheck = true;
 
   preCheck = ''
     patchShebangs ../test/


### PR DESCRIPTION
## Description of changes

https://github.com/Exiv2/exiv2/blob/v0.28.1/doc/ChangeLog

Fixes [CVE-2023-44398](https://github.com/Exiv2/exiv2/security/advisories/GHSA-hrw9-ggg3-3r4r) (High).

https://github.com/Exiv2/exiv2/issues/2762 is now fixed upstream, so make `checkPhase` run unconditionally again.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
