### PR TITLE
blisp: add bdd as maintainer

### DIFF
--- a/pkgs/development/embedded/blisp/default.nix
+++ b/pkgs/development/embedded/blisp/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     mainProgram = "blisp";
     homepage = "https://github.com/pine64/blisp";
-    maintainers = [ maintainers.fortuneteller2k ];
+    maintainers = [ maintainers.bdd ];
   };
 })


### PR DESCRIPTION
## Description of changes

Add myself as a maintainer.

Looks like current sole maintainer @fortuneteller2k is no longer on GitHub.
