### PR TITLE
fortune-kind: 0.1.7 -> 0.1.8

### DIFF
--- a/pkgs/by-name/fo/fortune-kind/package.nix
+++ b/pkgs/by-name/fo/fortune-kind/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fortune-kind";
-  version = "0.1.7";
+  version = "0.1.8";
 
   src = fetchFromGitHub {
     owner = "cafkafk";
     repo = "fortune-kind";
     rev = "v${version}";
-    hash = "sha256-txFboO7TdmwFm8BPP2onDJs1LSp4fXTwciIyAnC4Q04=";
+    hash = "sha256-8xXRIp6fNYo0Eylzz+i+YccEJZjqiT0TxguZheIblns=";
   };
 
-  cargoHash = "sha256-3HxkKE2cQK91dBTtrsNG9VDk0efo1Ci5VfaG3UjvLNU=";
+  cargoHash = "sha256-v1LmZRuknWFAwwuw4U7Y7jnhBi8UkglY0sege9nSKes=";
 
   nativeBuildInputs = [ makeBinaryWrapper installShellFiles ];
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];


### PR DESCRIPTION
- chromium: late-bind xdg-utils if broken
- {birdtray,isgx,mycrypto,osu-lazer,stretchly,tree-sitter}: remove oxalica as maintainer
- nixos/smartd: Fix mail recipient field
- pandoc: use library's version
- box64: Fetch patch to fix SDL1 support regression
- box64: Migrate to finalAttrs pattern
- box64: Refactor cmakeFlags, only check if executable, add meta.mainProgram
- box64: Enable build & dynarec on more platforms
- maintainers: add javimerino
- guilt: init at 0.37-rc1
- python3Packages.ray: 2.6.1 -> 2.7.0
- kernel/common-config: arm: configure alignment traps
- texlive.combine: only derivations under .packages
- texlive.tlpdb.nix: detect presence of info pages
- maintainers: add argrat
- postgresqlPackages.pg_embedding: init at 0.3.6
- lunarml: unstable-2023-09-21 → 0.0.20230924
- nixos/virtualisation: add hostname option to oci-containers.
- kernelPackages.nct6687d: init at unstable-2023-09-22
- texlive.buildTeXLivePackage: switch to fake multi-output derivations for TeX Live packages
- tests.texlive.binaries: use new texlive package source
- tests.texlive.shebangs: use new texlive package source
- texlive.bin.pygmentex: use new texlive package source
- texlive.bin.xpdfopen: use new texlive package source
- iwona: use new texlive package source
- biber: use new texlive package source
- biber-ms: use new texlive package source
- mftrace: use new tex package structure
- sagetex: use new tex package structure
- texlive: document new texlive.pkgs attribute
- nixos/tests/openssh: wait for sshd(.socket) units, add timeout=30
- keepass: 2.54 -> 2.55
- python310Packages.gtts: 2.3.2 -> 2.4.0
- python310Packages.opencensus-ext-azure: 1.1.9 -> 1.1.11
- prosody: use default network, remove libevent, config deprecated
- vieb: 10.3.0 -> 10.4.0
- python311Packages.questionary: unstable-2022-07-27 -> 2.0.1
- python311Packages.questionary: add changelog to meta
- python311Packages.pilkit: unstable-2022-02-17 -> 3.0
- python311Packages.pilkit: change the license to BSD3
- composefs: 1.0.0 -> 1.0.1
- nng: 1.6.0-prerelease update for rPackages.nanonext
- rshim-user-space: add bfb-install
- openraPackages.engines.release: 20230225 -> 20231010
- heroic: add libunwind to FHS env
- steam: add libunwind to FHS env
- dropbox: 111.3.447 -> 185.4.6054
- dropbox-cli: 2020.03.04 -> 2023.09.06
- dropbox-cli: add meta.mainProgram
- yaml-cpp: 0.7.0 -> 0.8.0
- wavebox: 10.114.26-2 -> 10.117.18-2
- wavebox: add update script
- wavebox: 10.117.18-2 -> 10.117.21-2
- wavebox: use proper API endpoint in update
- wavebox: 10.117.21-2 -> 10.118.5-2
- homebank: 5.6.6 -> 5.7.1
- nixos/hardware: use mkEnableOption
- dante: fix build with clang 16
- nixos-rebuild: Drop incorrectly implemented short args for build/target host
- nixos-rebuild: Locally own the nixos-rebuild completion
- nix-bash-completions: Drop nixos-rebuild completion
- kakounePlugins: updated the 10-22-2023
- texlive: implement __overrideTeXConfig and withPackage
- linux: allow to omit the common-config.nix
- qgroundcontrol: 4.2.8 -> 4.2.9
- crystal: fix build with newer versions of clang
- vitess: 17.0.2 -> 17.0.3
- vmagent: 1.93.5 -> 1.93.6
- vokoscreen-ng: 3.7.0 -> 3.8.0
- vttest: 20230201 -> 20230924
- vulkan-utility-libraries: 1.3.261 -> 1.3.269
- wallabag: 2.6.6 -> 2.6.7
- weaviate: 1.21.1 -> 1.21.7
- lunar-client: migrate to by-name
- wfa2-lib: 2.3.3 -> 2.3.4
- lunar-client: add updateScript
- wipefreespace: 2.5 -> 2.6
- picosnitch: 0.14.0 -> 1.0.1
- wxsqlite3: 4.9.4 -> 4.9.6
- rPackages: CRAN and BioC update
- xastir: 2.1.8 -> 2.2.0
- xlockmore: 5.72 -> 5.73
- xmlbird: 1.2.12 -> 1.2.14
- yoshimi: 2.3.0.3 -> 2.3.1
- linode-cli: add techknowlogick to maintainers
- yubihsm-shell: 2.4.0 -> 2.4.1
- pyenv: 2.3.28 -> 2.3.31
- zef: 0.19.1 -> 0.20.0
- zrok: 0.4.6 -> 0.4.10
- albert: 0.22.13 -> 0.22.14
- gsound: enable introspection/vala when cross compiled
- aespipe: 2.4f -> 2.4g
- fim: 0.6 -> 0.7
- go-camo: 2.4.4 -> 2.4.5
- nixos/hostapd: document that legacy example should have optional MFP
- nixos/hostapd: remove managementFrameProtection
- crowdsec: 1.5.4 -> 1.5.5
- Revert "nixos/sway: add enableRealtime option"
- aravis: 0.8.28 -> 0.8.30
- benthos: 4.19.0 -> 4.22.0
- codeql: 2.14.6 -> 2.15.1
- coreth: 0.12.5 -> 0.12.6
- coin-utils: 2.11.9 -> 2.11.10
- opkg: 0.6.1 -> 0.6.2
- celeste: 0.7.0 -> 0.8.0
- otpclient: 3.1.9 -> 3.2.0
- displaylink: Add aarch64 support
- fishPlugins.bobthefish: unstable-2022-08-02 -> unstable-2023-06-16
- zsnes: fix build against zlib-1.3
- docker-compose: 2.21.0 -> 2.23.0
- rPackages.httpuv: fix build
- nixos/grafana-image-renderer: use Grafana's http_addr rather than localhost
- tokyo-night-gtk: unstable-2023-01-17 -> unstable-2023-05-30
- lib2geom: 1.2.2 → 1.3
- python3.pkgs.inkex: inherit source from Inkscape
- govc: 0.32.0 -> 0.33.0
- level-zero: 1.14.0 -> 1.15.1
- inkscape: inherit filelock dependency from cachecontrol
- inkscape: 1.2.2 → 1.3
- spring-boot-cli: 2.3.2 -> 3.1.5
- spring-boot-cli: add passthru.{updateScript,tests.version}
- spring-boot-cli: add meta.mainProgram
- upx: 4.1.0 -> 4.2.0
- asm-lsp: init at v0.4.2
- nixos/sudo: fix `security.sudo.package`
- ergo: 5.0.14 -> 5.0.15
- bruno: 0.27.0 -> 0.27.2
- frugal: 3.17.2 -> 3.17.5
- zfstools: fix missing zpool in PATH
- wakapi: 2.9.1 -> 2.9.2
- bacnet-stack: 1.0.0 -> 1.3.1
- clamav: 1.2.0 -> 1.2.1
- flat-remix-gnome: 20230606 -> 20231026
- maintainers: add sysedwinistrator
- jq-lsp: init at 2023-10-27
- flink: 1.17.1 -> 1.18.0
- ssh-audit: add test of audited configuration
- nixos/paperless: set PAPERLESS_SECRET_KEY
- streamlink: 6.2.1 -> 6.3.1
- linkerd_stable: 2.14.1 -> 2.14.2
- poco: 1.12.4 -> 1.12.5
- osi: 0.108.8 -> 0.108.9
- python310Packages.eccodes: 2.32.0 -> 2.32.1
- go-ios: 1.0.117 -> 1.0.120
- birdfont: 2.33.1 -> 2.33.3
- goeland: 0.15.0 -> 0.16.0
- hyperrogue: 12.1q -> 12.1x
- mssql_jdbc: 12.4.1 -> 12.4.2
- gotrue-supabase: 2.99.0 -> 2.105.0
- gpodder: 3.11.3 -> 3.11.4
- gthumb: 3.12.3 -> 3.12.4
- iotop-c: 1.24 -> 1.25
- jfrog-cli: 2.50.0 -> 2.50.4
- k8sgpt: 0.3.17 -> 0.3.19
- kics: 1.7.8 -> 1.7.10
- kubedb-cli: 0.35.1 -> 0.36.0
- kustomize-sops: 4.2.3 -> 4.2.5
- libdnf: 0.71.0 -> 0.72.0
- alfaview: 9.2.0 -> 9.4.0
- argo: 3.4.11 -> 3.5.0
- cardinal: 23.09 -> 23.10
- ballerina: 2201.8.1 -> 2201.8.2
- besu: 23.7.3 -> 23.10.0
- qemu-utils: Rework as an emulatorless qemu build
- qemu: Build qemu-utils on ofborg
- schismtracker: 20230906 -> 20231029
- maintainers: add jl178
- python311Packages.msal: 1.24.0 -> 1.24.1
- git-extras: 7.0.0 -> 7.1.0
- podofo010: 0.10.1 -> 0.10.2
- spidermonkey_91: add patch to allow building with python311
- mitmproxy: 9.0.1 -> 10.1.1
- riemann: 0.3.8 -> 0.3.9
- odoo: 16.0.20230722 -> 16.0.20231024
- xsubfind3r: 0.3.0 -> 0.4.0
- maintainer: add giomf
- mongodb-5_0: 5.0.21 -> 5.0.22
- mongodb_6-0: 6.0.10 -> 6.0.11
- escrotum: add ffmpeg-full to PATH of wrapper
- dar: 2.7.10 -> 2.7.13
- dnsdist: 1.8.1 -> 1.8.2
- dprint: 0.41.0 -> 0.42.5
- exodus: 23.9.25 -> 23.10.24
- flashprint: 5.8.0 -> 5.8.1
- fstar: 2023.04.25 -> 2023.09.03
- parson: 1.5.2 -> 1.5.3
- python311Packages.img2pdf: 0.4.4 -> 0.5.0
- python311Packages.peewee: 3.16.3 -> 3.17.0
- microsoft-edge: added overwriteable command line args
- isso: fix tests
- airlift: init at 0.3.0
- pgweb: 0.14.1 -> 0.14.2
- lib.fileset.difference: init
- odoo: update dependencies
- circom: init at 2.1.6
- prometheus-systemd-exporter: 0.5.0 → 0.6.0
- netdata: add systemd-journal plugin
- chickenPackages.chickenEggs.sdl-base: fix build on linux
- chickenPackages.chickenEggs.taglib: fix build
- restic: 0.16.1 -> 0.16.2
- numbat: init at 1.6.3
- meritous: migrate to by-name
- meritous: 1.4 -> 1.5
- meritous: add meta.{changelog,mainProgram}
- mysql80: 8.0.34 -> 8.0.35
- libre: 2.9.0 -> 3.6.0
- baresip: 2.9.0 -> 3.6.0
- hyprnome: 0.1.0 -> 0.2.0
- wyoming-piper: 1.3.2 -> 1.4.0
- python311Packages.home-assistant-chip-core: 2023.10.1 -> 2023.10.2
- python311Packages.home-assistant-chip-clusters: 2023.10.1 -> 2023.10.2
- hyprpicker: 0.1.1 -> 0.2.0
- marksman: 2023-07-25 -> 2023-10-30
- dolphin-emu: switch to zlib, zlib-ng fails to link
- mdcat: 2.0.4 -> 2.1.0
- direwolf: remove fix-strlcpy-usage patch
- melt: 0.5.0 -> 0.6.0
- bazecor: init at 1.3.6
- check-meta.nix: Fix flake note
- cargo-xwin: 0.14.8 -> 0.14.9
- strace: 6.5 -> 6.6
- nixos/woodpecker-server: change type of environmentFile to list of paths
- formats.libconfig: fix unstable store path dependency in test
- gotify-desktop: 1.3.1 -> 1.3.2
- libdatachannel: fix include path in cmake files
- libdatachannel: 0.19.2 -> 0.19.3
- i3: 4.22 -> 4.23
- biome: 1.2.2 -> 1.3.3
- python3Packages.bip32: init at 3.4
- python3Packages.ledger-bitcoin: fix build
- element-{web,desktop}: 1.11.46 -> 1.11.47
- mcuboot-imgtool: init at 1.10.0
- tkdiff: patch to trigger recursive inline diffs
- ispell: 3.4.05 -> 3.4.06
- jpeginfo: 1.7.0 -> 1.7.1
- octoprint: fix flask compatibility
- jaq: 1.0.0 -> 1.1.0
- fw: 2.17.1 -> 2.18.0
- fblog: 4.4.0 -> 4.5.0
- lib.strings: add `replicate`
- nuget: allow aarch64-linux and darwin builds
- nixos/throttled: load required kernel module
- doc: fix dockerTools nix-prefetch-docker example
- python310Packages.stytra: opencv3 -> opencv4
- python310Packages.bpycv: opencv3 -> opencv4
- python310Packages.imagecorruptions: opencv3 -> opencv4
- python310Packages.imutils: opencv3 -> opencv4
- python310Packages.camelot: opencv3 -> opencv4
- python310Packages.imantics: opencv3 -> opencv4; enable tests
- python310Packages.easyocr: opencv3 -> opencv4
- python310Packages.moviepy: remove optional opencv3 dependency
- qutebrowser: Add pyperclip dependency
- shellcheck-minimal: init
- qpwgraph: switch to Qt 6
- qpwgraph: format using nixpkgs-fmt
- qpwgraph: use finalAttrs
- qpwgraph: set mainProgram
- shogun: opencv3 -> opencv4
- python310Packages.opencv3: remove
- nixos/services/netdata: add systemd-journald plugin as a privileged wrapper
- python311Packages.enlighten: 1.12.0 -> 1.12.2
- simde: init at 0.7.6
- stratisd: 3.6.0 -> 3.6.1
- esphome: 2023.10.4 -> 2023.10.5
- nixosTests.cinnamon: Extend the test
- signalbackup-tools: 20231015 -> 20231030-1
- use meson to build and install
- expand platforms
- remove period from description
- roxterm: 3.14.1 -> 3.14.2
- maintainers: add whiteley
- tetraproc: 0.8.6 -> 0.9.2
- vendir: 0.35.0 -> 0.35.2
- wander: 0.11.1 -> 0.11.2
- maintainers: add ludat
- evsieve: 1.3.1 -> 1.4.0
- terraform: 1.6.2 -> 1.6.3
- docker-slim: 1.40.4 -> 1.40.6
- brev-cli: 0.6.262 -> 0.6.264
- wavemon: 0.9.4 -> 0.9.5
- clash-verge: 1.3.7 -> 1.3.8
- grpc_cli: 1.59.1 -> 1.59.2
- kapp: 0.59.0 -> 0.59.1
- tuxmux: 0.1.0 -> 0.1.1
- python311Packages.sentry-sdk: 1.32.0 -> 1.33.1
- ibus-engines.typing-booster-unwrapped: 2.24.2 -> 2.24.4
- maestro: 1.33.1 -> 1.34.0
- twm: 0.7.0 -> 0.8.0
- terraform-plugin-docs: rename from tfplugindocs
- yersinia: 0.8.2 -> unstable-2022-11-20 unmark broken aarch64-linux
- chart-testing: 3.9.0 -> 3.10.0
- terraform-plugin-docs: add meta.{changelog,mainProgram}
- terraform-plugin-docs: add passthru.{tests,updateScript}
- terraform-plugin-docs: 0.14.1 -> 0.16.0
- terraform-plugin-docs: ensure go is in the PATH
- cloudflared: 2023.8.2 -> 2023.10.0
- netdata: 1.43.0 -> 1.43.2
- netdata: update go.d.plugin 0.56.3 -> 0.56.4
- runc: 1.1.9 -> 1.1.10
- crun: 1.11 -> 1.11.1
- mapcidr: 1.1.13 -> 1.1.14
- python311Packages.pysolcast: 1.0.15 -> 2.0.0
- python310Packages.array-record: 0.4.1 -> 0.5.0
- python311Packages.types-awscrt: 0.19.6 -> 0.19.7
- mmseqs2: 14-7e284 -> 15-6f452
- python311Packages.agate-excel: 0.2.5 -> 0.3.0
- python311Packages.bandcamp-api: 0.2.2 -> 0.2.3
- python311Packages.jinja2-pluralize: rename from jinja2_pluralize
- python311Packages.jinja2-pluralize: enable tests
- python311Packages.nitime: 0.10.1 -> 0.10.2
- linuxPackages.nvidia_x11: 530.41.03 -> 545.29.02
- act: 0.2.52 -> 0.2.53
- deck: 1.27.1 -> 1.28.0
- nixos/x11: move extraLayouts into xkb attrset
- pkgs: fix nixosTests command in docs
- konstraint: 0.31.0 -> 0.32.0
- phel: unstable-2023-10-27 -> 0.12.0
- phel: add `postCheckInstall` step
- gobgp: 3.19.0 -> 3.20.0
- freshrss: 1.21.0 -> 1.22.1
- nixos/freshrss: migrate to DATA_PATH
- fastfetch: 2.1.2 -> 2.2.0
- gobgpd: 3.19.0 -> 3.20.0
- webcord: 4.5.0 -> 4.5.1
- python310Packages.dvc: update checksum
- imgcrypt: 1.1.8 -> 1.1.9
- heygpt: 0.4.0 -> 0.4.1
- vencord: 1.6.1 -> 1.6.2
- maintainers: add mrtnvgr
- ttop: 1.2.6 -> 1.2.7
- python3.pkgs.mastodon-py: 1.8.1 -> unstable-2023-06-24 (fixes build)
- helm-ls: 0.0.6 -> 0.0.7
- maintainers: add chayleaf's GPG key
- vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.17.1 -> 0.17.5
- vscode-extensions.rust-lang.rust-analyzer 2023-07-31 -> 2023-10-16
- anki-bin: 2.1.66 -> 23.10
- xfce.xfconf: 4.18.2 -> 4.18.3
- xfce.thunar-archive-plugin: 0.5.1 -> 0.5.2
- bbin: 0.1.5 -> 0.2.1
- kotlin: 1.9.10 -> 1.9.20
- kail: 0.16.1 -> 0.17.0
- air: 1.46.0 -> 1.49.0
- bbin: add updateScript
- numbat: Add support for darwin
- logseq: 0.9.19 -> 0.9.20
- nixos/nix-channnel: fix setting up the default channel again
- triton: 7.15.4 -> 7.16.0
- celeste-classic: init at unstable-2020-12-08
- python310Packages.icalendar: 5.0.7 -> 5.0.10
- python310Packages.recurring-ical-events: 2.0.2 -> 2.1.0
- python311Packages.x-wr-timezone: disable tests
- prometheus-nats-exporter: 0.12.0 -> 0.13.0
- pscale: 0.156.0 -> 0.161.0
- python311Packages.aioquic-mitmproxy: 0.9.20.3 -> 0.9.21.1
- python311Packages.awscrt: 0.19.3 -> 0.19.7
- python311Packages.azure-mgmt-search: 9.0.0 -> 9.1.0
- python311Packages.casbin: 1.32.0 -> 1.33.0
- lib.filesystem: Don't test Nix-specific error messages
- glamoroustoolkit: 1.0.1 -> 1.0.2
- yandex-browser: 23.7.1.1215-1 -> 23.9.1.962-1
- cosmic-icons: init at unstable-2023-08-30
- last: 1471 -> 1499
- nixos/tests/predictable-interface-names: fix eval for systemd-stage1
- virtualbox: 7.0.10 -> 7.0.12
- owl-lisp: 0.2.1 -> 0.2.2
- nixos/restic: fix #264696 and add a regression test
- fishPlugins.bobthefisher: unstable-2023-03-09 -> unstable-2023-10-25
- python3Packages.pandas: fix build on 32-bit platforms
- python311Packages.aioairzone-cloud: 0.3.0 -> 0.3.1
- python311Packages.aiocomelit: 0.0.9 -> 0.3.0
- python311Packages.aiohomekit: 3.0.6 -> 3.0.8 (#262700)
- python311Packages.aiounifi: 63 -> 64
- python311Packages.aiovodafone: 0.3.1 -> 0.4.2
- python311Packages.bleak-retry-connector: 3.2.1 -> 3.3.0
- python311Package.blinkpy: 0.22.0 -> 0.22.2
- python311Packages.google-nest-sdm: 3.0.2 -> 3.0.3
- python311Packages.hass-nabucasa: 0.71.0 -> 0.74.0
- home-assistant.intents: 2023.10.2 -> 2023.10.16
- python311Packages.mastodon-py: unstable-2023-06-24 -> 1.8.1
- python311Packages.matrix-nio: 0.21.2 -> 0.22.1
- python311Packages.pyatv: 0.13.4 -> 0.14.4
- python311Packages.python-opensky: 0.2.1 -> 0.2.1
- python311Packages.zeroconf: 0.115.2 -> 0.119.0 (#260837)
- python311Packages.zigpy: 0.57.2 -> 0.58.1
- home-assistant: 2023.10.5 -> 2023.11.0
- lib.fileset: Add an additional argument in the design docs
- reaper: 7.0 -> 7.02
- python311Packages.zha-quirks: test with pytest-asyncio
- zigbee2mqtt: 1.33.1 -> 1.33.2
- discord-canary: 0.0.171 -> 0.0.173
- discord: 0.0.32 -> 0.0.33
- discord-ptb: 0.0.51 -> 0.0.53
- discord: 0.0.281 -> 0.0.282
- discord-ptb: 0.0.82 -> 0.0.84
- discord-canary: 0.0.320 -> 0.0.329
- gh: 2.37.0 -> 2.38.0
- gnunet-gtk: copy missing logo image
- godot_4: 4.1.1 -> 4.1.3-stable
- slstatus: unstable-2022-12-19 -> 1.0
- qt5: fix splicing
- qt5: remove `with self;`
- linuxKernel.kernels.linux_zen: 6.5.9-zen2 -> 6.6-zen1
- linuxKernel.kernels.linux_lqx: 6.5.9-lqx1 ->6.5.9-lqx2
- nixos/systemd-lib: fix building of empty unit files
- python3Packages.aw-core: 0.5.15 -> 0.5.16
- minify: 2.20.1 -> 2.20.5
- mkgmap: 4914 -> 4916
- mongodb-compass: 1.40.2 -> 1.40.4
- monkeysAudio: 10.24 -> 10.26
- moon: 1.15.0 -> 1.16.0
- munin: 2.0.74 -> 2.0.75
- mympd: 12.0.4 -> 13.0.0
- bitwarden: 2023.9.3 -> 2023.10.0
- bitwarden-cli: 2023.9.1 -> 2023.10.0
- nats-server: 2.10.2 -> 2.10.4
- aliyun-cli: 3.0.183 -> 3.0.184
- lighttpd: 1.4.72 -> 1.4.73
- conky: 1.19.5 -> 1.19.6
- python311Packages.python-fsutil: 0.10.0 -> 0.11.0
- python311Packages.python-fsutil: update disabled
- pleroma: 2.5.5 -> 2.6.0
- exploitdb: 2023-11-01 -> 2023-11-02
- python311Packages.aiowaqi: 2.1.0 -> 3.0.0
- python311Packages.py-nextbusnext: 1.0.0 -> 1.0.1
- python311Packages.aiosmb: 0.4.9 -> 0.4.10
- python311Packages.hahomematic: 2023.10.14 -> 2023.11.0
- pythonPackages.nbxmpp: 4.3.2 → 4.4.0
- gajim: 1.8.1 → 1.8.2
- python311Packages.agate-excel: add changelog to meta
- python311Packages.agate-excel: equalize content
- python311Packages.agate-excel: add format
- node-packages: regenerate
- cnspec: 9.4.0 -> 9.5.0
- ksmbd-tools: 3.4.9 -> 3.5.0
- pulumi-bin: 3.90.0 -> 3.91.1
- zwave-js: module init, zwave-js-server: init at 1.33.0
- python311Packages.pysigma: 0.10.5 -> 0.10.6
- python311Packages.evohome-async: 0.3.15 -> 0.4.3
- llama-cpp: init at 1469
- ollama: 0.0.17 -> 0.1.7, use llama-cpp
- add mainProgram
- fortune-kind: 0.1.6 -> 0.1.7
- cargo-bundle-licenses: 1.2.1 -> 1.3.0
- liblogging: add withSystemd option
- cargo-outdated: 0.13.1 -> 0.14.0
- python311Packages.objax: disable tests to fix build
- tailwindcss-language-server: init at 0.0.14
- pocket-casts: 0.6.0 -> 0.7.0
- littlefs-fuse: 2.7.2 -> 2.7.3
- hcxtools: 6.3.1 -> 6.3.2
- xulrunner: move to aliases.nix
- eza: 0.15.1 -> 0.15.2
- python311Packages.homeassistant-stubs: 2023.10.5 -> 2023.11.0
- installer/cd-dvd/channel: stop using lib
- installer/cd-dvd/channel: allow to disable bundled channel
- libuv: disable tests on powerpc64
- kubernetes-polaris: 8.5.1 -> 8.5.2
- kyverno: 1.10.3 -> 1.10.4
- dbip-country-lite: 2023-10 -> 2023-11
- python311Packages.edk2-pytool-library: 0.19.2 -> 0.19.4
- telegram-desktop.tg_owt: unstable-2023-10-17 -> unstable-2023-11-01
- telegram-desktop: 4.11.1 -> 4.11.2
- v2ray-domain-list-community: 20231030084219 -> 20231031055637
- ubootTools: fix cross
- linux_6_5: 6.5.9 -> 6.5.10
- linux_6_1: 6.1.60 -> 6.1.61
- linux-rt_5_15: 5.15.133-rt70 -> 5.15.137-rt71
- linux_latest-libre: 19417 -> 19438
- linux/hardened/patches/4.14: 4.14.327-hardened1 -> 4.14.328-hardened1
- linux/hardened/patches/4.19: 4.19.296-hardened1 -> 4.19.297-hardened1
- linux/hardened/patches/5.10: 5.10.198-hardened1 -> 5.10.199-hardened1
- linux/hardened/patches/5.15: 5.15.136-hardened1 -> 5.15.137-hardened1
- linux/hardened/patches/5.4: 5.4.258-hardened1 -> 5.4.259-hardened1
- linux/hardened/patches/6.1: 6.1.59-hardened1 -> 6.1.60-hardened1
- kernel: fix framebuffer console after 6.6
- zsnes: fix buffer size marking to avoid crash on _FORTIFY_SOURCE=3
- python311Packages.pyenphase: 1.14.0 -> 1.14.1
- cosmic-settings: init at unstable-2023-10-26
- typos: 1.16.21 -> 1.16.22
- surrealdb-migrations: 0.9.12 -> 1.0.0->preview.1
- trillian: 1.5.2 -> 1.5.3
- ydict: 2.2.1 -> 2.2.2
- postfix: enable parallel builds
- waybar: 0.9.22 -> 0.9.23
- kluctl: 2.20.8 -> 2.22.1
- typst-lsp: 0.10.1 -> 0.11.0
- vscode-extensions.nvarner.typst-lsp: 0.10.1 -> 0.11.0
- felix-fm: 2.9.0 -> 2.10.1
- coq: fix hompage url
- cosmopolitan: migrate to by-name
- cosmopolitan: rewrite
- cosmocc: move to cosmopolitan
- faudio: 23.10 -> 23.11
- python3Packages.zcbor: init at 0.7.0
- zsnes: amend fortify3 patch and fix initialization
- nexttrace: 1.2.2.2 -> 1.2.3.1
- nixdoc: 2.4.0 -> 2.5.1
- lib.makeScopeWithSplicing': add comments
- gita: 0.11.9 -> 0.16.6.1
- ArchiSteamFarm: add darwin as supported platforms
- hysteria: 2.1.1 -> 2.2.0
- fastnetmon-advanced: 2.0.352 -> 2.0.353 (#264837)
- nitter: unstable-2023-08-08 -> unstable-2023-10-31
- nominatim: fix issues with package
- python310Packages.pyside2: 5.15.10 -> 5.15.11
- gammastep: fix systemd unit directory
- wyoming-faster-whisper: 1.0.1 -> 1.0.2
- redshift: set meta.mainProgram
- gammastep: set meta.mainProgram
- gammastep: add eclairevoyant to maintainers
- freecad: use python from environment
- maintainers: add wladmis
- pam_mktemp: init at 1.1.1
- nixos/woodpecker-server: fix environmentFile example
- wasm-bindgen-cli: 0.2.87 -> 0.2.88
- nmap-formatter: 2.1.3 -> 2.1.4
- document differences to built-in fetchers (#263569)
- nmrpflash: 0.9.21 -> 0.9.22
- avalanchego: 1.10.11 -> 1.10.15
- ergochat: 2.11.1 -> 2.12.0
- harePackages: remove myself from maintainers
- fastfetch: fix uninitialized error
- granted: 0.18.0 -> 0.19.2
- apple-sdk-11.0: add Apple80211 private framework
- fastfetch: fix darwin build
- fastfetch: 2.2.0 -> 2.2.1
- maintainers: add plusgut
- elixir: make 1.15 default and pin existing pkgs to 1.14
- noto-fonts: 23.8.1 -> 23.11.1
- hubble: 0.12.1 -> 0.12.2
- netbird: 0.24.0 -> 0.24.2
- erofs-utils: 1.7 -> 1.7.1 (#265080)
- oelint-adv: 3.26.1 -> 3.26.2
- maintainers: add iogamaster
- vesktop: fix aarch64-linux builds
- oh-my-posh: 18.11.0 -> 18.22.0
- oh: 0.8.1 -> 0.8.3
- mpv: unpin ffmpeg (#265069)
- esphome: 2023.10.5 -> 2023.10.6
- redis: 7.2.2 -> 7.2.3 (#264857)
- unsilence: init at 1.0.9
- maintainers: add snowflake
- guile-aspell: init at 0.5.0
- nixos/incus: init module and tests
- nixos/incus: preseed should not trigger socket-activation
- nixos/incus: shutdown instances on service stop
- python311Packages.python-matter-server: 4.0.0 -> 4.0.1
- python311Packages.jarowinkler: 1.2.3 -> 2.0.1
- onlyoffice-documentserver: 7.4.1 -> 7.5.0
- python311Packages.django_5: 5.0a1 -> 5.0b1
- jemalloc: disable tests for pkgsStatic (#265093)
- open-pdf-sign: 0.1.6 -> 0.1.7
- telegram-desktop: 4.11.2 -> 4.11.3 (#265068)
- cargo-release: 0.24.12 -> 0.25.0 (#265028)
- hugo: 0.120.2 -> 0.120.3 (#265027)
- postfix: 3.8.2 -> 3.8.3 (#265022)
- m2libc: init at unstable-2023-05-22
- mescc-tools: init at 1.5.1
- erofs-utils: add selinuxSupport option
- mescc-tools-extra: init at 1.3.0
- m2-planet: init at 1.11.0
- m2-mesoplanet: init at 1.11.0
- linuxKernel.kernels.linux_lqx: 6.5.9-lqx2 -> 6.5.10-lqx1
- opengrok: 1.12.15 -> 1.12.21
- nixos/tests/incus: improve test resiliency under load
- kanidm: 1.1.0-beta.13 -> 1.1.0-rc.15
- opentelemetry-collector: 0.87.0 -> 0.88.0
- picom-allusive: 0.3.2 -> 1.2.5
- openvi: 7.4.24 -> 7.4.26
- aba: 0.7.0 -> 0.7.1
- orchard: 0.14.1 -> 0.14.3
- osv-scanner: 1.4.1 -> 1.4.3
- otel-cli: 0.4.0 -> 0.4.1
- python311Packages.prometheus-pandas: init at 0.3.2
- p2pool: 3.7 -> 3.8
- pachyderm: 2.7.2 -> 2.7.6
- initool: 0.13.0 -> 0.14.0
- linkerd_edge: 23.10.1 -> 23.10.4
- tailscale: 1.52.0 -> 1.52.1
- dotbot: init at 1.20.1
- tests.cross.sanity: add pkgs.pkgsMusl.pkgsCross.gnu64.hello (#262876)
- python310Packages.imapclient: 2.3.1 -> 3.0.0
- python311Packages.azure-monitor-ingestion: init at 1.0.2
- python311Packages.parsedmarc: add meta.mainProgram
- python311Packages.parsedmarc: add missing dependency
- pfetch-rs: 2.7.0 -> 2.8.1
- photoflare: 1.6.12 -> 1.6.13
- php81Extensions.amqp: 1.11.0 -> 2.1.1
- php81Extensions.datadog_trace: 0.92.2 -> 0.93.1
- php81Extensions.redis: 6.0.1 -> 6.0.2
- php81Extensions.phalcon: 5.3.1 -> 5.4.0
- awsebcli: set mainProgram
- php81Packages.php-cs-fixer: 3.34.1 -> 3.37.1
- php81Packages.phpcbf: 3.7.1 -> 3.7.2
- blender: allow functional declaration within withPackages
- gromit-mpx: 1.5.0 -> 1.5.1
- minimal-bootstrap-sources: unstable-2023-05-02 -> 1.6.0
- pixelorama: 0.11.2 -> 0.11.3
- arti: 1.1.9 -> 1.1.10
- apache-jena: 4.9.0 -> 4.10.0
- tmuxPlugins.tmux-fzf: unstable-2023-07-06 -> unstable-2023-10-24
- cri-o-unwrapped: 1.28.1 -> 1.28.2
- eiwd: init at 2.8-1 (#208844)
- gau: 2.2.0 -> 2.2.1
- exploitdb: 2023-11-02 -> 2023-11-03
- python311Packages.pyacaia-async: 0.0.8 -> 0.0.10
- linux_xanmod: 6.1.60 -> 6.1.61
- haruna: 0.12.1 -> 0.12.2
- linux_xanmod_latest: 6.5.9 -> 6.5.10
- nixos/firefox: update document link
- wp-cli: 2.6.0 -> 2.9.0 * Changelog: https://github.com/wp-cli/wp-cli/releases/tag/v2.9.0
- debianutils: 5.13 -> 5.14
- kube-linter: 0.6.4 -> 0.6.5
- wasmtime: 14.0.2 -> 14.0.4
- nixos/fwupd: make auto-refresh run (and work)
- cargo-temp: 0.2.18 -> 0.2.19
- gosu: 1.16 -> 1.17
- kubebuilder: 3.12.0 -> 3.13.0
- libsForQt5.kquickimageedit: 0.2.0 -> 0.3.0
- libsForQt5.kuserfeedback: 1.2.0 -> 1.3.0
- kssd: 1.1 -> 2.21
- kssd: refactor
- kssd: enable aarch64-linux support & tests
- wiremock: migrate to by-name
- wiremock: add anthonyroussel to maintainers
- wiremock: add meta.{changelog,mainProgram}
- wiremock: 2.35.0 -> 3.2.0
- wiremock: add passthru.updateScript
- libsForQt5.networkmanager-qt: backport patches to fix NM 1.44 incompatibility
- nkeys: 0.4.5 -> 0.4.6
- rustypaste: 0.14.0 -> 0.14.1
- simpleitk: 2.3.0 -> 2.3.1
- gitlab: 16.4.1 -> 16.5.0
- gitlab-container-registry: 3.84.0 -> 3.85.0
- gitlab: fix Puma low-level error handler location
- gitaly: exclude from r-ryantm
- gitlab-container-registry: exclude from r-ryantm
- gitlab-pages: exclude from r-ryantm
- gitlab-shell: exclude from r-ryantm
- gitlab-workhorse: exclude from r-ryantm
- gitlab: 16.5.0 -> 16.5.1
- kubectl-gadget: 0.21.0 -> 0.22.0
- marwaita-peppermint: add update script
- marwaita-peppermint: 10.3 -> 17.0
- oauth2c: 1.12.0 -> 1.12.1
- python311Packages.yalexs-ble: 2.3.1 -> 2.3.2
- python311Packages.opower: 0.0.38 -> 0.0.39
- python311Packages.holidays: add myself as maintainer
- python311Packages.holidays: 0.32 -> 0.35
- waybar: 0.9.23 -> 0.9.24
- vesktop: 0.4.2 -> 0.4.3
- maintainers: add pluiedev
- vesktop: add pluiedev as maintainer
- stalwart-mail: 0.4.0 -> 0.4.2
- icewm: 3.4.3 -> 3.4.4
- vector: 0.33.0 → 0.33.1
- python311Packages.aioairzone-cloud: 0.3.1 -> 0.3.2
- pnpm-lock-export: unstable-2023-07-31 -> unstable-2023-07-31
- pocketbase: 0.18.10 -> 0.19.2
- clifm: 1.14.6 -> 1.15
- python311Packages.python-crontab: disable failing test
- asciinema: 2.3.0 -> 2.4.0
- libdeltachat: 1.121.0 -> 1.128.0
- deltachat-desktop: 1.40.4 -> unstable-2023-10-02
- deltachat-cursed: 0.7.2 -> 0.8.0
- libdeltachat: also install interactive repl
- fantomas: 6.2.2 -> 6.2.3
- ugrep: 4.3.1 -> 4.3.2
- podman: 4.7.0 -> 4.7.2
- tusc-sh: 1.1.0 -> 1.1.1 https://github.com/adhocore/tusc.sh/releases/tag/1.1.1
- fwupd: drop unneeded smbios dependency
- fwupd: 1.9.6 -> 1.9.7
- poppler: 23.08.0 -> 23.10.0
- poppler: 23.10.0 -> 23.11.0
- Revert "libdeltachat: also install interactive repl"
- Revert "deltachat-cursed: 0.7.2 -> 0.8.0"
- Revert "deltachat-desktop: 1.40.4 -> unstable-2023-10-02"
- Revert "libdeltachat: 1.121.0 -> 1.128.0"
- ecc: 1.0.11 -> 1.0.12
- chromium: 118.0.5993.117 -> 119.0.6045.105
- ungoogled-chromium: 118.0.5993.117-1 -> 119.0.6045.105-1
- chromedriver: 118.0.5993.70 -> 119.0.6045.105
- python311Packages.aiojobs: disable failing test
- python311Packages.restructuredtext-lint: rename from restructuredtext_lint
- python311Packages.restructuredtext-lint: refactor
- aspino: drop gcc10StdenvCompat
- treewide: remove myself as maintainer
- tmuxPlugins.tilish: unstable-2020-08-12 -> unstable-2023-09-20
- ghr: 0.16.1 -> 0.16.2
- eslint_d: fix meta.homepage
- python311Packages.symengine: fix build
- lunatask: 1.7.7 -> 1.7.8
- fg-virgil: init at 0.16.1
- kubectl-cnpg: 1.20.2 -> 1.21.0
- pokeget-rs: 1.3.0 -> 1.4.0
- ocamlPackages.eio: 0.12 → 0.13 (#265029)
- guile: enable jit on aarch64-darwin
- process-compose: 0.65.1 -> 0.69.0
- procs: 0.14.0 -> 0.14.3
- talosctl: pin golang
- protonmail-bridge: 3.5.1 -> 3.6.1
- pv-migrate: 1.3.0 -> 1.7.1
- pyrosimple: 2.11.4 -> 2.12.0
- nuclei: 3.0.2 -> 3.0.3
- cnspec: 9.5.0 -> 9.5.1
- python311Packages.rns: 0.6.3 -> 0.6.5
- python311Packages.lxmf: 0.3.7 -> 0.3.8
- python311Packages.nomadnet: 0.4.1 -> 0.4.2
- python311Packages.pyduotecno: 2023.10.1 -> 2023.11.0
- python311Packages.neo4j: 5.14.0 -> 5.14.1
- python310Packages.accelerate: 0.23.0 -> 0.24.1
- python311Packages.pypitoken: 7.0.0 -> 7.0.1
- python311Packages.pyschlage: 2023.10.0 -> 2023.11.0
- python311Packages.python-smarttub: 0.0.33 -> 0.0.34
- python311Packages.rich-click: 1.7.0 -> 1.7.1
- python311Packages.stdlibs: 2022.10.9 -> 2023.11.2
- nixos/module-list: add virt-manager
- python311Packages.garth: 0.4.39 -> 0.4.41
- python311Packages.aiosmtplib: 3.0.0 -> 3.0.1
- python311Packages.aiosmtplib: add changelog to meta
- ruff: 0.1.3 -> 0.1.4
- python311Packages.xknxproject: 3.4.0 -> 3.4.1
- python311Packages.types-awscrt: 0.19.7 -> 0.19.8
- python311Packages.aiortm: 0.6.3 -> 0.6.4
- python311Packages.httpx-ntlm: 1.1.0 -> 1.4.0
- python311Packages.aioairq: 0.3.0 -> 0.3.1
- numbat: 1.6.3 -> 1.7.0
- tests: fix eval failures
- numbat: Add version tests
- python311Packages.timm: 0.9.8 -> 0.9.9
- python310Packages.aioairq: 0.3.0 -> 0.3.1
- jupyter team: add thomasjm
- python310Packages.aioairzone-cloud: 0.3.2 -> 0.3.4
- hop-cli: 0.2.54 -> 0.2.60
- nixos/systemd-boot: add julienmalka as maintainer
- python310Packages.aiortm: 0.6.3 -> 0.6.4
- zitadel: 2.37.2 -> 2.40.3
- gh-ost: 1.1.5 -> 1.1.6
- python311Packages.openapi3 init at 1.8.2
- linode-cli: 5.26.1 -> 5.45.0
- python311Packages.python-docs-theme: rename from python_docs_theme
- python310Packages.anywidget: 0.7.0 -> 0.7.1
- python311Packages.radio-beam: rename from radio_beam
- btrfs-progs: 6.5.3 -> 6.6
- python211Packages.radio-beam: refactor
- python311Packages.radio-beam: 0.3.4 -> 0.3.6
- hcxdumptool: 6.3.1 -> 6.3.2
- metabase: 0.47.3 -> 0.47.6
- python310Packages.approvaltests: 9.0.0 -> 10.0.0
- python310Packages.apipkg: 3.0.1 -> 3.0.2
- python311Packages.vega-datasets: rename from vega_datasets
- python310Packages.argostranslate: 1.8.1 -> 1.9.1
- opencolorio: 2.2 -> 2.3
- olive-editor: patch for opencolorio-2.3
- openimageio: fix build with zlib 1.3
- krita: patch for opencolorio-2.3
- python311Packages.vega-datasets: refactor
- python310Packages.atlassian-python-api: 3.41.1 -> 3.41.3
- lib.systems, test.cross.sanity: add test case for #264989
- gcc.libgcc: compare host and target platforms, rathern than their triples
- python310Packages.awscrt: 0.19.7 -> 0.19.8
- python310Packages.beartype: 0.15.0 -> 0.16.4
- python310Packages.bincopy: 19.1.0 -> 20.0.0
- dark-mode-notify: migrate to pkgs/by-name
- dark-mode-notify: add meta.mainProgram
- python310Packages.bip-utils: 2.7.1 -> 2.8.0
- signal-desktop: 6.36.0 -> 6.37.0
- python310Packages.boilerpy3: 1.0.6 -> 1.0.7
- python310Packages.boto3-stubs: 1.28.64 -> 1.28.78
- python310Packages.botocore-stubs: 1.31.64 -> 1.31.78
- ubootTools: fix cross properly this time
- uboot: fix patchShebangs invocation
- uboot: set SCP=/dev/null for all the allwinners
- ubootClearfog: fix output file name
- python310Packages.boxx: 0.10.10 -> 0.10.12
- python310Packages.bsdiff4: 1.2.3 -> 1.2.4
- python311Packages.bincopy: add format
- python310Packages.bip-utils: update disabled
- vimPlugins.molten-nvim: init at 2023-10-21
- python311Packages.bip-utils: remove postPatch section
- python311Packages.radio-beam: add changelog to meta
- python311Packages.python-docs-theme: add changelog to meta
- symfony-cli: 5.6.0 -> 5.7.0
- vimPlugins: updated the 11-04-2023
- python311Packages.python-docs-theme: equalize content
- python311Packages.python-docs-theme: disable on unsupported Python releases
- python311Packages.stdlibs: update disabled
- vimPlugins.nvim-treesitter: update grammars
- python311Packages.ical: 5.1.0 -> 5.1.1
- devspace: 6.3.3 -> 6.3.4
- python311Packages.pex: 2.1.148 -> 2.1.149
- python311Packages.publicsuffixlist: 0.10.0.20231030 -> 0.10.0.20231104
- fastly: 10.5.1 -> 10.6.1
- appflowy: 0.3.6 -> 0.3.7
- libretro.pcsx2: avoid $NIX_BUILD_TOP
- mercure: init at 0.15.5
- flyctl: 0.1.104 -> 0.1.117
- ktlint: add meta.mainProgram
- fiji: remove myself as maintainer
- python310Packages.clarifai-grpc: 9.9.3 -> 9.10.0
- gomplate: force build with go 1.20
- python310Packages.cleo: 2.0.1 -> 2.1.0
- python311Packages.pyinstrument: 4.5.3 -> 4.6.0
- python311Packages.pytest-ansible: 4.1.0 -> 4.1.1
- cloudlog: 2.4.11 -> 2.5.0
- python3Packages.ducc0: 0.31.0 -> 0.32.0
- python311Packages.cf-xarray: init at 0.8.6
- greenfoot: 3.8.0 -> 3.8.1
- decker: 1.31 -> 1.32
- jql: 7.0.4 -> 7.0.5
- foot: 1.16.1 -> 1.16.2
- dt: 1.2.5 -> 1.3.1
- meld: avoid -dev paths in runtime closure
- python311Packages.qcodes: 0.40.0 -> 0.41.1
- python311Packages.ring-doorbell: 0.7.4 -> 0.7.7
- python311Packages.stytra: mark broken
- python311Packages.yq: add meta.mainProgram
- python3Packages.spectral-cube: 0.6.2 -> 0.6.3
- python3Packages.spectral-cube: fix tests
- osmo-iuh: 1.4.0 -> 1.5.0
- nixos/plasma5: fix mismatch between nix and module system
- detekt: 1.23.1 -> 1.23.3
- tengine: 3.0.0 -> 3.1.0
- mautrix-discord: 0.6.2 -> 0.6.3
- cudatext-qt: 1.200.0 -> 1.201.0
- intel-gmmlib: 22.3.11 -> 22.3.12
- mdbook-admonish: 1.13.0 -> 1.13.1
- flannel: 0.22.3 -> 0.23.0
- mediastreamer: 5.2.98 -> 5.2.109
- gnustep.back: 0.29.0 -> 0.30.0
- freetds: 1.4.2 -> 1.4.6
- uhdm: 1.76 -> 1.77
- containerd: 1.7.7 -> 1.7.8
- gwyddion: 2.63 -> 2.64
- python311Packages.qcodes-loop: disable failing tests
- gnustep.make: 2.9.0 -> 2.9.1
- gickup: 0.10.21 -> 0.10.22
- panoply: 5.2.9 -> 5.2.10
- shairport-sync: add adamcstephens as maintainer
- shairport-sync: add meta.mainProgram
- nqptp: add meta.mainProgram
- vscode, vscode-server: 1.83.1 -> 1.84.0
- borealis-cursors: init at 2.0
- postgresql12JitPackages.plpgsql_check: 2.5.4 -> 2.6.0
- mold: 2.3.1 -> 2.3.2
- poppler: remove unused pcre
- poppler: remove unused arguments
- rabtap: 1.38.2 -> 1.39.0
- azpainter: 3.0.6 -> 3.0.7
- jumppad: 0.5.51 -> 0.5.53
- kuma: 2.3.1 -> 2.4.3
- gowitness: 2.5.0 -> 2.5.1
- gowitness: add changelog to meta
- ossutil: 1.7.16 -> 1.7.17
- zerotierone: 1.12.1 -> 1.12.2
- openvscode-server: 1.79.2 -> 1.84.0
- python310Packages.wand: 0.6.11 -> 0.6.13
- wvkbd: 0.14.1 -> 0.14.3
- python311Packages.meshtastic: 2.2.10 -> 2.2.11
- python311Packages.formulaic: 0.6.4 -> 0.6.6
- go-dependency-manager: drop
- python310Packages.botorch: 0.9.2 -> 0.9.3
- heroic: add unzip to FHS env
- python311Packages.x-wr-timezone: 0.0.5 -> 0.0.6
- texlive.combined.scheme-bookpub: init
- texlive: export schemes at top level
- texlive: do not recurse into attrs
- python311Packages.optimum: 1.13.1 -> 1.13.3
- python311Packages.peft: 0.5.0 -> 0.6.0
- routedns: 0.1.20 -> 0.1.51
- nile: 1.0.0 -> unstable-2023-10-03
- python3Packages.rasterio: 1.3.8 -> 1.3.9
- electrs: 0.9.13 -> 0.10.1
- gato: init at 1.5
- python311Packages.aiounifi: 64 -> 65
- python311Packages.segno: 1.5.2 -> 1.5.3
- python311Packages.py-nextbusnext: 1.0.1 -> 1.0.2
- python311Packages.reolink-aio: 0.7.12 -> 0.7.14
- home-assistant: 2023.11.0 -> 2023.11.0
- python311Packages.holidays: generate l10n files
- nixos/tests/home-assistant: replace ensureUsers with custom setup script for now
- treewide: change readded `overrideScope'`'s to `overrideScope`
- heroic: 2.9.2 -> 2.10.0
- python311Packages.timm: 0.9.9 -> 0.9.10
- portfolio: 0.65.4 -> 0.65.5
- libsForQt5.qtpbfimageplugin: 2.5 -> 2.6
- zotero: 6.0.27 -> 6.0.30
- ovftool: 4.5.0 -> 4.6.2 (4.6.0 on i686-linux)
- mattermost: 8.1.3 -> 8.1.4
- qutebrowser: repair vandalism
- lib.systems.inspect: add patternLogicalAnd
- qt5.qtdeclarative: add postFixup if cross compiling
- qt5.qtModule: reformat arguments
- qt5.qtModule: add buildPackages.stdenv.cc to depsBuildBuild if cross compiling
- qt5.qtModule: add explicit pkgsHostTarget.qt5.qtbase.dev to nativeBuildInputs if cross compiling
- qt5.qtwebchannel: omit "bin" output when cross compiling
- qt5.qtwebengine: fix cross
- qt5.qttranslations: disable if cross to prevent infinite recursion
- qt5.qtbase: fix cross
- qt5.pyqtwebengine: fix cross
- pyqt5: fix cross
- jasper: mark broken if cross
- qt5.qtimageformats: do not try to use broken libraries
- qt5.qmake-hook: move libs to depsTargetTargetPropagated
- qutebrowser: take python3 from buildPackages
- test.cross.sanity: add qt5.qutebrowser, firefox
- devpod: init at 0.4.1
- zesarux: migrate to by-name
- zesarux: 10.0 -> unstable-2023-10-31
- wtfis: remove patch
- wtfis: migrate to by-name
- wtfis: 0.6.1 -> 0.7.1
- ocserv: 1.2.1 -> 1.2.2
- fix(etesync-dav): remove pinned dependencies
- gzdoom: 4.11.1 -> 4.11.3
- nerdctl: 1.6.2 -> 1.7.0
- postgresql16Packages.plpgsql_check: 2.6.0 -> 2.6.1
- gallery-dl: 1.26.1 -> 1.26.2
- mystmd: 1.1.23 -> 1.1.26
- emacsPackages.lspce: init at unstable-2023-10-30
- python: add python.pythonOnBuildForHost
- pyqtwebengine: use python.pythonOnBuildForHost
- python3Packages.skl2onnx: fix build
- treewide: drop myself from packages that I don't activily maintain
- python311Packages.zxing-cpp: rename from zxing_cpp
- libmt32emu: 2.7.0 -> 2.7.1
- python311Packages.zxing-cpp: refactor
- python310Packages.click-odoo-contrib: 1.17.0 -> 1.18.0
- python310Packages.clickhouse-connect: 0.6.11 -> 0.6.18
- libdeltachat: 1.121.0 -> 1.128.0
- deltachat-desktop: 1.40.4 -> unstable-2023-11-03
- deltachat-cursed: 0.7.2 -> 0.8.0
- deltachat-repl: init at 1.128.0
- teams-for-linux: 1.3.14 -> 1.3.18
- python310Packages.cobs: 1.2.0 -> 1.2.1
- qtdeclarative: remove unnecessary postFixup
- python310Packages.coinmetrics-api-client: 2023.9.29.14 -> 2023.10.30.13
- python311Packages.proxy-tools: rename from proxy_tools
- python311Packages.proxy-tools: adopt pypa build
- python310Packages.correctionlib: 2.3.3 -> 2.4.0
- python310Packages.crate: 0.33.0 -> 0.34.0
- pict-rs: 0.4.3 -> 0.4.5
- carapace: 0.28.2 -> 0.28.3
- gitoxide: 0.30.0 -> 0.31.1
- ls-lint: 2.1.0 -> 2.2.2
- phrase-cli: 2.12.0 -> 2.15.0
- pylyzer: 0.0.48 -> 0.0.49
- python310Packages.cryptoparser: 0.10.3 -> 0.11.0
- python310Packages.cryptolyzer: 0.10.0 -> 0.10.3
- python310Packages.css-parser: 1.0.9 -> 1.0.10
- python310Packages.cx-freeze: 6.15.7 -> 6.15.10
- qgis-ltr: 3.28.11 -> 3.28.12
- cargo-leptos: 0.2.0 -> 0.2.1
- python311Packages.homeassistant-stubs: 2023.11.0 -> 2023.11.1
- python311Packages.whodap: 0.1.10 -> 0.1.11
- oil: 0.17.0 -> 0.18.0
- python3Packages.tweepy: Disable failing streaming tests
- tailspin: 1.6.0 -> 2.0.0
- cfripper: 1.13.2 -> 1.14.0
- python311Packages.alexapy: 1.27.6 -> 1.27.7
- python311Packages.boschshcpy: 0.2.72 -> 0.2.73
- python311Packages.aiocsv: 1.2.4 -> 1.2.5
- python310Packages.debianbts: 4.0.1 -> 4.0.2
- python311Packages.vine: 5.0.0 -> 5.1.0
- python310Packages.derpconf: 0.8.3 -> 0.8.4
- python310Packages.diagrams: 0.23.3 -> 0.23.4
- python311Packages.vine: add changelog to meta
-  python311Packages.vine: update disabled
- python311Packages.debianbts: update disabled
- jrnl: 4.0.1 -> 4.1
- jrnl: add version test
- kubectl-klock: 0.4.0 -> 0.5.0
- python310Packages.cx-freeze: add changelog
- python310Packages.cx-freeze: update disabled
- python311Packages.debianbts: refactor
- python310Packages.derpconf: add changelog to meta
- numcpp: 2.12.0 -> 2.12.1
- python310Packages.derpconf: add pythonImportsCheck
- nixos/greetd: autostart GNOME Keyring when enabled
- python310Packages.derpconf: add format
- python310Packages.diffsync: 1.8.0 -> 1.9.0
- vencord: 1.6.2 -> 1.6.3
- tests.texlive: replace texlive.combine with texlive.withPackages
- tests.texlive: use texlive.pkgs.PKGNAME attribute set instead of texlive.PKGNAME.pkgs list
- gnu-cobol: replace texlive.combined.scheme-basic with texliveBasic
- pari: replace texlive.combined.scheme-basic with texliveBasic
- pidginPackages: replace texlive.combined.scheme-basic with texliveBasic
- sagetex: replace texlive.combined.scheme-basic with texliveBasic
- scapy: replace texlive.combined.scheme-basic with texliveBasic
- blahtexml: replace texlive.combined.scheme-full with texliveFull
- bluespec: replace texlive.combined.scheme-full with texliveFull
- advi: replace texlive.combined.scheme-medium with texliveMedium
- asl: replace texlive.combined.scheme-medium with texliveMedium
- apostrophe: replace texlive.combined.scheme-medium with texliveMedium
- avrdude: replace texlive.combined.scheme-medium with texliveMedium
- linuxdoc-tools: replace texlive.combined.scheme-medium with texliveMedium
- ne: replace texlive.combined.scheme-medium with texliveMedium
- ns-3: replace texlive.combined.scheme-medium with texliveMedium
- nuweb: replace texlive.combined.scheme-medium with texliveMedium
- rPackages: replace texlive.combined.scheme-medium with texliveMedium
- zettlr: replace texlive.combined.scheme-medium with texliveMedium
- openmolcas: replace texlive.combined.scheme-minimal with texliveMinimal
- cddblib: replace texlive.combined.scheme-small with texliveSmall
- enblend-enfuse: replace texlive.combine with texliveSmall
- giac: replace texlive.combined.scheme-small with texliveSmall
- gnuplot: replace texlive.combine with texliveSmall
- ipe: replace texlive.combine with texliveSmall
- python3Packages.pypandoc: replace texlive.combined.scheme-small with texliveSmall
- ragel: replace texlive.combined.scheme-small with texliveSmall
- singular: replace texlive.combined.scheme-small with texliveSmall
- skribilo: replace texlive.combined.scheme-small with texliveSmall
- texmacs: replace texlive.combined.scheme-small with texliveSmall
- pandoc-drawio-filter: replace texlive.combined.scheme-tetex with texliveTeTeX
- therion: replace texlive.combined.scheme-tetex with texliveTeTeX
- dblatex: replace texlive.combine with texliveBasic.withPackages
- dwarf-fortress: replace texlive.combine with texliveBasic.withPackages
- pari: replace texlive.combine with texliveBasic.withPackages
- rivet: replace texlive.combine with texliveBasic.withPackages
- xyce: replace texlive.combine with texliveMedium.withPackages
- python311Packages.x11-hash: rename from x11_hash
- python311Packages.x11-hash: refactor
- python310Packages.django-admin-sortable2: 2.1.9 -> 2.1.10
- cargo-outdated: add missing `CoreServices` buildinput
- graphite-gtk-theme: fix wallpapers
- nwchem: 7.2.1 -> 7.2.2
- python311Packages.django-redis: ignore DeprecationWarning
- vdrPlugins.nopacity: 1.1.14 -> 1.1.16
- androidenv: updates for Android API 34
- vdrPlugings.softhddevice: 1.12.1 -> 1.12.5
- vdrPlugins.markad: 3.3.5 -> 3.3.6
- python311Packages.django-redis: migrate to pyproject
- catdvi: replace texlive.combine with texliveInfraOnly.withPackages
- manim: replace texlive.combine with texliveInfraOnly.withPackages
- asciidoc: replace texlive.combine with texliveMinimal.withPackages
- asymptote: replace texlive.combine with texliveSmall.withPackages
- dot2tex: replace texlive.combine with texliveSmall.withPackages
- lilypond: replace texlive.combine with texliveSmall.withPackages
- mitscheme: replace texlive.combine with texliveSmall.withPackages
- paperwork: replace texlive.combine with texliveSmall.withPackages
- python3Packages.sphinxcontrib-tikz: replace texlive.combine with texliveSmall.withPackages
- R: replace texlive.combine with texliveSmall.withPackages
- rocmPackages.migraphx: replace texlive.combine with texliveSmall.withPackages
- rocmPackages.miopen: replace texlive.combine with texliveSmall.withPackages
- rocmPackages.miopengemm: replace texlive.combine with texliveSmall.withPackages
- rocmPackages.rdc: replace texlive.combine with texliveSmall.withPackages
- rocmPackages.rocdbgapi: replace texlive.combine with texliveSmall.withPackages
- pandoc-acro: replace texlive.combine with texliveTeTeX.withPackages
- tests.texlive.fixedHashes: ignore .tex attribute sets that are not derivations
- python311Packages.aiosql: adjust inputs
- python311Packages.django-q: mark as broken
- vscode-extensions.griimick.vhs: init at 0.0.4 (#265634)
- nixos/printing: Add openFirewall option (#176539)
- python311Packages.python-smarttub: 0.0.34 -> 0.0.35
- python311Packages.python-on-whales: 0.65.0 -> 0.66.0
- python311Packages.radish-bdd: 0.17.0 -> 0.17.1
- top-level/mpvScripts: import → callPackage
- mpvScripts: refactor around `buildLua` helper
- mpvScripts.{blacklistExtensions, seekTo}: makeOverridable & refactor
- mpvScripts.buildLua: Run {pre, post}install hooks
- Revert "btrfs-progs: 6.5.3 -> 6.6"
- sqlite-utils: 3.35.1 -> 3.35.2
- tbox: 1.7.4 -> 1.7.5
- grpc: explicitly use the build platform for `grpc_cpp_plugin` when cross building grpc use the build platform `grpc_cpp_plugin` to generate the internal protos
- mopidy-spotify: add updateScript
- mopidy-spotify: unstable-2023-04-21 -> unstable-2023-11-01
- wasmedge: 0.13.4 -> 0.13.5
- gdal: 3.7.2 -> 3.7.3
- open-english-wordnet: init at 2022
- open-english-wordnet: Fix merge.py
- uiua: 0.0.25 -> 0.1.0
- nix-prefetch-git: download submodules with --progress
- yuzu: 1595 -> 1611, yuzu-ea: 3940 -> 3966
- kodiPackages.pvr-hts: 20.6.3 -> 20.6.4
- iosevka: 27.3.2 -> 27.3.4
- nixos/prometheus.exporters.knot: migrate from extraConfig to settingsFile
- nixos/prometheus.exporters.pgbouncer: migrate from connectionString to connectionStringFile
- ghostscript: pad headers at link time to prevent install_name_tool failure on Darwin (#263833)
- python310Packages.django-crispy-forms: 2.0 -> 2.1
- python310Packages.django-configurations: 2.4.1 -> 2.5
- xpano: 0.16.1 -> 0.17.0
- python310Packages.django-cacheops: 7.0.1 -> 7.0.2
- python311Packages.latexify-py: 0.2.0 -> 0.3.1
- python310Packages.django-ipware: 5.0.0 -> 5.0.2
- libgpiod: 2.0.2 -> 2.1
- nixos/matrix-sliding-sync: add dependency on matrix-synapse if running locally and restart
- nixos/matrix-synapse: add readOnly serviceUnit option
- nixos/matrix/*: change dependencies on matrix-synapse.service to serviceUnit
- gut: 0.2.10 -> 0.3.0
- nixos-firewall-tool: init at 0.0.1
- uxn: unstable-2023-09-29 -> unstable-2023-10-23
- python310Packages.djangorestframework-dataclasses: 1.3.0 -> 1.3.1
- smlfmt: 1.0.0 -> 1.1.0
- ocamlPackages.sodium: disable for OCaml ≥ 5.0
- ocamlPackages.camlimages: fix build with OCaml ≥ 5.0
- ocamlPackages.cry: fix build with OCaml ≥ 5.0
- ocamlPackages.piqi: disable for OCaml ≥ 5.0
- ocamlPackages.dum: fix build with OCaml ≥ 5.0
- polybar: 3.6.3 -> 3.7.0
- maintainers: quantenzitrone github account rename
- llm-ls: init at 0.4.0
- python310Packages.duckduckgo-search: 3.8.5 -> 3.9.4
- python311Packages.img2pdf: fix evaluation on darwin
- python310Packages.dvclive: 3.1.0 -> 3.2.0
- treewide: change pythonForBuild to pythonOnBuildForHost
- python310Packages.easydict: 1.10 -> 1.11
- python310Packages.einops: 0.6.1 -> 0.7.0
- qutebrowser: add meta attributes
- qutebrowser: cleanup
- terragrunt: 0.53.0 -> 0.53.2
- python310Packages.ezyrb: 1.3.0.post2309 -> 1.3.0.post2311
- python310Packages.faster-whisper: 0.8.0 -> 0.9.0
- python310Packages.fasttext-predict: 0.9.2.1 -> 0.9.2.2
- python310Packages.finvizfinance: 0.14.6 -> 0.14.7
- twilio-cli: 5.15.0 -> 5.16.1
- python310Packages.flask-paginate: 2023.10.8 -> 2023.10.24
- age: skip flaky plugin test
- python310Packages.glcontext: 2.4.0 -> 2.5.0
- pretendard: 1.3.8 -> 1.3.9
- geph.{cli,gui}: 4.7.8 -> 4.10.1
- python310Packages.globus-sdk: 3.29.0 -> 3.31.0
- python310Packages.gocardless-pro: 1.47.0 -> 1.48.0
- heroic: fix infinite loop when starting some games
- legendary-gl: 0.20.33 -> unstable-2023-10-14
- python311Packages.alexapy: 1.27.7 -> 1.27.8
- python311Packages.boschshcpy: 0.2.73 -> 0.2.75
- python311Packages.dvclive: 3.1.0 -> 3.2.0
- python311Packages.aiocomelit: 0.3.0 -> 0.3.1
- python311Packages.amqp: 5.1.1 -> 5.2.0
- python311Packages.amqp: add changelog to meta
- python311Packages.amqp: update disabled
- python311Packages.blinkpy: 0.22.2 -> 0.22.3
- python311Packages.evohome-async: 0.4.3 -> 0.4.4
- python311Packages.meshtastic: 2.2.11 -> 2.2.12
- python311Packages.lsassy: 3.1.8 -> 3.1.9
- python311Packages.rns: 0.6.5 -> 0.6.6
- python311Packages.publicsuffixlist: 0.10.0.20231104 -> 0.10.0.20231105
- python311Packages.plugwise: 0.34.4 -> 0.34.5
- python311Packages.pyoverkiz: 1.12.1 -> 1.12.2
- python311Packages.pycep-parser: 0.4.1 -> 0.4.2
- python311Packages.pysml: 0.1.0 -> 0.1.1
- python311Packages.tplink-omada-client: 1.3.5 -> 1.3.6
- python311Packages.tldextract: 5.0.1 -> 5.1.0
- pb: 0.1.0 -> 0.2.0
- python310Packages.fschat: 0.2.30 -> 0.2.32
- python311Packages.skodaconnect: 1.3.7 -> 1.3.8
- vaultwarden: 1.29.2 -> 1.30.0
- vaultwarden.webvault: 2023.7.1 -> 2023.10.0
- python310Packages.gptcache: 0.1.41 -> 0.1.42
- autokey: 0.95.10 -> 0.96.0
- syncoid: disable PrivateUsers in systemd unit
- python310Packages.greeneye-monitor: 5.0 -> 5.0.1
- lua-rtoml: init 0.2
- rshim-user-space: make bfb-install optional
- mkpasswd: fix build with clang
- sxhkd: refactor
- xosview: migrate to by-name
- xosview: set meta.mainProgram
- xosview: split man output
- xosview2: migrate to by-name
- xosview2: set meta.mainProgram
- xosview2: 2.3.2 -> 2.3.3
- python311Packages.gphoto2: fix setuptools.__version__ build breakage
- librime: set darwin as support platforms
- python311Packages.jaxopt: 0.8.1 -> 0.8.2
- python310Packages.gspread: 5.11.3 -> 5.12.0
- docker-machine-hyperkit: disable on aarch64-darwin
- nixos/testing/nodes: Do allow aliases
- python310Packages.hg-evolve: 11.0.2 -> 11.1.0
- nixos/vagrant-guest: Set `security.sudo-rs.wheelNeedsPassword` too
- python310Packages.holoviews: 1.17.1 -> 1.18.0
- inkscape: fix runtime error on darwin
- python310Packages.httpx-socks: 0.7.8 -> 0.8.0
- python310Packages.grpcio-reflection: 1.59.0 -> 1.59.2
- python310Packages.grpcio-channelz: 1.59.0 -> 1.59.2
- nixos/qemu-vm: fix infinite recursion
- python310Packages.ignite: 0.4.12 -> 0.4.13
- python310Packages.intellifire4py: 3.1.29 -> 3.1.30
- sing-box: 1.6.0 -> 1.6.1
- nixos/stage-1: create initramfs /lib at build time
- clamtk: init at 6.16
- neatvnc: 0.7.0 -> 0.7.1
- wayvnc: 0.7.1 -> 0.7.2
- python311Packages.lru-dict: 1.2.0 -> 1.3.0
- nvidia-vaapi-driver: 0.0.10 -> 0.0.11
- python310Packages.jc: 1.23.5 -> 1.23.6
- python310Packages.jug: 2.3.0 -> 2.3.1
- home-assistant: backport litterrobot tests fix
- google-cloud-sdk: 446.0.1 -> 452.0.1 (#264589)
- lsp-plugins: 1.2.12 -> 1.2.13
- rsync: fix regression with _FORTIFY_SOURCE=2
- python311Packages.rchitect: 0.4.2 -> 0.4.4
- python311Packages.radian: 0.6.7 -> 0.6.8
- trust-dns: 0.23.0 -> 0.24.0
- python310Packages.langsmith: 0.0.53 -> 0.0.57
- vlang: 2023.42 -> 2023.44
- maintainers: add delta231
- vlang: add delta231 as maintainer
- Revert "rsync: fix regression with _FORTIFY_SOURCE=2" (#265876)
- piper-phonemize: 2023.9.27-2 -> 2023.11.6-1
- piper-tts: 2023.9.27-1 -> 2023.11.6-1
- fishPlugins.fzf-fish: 10.0 -> 10.1
- vaultwarden: fix update-script
- python310Packages.mandown: 1.5.0 -> 1.6.0
- tippecanoe: 2.19.0 → 2.35.0
- python310Packages.manimpango: 0.4.4 -> 0.5.0
- python310Packages.manifestoo-core: 1.0 -> 1.3
- spicetify-cli: 2.25.2 -> 2.26.0
- Gleam: 0.31.0 -> 0.32.2
- python310Packages.litellm: 0.1.738 -> 0.11.1
- signalbackup-tools: 20231030-1 -> 20231106-1
- cargo-readme: 3.2.0 -> 3.3.1
- osu-lazer: 2023.815.0 -> 2023.1026.0
- python311Packages.roonapi: 0.1.4 -> 0.1.5
- typos: 1.16.22 -> 1.16.23
- python311Packages.twilio: 8.10.0 -> 8.10.1
- python311Packages.gios: 3.2.0 -> 3.2.1
- python311Packages.nextdns: 2.0.0 -> 2.0.1
- trivy: 0.46.1 -> 0.47.0
- git-mit: 5.12.169 -> 5.12.171
- jaq: 1.1.0 -> 1.1.2
- xq-xml: 1.2.2 -> 1.2.3
- kbt: 1.2.3 -> 2.0.6
- python310Packages.mhcflurry: 2.0.6 -> 2.1.0
- gtree: 1.9.12 -> 1.10.2
- jql: 7.0.5 -> 7.0.6
- poethepoet: 0.24.1 -> 0.24.2
- scip: 0.3.1 -> 0.3.2
- python310Packages.mkdocs-git-revision-date-localized-plugin: 1.2.0 -> 1.2.1
- python310Packages.mkdocs-jupyter: 0.24.5 -> 0.24.6
- sudo: 1.9.14p3 -> 1.9.15
- python3Packages.simpful: unbreak
- lunarvim: init at 1.3.0
- python310Packages.mkdocs-swagger-ui-tag: 0.6.5 -> 0.6.6
- libtorrent-rasterbar: fix the path to the library in the CMake module
- qbittorrent: 4.5.5 -> 4.6.0 + other changes
- nixos/mediawiki: fix rewrites for static ressources and rest API
- nixos/mediawiki: pin php to 8.1
- python310Packages.dask-histogram: 2023.6.0 -> 2023.10.0
- python311Packages.objax: 1.7.0 -> 1.8.0
- python311Packages.dsmr-parser: 1.3.0 -> 1.3.1
- python311Packages.kombu: 5.3.2 -> 5.3.3
- qovery-cli: 0.74.2 -> 0.74.3
- try: fix homepage
- enum4linux-ng: 1.3.1 -> 1.3.2
- python311Packages.aioairzone-cloud: 0.3.4 -> 0.3.6
- python311Packages.botocore-stubs: 1.31.78 -> 1.31.79
- cnspec: 9.5.1 -> 9.5.2
- felix-fm: fix build on darwin
- felix-fm: remove unused patch
- libtickit: refactor derivation
- turso-cli: 0.86.3 -> 0.87.1
- open-english-wordnet: Use unique filename under `share/`
- python310Packages.mypy-boto3-builder: 7.19.0 -> 7.19.1
- nixos/lib/make-btrfs-fs: Use fakeroot and faketime (#265686)
- python: deprecate pythonForBuild in favor of pythonOnBuildForHost
- fw: fix build on darwin
- wolfssl: fix condition for ASM SP Math support
- orogene: fix build on darwin
- mbedtls: 3.4.1 -> 3.5.0
- mbedtls_2: 2.28.4 -> 2.28.5
- root: drop patches
- fastfetch: 2.2.1 -> 2.2.2
- firefox-unwrapped: 119.0 -> 119.0.1
- firefox-bin-unwrapped: 119.0 -> 119.0.1
- python310Packages.nilearn: 0.10.1 -> 0.10.2
- ocaml-top: remove unused dependencies
- ocamlPackages.ocp-build: disable for OCaml ≥ 5.0
- ocamlPackages.ocamlify: disable for OCaml ≥ 5.0
- python310Packages.nunavut: 2.3.0 -> 2.3.1
- pcloud: 1.14.1 -> 1.14.2
- argparse: 2.9 -> 3.0
- python311Packages.dask-awkward: 2023.10.1 -> 2023.11.0
- python311Packages.awkward: 2.4.6 -> 2.4.9
- python311Packages.dask: 2023.10.0 -> 2023.10.1
- goreleaser: 1.21.2 -> 1.22.0
- python3Packages.insightface: unbreak
- linuxPackages.nvidia_x11_vulkan_beta: 535.43.15 -> 535.43.16
- krapslog: 0.5.3 -> 0.5.4
- kdoctor: 1.0.1 -> 1.1.0
- python311Packages.jaxlib: fix hash
- build(deps): bump korthout/backport-action from 2.0.0 to 2.1.0
- rofi-wayland: add meta.mainProgram
- rufo: 0.12.0 -> 0.16.2
- k9s: 0.27.4 -> 0.28.0
- summoning-pixel-dungeon: 1.2.5 -> 1.2.5a
- papirus-folders: 1.12.1 -> 1.13.1
- zellij: 0.38.2 -> 0.39.0
- ocamlPackages.pyml: 20220905 → 20231101
- gcc: move version information to gcc/versions.nix
- gcc: move version iteration out of all-packages.nix
- gcc: inline pointless inherit ({..})
- tqsl: unpin OpenSSL
- bun: 1.0.7 -> 1.0.10
- polymake: 4.10 -> 4.11
- deno: 1.37.2 -> 1.38.0
- python310Packages.formencode: 2.0.1 -> 2.1.0
- skawarePackages.buildPackage: make sha256 optional
- Revert "tdesktop: fix for loading libXcursor"
- python311Packages.folium: 0.14.0 -> 0.15.0
- python311Packages.pyoverkiz: 1.12.2 -> 1.13.0
- numbat: Add modules folder
- nixos/virtualization: fix shellcheck login
- wiremock: 3.2.0 -> 3.3.1
- symfony-cli: 5.7.0 -> 5.7.2 (#266011)
- vhdl-ls: 0.66.0 -> 0.67.0
- skalibs: 2.13.1.1 -> 2.14.0.0
- nsss: 0.2.0.3 -> 0.2.0.4
- utmps: 0.1.2.1 -> 0.1.2.2
- execline: 2.9.3.0 -> 2.9.4.0
- s6: 2.11.3.2 -> 2.12.0.0
- s6-rc: 0.5.4.1 -> 0.5.4.2
- s6-linux-init: 1.1.1.0 -> 1.1.2.0
- s6-portable-utils: 2.3.0.2 -> 2.3.0.3
- s6-linux-utils: 2.6.1.2 -> 2.6.2.0
- s6-dns: 2.3.5.5 -> 2.3.6.0
- s6-networking: 2.5.1.3 -> 2.6.0.0
- mdevd: 0.1.6.2 -> 0.1.6.3
- nixos/journald: add `storage` option
- zam-plugins: 4.1 -> 4.2
- sing-box: 1.6.1 -> 1.6.2
- trompeloeil: 45 -> 46
- cosign: 2.2.0 -> 2.2.1
- hare: add onemoresuza as the maintainer
- python311Packages.edk2-pytool-library: set meta.platforms
- python311Packages.mhcflurry: drop hack for vestigial np-utils dependency
- python311Packages.mhcflurry: re-enable fixed tests
- python311Packages.flax: 0.7.4 -> 0.7.5
- telegram-desktop: 4.11.3 -> 4.11.5
- python311Packages.dalle-mini: mark as broken
- wordpressPackages: update and add embed-extended
- csharp-ls: 0.8.0 -> 0.10.0
- swagger-codegen3: 3.0.36 -> 3.0.50
- swagger-codegen3: add meta.mainProram
- swagger-codegen3: add passthru.tests.version
- python311Packages.scikit-survival: 0.21.0 -> 0.22.1; fix build
- nixos/tests/vaultwarden: fix database creation
- solaar: 1.1.9 -> 1.1.10
- grafana-agent: 0.37.3 -> 0.37.4
- nixos/mobilizon: fix integration test by using postgresql_14
- mobilizon: build with Elixir 1.15
- qutebrowser: disable vulkan by default
- mommy: 1.2.3 -> 1.2.4
- mommy: migrate to by-name
- treewide: replace `<command> | systemd-cat` with `systemd-cat <command>`
- nixosTests.gitea: remove emilylange from maintainers
- nixos/initrd-ssh: Only warn about shell when using systemd initrd
- ldeep: 1.0.43 -> 1.0.44
- python311Packages.aiomysensors: 0.3.9 -> 0.3.10
- python311Packages.pyparted: fix build for version 3.13.0
- python311Packages.pyparted: use pytestCheckHook
- shattered-pixel-dungeon: 2.1.4 -> 2.2.1
- nixosTests.shattered-pixel-dungeon: use wait_for_text
- python311Packages.pyenphase: 1.14.1 -> 1.14.2
- python311Packages.pyduotecno: 2023.11.0 -> 2023.11.1
- python311Packages.reolink-aio: 0.7.14 -> 0.7.15
- texlive: document new texlive.withPackages interface (#265658)
- python311Packages.python-songpal: 0.15.2 -> 0.16
- prismlauncher: 7.2 -> 8.0
- datafusion-cli: 31.0.0 -> 32.0.0
- syncthing: 1.25.0 -> 1.26.0
- doc: move doc/builders/packages -> doc/packages
- doc: move section darwin-builder under chapter packages
- doc: darwin.linux-builder: replace "builder" with "remote builder"
- doc: builders -> build helpers to reduce ambigualty
- doc: add introduction to build helpers
- doc: rename sub-section Recursive attributes in stdenv -> Fixed-point arguments in stdenv
- supersonic: 0.6.0 -> 0.7.0
- stellarium: fix version
- python311Packages.tlds: 2023102600 -> 2023110300
- sketchybar-app-font: 1.0.17 -> 1.0.20
- nfs-ganesha: 5.6 -> 5.7
- maintainers: add ahoneybun
- cosmic-edit: init at unstable-2023-11-02
- sigtop: 0.3.1 -> 0.7.0
- haskell.lib.packagesFromDirectory: only `.nix` files
- python310Packages.nvidia-ml-py: 12.535.108 -> 12.535.133
- tokyo-night-gtk: refactor and default to tokyo-night-gtk-variants.full
- signalbackup-tools: 20231106-1 -> 20231107-1
- vector: 0.33.1 → 0.34.0
- nixos/wireguard: add wireguard to default kernel modules
- wpsoffice: 11.1.0.11704 -> 11.1.0.11708
- python310Packages.optimum: 1.13.3 -> 1.14.0
- python310Packages.orange-canvas-core: 0.1.33 -> 0.1.35
- python310Packages.orange3: 3.36.1 -> 3.36.2
- go_1_20: 1.20.10 -> 1.20.11
- squawk: 0.24.1 -> 0.24.2
- gping: 1.14.0 -> 1.15.1
- python311Packages.pydrawise: 2023.10.0 -> 2023.11.0
- python311Packages.dbus-fast: 2.12.0 -> 2.13.1
- terraform-providers.mongodbatlas: 1.12.2 -> 1.12.3
- pulumiPackages.pulumi-azure-native: 2.11 -> 2.13
- dinghy: 1.3.0 -> 1.3.2; fix build
- python311Packages.archinfo: 9.2.75 -> 9.2.76
- python311Packages.ailment: 9.2.75 -> 9.2.76
- python311Packages.pyvex: 9.2.75 -> 9.2.76
- python311Packages.claripy: 9.2.75 -> 9.2.76
- python311Packages.angr: 9.2.75 -> 9.2.76
- python311Packages.cle: 9.2.75 -> 9.2.76
- gcc48: disable on x86_64-darwin
- gnucash: build and include documentation
- gnucash: avoid parameterizing pname
- phpExtensions.memprof: init at 3.0.2 (#266086)
- gtk4-layer-shell: 1.0.1 -> 1.0.2
- teller: fix build
- nest-cli: 10.1.17 -> 10.2.1
- python311Packages.tensorflow-probability: 0.19.0 -> 0.21.0
- python311Packages.tensorflow-probability: add GaetanLepage as maintainer
- python311Packages.dash: 2.13.0 -> 2.14.1
- python310Packages.paddle2onnx: 1.0.9 -> 1.1.0
- python311Packages.rank_bm25: rename to rank-bm25
- python311Packages.farm-haystack: init at 1.21.2
- python311Packages.transformers: 4.34.1 -> 4.35.0
- python311Packages.flax: dependencies and tests check up
- python3Packages.wikitextparser: 0.54.0 -> 0.55.5
- vaultwarden: add missing dependency
- gcc11: fix build on aarch64-darwin
- gcc{48,49,6}: don’t use -pipe with clang assembler
- gcc{8,9}: don’t pass --gstabs to clang assembler
- gcc{48,49,6,7,8,9,10}: fix missing symbol errors on x86_64-darwin
- gcc{48,49,6,7,8,9,10}: improve cctools-llvm compatibility
- Update pkgs/development/compilers/gcc/patches/default.nix
- spyder: 5.4.5 -> 5.5.0
- gerrit-queue: init at 0.0.1 (#265922)
- hyprland: 0.31.0 -> 0.32.0
- xdg-desktop-portal-hyprland: 1.2.3 -> 1.2.4
- vlc: 3.0.18 -> 3.0.20
- polkadot: remove asymmetric from maintainers
- libsolv: 0.7.25 -> 0.7.26
- linux_6_6: 6.6 -> 6.6.1
- linux_5_4: 5.4.259 -> 5.4.260
- linux_4_19: 4.19.297 -> 4.19.298
- linux_4_14: 4.14.328 -> 4.14.329
- linux/hardened/patches/6.1: 6.1.60-hardened1 -> 6.1.61-hardened1
- linux/hardened/patches/6.4: init at 6.4.16-hardened1
- linux/hardened/patches/6.5: 6.5.8-hardened1 -> 6.5.10-hardened1
- linuxPackages.evdi: mark broken on linux 6.6
- linuxPackages.evdi: fix build for Linux 4.19
- wyoming-faster-whisper fix CUDA devices not being detected. (#266167)
- python3Packages.wagtail: relax draftjs_exporter dep to allow using 5.0
- python3Packages.wagtail: 5.1.1 -> 5.1.3
- python3Packages.wagtail-localize: 1.5.2 -> 1.6
- linux_6_5: 6.5.10 -> 6.5.11
- linux_6_1: 6.1.61 -> 6.1.62
- python3Packages.bork: init at 7.0.0
- python3Packages.bork: Drop obsolete dependency on click
- python3Packages.bork: Add basic import checks
- fastfetch: 2.2.2 -> 2.2.3
- memtree: init at unstable-2023-11-04
- kubernetes-helm: 3.13.1 -> 3.13.2
- pdm: fix runtime error with "pdm init" #265883
- pdm: 2.10.0 -> 2.10.1
- python311Packages.azure-storage-file-share: 12.14.2 -> 12.15.0
- maintainers: update xfix's name and email
- python311Packages.htmllistparse: init at 0.6.1
- fix: solve changed commit tag in upstream for version 0.4.1
- python311Packages.pyglet: 2.0.9 -> 2.0.10
- odin: dev-2023-08 -> dev-2023-11
- maintainers: add volfyd
- ols: nightly-2023-07-09 -> nightly-2023-11-04
- dvb-apps: init at 1.1.1-unstable-2014-03-21
- spicetify-cli: 2.26.0 -> 2.27.0
- linuxKernel.kernels.linux_zen: 6.6-zen1 -> 6.6.1-zen1
- linuxKernel.kernels.linux_lqx: 6.5.10-lqx1 -> 6.5.11-lqx1
- google-compute-image: support NVMe and UEFI
- nixos/doc: release notes for `virtualisation.googleComputeImage.efi`
- python3Packages.cassandra-driver: 3.26.0 -> 3.28.0
- texlive.withPackages: respect .outputSpecified even for old style packages (#265645)
- alire: add meta.mainProgram
- php: add `phpSrc` attribute (#254556)
- lib.licenses: add NVIDIA licenses
- cudatoolkit: add NVIDIA license
- cudnn_cudatoolkit: add NVIDIA license
- lib.licenses: nvidia*: use same fullNames as conda does
- cudaPackages: redist components: per-package license url
- cudaPackages: redist: mark as prebuilt binary
- lib.licenses: nvidia*: add shortName-s
- cudaPackages: redist: EULA notice in the description
- jasper: 4.0.0 -> 4.0.1
- jasper: "remove" dev and lib outputs
- {anytype,dogdns,envchain,kafka-delta-ingest,nwg-launchers,pazi,starship,tab-rs,yggdrasil,zenith}: remove bbigras as maintainer
- quickemu: 4.8 -> 4.9
- xmake: 2.8.3 -> 2.8.5
- fetchgit: shallow clone for submodules (#254172)
- ocamlPackages.semver: 0.1.0 → 0.2.1
- coqPackages.vcfloat: fix
- vscode-extensions.ms-python.vscode-pylance: 2022.7.11 -> 2023.8.50
- fortune-kind: 0.1.7 -> 0.1.8

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
