### PR TITLE
[staging-next] python311Packages.shiboken2: use llvmPackages_15 since pyside2 only supports libclang<16

### DIFF
--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , qt5
 , libxcrypt
-, llvmPackages
+, llvmPackages_15
 }:
 
 stdenv.mkDerivation {
@@ -21,12 +21,12 @@ stdenv.mkDerivation {
     cd sources/shiboken2
   '';
 
-  CLANG_INSTALL_DIR = llvmPackages.libclang.out;
+  CLANG_INSTALL_DIR = llvmPackages_15.libclang.out;
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    llvmPackages.libclang
+    llvmPackages_15.libclang
     python
     python.pkgs.setuptools
     qt5.qtbase

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12787,7 +12787,7 @@ self: super: with self; {
   shellingham = callPackage ../development/python-modules/shellingham { };
 
   shiboken2 = toPythonModule (callPackage ../development/python-modules/shiboken2 {
-    inherit (pkgs) cmake llvmPackages qt5;
+    inherit (pkgs) cmake llvmPackages_15 qt5;
   });
 
   shiboken6 = toPythonModule (callPackage ../development/python-modules/shiboken6 {


### PR DESCRIPTION
## Description of changes

Fixes broken pyside2 build: https://hydra.nixos.org/build/239892291

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>tumpa</li>
    <li>tumpa.dist</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build: (broken on master, unrelated to this PR)</summary>
  <ul>
    <li>cutter</li>
    <li>cutterPlugins.rz-ghidra</li>
  </ul>
</details>
<details>
  <summary>26 packages built:</summary>
  <ul>
    <li>freecad</li>
    <li>napari (python311Packages.napari)</li>
    <li>napari.dist (python311Packages.napari.dist)</li>
    <li>natron</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>patray</li>
    <li>patray.dist</li>
    <li>python310Packages.magicgui</li>
    <li>python310Packages.magicgui.dist</li>
    <li>python310Packages.napari</li>
    <li>python310Packages.napari-npe2</li>
    <li>python310Packages.napari-npe2.dist</li>
    <li>python310Packages.napari.dist</li>
    <li>python310Packages.pyside2</li>
    <li>python310Packages.pyside2-tools</li>
    <li>python310Packages.shiboken2</li>
    <li>python311Packages.magicgui</li>
    <li>python311Packages.magicgui.dist</li>
    <li>python311Packages.napari-npe2</li>
    <li>python311Packages.napari-npe2.dist</li>
    <li>python311Packages.pyside2</li>
    <li>python311Packages.pyside2-tools</li>
    <li>python311Packages.shiboken2</li>
    <li>renderdoc</li>
    <li>sl1-to-photon</li>
  </ul>
</details>