### PR TITLE
nsf-ordlista: init at unstable-2022-08-15

### DIFF
--- a/pkgs/by-name/ns/nsf-ordlista/package.nix
+++ b/pkgs/by-name/ns/nsf-ordlista/package.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+}:
+stdenvNoCC.mkDerivation {
+  pname = "nsf-ordlista";
+  version = "unstable-2023-08-20";
+  src = fetchzip {
+    url = "http://www2.scrabbleforbundet.no/wp-content/uploads/2023/08/nsf2023.zip";
+    hash = "sha256-bcVqZ2yPHurl6sRNgeLNAyyR8WR9ewmtn85Xuw/rZ3s=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 nsf2023.txt $out/share/wordlists/nsf.txt
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Wordlist from the Norwegian Scrabble Federation";
+    homepage = "https://www2.scrabbleforbundet.no/";
+    downloadPage = "https://www2.scrabbleforbundet.no/?p=4881#more-4881";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ h7x4 ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Norwegian wordlist, mainly used by scrabble players but also sometimes for Norwegian CTFs and security research.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
