### PR TITLE
freecad: switch back to isolated config with env vars turned on

### DIFF
--- a/pkgs/applications/graphics/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+++ b/pkgs/applications/graphics/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -24,12 +24,13 @@ diff --git a/src/Base/Interpreter.cpp b/src/Base/Interpreter.cpp
 index 52c47168af..9966bd0013 100644
 --- a/src/Base/Interpreter.cpp
 +++ b/src/Base/Interpreter.cpp
-@@ -554,7 +554,7 @@ void initInterpreter(int argc,char *argv[])
+@@ -554,7 +554,9 @@ void initInterpreter(int argc,char *argv[])
  {
      PyStatus status;
      PyConfig config;
--    PyConfig_InitIsolatedConfig(&config);
-+    PyConfig_InitPythonConfig(&config);
+     PyConfig_InitIsolatedConfig(&config);
++    config.isolated = 0;
++    config.use_environment = 1;
  
      status = PyConfig_SetBytesArgv(&config, argc, argv);
      if (PyStatus_Exception(status)) {

--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -9,6 +9,7 @@
 , boost
 , coin3d
 , eigen
+, freecad  # for passthru.tests
 , gfortran
 , gts
 , hdf5
@@ -35,6 +36,7 @@
 , qtwebengine
 , qtx11extras
 , qtxmlpatterns
+, runCommand  # for passthru.tests
 , scipy
 , shiboken2
 , soqt
@@ -146,6 +148,21 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/bin/FreeCAD $out/bin/freecad
     ln -s $out/bin/FreeCADCmd $out/bin/freecadcmd
   '';
+
+  passthru.tests = {
+    # Check that things such as argument parsing still work correctly with
+    # the above PYTHONPATH patch. Previously the patch used above changed
+    # the `PyConfig_InitIsolatedConfig` to `PyConfig_InitPythonConfig`,
+    # which caused the built-in interpreter to attempt (and fail) to doubly
+    # parse argv. This should catch if that ever regresses and also ensures
+    # that PYTHONPATH is still respected enough for the FreeCAD console to
+    # successfully run and check that it was included in `sys.path`.
+    python-path = runCommand "freecad-test-console" {
+      nativeBuildInputs = [ freecad ];
+    } ''
+      HOME="$(mktemp -d)" PYTHONPATH="$(pwd)/test" FreeCADCmd --log-file $out -c "if not '$(pwd)/test' in sys.path: sys.exit(1)" </dev/null
+    '';
+  };
 
   meta = {
     homepage = "https://www.freecad.org";


### PR DESCRIPTION
## Description of changes

Fixes some environmental issues with FreeCAD, such as the Python interpreter erroneously parsing `argv` in #266246

Fixes #266246

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).