### PR TITLE
waagent: enable provisioning

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -185,6 +185,8 @@
 
 - JACK tools (`jack_*` except `jack_control`) have moved from the `jack2` package to `jack-example-tools`
 
+- The `waagent` service does provisioning now
+
 - The `matrix-synapse` package & module have undergone some significant internal changes, for most setups no intervention is needed, though:
   - The option [`services.matrix-synapse.package`](#opt-services.matrix-synapse.package) is now read-only. For modifying the package, use an overlay which modifies `matrix-synapse-unwrapped` instead. More on that below.
   - The `enableSystemd` & `enableRedis` arguments have been removed and `matrix-synapse` has been renamed to `matrix-synapse-unwrapped`. Also, several optional dependencies (such as `psycopg2` or `authlib`) have been removed.

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -61,7 +61,7 @@ in
 
         # Which provisioning agent to use. Supported values are "auto" (default), "waagent",
         # "cloud-init", or "disabled".
-        Provisioning.Agent=disabled
+        Provisioning.Agent=auto
 
         # Password authentication for root account will be unavailable.
         Provisioning.DeleteRootPassword=n
@@ -246,7 +246,7 @@ in
         pkgs.bash
 
         # waagent's Microsoft.OSTCExtensions.VMAccessForLinux needs Python 3
-        pkgs.python3
+        pkgs.python39
 
         # waagent's Microsoft.CPlat.Core.RunCommandLinux needs lsof
         pkgs.lsof
@@ -258,6 +258,11 @@ in
         Type = "simple";
       };
     };
+
+    # waagent will generate files under /etc/sudoers.d during provisioning
+    security.sudo.extraConfig = ''
+      #includedir /etc/sudoers.d
+    '';
 
   };
 }

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -37,42 +37,5 @@ in
       inherit config lib pkgs;
     };
 
-    # Azure metadata is available as a CD-ROM drive.
-    fileSystems."/metadata".device = "/dev/sr0";
-
-    systemd.services.fetch-ssh-keys = {
-      description = "Fetch host keys and authorized_keys for root user";
-
-      wantedBy = [ "sshd.service" "waagent.service" ];
-      before = [ "sshd.service" "waagent.service" ];
-
-      path  = [ pkgs.coreutils ];
-      script =
-        ''
-          eval "$(cat /metadata/CustomData.bin)"
-          if ! [ -z "$ssh_host_ecdsa_key" ]; then
-            echo "downloaded ssh_host_ecdsa_key"
-            echo "$ssh_host_ecdsa_key" > /etc/ssh/ssh_host_ed25519_key
-            chmod 600 /etc/ssh/ssh_host_ed25519_key
-          fi
-
-          if ! [ -z "$ssh_host_ecdsa_key_pub" ]; then
-            echo "downloaded ssh_host_ecdsa_key_pub"
-            echo "$ssh_host_ecdsa_key_pub" > /etc/ssh/ssh_host_ed25519_key.pub
-            chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
-          fi
-
-          if ! [ -z "$ssh_root_auth_key" ]; then
-            echo "downloaded ssh_root_auth_key"
-            mkdir -m 0700 -p /root/.ssh
-            echo "$ssh_root_auth_key" > /root/.ssh/authorized_keys
-            chmod 600 /root/.ssh/authorized_keys
-          fi
-        '';
-      serviceConfig.Type = "oneshot";
-      serviceConfig.RemainAfterExit = true;
-      serviceConfig.StandardError = "journal+console";
-      serviceConfig.StandardOutput = "journal+console";
-    };
   };
 }

--- a/pkgs/applications/networking/cluster/waagent/default.nix
+++ b/pkgs/applications/networking/cluster/waagent/default.nix
@@ -10,7 +10,7 @@
   openssl,
   parted,
   procps, # for pidof,
-  python3,
+  python39, # the latest python version that waagent test against according to https://github.com/Azure/WALinuxAgent/blob/28345a55f9b21dae89472111635fd6e41809d958/.github/workflows/ci_pr.yml#L75
   shadow, # for useradd, usermod
   util-linux, # for (u)mount, fdisk, sfdisk, mkswap
 }:
@@ -19,7 +19,7 @@ let
   inherit (lib) makeBinPath;
 
 in
-python3.pkgs.buildPythonPackage rec {
+python39.pkgs.buildPythonPackage rec {
   pname = "waagent";
   version = "2.8.0.11";
   src = fetchFromGitHub {
@@ -28,9 +28,14 @@ python3.pkgs.buildPythonPackage rec {
     rev = "04ded9f0b708cfaf4f9b68eead1aef4cc4f32eeb";
     sha256 = "0fvjanvsz1zyzhbjr2alq5fnld43mdd776r2qid5jy5glzv0xbhf";
   };
+  patches = [
+    # Suppress the following error when waagent try to configure sshd:
+    # Read-only file system: '/etc/ssh/sshd_config'
+    ./dont-configure-sshd.patch
+  ];
   doCheck = false;
 
-  buildInputs = with python3.pkgs; [ distro ];
+  buildInputs = with python39.pkgs; [ distro ];
   runtimeDeps = [
     findutils
     gnugrep

--- a/pkgs/applications/networking/cluster/waagent/dont-configure-sshd.patch
+++ b/pkgs/applications/networking/cluster/waagent/dont-configure-sshd.patch
@@ -1,0 +1,23 @@
+From 383e7c826906baedcd12ae7c20a4a5d4b32b104a Mon Sep 17 00:00:00 2001
+From: "Yang, Bo" <bo@preemo.io>
+Date: Wed, 8 Nov 2023 23:08:07 +0000
+Subject: [PATCH] Don't configure sshd
+
+---
+ azurelinuxagent/pa/provision/default.py | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/azurelinuxagent/pa/provision/default.py b/azurelinuxagent/pa/provision/default.py
+index 91fe04edab..48edf01490 100644
+--- a/azurelinuxagent/pa/provision/default.py
++++ b/azurelinuxagent/pa/provision/default.py
+@@ -237,9 +237,6 @@ def config_user_account(self, ovfenv):
+         self.osutil.conf_sudoer(ovfenv.username,
+                                 nopasswd=ovfenv.user_password is None)
+ 
+-        logger.info("Configure sshd")
+-        self.osutil.conf_sshd(ovfenv.disable_ssh_password_auth)
+-
+         self.deploy_ssh_pubkeys(ovfenv)
+         self.deploy_ssh_keypairs(ovfenv)
+ 


### PR DESCRIPTION
## Description of changes

Currently there are two issues in Azure provisioning:

1. Provisioning in `waagent` was disabled in #206974 because provisioning always failed. 
2. Azure VM will timeout after 90 seconds when mounting `/dev/sr0` during restarting an Azure VM, because `/dev/sr0` is only available the first time starting an Azure VM.

This PR fixes provisioning in `waagent` and enables it.

## Things done

- Switched Python version to 3.9, because `waagent` 2.8.0.11 is not compatible with Python 3.10. See https://github.com/Azure/WALinuxAgent/issues/2753
- Removed the call to `self.osutil.conf_sshd` because it will try to modify `/etc/sshd/sshd_config` and raise an error about read-only file system
- Stopped mounting `/dev/sr0` because it should be handled by `waagent`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
