### PR TITLE
mpvScripts.convert: refactor around `buildLua`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -1,7 +1,7 @@
-{ stdenvNoCC, fetchgit, lib
+{ lib, fetchgit, buildLua
 , yad, mkvtoolnix-cli, libnotify }:
 
-stdenvNoCC.mkDerivation {
+buildLua {
   pname = "mpv-convert-script";
   version = "2016-03-18";
   src = fetchgit {
@@ -22,15 +22,9 @@ stdenvNoCC.mkDerivation {
                 'yad_exe = "${yad}/bin/yad"' \
       --replace 'notify_send_exe = "notify-send"' \
                 'notify_send_exe = "${libnotify}/bin/notify-send"' \
-
   '';
 
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/share/mpv/scripts
-    cp convert_script.lua $out/share/mpv/scripts
-  '';
-  passthru.scriptName = "convert_script.lua";
+  scriptPath = "convert_script.lua";
 
   meta = with lib; {
     description = "Convert parts of a video while you are watching it in mpv";

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -11,7 +11,7 @@ in lib.recurseIntoAttrs
     autodeint = callPackage ./autodeint.nix { };
     autoload = callPackage ./autoload.nix { };
     chapterskip = callPackage ./chapterskip.nix { inherit buildLua; };
-    convert = callPackage ./convert.nix { };
+    convert = callPackage ./convert.nix { inherit buildLua; };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };


### PR DESCRIPTION
## Description of changes

Refactored `mpvScripts.convert` using the new `buildLua` helper.

cc @Profpatsch


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
