### PR TITLE
pharo: 10.0.5 -> 10.0.8

### DIFF
--- a/pkgs/development/pharo/default.nix
+++ b/pkgs/development/pharo/default.nix
@@ -23,8 +23,8 @@ let
   pharo-sources = fetchurl {
     # It is necessary to download from there instead of from the repository because that archive
     # also contains artifacts necessary for the bootstrapping.
-    url = "https://files.pharo.org/vm/pharo-spur64-headless/Linux-x86_64/source/PharoVM-10.0.5-2757766-Linux-x86_64-c-src.zip";
-    hash = "sha256-i6WwhdVdyzmqGlx1Fn12mCq5+HnRORT65HEiJo0joCE=";
+    url = "https://files.pharo.org/vm/pharo-spur64-headless/Linux-x86_64/source/PharoVM-10.0.8-b323c5f-Linux-x86_64-c-src.zip";
+    hash = "sha256-5IHymk6yl3pMLG3FeM4nqos0yLYMa3B2+hYW08Yo1V0=";
   };
   library_path = makeLibraryPath [
     libgit2
@@ -35,7 +35,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "pharo";
-  version = "10.0.5";
+  version = "10.0.8";
   src = pharo-sources;
 
   buildInputs = [
@@ -64,6 +64,8 @@ stdenv.mkDerivation {
   cmakeFlags = [
     # Necessary to perform the bootstrapping without already having Pharo available.
     "-DGENERATED_SOURCE_DIR=."
+    "-DALWAYS_INTERACTIVE=ON"
+    "-DBUILD_IS_RELEASE=ON"
     "-DGENERATE_SOURCES=OFF"
     # Prevents CMake from trying to download stuff.
     "-DBUILD_BUNDLE=OFF"


### PR DESCRIPTION
## Description of changes

- Version pdate
- Additional CMake flags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
