### PR TITLE
nixos/sonic-server: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1152,6 +1152,7 @@
   ./services/search/meilisearch.nix
   ./services/search/opensearch.nix
   ./services/search/qdrant.nix
+  ./services/search/sonic-server.nix
   ./services/search/typesense.nix
   ./services/security/aesmd.nix
   ./services/security/authelia.nix

--- a/nixos/modules/services/search/sonic-server.nix
+++ b/nixos/modules/services/search/sonic-server.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.sonic-server;
+
+  settingsFormat = pkgs.formats.toml { };
+  configFile = settingsFormat.generate "sonic-server-config.toml" cfg.settings;
+
+in {
+  meta.maintainers = [ lib.maintainers.anthonyroussel ];
+
+  options = {
+    services.sonic-server = {
+      enable = lib.mkEnableOption (lib.mdDoc "Sonic Search Index");
+
+      package = lib.mkPackageOptionMD pkgs "sonic-server" { };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule { freeformType = settingsFormat.type; };
+        default = {
+          store.kv.path = "/var/lib/sonic/kv";
+          store.fst.path = "/var/lib/sonic/fst";
+        };
+        example = {
+          server.log_level = "debug";
+          channel.inet = "[::1]:1491";
+        };
+        description = lib.mdDoc ''
+          Sonic Server configuration options.
+
+          Refer to
+          <https://github.com/valeriansaliou/sonic/blob/master/CONFIGURATION.md>
+          for a full list of available options.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.sonic-server.settings = lib.mapAttrs (name: lib.mkDefault) {
+      server = {};
+      channel.search = {};
+      store = {
+        kv = {
+          path = "/var/lib/sonic/kv";
+          database = {};
+          pool = {};
+        };
+        fst = {
+          path = "/var/lib/sonic/fst";
+          graph = {};
+          pool = {};
+        };
+      };
+    };
+
+    systemd.services.sonic-server = {
+      description = "Sonic Search Index";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+
+        ExecStart = "${lib.getExe cfg.package} -c ${configFile}";
+        DynamicUser = true;
+        Group = "sonic";
+        LimitNOFILE = "infinity";
+        Restart = "on-failure";
+        StateDirectory = "sonic";
+        StateDirectoryMode = "750";
+        User = "sonic";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -758,6 +758,7 @@ in {
   sogo = handleTest ./sogo.nix {};
   solanum = handleTest ./solanum.nix {};
   sonarr = handleTest ./sonarr.nix {};
+  sonic-server = handleTest ./sonic-server.nix {};
   sourcehut = handleTest ./sourcehut.nix {};
   spacecookie = handleTest ./spacecookie.nix {};
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark {};

--- a/nixos/tests/sonic-server.nix
+++ b/nixos/tests/sonic-server.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "sonic-server";
+
+  meta = {
+    maintainers = with lib.maintainers; [ anthonyroussel ];
+  };
+
+  nodes.machine = { pkgs, ... }: {
+    services.sonic-server.enable = true;
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("sonic-server.service")
+    machine.wait_for_open_port(1491)
+
+    with subtest("Check control mode"):
+      result = machine.succeed('(echo START control; sleep 1; echo PING; echo QUIT) | nc localhost 1491').splitlines()
+      assert result[2] == "PONG", f"expected 'PONG', got '{result[2]}'"
+  '';
+})

--- a/pkgs/servers/search/sonic-server/default.nix
+++ b/pkgs/servers/search/sonic-server/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , nix-update-script
+, nixosTests
 , testers
 , sonic-server
 }:
@@ -42,6 +43,7 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     tests = {
+      inherit (nixosTests) sonic-server;
       version = testers.testVersion {
         command = "sonic --version";
         package = sonic-server;


### PR DESCRIPTION
## Description of changes

https://github.com/valeriansaliou/sonic

> Sonic is a fast, lightweight and schema-less search backend. It ingests search texts and identifier tuples that can then be queried against in a microsecond's time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
