### PR TITLE
python3Packages.python-telegram: fix build

### DIFF
--- a/pkgs/development/python-modules/python-telegram/default.nix
+++ b/pkgs/development/python-modules/python-telegram/default.nix
@@ -1,11 +1,12 @@
 { lib
 , stdenv
-, fetchpatch
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
 , setuptools
 , tdlib
+, telegram-text
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -13,30 +14,29 @@ buildPythonPackage rec {
   version = "0.18.0";
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-UbJW/op01qe/HchfJUlBPBY9/W8NbZkEmFM8gZ5+EmI=";
+  src = fetchFromGitHub {
+    owner = "alexander-akhmetov";
+    repo = "python-telegram";
+    rev = version;
+    hash = "sha256-2Q0nUZ2TMVWznd05+fqYojkRn4xfFZJrlqb1PMuBsAY=";
   };
-
-  patches = [
-    # Search for the system library first, and fallback to the embedded one if the system was not found
-    (fetchpatch {
-      url = "https://github.com/alexander-akhmetov/python-telegram/commit/b0af0985910ebb8940cff1b92961387aad683287.patch";
-      hash = "sha256-ZqsntaiC2y9l034gXDMeD2BLO/RcsbBII8FomZ65/24=";
-    })
-  ];
 
   postPatch = ''
     # Remove bundled libtdjson
     rm -fr telegram/lib
 
     substituteInPlace telegram/tdjson.py \
-      --replace "ctypes.util.find_library(\"libtdjson\")" \
+      --replace "ctypes.util.find_library(\"tdjson\")" \
                 "\"${tdlib}/lib/libtdjson${stdenv.hostPlatform.extensions.sharedLibrary}\""
   '';
 
   propagatedBuildInputs = [
     setuptools
+    telegram-text
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/telegram-text/default.nix
+++ b/pkgs/development/python-modules/telegram-text/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, poetry-core
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "telegram-text";
+  version = "0.1.2";
+  pyproject = true;
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "SKY-ALIN";
+    repo = "telegram-text";
+    rev = "v${version}";
+    hash = "sha256-p8SVQq7IvkVuOFE8VDugROLY5Wk0L2HmXyacTzFFSP4=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python markup module for Telegram messenger";
+    downloadPage = "https://github.com/SKY-ALIN/telegram-text";
+    homepage = "https://telegram-text.alinsky.tech/";
+    changelog = "https://github.com/SKY-ALIN/telegram-text/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13675,6 +13675,8 @@ self: super: with self; {
 
   telfhash = callPackage ../development/python-modules/telfhash { };
 
+  telegram-text = callPackage ../development/python-modules/telegram-text { };
+
   temescal = callPackage ../development/python-modules/temescal { };
 
   temperusb = callPackage ../development/python-modules/temperusb { };


### PR DESCRIPTION
## Description of changes
Fix https://hydra.nixos.org/build/239153404

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

