### PR TITLE
litterbox: init at 1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -601,6 +601,12 @@
     githubId = 1229027;
     name = "Andreas Schrägle";
   };
+  ajwhouse = {
+    email = "adam@ajwh.chat";
+    github = "ajwhouse";
+    githubId = 56616368;
+    name = "Adam House";
+  };
   ak = {
     email = "ak@formalprivacy.com";
     github = "alexanderkjeldaas";

--- a/pkgs/by-name/li/litterbox/package.nix
+++ b/pkgs/by-name/li/litterbox/package.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, libressl, fetchzip, pkg-config, sqlite }:
+
+stdenv.mkDerivation rec {
+  pname = "litterbox";
+  version = "1.9";
+
+  src = fetchzip {
+    url = "https://git.causal.agency/litterbox/snapshot/litterbox-${version}.tar.gz";
+    hash = "sha256-w4qW7J5CKm+hXHsNNbl9roBslHD14JOe0Nj5WntETqM=";
+  };
+
+  buildInputs = [ libressl sqlite ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  strictDeps = true;
+
+  buildFlags = [ "all" ];
+
+  meta = with lib; {
+    description = "Simple TLS-only IRC logger";
+    homepage = "https://code.causal.agency/june/litterbox";
+    license = licenses.gpl3Plus;
+    mainProgram = "litterbox";
+    maintainers = with maintainers; [ ajwhouse ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

[Litterbox](https://git.causal.agency/litterbox/about/) is a simple IRC logger that is designed to work with [pounce](https://git.causal.agency/pounce/about/), which is [already in nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/servers/pounce/default.nix#L24).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->