### PR TITLE
monaspace: init at v1.000

### DIFF
--- a/pkgs/data/fonts/monaspace/default.nix
+++ b/pkgs/data/fonts/monaspace/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "monaspace";
+  version = "1.000";
+
+  src = fetchzip {
+    url = "https://github.com/githubnext/monaspace/releases/download/v${version}/monaspace-v${version}.zip";
+    hash = "sha256-H8NOS+pVkrY9DofuJhPR2OlzkF4fMdmP2zfDBfrk83A=";
+    stripRoot = false;
+  };
+
+  outputs = [ "out" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/monaspace
+    mkdir -p $out/share/fonts/monaspace-variable
+
+    cp monaspace-v${version}/fonts/otf/*.otf $out/share/fonts/monaspace
+    cp monaspace-v${version}/fonts/variable/*.ttf $out/share/fonts/monaspace-variable
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Monaspace";
+    longDescription = "An innovative superfamily of fonts for code.";
+    homepage = "https://monaspace.githubnext.com/";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6042,6 +6042,8 @@ with pkgs;
     inherit (gst_all_1) gstreamer gst-plugins-base;
   };
 
+  monaspace = callPackage ../data/fonts/monaspace { };
+
   mons = callPackage ../tools/misc/mons { };
 
   monsoon = callPackage ../tools/security/monsoon { };


### PR DESCRIPTION
## Description of changes

This adds the "Monaspace type system" to nixpkgs. It is a just-released font from Github. More information: https://monaspace.githubnext.com/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).