### PR TITLE
vscode-extensions.ms-toolsai.jupyter: patch to avoid writing to read-only store

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-toolsai.jupyter/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-toolsai.jupyter/default.nix
@@ -28,6 +28,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
     EOF
     }
     jq "$(print_jq_query)" ./package.json | sponge ./package.json
+    # Add a link from temp to /tmp so that the extension gets a writable
+    # directory to write to.
+    ln -s /tmp temp
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

Since an update quite some time ago (early 2023), ms-toolsai.jupyter can no longer properly launch a Jupyter kernel when Python and the notebook (Python) package are in scope because it tries to create a `temp` directory in its own extension directory, which happens to be in the read-only Nix store, when it was installed with Nix. There is an open issue since May (https://github.com/microsoft/vscode-jupyter/issues/13525) to make this directory configurable, and just two weeks ago someone commented that this issue is quite relevant to Nix users in particular.

This pull request simply patches the installed extension so that there exists a link from this `temp` directory that the extension requires to `/tmp`. This is a workaround until the upstream issue can be fixed, but it seems reasonable enough, it works, and it makes the extension usable again until a better solution is proposed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
