### PR TITLE
yosys: 0.34 -> 0.35

### DIFF
--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "A tool for squential logic synthesis and formal verification";
     homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc";
     license     = licenses.mit;
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = with maintainers; [ thoughtpolice Luflosi ];
     mainProgram = "abc";
     platforms   = platforms.unix;
   };

--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -1,8 +1,11 @@
-{ lib, stdenv, fetchFromGitHub
-, readline, cmake
+{ lib
+, stdenv
+, fetchFromGitHub
+, readline
+, cmake
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname   = "abc-verifier";
   version = "unstable-2023-09-13";
 
@@ -16,10 +19,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];
 
-  installPhase = "mkdir -p $out/bin && mv abc $out/bin";
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 'abc' "$out/bin/abc"
+    runHook postInstall
+  '';
 
   # needed by yosys
-  passthru.rev = src.rev;
+  passthru.rev = finalAttrs.src.rev;
 
   meta = with lib; {
     description = "A tool for squential logic synthesis and formal verification";
@@ -29,4 +36,4 @@ stdenv.mkDerivation rec {
     mainProgram = "abc";
     platforms   = platforms.unix;
   };
-}
+})

--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname   = "abc-verifier";
-  version = "unstable-2023-09-13";
+  version = "unstable-2023-10-13";
 
   src = fetchFromGitHub {
     owner = "yosyshq";
     repo  = "abc";
-    rev   = "daad9ede0137dc58487a0abc126253e671a85b14";
-    hash  = "sha256-5XeFYvdqT08xduFUDC5yK1jEOV1fYzyQD7N9ZmG3mpQ=";
+    rev   = "896e5e7dedf9b9b1459fa019f1fa8aa8101fdf43";
+    hash  = "sha256-ou+E2lvDEOxXRXNygE/TyVi7quqk+CJHRI+HDI0xljE=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -150,6 +150,6 @@ in stdenv.mkDerivation rec {
     homepage    = "https://yosyshq.net/yosys/";
     license     = licenses.isc;
     platforms   = platforms.all;
-    maintainers = with maintainers; [ shell thoughtpolice emily ];
+    maintainers = with maintainers; [ shell thoughtpolice emily Luflosi ];
   };
 }

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -69,14 +69,14 @@ let
   } // (yosys-symbiflow);
 
 
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname   = "yosys";
   version = "0.34";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
-    rev   = "refs/tags/${pname}-${version}";
+    rev   = "refs/tags/${finalAttrs.pname}-${finalAttrs.version}";
     hash  = "sha256-GHDsMBj7DRb9ffESgzd1HzDAA6Cyft5PomidvIMzn9g=";
   };
 
@@ -101,7 +101,7 @@ in stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./Makefile \
-      --replace 'echo UNKNOWN' 'echo ${builtins.substring 0 10 src.rev}'
+      --replace 'echo UNKNOWN' 'echo ${builtins.substring 0 10 finalAttrs.src.rev}'
 
     chmod +x ./misc/yosys-config.in
     patchShebangs tests ./misc/yosys-config.in
@@ -120,7 +120,7 @@ in stdenv.mkDerivation rec {
     fi
 
     if ! grep -q "YOSYS_VER := $version" Makefile; then
-      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (allegedly ${version}), failing."
+      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (allegedly ${finalAttrs.version}), failing."
       exit 1
     fi
   '';
@@ -152,4 +152,4 @@ in stdenv.mkDerivation rec {
     platforms   = platforms.all;
     maintainers = with maintainers; [ shell thoughtpolice emily Luflosi ];
   };
-}
+})

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -71,13 +71,13 @@ let
 
 in stdenv.mkDerivation (finalAttrs: {
   pname   = "yosys";
-  version = "0.34";
+  version = "0.35";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
     rev   = "refs/tags/${finalAttrs.pname}-${finalAttrs.version}";
-    hash  = "sha256-GHDsMBj7DRb9ffESgzd1HzDAA6Cyft5PomidvIMzn9g=";
+    hash  = "sha256-jB8y7XGDX9rVF6c4FSTLOyvsxPhdjU8Taj6MQeoU4KQ=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes
https://github.com/YosysHQ/yosys/releases/tag/yosys-0.35

Also update abc-verifier to the version yosys requires, do some cleanup and add myself as a maintainer.

`python3Packages.edalize` (and the dependent packages `fusesoc` and `silice`) also fail to compile without this PR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).