### PR TITLE
dnf4: init at 4.18.1

### DIFF
--- a/pkgs/development/python-modules/dnf4/default.nix
+++ b/pkgs/development/python-modules/dnf4/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, buildPythonPackage
+, cmake
+, fetchFromGitHub
+, gettext
+, libcomps
+, libdnf
+, python
+, rpm
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "dnf4";
+  version = "4.18.1";
+  format = "other";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitHub {
+    owner = "rpm-software-management";
+    repo = "dnf";
+    rev = version;
+    hash = "sha256-pgS4y87HbFiaS+fftdhKHOZAl2hYTUds3XVXUuQN6tU=";
+  };
+
+  patches = [
+    ./fix-python-install-dir.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "@PYTHON_INSTALL_DIR@" "$out/${python.sitePackages}" \
+      --replace "SYSCONFDIR /etc" "SYSCONFDIR $out/etc" \
+      --replace "SYSTEMD_DIR /usr/lib/systemd/system" "SYSTEMD_DIR $out/lib/systemd/system"
+    substituteInPlace etc/tmpfiles.d/CMakeLists.txt \
+      --replace "DESTINATION /usr/lib/tmpfiles.d" "DESTINATION $out/usr/lib/tmpfiles.d"
+    substituteInPlace dnf/const.py.in \
+      --replace "/etc" "$out/etc"
+    substituteInPlace doc/CMakeLists.txt \
+      --replace 'SPHINX_BUILD_NAME "sphinx-build-3"' 'SPHINX_BUILD_NAME "${sphinx}/bin/sphinx-build"'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    sphinx
+  ];
+
+  propagatedBuildInputs = [
+    libcomps
+    libdnf
+    rpm
+  ];
+
+  cmakeFlags = [
+    "-DPYTHON_DESIRED=${lib.head (lib.splitString ["."] python.version)}"
+  ];
+
+  postBuild = ''
+    make doc-man
+  '';
+
+  postInstall = ''
+    # See https://github.com/rpm-software-management/dnf/blob/41a287e2bd60b4d1100c329a274776ff32ba8740/dnf.spec#L218-L220
+    ln -s dnf-3 $out/bin/dnf
+    ln -s dnf-3 $out/bin/dnf4
+    mv $out/bin/dnf-automatic-3 $out/bin/dnf-automatic
+    # See https://github.com/rpm-software-management/dnf/blob/41a287e2bd60b4d1100c329a274776ff32ba8740/dnf.spec#L231-L232
+    ln -s $out/etc/dnf/dnf.conf $out/etc/yum.conf
+    ln -s dnf-3 $out/bin/yum
+  '';
+
+  meta = with lib; {
+    description = "Package manager based on libdnf and libsolv. Replaces YUM";
+    homepage = "https://github.com/rpm-software-management/dnf";
+    changelog = "https://github.com/rpm-software-management/dnf/releases/tag/${version}";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ katexochen ];
+    mainProgram = "dnf";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/dnf4/fix-python-install-dir.patch
+++ b/pkgs/development/python-modules/dnf4/fix-python-install-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4aee99fb..0bb28897 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,7 +19,7 @@ ELSE ()
+     MESSAGE (FATAL_ERROR "Invalid PYTHON_DESIRED value: " ${PYTHON_DESIRED})
+ ENDIF()
+
+-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from sysconfig import get_path; stdout.write(get_path('purelib'))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
++SET(PYTHON_INSTALL_DIR "@PYTHON_INSTALL_DIR@")
+ MESSAGE(STATUS "Python install dir is ${PYTHON_INSTALL_DIR}")
+
+ ADD_SUBDIRECTORY (dnf)

--- a/pkgs/tools/package-management/libcomps/default.nix
+++ b/pkgs/tools/package-management/libcomps/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, check
+, cmake
+, doxygen
+, expat
+, fetchFromGitHub
+, libxml2
+, python
+, sphinx
+, stdenv
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcomps";
+  version = "0.1.20";
+
+  outputs = [ "out" "dev" "py" ];
+
+  src = fetchFromGitHub {
+    owner = "rpm-software-management";
+    repo = "libcomps";
+    rev = version;
+    hash = "sha256-IX4du1+G7lwWrGnllydnBDap2aqK5pzos1Mdyu4MzOU=";
+  };
+
+  patches = [
+    ./fix-python-install-dir.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace libcomps/src/python/src/CMakeLists.txt \
+      --replace "@PYTHON_INSTALL_DIR@" "$out/${python.sitePackages}"
+  '';
+
+  nativeBuildInputs = [
+    check
+    cmake
+    doxygen
+    python
+    sphinx
+  ];
+
+  buildInputs = [
+    expat
+    libxml2
+    zlib
+  ];
+
+  dontUseCmakeBuildDir = true;
+  cmakeDir = "libcomps";
+
+  postFixup = ''
+    ls $out/lib
+    moveToOutput "lib/${python.libPrefix}" "$py"
+  '';
+
+  meta = with lib; {
+    description = "Comps XML file manipulation library";
+    homepage = "https://github.com/rpm-software-management/libcomps";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ katexochen ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/package-management/libcomps/fix-python-install-dir.patch
+++ b/pkgs/tools/package-management/libcomps/fix-python-install-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/libcomps/src/python/src/CMakeLists.txt b/libcomps/src/python/src/CMakeLists.txt
+index d22b84e..57bd1c2 100644
+--- a/libcomps/src/python/src/CMakeLists.txt
++++ b/libcomps/src/python/src/CMakeLists.txt
+@@ -85,7 +85,7 @@ IF (SKBUILD)
+     INSTALL(FILES libcomps/__init__.py DESTINATION libcomps/src/python/src/libcomps)
+     INSTALL(TARGETS pycomps LIBRARY DESTINATION libcomps/src/python/src/libcomps)
+ ELSE ()
+-    EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from sysconfig import get_path; stdout.write(get_path('platlib'))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
++    SET(PYTHON_INSTALL_DIR "@PYTHON_INSTALL_DIR@")
+
+     INSTALL(FILES ${pycomps_SRCDIR}/libcomps/__init__.py DESTINATION ${PYTHON_INSTALL_DIR}/libcomps)
+     #INSTALL(FILES ${pycomps_SRCDIR}/tests/__test.py DESTINATION

--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -99,6 +99,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/rpm-software-management/libdnf/releases/tag/${version}";
     license = licenses.gpl2Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ rb2k ];
+    maintainers = with maintainers; [ rb2k katexochen ];
   };
 }

--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -15,6 +15,7 @@
 , libyaml
 , rpm
 , zchunk
+, cppunit
 }:
 
 stdenv.mkDerivation rec {
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     check
+    cppunit
     openssl
     json_c
     libsmartcols
@@ -57,11 +59,6 @@ stdenv.mkDerivation rec {
   '';
 
   postPatch = ''
-    # See https://github.com/NixOS/nixpkgs/issues/107428
-    substituteInPlace CMakeLists.txt \
-      --replace "enable_testing()" "" \
-      --replace "add_subdirectory(tests)" ""
-
     # https://github.com/rpm-software-management/libdnf/issues/1518
     substituteInPlace libdnf/libdnf.pc.in \
       --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@

--- a/pkgs/tools/package-management/libdnf/fix-python-install-dir.patch
+++ b/pkgs/tools/package-management/libdnf/fix-python-install-dir.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/modules/FindPythonInstDir.cmake b/cmake/modules/FindPythonInstDir.cmake
+index ed098ded..2a2e1543 100644
+--- a/cmake/modules/FindPythonInstDir.cmake
++++ b/cmake/modules/FindPythonInstDir.cmake
+@@ -1,6 +1 @@
+-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+-from sys import stdout
+-from sysconfig import get_path
+-path=get_path(name='platlib', vars={'platbase':'${CMAKE_INSTALL_PREFIX}'})
+-stdout.write(path)"
+-OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
++SET(PYTHON_INSTALL_DIR "@PYTHON_INSTALL_DIR@")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -605,6 +605,8 @@ with pkgs;
 
   dec-decode = callPackage ../development/tools/dec-decode { };
 
+  dnf4 =  with python3Packages; toPythonApplication dnf4;
+
   dnf5 = callPackage ../tools/package-management/dnf5 { };
 
   documenso = callPackage ../applications/office/documenso { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22570,6 +22570,8 @@ with pkgs;
 
   libcollectdclient = callPackage ../development/libraries/libcollectdclient { };
 
+  libcomps = callPackage ../tools/package-management/libcomps { python = python3; };
+
   libcpr = callPackage ../development/libraries/libcpr { };
 
   libcredis = callPackage ../development/libraries/libcredis { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22658,7 +22658,7 @@ with pkgs;
 
   libdnet = callPackage ../development/libraries/libdnet { };
 
-  libdnf = callPackage ../tools/package-management/libdnf { };
+  libdnf = callPackage ../tools/package-management/libdnf { python = python3; };
 
   libdovi = callPackage ../development/libraries/libdovi { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3204,6 +3204,8 @@ self: super: with self; {
 
   dnachisel = callPackage ../development/python-modules/dnachisel { };
 
+  dnf4 = callPackage ../development/python-modules/dnf4 { };
+
   dnfile = callPackage ../development/python-modules/dnfile { };
 
   dnslib = callPackage ../development/python-modules/dnslib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6139,6 +6139,13 @@ self: super: with self; {
 
   libcst = callPackage ../development/python-modules/libcst { };
 
+  libdnf = lib.pipe pkgs.libdnf [
+    toPythonModule
+    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
+    (p: p.override { inherit python; })
+    (p: p.py)
+  ];
+
   libevdev = callPackage ../development/python-modules/libevdev { };
 
   libfdt = toPythonModule (pkgs.dtc.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6137,6 +6137,13 @@ self: super: with self; {
 
   libcloud = callPackage ../development/python-modules/libcloud { };
 
+  libcomps = lib.pipe pkgs.libcomps [
+    toPythonModule
+    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
+    (p: p.override { inherit python; })
+    (p: p.py)
+  ];
+
   libcst = callPackage ../development/python-modules/libcst { };
 
   libdnf = lib.pipe pkgs.libdnf [


### PR DESCRIPTION
## Description of changes

- Adding `dnf4`.
- Adding `libcomps`, which is a dependency of dnf4. libcomps is mostly C, but uses pyproject/setuptools for the python build, so I've placed it in `python3.pkgs`. Not sure this is right.
- Enabling python bindings in `libdnf`. The cppunit issue seems to have resolved itself, I've just re-added the dependency and removed the fix. Closes #107428.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
