### PR TITLE
python311Packages.camelot: enable tests and fix runtime error

### DIFF
--- a/pkgs/development/python-modules/camelot/default.nix
+++ b/pkgs/development/python-modules/camelot/default.nix
@@ -1,19 +1,23 @@
 { lib
-, stdenv
 , buildPythonPackage
-, chardet
-, openpyxl
-, charset-normalizer
-, fetchPypi
+, fetchFromGitHub
 , fetchpatch
 , pythonOlder
-, pandas
-, tabulate
+, setuptools
+, chardet
 , click
+, numpy
+, openpyxl
+, pandas
 , pdfminer-six
 , pypdf
+, tabulate
+, ghostscript
+, matplotlib
 , opencv4
-, setuptools
+, pytest-mpl
+, pytest-xdist
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -23,26 +27,85 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-l6fZBtaF5AWaSlSaY646UfCrcqPIJlV/hEPGWhGB3+Y=";
+  src = fetchFromGitHub {
+    owner = "camelot-dev";
+    repo = "camelot";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-vR/oX3t2npPTrd7RM1GiZwryp88dlJ0fzSgPS36/QXw=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "pandas_2-compatibility.patch";
+      url = "https://github.com/camelot-dev/camelot/commit/44b4e6846ffda916b288d81f4e700dbb9e0e9ca9.patch";
+      hash = "sha256-voHUXgdGbGfnUsfKPfG2tXedljrZwVk4ru9yuyXIZK8=";
+    })
+  ];
+
+  # the exception is thrown because ctypes.util.find_library() is used to find the ghostscript,
+  # but we don't need that exception
+  postPatch = ''
+    substituteInPlace camelot/backends/ghostscript_backend.py \
+      --replace "if not self.installed():" "if False:"
+  '';
 
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [
-    charset-normalizer
     chardet
-    pandas
-    tabulate
     click
-    pdfminer-six
+    numpy
     openpyxl
+    pandas
+    pdfminer-six
     pypdf
-    opencv4
+    tabulate
+    # it is an optional-dependencies, but necessary for minimal usage
+  ] ++ passthru.optional-dependencies.base;
+
+  passthru.optional-dependencies = {
+    all = passthru.optional-dependencies.base ++ passthru.optional-dependencies.plot;
+    base = [
+      ghostscript
+      opencv4
+      # it is very wired to deal with a vendor poppler
+      # also, it is an alternative backend to ghostscript, so there is no significant problem without it
+      # pdftopng
+    ];
+    plot = [
+      matplotlib
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest-mpl
+    pytest-xdist
+    pytestCheckHook
   ];
 
-  doCheck = false;
+  preCheck = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov-config .coveragerc --cov-report term --cov-report xml --cov=camelot" ""
+  '';
+
+  disabledTests = [
+    # touch the network
+    "test_pages_poppler"
+    "test_repr_poppler"
+    "test_url_poppler"
+    "test_pages_ghostscript"
+    "test_url_ghostscript"
+
+    # require pdftopng
+    "test_grid_plot_poppler"
+    "test_lattice_contour_plot_poppler"
+    "test_joint_plot_poppler"
+    "test_line_plot_poppler"
+
+    # flaky tests that fail because of noise in the image
+    "test_joint_plot_ghostscript"
+    "test_lattice_contour_plot_ghostscript"
+  ];
 
   pythonImportsCheck = [
     "camelot"

--- a/pkgs/development/python-modules/ghostscript/default.nix
+++ b/pkgs/development/python-modules/ghostscript/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitLab
+, ghostscript_headless
+, setuptools
+, wheel
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ghostscript";
+  version = "0.7";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "pdftools";
+    repo = "python-ghostscript";
+    rev = "v${version}";
+    hash = "sha256-yBJuAnLK/4YDU9PBsSWPQay4pDws3bP+3rCplysq41w=";
+  };
+
+  # AttributeError: module 'ghostscript' has no attribute '__version__'
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "attr:ghostscript.__version__" ${version}
+    substituteInPlace ghostscript/_gsprint.py \
+      --replace 'cdll.LoadLibrary("libgs.so")' "cdll.LoadLibrary('${ghostscript_headless}/lib/libgs${stdenv.hostPlatform.extensions.sharedLibrary}')"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    ghostscript_headless
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # flaky test that fails because 2 or 3 pixels cannot be reproduced
+    "test_simple"
+    "test_unicode_arguments"
+    "test_run_string"
+    "test_stdin"
+    "test_run_string"
+    "test_simple"
+    "test_stdin"
+  ];
+
+  pythonImportsCheck = [ "ghostscript" ];
+
+  meta = with lib; {
+    description = "Interface to the Ghostscript C-API";
+    homepage = "https://gitlab.com/pdftools/python-ghostscript";
+    changelog = "https://gitlab.com/pdftools/python-ghostscript/-/blob/${src.rev}/CHANGES.txt";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -10,7 +10,7 @@
 , pillow
 , stdenv
 , exiftool
-, ghostscript
+, ghostscript_headless
 , imagemagick
 , mupdf
 , netpbm
@@ -68,7 +68,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     exiftool
-    ghostscript
+    ghostscript_headless
     imagemagick
     mupdf
     netpbm

--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , deprecation
 , fetchFromGitHub
-, ghostscript
+, ghostscript_headless
 , hypothesis
 , img2pdf
 , importlib-resources
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      gs = lib.getExe ghostscript;
+      gs = lib.getExe ghostscript_headless;
       jbig2 = lib.getExe jbig2enc;
       pngquant = lib.getExe pngquant;
       tesseract = lib.getExe tesseract;

--- a/pkgs/development/python-modules/pydyf/default.nix
+++ b/pkgs/development/python-modules/pydyf/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , flit-core
-, ghostscript
+, ghostscript_headless
 , pillow
 , pytestCheckHook
 , pythonOlder
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    ghostscript
+    ghostscript_headless
     pillow
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pygmt/default.nix
+++ b/pkgs/development/python-modules/pygmt/default.nix
@@ -12,7 +12,7 @@
 , xarray
 , pytest-mpl
 , ipython
-, ghostscript
+, ghostscript_headless
 , pytestCheckHook
 }:
 
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mpl
-    ghostscript
+    ghostscript_headless
     ipython
   ];
 

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -8,7 +8,7 @@
 , flit-core
 , fontconfig
 , fonttools
-, ghostscript
+, ghostscript_headless
 , glib
 , harfbuzz
 , html5lib
@@ -64,7 +64,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    ghostscript
+    ghostscript_headless
   ];
 
   disabledTests = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4435,6 +4435,8 @@ self: super: with self; {
 
   ghdiff = callPackage ../development/python-modules/ghdiff { };
 
+  ghostscript = callPackage ../development/python-modules/ghostscript { };
+
   ghp-import = callPackage ../development/python-modules/ghp-import { };
 
   ghrepo-stats = callPackage ../development/python-modules/ghrepo-stats { };


### PR DESCRIPTION
## Description of changes

- packaged a missing library, python311Packages.ghostscript, which is essential for operation
  - https://gitlab.com/pdftools/python-ghostscript
- enabled tests and checked the behavior

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
