### PR TITLE
mpvScripts.thumbnail: Refactor with `buildLua`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -21,7 +21,7 @@ in lib.recurseIntoAttrs
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };
     thumbfast = callPackage ./thumbfast.nix { };
-    thumbnail = callPackage ./thumbnail.nix { };
+    thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };
     uosc = callPackage ./uosc.nix { };
     visualizer = callPackage ./visualizer.nix { };
     vr-reversal = callPackage ./vr-reversal.nix { };

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -1,6 +1,6 @@
-{ lib, stdenvNoCC, fetchFromGitHub, python3 }:
+{ lib, buildLua, fetchFromGitHub, python3 }:
 
-stdenvNoCC.mkDerivation rec {
+buildLua rec {
   pname = "mpv-thumbnail-script";
   version = "0.5.3";
 
@@ -12,19 +12,10 @@ stdenvNoCC.mkDerivation rec {
   };
 
   nativeBuildInputs = [ python3 ];
+  postPatch = "patchShebangs concat_files.py";
+  dontBuild = false;
 
-  postPatch = ''
-    patchShebangs concat_files.py
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/mpv/scripts
-    cp mpv_thumbnail_script_{client_osc,server}.lua $out/share/mpv/scripts
-    runHook postInstall
-  '';
-
-  passthru.scriptName = "mpv_thumbnail_script_{client_osc,server}.lua";
+  scriptPath = "mpv_thumbnail_script_{client_osc,server}.lua";
 
   meta = with lib; {
     description = "A lua script to show preview thumbnails in mpv's OSC seekbar";


### PR DESCRIPTION
## Description of changes

Refactored `mpvScripts.thumbnail` using the new `buildLua` helper.

cc @figsoda


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  ... but I checked there is no significant difference in the output (using `diff -r`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
