### PR TITLE
osmo-rtl-sdr: init at 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16513,6 +16513,11 @@
     githubId = 158321;
     name = "Stewart Mackenzie";
   };
+  skovati = {
+    github = "skovati";
+    githubId = 49844593;
+    name = "skovati";
+  };
   skykanin = {
     github = "skykanin";
     githubId = 3789764;

--- a/pkgs/by-name/rt/rtl-sdr-osmocom/package.nix
+++ b/pkgs/by-name/rt/rtl-sdr-osmocom/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, cmake
+, pkg-config
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rtl-sdr-osmocom";
+  version = "2.0.1";
+
+  src = fetchFromGitea {
+    domain = "gitea.osmocom.org";
+    owner = "sdr";
+    repo = "rtl-sdr";
+    rev = "v${version}";
+    hash = "sha256-+RYSCn+wAkb9e7NRI5kLY8a6OXtJu7QcSUht1R6wDX0=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d" \
+      --replace "VERSION_INFO_PATCH_VERSION git" "VERSION_INFO_PATCH_VERSION ${lib.versions.patch version}"
+
+    substituteInPlace rtl-sdr.rules \
+      --replace 'MODE:="0666"' 'ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"'
+  '';
+
+  nativeBuildInputs = [ pkg-config cmake ];
+
+  propagatedBuildInputs = [ libusb1 ];
+
+  cmakeFlags = lib.optionals stdenv.isLinux [
+    "-DINSTALL_UDEV_RULES=ON"
+    "-DWITH_RPC=ON"
+  ];
+
+  meta = with lib; {
+    description = "Software to turn the RTL2832U into a SDR receiver";
+    longDescription = ''
+    This packages the rtl-sdr library by the Osmocom project. This is the upstream codebase of the unsuffixed "rtl-sdr" package, which is a downstream fork. A list of differences can be found here:
+    https://github.com/librtlsdr/librtlsdr/blob/master/README_improvements.md
+
+    The Osmocom upstream has a regular release schedule, so this package will likely support newer SDR dongles. It should be compatible with most software that currently depends on the "rtl-sdr" nixpkg, but comptabiliy should be manually confirmed.
+    '';
+    homepage = "https://gitea.osmocom.org/sdr/rtl-sdr";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ skovati ];
+    platforms = platforms.unix;
+    mainProgram = "rtl_sdr";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`osmo-rtl-sdr` is a library for turning a RTL2832 based DVB dongle into a Software Defined Radio (SDR).

This propose package is the upstream of the existing `rtl-sdr` nixpkg, [which is a fork](https://github.com/librtlsdr/librtlsdr). This `rtl-sdr` fork no longer cuts releases, so the nixpkg is stuck on a 2020 release.

`osmo-rtl-sdr`, the new package this PR adds, instead directly builds the upstream project, which gets regularly versioned releases.

https://gitea.osmocom.org/sdr/rtl-sdr/
https://osmocom.org/projects/rtl-sdr/wiki

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
