### PR TITLE
nixos/modules/services/web-apps/miniflux: fix permissions for PostgreSQL 15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -588,6 +588,12 @@
     githubId = 4717906;
     name = "Jakub Skokan";
   };
+  ajaxbits = {
+    email = "contact@ajaxbits.com";
+    github = "ajaxbits";
+    githubId = 45179933;
+    name = "Ajax";
+  };
   ajgrf = {
     email = "a@ajgrf.com";
     github = "ajgrf";

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -13,6 +13,7 @@ let
   preStart = pkgs.writeScript "miniflux-pre-start" ''
     #!${pkgs.runtimeShell}
     ${pgbin}/psql "${dbName}" -c "CREATE EXTENSION IF NOT EXISTS hstore"
+    ${pgbin}/psql "${dbName}" -c "ALTER DATABASE ${dbName} OWNER TO ${dbUser};"
   '';
 in
 

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -19,7 +19,7 @@ let
 in
 {
   name = "miniflux";
-  meta.maintainers = [ ];
+  meta.maintainers = with lib.maintainers; [ ajaxbits ];
 
   nodes = {
     default =


### PR DESCRIPTION
In 23.11 and above, `services.postgresql` is going to [default to Postgres 15](https://github.com/NixOS/nixpkgs/commit/e0379772393d14090d1b112a7340bfefe580b0c9).  Postgres 15 [removes `CREATE` permissions](https://www.postgresql.org/about/news/postgresql-15-released-2526/) for all users on the `public` schema. 

Miniflux [needs `CREATE` permissions](https://github.com/miniflux/v2/blob/1bd5d57884a9a812ae8e703ca5a5502a702b9551/internal/database/migrations.go#L16) in order to do migrations. This PR adds that capability back.

Associated NixOS tests now pass successfully.

Part of ZHF: #265948

## Description of changes

- Makes the miniflux `${dbUser}` the owner of the `${dbName}` database. Giving them all necessary permissions.
- Adds a maintainer to the associated NixOS test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) [Made sure it worked with `nixos-shell`].
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
