### PR TITLE
mpvScripts.thumbfast: unstable-2023-06-06 → 2023-06-08

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -20,7 +20,7 @@ in lib.recurseIntoAttrs
     quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };
-    thumbfast = callPackage ./thumbfast.nix { };
+    thumbfast = callPackage ./thumbfast.nix { inherit buildLua; };
     thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };
     uosc = callPackage ./uosc.nix { };
     visualizer = callPackage ./visualizer.nix { };

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -7,8 +7,8 @@ buildLua {
   src = fetchFromGitHub {
     owner = "po5";
     repo = "thumbfast";
-    rev = "6f1d92da25a7b807427f55f085e7ad4d60c4e0d7";
-    hash = "sha256-7CCxMPmZZRDIcWn+YbV4xzZFL80qZS5UFA25E+Y2P2Q=";
+    rev = "4241c7daa444d3859b51b65a39d30e922adb87e9";
+    hash = "sha256-7EnFJVjEzqhWXAvhzURoOp/kad6WzwyidWxug6u8lVw=";
   };
 
   postPatch = ''

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -1,7 +1,7 @@
-{ lib, stdenvNoCC, fetchFromGitHub, mpv-unwrapped }:
+{ lib, fetchFromGitHub, buildLua, mpv-unwrapped }:
 
-stdenvNoCC.mkDerivation {
-  name = "mpv-thumbfast";
+buildLua {
+  pname = "mpv-thumbfast";
   version = "unstable-2023-06-04";
 
   src = fetchFromGitHub {
@@ -16,18 +16,7 @@ stdenvNoCC.mkDerivation {
       --replace 'mpv_path = "mpv"' 'mpv_path = "${lib.getExe mpv-unwrapped}"'
   '';
 
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/mpv/scripts
-    cp -r thumbfast.lua $out/share/mpv/scripts/thumbfast.lua
-
-    runHook postInstall
-  '';
-
-  passthru.scriptName = "thumbfast.lua";
+  scriptPath = "thumbfast.lua";
 
   meta = {
     description = "High-performance on-the-fly thumbnailer for mpv";


### PR DESCRIPTION
## Description of changes

In `mpvScripts.thumbfast`:
- refactored using the `buildLua` helper;
- updated to a commit from 2023-06-08 (2 days later) to include a bugfix.

cc @apfelkuchen6


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
