### PR TITLE
python2: fix build with clang 16 on x86_64-darwin

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -133,6 +133,11 @@ let
 
     ] ++ lib.optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
+
+    ] ++ lib.optionals stdenv.isDarwin [
+      # Fix darwin build https://bugs.python.org/issue34027
+      ../3.7/darwin-libutil.patch
+
     ] ++ lib.optionals stdenv.isLinux [
 
       # Disable the use of ldconfig in ctypes.util.find_library (since

--- a/pkgs/development/misc/resholve/0014-clang_incompatible_function_pointer_conversions.patch
+++ b/pkgs/development/misc/resholve/0014-clang_incompatible_function_pointer_conversions.patch
@@ -1,0 +1,42 @@
+diff -ur a/decoder.c b/decoder.c
+--- a/decoder.c	1980-01-02 00:00:00.000000000 -0500
++++ b/decoder.c	2023-11-08 17:42:43.981838074 -0500
+@@ -94,7 +94,7 @@
+     return PlaceObject(ctx, PyBool_FromLong((long)(value)));
+ }
+ 
+-static int handle_number(void *ctx, const char *value, unsigned int length)
++static int handle_number(void *ctx, const char *value, size_t length)
+ {
+     //fprintf(stderr, "handle_number: ");
+     //fwrite(value, length, 1, stderr);
+@@ -127,7 +127,7 @@
+     return status;
+ }
+ 
+-static int handle_string(void *ctx, const unsigned char *value, unsigned int length)
++static int handle_string(void *ctx, const unsigned char *value, size_t length)
+ {
+     return PlaceObject(ctx, PyString_FromStringAndSize((char *)value, length));
+ }
+@@ -142,7 +142,7 @@
+     return success;
+ }
+ 
+-static int handle_dict_key(void *ctx, const unsigned char *value, unsigned int length)
++static int handle_dict_key(void *ctx, const unsigned char *value, size_t length)
+ {
+     PyObject *object = PyString_FromStringAndSize((const char *) value, length);
+ 
+diff -ur a/yajl.c b/yajl.c
+--- a/yajl.c	1980-01-02 00:00:00.000000000 -0500
++++ b/yajl.c	2023-11-08 17:41:18.781350335 -0500
+@@ -161,7 +161,7 @@
+ }
+ 
+ static struct PyMethodDef yajl_methods[] = {
+-    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
++    {"dumps", (PyCFunction)(py_dumps), METH_VARARGS | METH_KEYWORDS,
+ "yajl.dumps(obj [, indent=None])\n\n\
+ Returns an encoded JSON string of the specified `obj`\n\
+ \n\

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -42,6 +42,10 @@ rec {
       hash = "sha256-H3GKN0Pq1VFD5+SWxm8CXUVO7zAyj/ngKVmDaG/aRT4=";
       fetchSubmodules = true;
     };
+    patches = [
+      # Fixes several incompatible function pointer conversions, which are errors in clang 16.
+      ./0014-clang_incompatible_function_pointer_conversions.patch
+    ];
     # just for submodule IIRC
     nativeBuildInputs = [ git ];
   };

--- a/pkgs/development/tools/packcc/default.nix
+++ b/pkgs/development/tools/packcc/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
 
     # Disable a failing test.
     rm -rf ../../tests/style.d
+  '' + lib.optionalString stdenv.cc.isClang ''
+    export NIX_CFLAGS_COMPILE+=' -Wno-error=strict-prototypes -Wno-error=int-conversion'
   '';
 
   installPhase = ''

--- a/pkgs/tools/networking/lftp/default.nix
+++ b/pkgs/tools/networking/lftp/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = lib.optional stdenv.isDarwin "format";
 
+  env = lib.optionalAttrs stdenv.isDarwin {
+    # Required to build with clang 16 or `configure` will fail to detect several standard functions.
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
   configureFlags = [
     "--with-openssl"
     "--with-readline=${readline.dev}"


### PR DESCRIPTION
## Description of changes

Fixes Python 2 and dependent packages (found running nixpkgs-review) failing to build on staging-next #263535.

* Python 2: https://hydra.nixos.org/build/239425695

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
