### PR TITLE
python3Packages.click-aliases: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/development/python-modules/click-aliases/default.nix
+++ b/pkgs/development/python-modules/click-aliases/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "click-aliases";
-  version = "1.0.2";
+  version = "1.0.3";
 
   pyproject = true;
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "click-contrib";
     repo = "click-aliases";
     rev = "v${version}";
-    hash = "sha256-ZrNdxUMLRre0U9xCyyU8HjByNGMSXiuMDVjW9e88eyk=";
+    hash = "sha256-HTjo6ID27W7D4MZjeAJMSy5yVd6oKg0Ed9/kDtQZ7Vw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Small patch release with very few changes (mostly related to poetry), see:
https://github.com/click-contrib/click-aliases/compare/v1.0.2...v1.0.3

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages built:</summary>
  <ul>
    <li>nitrokey-app2</li>
    <li>nitrokey-app2.dist</li>
    <li>pynitrokey</li>
    <li>pynitrokey.dist</li>
    <li>python310Packages.click-aliases</li>
    <li>python310Packages.click-aliases.dist</li>
    <li>python311Packages.click-aliases</li>
    <li>python311Packages.click-aliases.dist</li>
  </ul>
</details>