### PR TITLE
root5: Fix build

### DIFF
--- a/pkgs/applications/science/misc/root/5.nix
+++ b/pkgs/applications/science/misc/root/5.nix
@@ -64,6 +64,9 @@ stdenv.mkDerivation rec {
       url = "https://github.com/root-project/root/commit/c75458024082de0cc35b45505c652b8460a9e71b.patch";
       sha256 = "sha256-A5zEjQE9OGPFp/L1HUs4NIdxQMRiwbwCRNWOLN2ENrM=";
     })
+    # Backport Python 3.11 fix to v5 from v6.26
+    # https://github.com/root-project/root/commit/484deb056dacf768aba4954073b41105c431bffc
+    ./root5-python311-fix.patch
   ];
 
   # https://github.com/root-project/root/issues/13216

--- a/pkgs/applications/science/misc/root/root5-python311-fix.patch
+++ b/pkgs/applications/science/misc/root/root5-python311-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/bindings/pyroot/src/MethodProxy.cxx b/bindings/pyroot/src/MethodProxy.cxx
+--- a/bindings/pyroot/src/MethodProxy.cxx
++++ b/bindings/pyroot/src/MethodProxy.cxx
+@@ -4,10 +4,10 @@
+ // Bindings
+ #include "PyROOT.h"
+ #include "structmember.h"    // from Python
+-#if PY_VERSION_HEX >= 0x02050000
+-#include "code.h"            // from Python
+-#else
++#if PY_VERSION_HEX < 0x02050000
+ #include "compile.h"         // from Python
++#elif PY_VERSION_HEX < 0x030b0000
++#include "code.h"            // from Python
+ #endif
+ #ifndef CO_NOFREE
+ // python2.2 does not have CO_NOFREE defined

--- a/pkgs/development/libraries/physics/apfelgrid/default.nix
+++ b/pkgs/development/libraries/physics/apfelgrid/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Ultra-fast theory predictions for collider observables";
     license     = licenses.mit;
-    homepage    = "http://nhartland.github.io/APFELgrid/";
+    homepage    = "https://nhartland.github.io/APFELgrid/";
     platforms   = platforms.unix;
     maintainers = with maintainers; [ veprbl ];
   };


### PR DESCRIPTION
## Description of changes

Fixes root5, fixing the builds for applgrid, apfelgrid and xfitter

Done during [Nix Hour 51](https://www.youtube.com/watch?v=90BEKi4Iz8U&list=PLyzwHTVJlRc8yjlx4VR4LU5A5O44og9in&index=1&pp=iAQB), for ZHF https://github.com/NixOS/nixpkgs/issues/265948

See also https://github.com/NixOS/nixpkgs/pull/266538 for dropping root5

## Things done

- [x] Built successfully for all commits on x86_64-linux:
  - [x] root5
  - [x] applgrid
  - [x] apfelgrid
  - [x] xfitter