### PR TITLE
emacsPackages.notdeft: init at 20211204.0846

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -65,6 +65,8 @@ in
 
   mu4e = callPackage ./manual-packages/mu4e { };
 
+  notdeft = callPackage ./manual-packages/notdeft { };
+
   ott-mode = callPackage ./manual-packages/ott-mode { };
 
   perl-completion = callPackage ./manual-packages/perl-completion { };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, trivialBuild
+, fetchFromGitHub
+, emacs
+, hydra
+, ivy
+, pkg-config
+, tclap
+, xapian
+  # Include pre-configured hydras
+, withHydra ? false
+  # Include Ivy integration
+, withIvy ? false
+}:
+
+let
+  pname = "notdeft";
+  version = "20211204.0846";
+
+  src = fetchFromGitHub {
+    owner = "hasu";
+    repo = "notdeft";
+    rev = "1b7054dcfc3547a7cafeb621552cec01d0540478";
+    hash = "sha256-LMMLJFVpmoE/y3MqrgY2fmsehmzk6TkLsVoHmFUxiSw=";
+  };
+
+  # Xapian bindings for NotDeft
+  notdeft-xapian = stdenv.mkDerivation {
+    pname = "notdeft-xapian";
+    inherit version src;
+
+    sourceRoot = "${src.name}/xapian";
+
+    nativeBuildInputs = [ pkg-config tclap xapian ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      cp notdeft-xapian $out/bin
+
+      runHook postInstall
+    '';
+  };
+in
+trivialBuild {
+  inherit pname version src;
+  packageRequires = lib.optional withHydra hydra
+    ++ lib.optional withIvy ivy;
+  buildInputs = [ xapian ];
+
+  postPatch = ''
+    substituteInPlace notdeft-xapian.el \
+      --replace 'defcustom notdeft-xapian-program nil' \
+                "defcustom notdeft-xapian-program \"${notdeft-xapian}/bin/notdeft-xapian\""
+  '';
+
+  # Extra modules are contained in the extras/ directory
+  preBuild = lib.optionalString withHydra ''
+    mv extras/notdeft-{mode-hydra,global-hydra}.el ./
+  '' +
+  lib.optionalString withIvy ''
+    mv extras/notdeft-ivy.el ./
+  '' + ''
+    rm -r extras/
+  '';
+
+  meta = with lib; {
+    homepage = "https://tero.hasu.is/notdeft/";
+    description = "Fork of Deft that uses Xapian as a search engine";
+    maintainers = [ maintainers.nessdoor ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A fork of Deft that relies on an external [Xapian](https://xapian.org/) search engine for faster handling of large note collections.

Homepage: https://tero.hasu.is/notdeft/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
