### PR TITLE
python311Packages.pillow-heif: disable test on darwin

### DIFF
--- a/pkgs/development/python-modules/pillow-heif/default.nix
+++ b/pkgs/development/python-modules/pillow-heif/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, stdenv
 
 # build-system
 , cmake
@@ -61,6 +62,12 @@ buildPythonPackage rec {
     numpy
     pympler
     pytestCheckHook
+  ];
+
+  disabledTests = lib.optional (stdenv.isDarwin) [
+    # does not crash on darwin for us
+    # https://github.com/bigcat88/pillow_heif/issues/89
+    "test_opencv_crash"
   ];
 
   meta = {


### PR DESCRIPTION
Upstream in response to an issue created a test, that would crash opencv somewhere in x265, but that crash does not happen on nixpkgs.

```
pillow-heif-aarch64-darwin> ______________________________ test_opencv_crash _______________________________
pillow-heif-aarch64-darwin> 
pillow-heif-aarch64-darwin>     def test_opencv_crash():
pillow-heif-aarch64-darwin>         # https://github.com/bigcat88/pillow_heif/issues/89
pillow-heif-aarch64-darwin>         path_to_test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "opencv_bug.py")
pillow-heif-aarch64-darwin>         if sys.platform.lower() == "darwin":
pillow-heif-aarch64-darwin> >           with pytest.raises(CalledProcessError):
pillow-heif-aarch64-darwin> E           Failed: DID NOT RAISE <class 'subprocess.CalledProcessError'>
pillow-heif-aarch64-darwin> 
pillow-heif-aarch64-darwin> /private/tmp/nix-build-python3.11-pillow-heif-0.13.0.drv-0/source/tests/opencv_test.py:156: Failed
pillow-heif-aarch64-darwin> ----------------------------- Captured stdout call -----------------------------
pillow-heif-aarch64-darwin> {'libheif': '1.15.2', 'HEIF': 'x265 HEVC encoder (3.5+1-f0c1022b6)', 'AVIF': 'AOMedia Project AV1 Encoder 3.6.1'}
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
