### PR TITLE
sha2wordlist: init at unstable-2023-02-20

### DIFF
--- a/pkgs/by-name/sh/sha2wordlist/package.nix
+++ b/pkgs/by-name/sh/sha2wordlist/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libbsd
+}:
+
+stdenv.mkDerivation {
+  pname = "sha2wordlist";
+  version = "unstable-2023-02-20";
+
+  src = fetchFromGitHub {
+    owner = "kirei";
+    repo = "sha2wordlist";
+    rev = "2017b7ac786cfb5ad7f35f3f9068333b426d65f7";
+    hash = "sha256-A5KIXvwllzUcUm52lhw0QDjhEkCVTcbLQGFZWmHrFpU=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "gcc" "$CC"
+  '';
+
+  buildInputs = [
+    libbsd
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 755 sha2wordlist $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Display SHA-256 as PGP words";
+    homepage = "https://github.com/kirei/sha2wordlist";
+    maintainers = with maintainers; [ baloo ];
+    license = [ licenses.bsd2 ];
+    platforms = platforms.all;
+    mainProgram = "sha2wordlist";
+  };
+}


### PR DESCRIPTION
## Description of changes

sha2wordlist is used to display sha256 values as word lists.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
