### PR TITLE
yarn-berry: 3.4.1 -> 4.0.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -33,6 +33,8 @@
 - All [ROCm](https://rocm.docs.amd.com/en/latest/) packages have been updated to 5.7.0.
   - [ROCm](https://rocm.docs.amd.com/en/latest/) package attribute sets are versioned: `rocmPackages` -> `rocmPackages_5`.
 
+- `yarn-berry` has been updated to 4.0.1. This means that NodeJS versions less than `18.12` are no longer supported by it. More details at the [upstream changelog](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md).
+
 - If the user has a custom shell enabled via `users.users.${USERNAME}.shell = ${CUSTOMSHELL}`, the
   assertion will require them to also set `programs.${CUSTOMSHELL}.enable =
   true`. This is generally safe behavior, but for anyone needing to opt out from

--- a/pkgs/development/tools/yarn-berry/default.nix
+++ b/pkgs/development/tools/yarn-berry/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "yarn-berry";
-  version = "3.4.1";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "yarnpkg";
     repo = "berry";
     rev = "@yarnpkg/cli/${version}";
-    hash = "sha256-eBBB/F+mnGi93Qf23xgt306/ogoV76RXOM90O14u5Tw=";
+    hash = "sha256-9QNeXamNqRx+Bfg8nAhnImPuNFyqrHIs1eF9prSwIR4=";
   };
 
   buildInputs = [
@@ -33,11 +33,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-   meta = with lib; {
+  meta = with lib; {
     homepage = "https://yarnpkg.com/";
     description = "Fast, reliable, and secure dependency management.";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ ryota-ka ];
+    maintainers = with maintainers; [ ryota-ka thehedgeh0g ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes
The only breaking change here is that Yarn drops support for NodeJS versions <18.12

Besides that, no major changes that I think deserve a mention.

See the [upstream changelog](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md) for more info on changes between the current and new version.

## Things done

- Updated `yarn-berry` from 3.4.1 to 4.0.1
- Updated 23.11 changelog to reflect this, as it is a major version bump and incurs breaking changes.
- Run the result binaries on the [iceshrimp](https://iceshrimp.dev/iceshrimp/iceshrimp) repo, a large production codebase. No difference between this and other non-nixos contributors using non nix-packaged yarn 4.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
