### PR TITLE
wolfssl: backport patch to fix tests

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , Security
 , autoreconfHook
 , util-linux
@@ -21,6 +22,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "refs/tags/v${finalAttrs.version}-stable";
     hash = "sha256-UN4zs+Rxh/bsLD1BQA+f1YN/UOJ6OB2HduhoetEp10Y=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-expected-test-response.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/ca694938fd053a8557f9f08b1b4265292d8bef65.patch";
+      hash = "sha256-ETxszjjEMk0WdYgXHWTxTaWZPpyDs9jdko0jtkjzgwI=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./scripts


### PR DESCRIPTION
This fixes the following build failure I get locally:

> ERROR - tests/api.c line 5684 failed with:
>     expected: test_ssl_memio_do_handshake(&test_ctx, 10, ((void *)0)) == (1)
>     result:   0 != 1
>
>  passed (  0.00945)
>    845: test_dtls13_bad_epoch_ch                            : skipped
>    846: test_wolfSSL_dtls13_null_cipher                     : skipped
>    847: test_dtls_msg_from_other_peer                       :Client message: hello wolfssl!
> Server response: I hear you fa shizzle!
>  passed (  0.00186)
>    848: test_dtls_ipv6_check                                : passed (  0.00008)
>    849: test_stubs_are_stubs                                : passed (  0.00000)
>
> FAILURES:
>     24: test_wolfSSL_CertManagerCheckOCSPResponse

This fix is not included in any released version of wolfssl, so this change is orthogonal to #264440.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
