### PR TITLE
ddccontrol: Fix version number

### DIFF
--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , intltool
 , libxml2
@@ -32,6 +33,14 @@ stdenv.mkDerivation rec {
     pciutils
     gtk2
     ddccontrol-db
+  ];
+
+  patches = [
+    # Upstream commit, fixed the version number in v1.0.0
+    (fetchpatch {
+      url = "https://github.com/ddccontrol/ddccontrol/commit/fc8c5b5d0f2b64b08b95f4a7d8f47f2fd8ceec34.patch";
+      hash = "sha256-SB1BaolTNCUYgj38nMg1uLUqOHvnwCr8T3cnfu/7rjI=";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
## Description of changes

Pulled in an additional commit from upstream, updating the version number in
`configure.ac`.  Because it wasn't updated when releasing v1.0.0, the utility
wrongly reports its version as being 0.6.0.

cc @pakhfn


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- No automated tests available.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
