### PR TITLE
mpvScripts.simple-mpv-webui: 2.1.0 → 3.0.0

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -2,8 +2,18 @@
 , stdenvNoCC }:
 
 let
+  inherit (lib) hasPrefix hasSuffix removeSuffix;
   escapedList = with lib; concatMapStringsSep " " (s: "'${escape [ "'" ] s}'");
   fileName = pathStr: lib.last (lib.splitString "/" pathStr);
+  nameFromPath = pathStr:
+    let fN = fileName pathStr; in
+    if hasSuffix ".lua" fN then
+      fN
+    else if !(hasPrefix "." fN) then
+      "${fN}.lua"
+    else
+      null
+  ;
   scriptsDir = "$out/share/mpv/scripts";
 in
 lib.makeOverridable (
@@ -13,8 +23,8 @@ lib.makeOverridable (
   let
     # either passthru.scriptName, inferred from scriptPath, or from pname
     scriptName = (args.passthru or {}).scriptName or (
-      if args ? scriptPath
-      then fileName args.scriptPath
+      if args ? scriptPath && nameFromPath args.scriptPath != null
+      then nameFromPath args.scriptPath
       else "${pname}.lua"
     );
     scriptPath = args.scriptPath or "./${scriptName}";
@@ -26,8 +36,24 @@ lib.makeOverridable (
     outputHashMode = "recursive";
     installPhase = ''
       runHook preInstall
-      install -m644 -Dt "${scriptsDir}" \
-        ${escapedList ([ scriptPath ] ++ extraScripts)}
+
+      if [ -d "${scriptPath}" ]; then
+        [ -f "${scriptPath}/main.lua" ] || {
+          echo "Script directory '${scriptPath}' does not contain 'main.lua'" >&2
+          exit 1
+        }
+        [ ${with builtins; toString (length extraScripts)} -eq 0 ] || {
+          echo "mpvScripts.buildLua does not support 'extraScripts'" \
+               "when 'scriptPath' is a directory"
+          exit 1
+        }
+        mkdir -p "${scriptsDir}"
+        cp -a "${scriptPath}" "${scriptsDir}/${lib.removeSuffix ".lua" scriptName}"
+      else
+        install -m644 -Dt "${scriptsDir}" \
+          ${escapedList ([ scriptPath ] ++ extraScripts)}
+      fi
+
       runHook postInstall
     '';
 

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -18,7 +18,7 @@ in lib.recurseIntoAttrs
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { inherit buildLua; };
     quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
-    simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
+    simple-mpv-webui = callPackage ./simple-mpv-webui.nix { inherit buildLua; };
     sponsorblock = callPackage ./sponsorblock.nix { };
     thumbfast = callPackage ./thumbfast.nix { inherit buildLua; };
     thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -2,17 +2,18 @@
 , fetchFromGitHub }:
 buildLua rec {
   pname = "simple-mpv-ui";
-  version = "2.1.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "open-dynaMIX";
     repo = "simple-mpv-webui";
     rev = "v${version}";
-    sha256 = "1z0y8sdv5mbxznxqh43w5592ym688vkvqg7w26p8cinrhf09pbw8";
+    hash = "sha256-I8lwpo3Hfpy3UnPMmHEJCdArVQnNL245NkxsYVmnMF0=";
+    sparseCheckout = [ "main.lua" "webui-page" ];
   };
 
-  scriptPath = "webui.lua";
-  postInstall = "cp -a webui-page $out/share/mpv/scripts/";
+  scriptPath = ".";
+  passthru.scriptName = "webui.lua";
 
   meta = with lib; {
     description = "A web based user interface with controls for the mpv mediaplayer";

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -1,6 +1,6 @@
-{ lib, stdenvNoCC
+{ lib, buildLua
 , fetchFromGitHub }:
-stdenvNoCC.mkDerivation rec {
+buildLua rec {
   pname = "simple-mpv-ui";
   version = "2.1.0";
 
@@ -11,12 +11,8 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "1z0y8sdv5mbxznxqh43w5592ym688vkvqg7w26p8cinrhf09pbw8";
   };
 
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/share/mpv/scripts
-    cp -r webui.lua webui-page $out/share/mpv/scripts/
-  '';
-  passthru.scriptName = "webui.lua";
+  scriptPath = "webui.lua";
+  postInstall = "cp -a webui-page $out/share/mpv/scripts/";
 
   meta = with lib; {
     description = "A web based user interface with controls for the mpv mediaplayer";
@@ -30,4 +26,3 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.mit;
   };
 }
-


### PR DESCRIPTION
## Description of changes

In `mpvScripts`:
- update `buildLua` to handle scripts packaged as directories ;
- refactor `simple-mpv-ui` using `buildLua` and update to v3.0.0.

cc @cript0nauta, @zopieux


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
