### PR TITLE
clippy-sarif: init at 0.4.2

### DIFF
--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  clippy,
+  clippy-sarif,
+  testers,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "clippy-sarif";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "psastras";
+    repo = "sarif-rs";
+    rev = "clippy-sarif-v${version}";
+    hash = "sha256-EzWzDeIeSJ11CVcVyAhMjYQJcKHnieRrFkULc5eXAno=";
+  };
+
+  cargoHash = "sha256-F3NrqkqLdvMRIuozCMMqwlrrf5QrnmcEhy4TGSzPhiU=";
+  cargoBuildFlags = [
+    "--package"
+    "clippy-sarif"
+  ];
+  cargoTestFlags = cargoBuildFlags;
+
+  passthru = {
+    tests.version = testers.testVersion { package = clippy-sarif; };
+  };
+
+  meta = {
+    description = "A CLI tool to convert clippy diagnostics into SARIF";
+    mainProgram = "clippy-sarif";
+    homepage = "https://psastras.github.io/sarif-rs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ getchoo ];
+    inherit (clippy.meta) platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

`clippy-sarif` is a CLI tool to convert clippy diagnostics into SARIF. It is a part of the [sarif-rs](https://psastras.github.io/sarif-rs/) group of projects.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
