### PR TITLE
mcpp: fix build with clang 16

### DIFF
--- a/pkgs/development/compilers/mcpp/default.nix
+++ b/pkgs/development/compilers/mcpp/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash= "sha256-T4feegblOeG+NU+c+PAobf8HT8KDSfcINkRAa1hNpkY=";
   };
 
+  patches = [
+    ./readlink.patch
+  ];
+
   configureFlags = [ "--enable-mcpplib" ];
 
   meta = with lib; {

--- a/pkgs/development/compilers/mcpp/readlink.patch
+++ b/pkgs/development/compilers/mcpp/readlink.patch
@@ -1,0 +1,24 @@
+From 1c4b0f26614bff331eb8a9f2b514309af6f31fd0 Mon Sep 17 00:00:00 2001
+From: Jose <pepone@users.noreply.github.com>
+Date: Mon, 26 Jun 2023 16:43:43 +0200
+Subject: [PATCH] Add 'unistd' header for readlink (#8)
+
+---
+ src/system.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/system.c b/src/system.c
+index a3501f9..646caf6 100644
+--- a/src/system.c
++++ b/src/system.c
+@@ -37,6 +37,11 @@
+  *      2. append the system-dependent routines in this file.
+  */
++
++#ifndef _MSC_VER
++#  include <unistd.h> // For readlink()
++#endif
++
+ #if PREPROCESSED
+ #include    "mcpp.H"
+ #else


### PR DESCRIPTION
## Description of changes

https://github.com/Homebrew/homebrew-core/commit/a0e87996291840a2c6971109ce48c4557bbae49a

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
