### PR TITLE
mpvScripts.mpvacious: Refactor and update to v0.25

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -16,7 +16,7 @@ in lib.recurseIntoAttrs
     mpris = callPackage ./mpris.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { inherit buildLua; };
     mpv-webm = callPackage ./mpv-webm.nix { };
-    mpvacious = callPackage ./mpvacious.nix { };
+    mpvacious = callPackage ./mpvacious.nix { inherit buildLua; };
     quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -1,12 +1,12 @@
 { lib
-, stdenvNoCC
+, buildLua
 , fetchFromGitHub
 , curl
 , wl-clipboard
 , xclip
 }:
 
-stdenvNoCC.mkDerivation rec {
+buildLua rec {
   pname = "mpvacious";
   version = "0.24";
 
@@ -26,23 +26,16 @@ stdenvNoCC.mkDerivation rec {
       --replace "'xclip" "'${xclip}/bin/xclip"
   '';
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
-    rm -r .github
-    mkdir -p $out/share/mpv/scripts
-    cp -r . $out/share/mpv/scripts/mpvacious
+    make PREFIX=$out/share/mpv install
     runHook postInstall
   '';
-
-  passthru.scriptName = "mpvacious";
 
   meta = with lib; {
     description = "Adds mpv keybindings to create Anki cards from movies and TV shows";
     homepage = "https://github.com/Ajatt-Tools/mpvacious";
     license = licenses.gpl3Plus;
-    platforms = platforms.all;
     maintainers = with maintainers; [ kmicklas ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -8,13 +8,13 @@
 
 buildLua rec {
   pname = "mpvacious";
-  version = "0.24";
+  version = "0.25";
 
   src = fetchFromGitHub {
     owner = "Ajatt-Tools";
     repo = "mpvacious";
     rev = "v${version}";
-    sha256 = "sha256-o0YcoSI+4934HlyIoI5V1h/FalCe+6tXS8Lg6kXWjSg=";
+    sha256 = "sha256-XTnib4cguWFEvZtmsLfkesbjFbkt2YoyYLT587ajyUM=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

In `mpvScripts`:
- extend `buildLua` to handle scripts [packaged as directories];
- `mpvacious`: v0.24 → 0.25 and refactor with `buildLua`.

[packaged as directories]: https://mpv.io/manual/master/#script-location


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
