### PR TITLE
nixos/fwupd: Fix fwupd-refresh service

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -187,12 +187,17 @@ in {
       # fwupd-refresh expects a user that we do not create, so just run with DynamicUser
       # instead and ensure we take ownership of /var/lib/fwupd
       services.fwupd-refresh.serviceConfig = {
-        DynamicUser = true;
         StateDirectory = "fwupd";
       };
 
       timers.fwupd-refresh.wantedBy = [ "timers.target" ];
     };
+
+    users.users.fwupd-refresh = {
+      isSystemUser = true;
+      group = "fwupd-refresh";
+    };
+    users.groups.fwupd-refresh = {};
 
     security.polkit.enable = true;
   };

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -188,6 +188,8 @@ in {
       # instead and ensure we take ownership of /var/lib/fwupd
       services.fwupd-refresh.serviceConfig = {
         StateDirectory = "fwupd";
+        # Better for debugging, upstream sets stderr to null for some reason..
+        StandardError = "inherit";
       };
 
       timers.fwupd-refresh.wantedBy = [ "timers.target" ];


### PR DESCRIPTION
## Description of changes

I'm running into this issue (though the error isn't visible unless you do `StandardError = "inherit"` for the `fwupd-refresh` service, which I'm also adding in this PR):

    fwupdmgr[439074]: Failed to connect to daemon: The connection is closed

This PR fixes this by creating a persistent user for fwupd, getting rid of the DynamicUser which was just recently introduced by @peterhoeg in https://github.com/NixOS/nixpkgs/commit/dde6a4f397532bbd01b346466ea751e7c3cd9d06

@GaetanLepage also ran into this, see https://github.com/NixOS/nixpkgs/pull/261993#issuecomment-1801845171 for more context

## Things done
- [x] Tested on my x86_64-linux