### PR TITLE
ocamlPackages.camlidl: 1.11 → 1.12

### DIFF
--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -5,13 +5,13 @@ lib.throwIfNot (lib.versionAtLeast ocaml.version "4.03")
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-camlidl";
-  version = "1.11";
+  version = "1.12";
 
   src = fetchFromGitHub {
     owner = "xavierleroy";
     repo = "camlidl";
-    rev = "camlidl111";
-    sha256 = "sha256-8m0zem/6nvpEJtjJNP/+vafeVLlMvNQGdl8lyf/OeBg=";
+    rev = "camlidl112";
+    hash = "sha256-ONPQMDFaU2OzFa5jgMVKx+ZRKk8ZgBZyk42vDvbM7E0=";
   };
 
   nativeBuildInputs = [ ocaml ];
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     substituteInPlace config/Makefile --replace BINDIR=/usr/local/bin BINDIR=$out
     substituteInPlace config/Makefile --replace 'OCAMLLIB=$(shell $(OCAMLC) -where)' OCAMLLIB=$out/lib/ocaml/${ocaml.version}/site-lib/camlidl
     substituteInPlace config/Makefile --replace CPP=cpp CPP=${stdenv.cc}/bin/cpp
+    substituteInPlace lib/Makefile --replace '$(OCAMLLIB)/Makefile.config' "${ocaml}/lib/ocaml/Makefile.config"
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/caml
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/stublibs
   '';


### PR DESCRIPTION
## Description of changes

https://github.com/xavierleroy/camlidl/releases/tag/camlidl112

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
