### PR TITLE
`lib.fileset.fileFilter`: Predicate attribute for file extension

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -573,6 +573,7 @@ in {
         ({
           name :: String,
           type :: String,
+          hasExt :: String -> Bool,
           ...
         } -> Bool)
         -> Path
@@ -583,7 +584,7 @@ in {
       fileFilter (file: file.name == "default.nix") ./.
 
       # Include all non-Nix files from the current directory
-      fileFilter (file: ! hasSuffix ".nix" file.name) ./.
+      fileFilter (file: ! file.hasExt "nix") ./.
 
       # Include all files that start with a "." in the current directory
       fileFilter (file: hasPrefix "." file.name) ./.
@@ -602,6 +603,12 @@ in {
 
       - `type` (String, one of `"regular"`, `"symlink"` or `"unknown"`): The type of the file.
         This matches result of calling [`builtins.readFileType`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-readFileType) on the file's path.
+
+      - `hasExt` (String -> Bool): Whether the file has a certain file extension.
+        `hasExt ext` is true only if `hasSuffix ".${ext}" name`.
+
+        This also means that e.g. for a file with name `.gitignore`,
+        `hasExt "gitignore"` is true.
 
       Other attributes may be added in the future.
     */

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -52,6 +52,7 @@ let
     concatStringsSep
     substring
     stringLength
+    hasSuffix
     ;
 
 in
@@ -796,9 +797,11 @@ rec {
         if
           predicate {
             inherit name type;
+            hasExt = ext: hasSuffix ".${ext}" name;
+
             # To ensure forwards compatibility with more arguments being added in the future,
             # adding an attribute which can't be deconstructed :)
-            "lib.fileset.fileFilter: The predicate function passed as the first argument must be able to handle extra attributes for future compatibility. If you're using `{ name, file }:`, use `{ name, file, ... }:` instead." = null;
+            "lib.fileset.fileFilter: The predicate function passed as the first argument must be able to handle extra attributes for future compatibility. If you're using `{ name, file, hasExt }:`, use `{ name, file, hasExt, ... }:` instead." = null;
           }
         then
           type

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -846,7 +846,7 @@ checkFileset 'fileFilter (file: abort "this is not needed") ./.'
 
 # The predicate must be able to handle extra attributes
 touch a
-expectFailure 'toSource { root = ./.; fileset = fileFilter ({ name, type }: true) ./.; }' 'called with unexpected argument '\''"lib.fileset.fileFilter: The predicate function passed as the first argument must be able to handle extra attributes for future compatibility. If you'\''re using `\{ name, file \}:`, use `\{ name, file, ... \}:` instead."'\'
+expectFailure 'toSource { root = ./.; fileset = fileFilter ({ name, type, hasExt }: true) ./.; }' 'called with unexpected argument '\''"lib.fileset.fileFilter: The predicate function passed as the first argument must be able to handle extra attributes for future compatibility. If you'\''re using `\{ name, file, hasExt \}:`, use `\{ name, file, hasExt, ... \}:` instead."'\'
 rm -rf -- *
 
 # .name is the name, and it works correctly, even recursively
@@ -893,6 +893,39 @@ expectEqual \
     'toSource { root = ./.; fileset = fileFilter (file: file.type != "unknown") ./.; }' \
     'toSource { root = ./.; fileset = union ./d/a ./d/b; }'
 rm -rf -- *
+
+# Check that .hasExt checks for the file extension
+# The empty extension is the same as a file ending with a .
+tree=(
+    [a]=0
+    [a.]=1
+    [a.b]=0
+    [a.b.]=1
+    [a.b.c]=0
+)
+checkFileset 'fileFilter (file: file.hasExt "") ./.'
+
+# It can check for the last extension
+tree=(
+    [a]=0
+    [.a]=1
+    [.a.]=0
+    [.b.a]=1
+    [.b.a.]=0
+)
+checkFileset 'fileFilter (file: file.hasExt "a") ./.'
+
+# It can check for any extension
+tree=(
+    [a.b.c.d]=1
+)
+checkFileset 'fileFilter (file:
+  all file.hasExt [
+    "b.c.d"
+    "c.d"
+    "d"
+  ]
+) ./.'
 
 # It's lazy
 tree=(


### PR DESCRIPTION
## Description of changes

Makes it more convenient to use `lib.fileset.fileFilter` to filter by file extension:
```nix
lib.fileset.fileFilter (file:
  lib.any file.hasExt [ "nix" "hs" ]
) ./.
```

Whereas previously this would've needed
```nix
lib.fileset.fileFilter (file:
  lib.any (ext: lib.hasSuffix ".${ext}" file.name) [ "nix" "hs" ]
) ./.
```

I'd imagine this should be fairly popular, but we need to confirm first.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done

- [x] Tests
- [x] Docs