### PR TITLE
mpvScripts.{mpv-playlistmanager, quality-menu}: Refactor & update

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -14,7 +14,7 @@ in lib.recurseIntoAttrs
     convert = callPackage ./convert.nix { };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
-    mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
+    mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { inherit buildLua; };
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { };
     quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -17,7 +17,7 @@ in lib.recurseIntoAttrs
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { };
-    quality-menu = callPackage ./quality-menu.nix { };
+    quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };
     thumbfast = callPackage ./thumbfast.nix { };

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -1,6 +1,6 @@
-{ lib, stdenvNoCC, fetchFromGitHub, yt-dlp }:
+{ lib, buildLua, fetchFromGitHub, yt-dlp }:
 
-stdenvNoCC.mkDerivation rec {
+buildLua rec {
   pname = "mpv-playlistmanager";
   version = "unstable-2023-08-09";
 
@@ -17,21 +17,12 @@ stdenvNoCC.mkDerivation rec {
       'youtube_dl_executable = "${lib.getBin yt-dlp}/bin/yt-dlp"',
   '';
 
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-    install -D -t $out/share/mpv/scripts playlistmanager.lua
-    runHook postInstall
-  '';
-
-  passthru.scriptName = "playlistmanager.lua";
+  scriptPath = "playlistmanager.lua";
 
   meta = with lib; {
     description = "Mpv lua script to create and manage playlists";
     homepage = "https://github.com/jonniek/mpv-playlistmanager";
     license = licenses.unlicense;
-    platforms = platforms.all;
     maintainers = with maintainers; [ lunik1 ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -6,13 +6,13 @@
 
 buildLua rec {
   pname = "mpv-quality-menu";
-  version = "4.1.0";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "christoph-heinrich";
     repo = "mpv-quality-menu";
     rev = "v${version}";
-    hash = "sha256-93WoTeX61xzbjx/tgBgUVuwyR9MkAUzCfVSrbAC7Ddc=";
+    hash = "sha256-yrcTxqpLnOI1Tq3khhflO3wzhyeTPuvKifyH5/P57Ns=";
   };
 
   passthru.scriptName = "quality-menu.lua";

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -1,10 +1,10 @@
 { lib
-, stdenvNoCC
+, buildLua
 , fetchFromGitHub
 , oscSupport ? false
 }:
 
-stdenvNoCC.mkDerivation rec {
+buildLua rec {
   pname = "mpv-quality-menu";
   version = "4.1.0";
 
@@ -15,19 +15,8 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-93WoTeX61xzbjx/tgBgUVuwyR9MkAUzCfVSrbAC7Ddc=";
   };
 
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/mpv/scripts
-    cp quality-menu.lua $out/share/mpv/scripts
-  '' + lib.optionalString oscSupport ''
-    cp quality-menu-osc.lua $out/share/mpv/scripts
-  '' + ''
-    runHook postInstall
-  '';
-
   passthru.scriptName = "quality-menu.lua";
+  scriptPath = if oscSupport then "*.lua" else passthru.scriptName;
 
   meta = with lib; {
     description = "A userscript for MPV that allows you to change youtube video quality (ytdl-format) on the fly";


### PR DESCRIPTION
## Description of changes

- `mpvScripts`: Refactor `mpv-playlistmanager` and `quality-menu` using the new `buildLua` helper.
- `mpvScripts.quality-menu`: 4.1.0 → 4.1.1

cc @lunik1


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
