### PR TITLE
goModule: allow passing in NIX_GIT_SSL_CAINFO

### DIFF
--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -81,6 +81,7 @@ let
       "GIT_PROXY_COMMAND"
       "SOCKS_SERVER"
       "GOPROXY"
+      "NIX_GIT_SSL_CAINFO"
     ];
 
     configurePhase = args.modConfigurePhase or ''
@@ -105,6 +106,8 @@ let
         echo "vendor folder exists, please set 'vendorHash = null;' in your expression"
         exit 10
       fi
+
+      export GIT_SSL_CAINFO=''${NIX_GIT_SSL_CAINFO:-$GIT_SSL_CAINFO}
 
       ${if proxyVendor then ''
         mkdir -p "''${GOPATH}/pkg/mod/cache/download"


### PR DESCRIPTION
## Description of changes

Go module fetcher: support (impure) NIX_GIT_SSL_CAINFO

This is the same idea / envvar as used in `fetchgit`, added in https://github.com/NixOS/nixpkgs/commit/6f53c067482743fd68a5beceeb1205fab0ebe4c4

The primary use case is when there's a http(s) proxy, the user may want to override the nix-provided CA certificates.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
