### PR TITLE
jasp-desktop: init at 0.18.2

### DIFF
--- a/pkgs/by-name/ja/jasp-desktop/cmake.patch
+++ b/pkgs/by-name/ja/jasp-desktop/cmake.patch
@@ -1,0 +1,46 @@
+diff --git a/Tools/CMake/Libraries.cmake b/Tools/CMake/Libraries.cmake
+index cc4681a..f484013 100644
+--- a/Tools/CMake/Libraries.cmake
++++ b/Tools/CMake/Libraries.cmake
+@@ -67,7 +67,7 @@ if((NOT LibArchive_FOUND) AND (NOT WIN32))
+   endif()
+ endif()
+ 
+-set(Boost_USE_STATIC_LIBS ON)
++add_definitions(-DBOOST_LOG_DYN_LINK)
+ find_package(
+   Boost 1.78 REQUIRED
+   COMPONENTS filesystem
+@@ -178,10 +178,10 @@ if(LINUX)
+     set(LIBREADSTAT_INCLUDE_DIRS /app/include)
+     set(LIBREADSTAT_LIBRARY_DIRS /app/lib)
+   else()
+-    set(LIBREADSTAT_INCLUDE_DIRS /usr/local/include /usr/include)
++    set(LIBREADSTAT_INCLUDE_DIRS @readstat@/include /usr/include)
+     # The last two library paths handle the two most common multiarch cases.
+     # Other multiarch-compliant paths may come up but should be rare.
+-    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
++    set(LIBREADSTAT_LIBRARY_DIRS @readstat@/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
+   endif()
+ 
+   message(CHECK_START "Looking for libreadstat.so")
+diff --git a/Tools/CMake/Programs.cmake b/Tools/CMake/Programs.cmake
+index dbd089d..ef6857a 100644
+--- a/Tools/CMake/Programs.cmake
++++ b/Tools/CMake/Programs.cmake
+@@ -39,6 +39,7 @@ endif()
+ 
+ # ------ Linux Tools/Programs
+ 
++#[[
+ if(LINUX)
+ 
+   message(CHECK_START "Looking for 'gfortran'")
+@@ -81,6 +82,7 @@ if(LINUX)
+   endif()
+ 
+ endif()
++]]#
+ 
+ # ----------------------
+ 

--- a/pkgs/by-name/ja/jasp-desktop/modules.nix
+++ b/pkgs/by-name/ja/jasp-desktop/modules.nix
@@ -1,0 +1,134 @@
+{ R
+, rPackages
+, fetchFromGitHub
+, jasp-src
+, jasp-version
+}:
+
+with rPackages;
+let
+  jaspColumnEncoder-src = fetchFromGitHub {
+    owner = "jasp-stats";
+    repo = "jaspColumnEncoder";
+    rev = "c54987bb25de8963866ae69ad3a6ae5a9a9f1240";
+    hash = "sha256-aWfRG7DXO1MYFvmMLkX/xtHvGeIhFRcRDrVBrhkvYuI=";
+  };
+
+  jaspGraphs = buildRPackage {
+    name = "jaspGraphs-${jasp-version}";
+    version = jasp-version;
+
+    src = jasp-src;
+    sourceRoot = "${jasp-src.name}/Engine/jaspGraphs";
+
+    propagatedBuildInputs = [ ggplot2 gridExtra gtable lifecycle jsonlite R6 RColorBrewer rlang scales viridisLite ];
+  };
+
+  jaspBase = buildRPackage {
+    name = "jaspBase-${jasp-version}";
+    version = jasp-version;
+
+    src = jasp-src;
+    sourceRoot = "${jasp-src.name}/Engine/jaspBase";
+
+    env.INCLUDE_DIR = "../inst/include/jaspColumnEncoder";
+
+    postPatch = ''
+      mkdir -p inst/include
+      cp -r --no-preserve=all ${jaspColumnEncoder-src} inst/include/jaspColumnEncoder
+    '';
+
+    propagatedBuildInputs = [ cli codetools ggplot2 gridExtra gridGraphics jaspGraphs jsonlite lifecycle modules officer pkgbuild plyr qgraph ragg R6 Rcpp renv remotes rjson rvg svglite systemfonts withr ];
+  };
+
+  stanova = buildRPackage {
+    name = "stanova";
+    src = fetchFromGitHub {
+      owner = "bayesstuff";
+      repo = "stanova";
+      rev = "988ad8e07cda1674b881570a85502be7795fbd4e";
+      hash = "sha256-tAeHqTHao2KVRNFBDWmuF++H31aNN6O1ss1Io500QBY=";
+    };
+    propagatedBuildInputs = [ emmeans lme4 coda rstan MASS ];
+  };
+
+  bstats = buildRPackage {
+    name = "bstats";
+    src = fetchFromGitHub {
+      owner = "AlexanderLyNL";
+      repo = "bstats";
+      rev = "42d34c18df08d233825bae34fdc0dfa0cd70ce8c";
+      hash = "sha256-N2KmbTPbyvzsZTWBRE2x7bteccnzokUWDOB4mOWUdJk=";
+    };
+    propagatedBuildInputs = [ hypergeo purrr SuppDists ];
+  };
+
+  flexplot = buildRPackage {
+    name = "flexplot";
+    src = fetchFromGitHub {
+      owner = "dustinfife";
+      repo = "flexplot";
+      rev = "4223ad5fb56028018b964d6f9f5aa5bac8710821";
+      hash = "sha256-L+Ed2bIWjq3ZIAGookp8dAjDSeldEbcwynwFVVZ9IcU=";
+    };
+    propagatedBuildInputs = [ cowplot MASS tibble withr dplyr magrittr forcats purrr plyr R6 ggplot2 patchwork ggsci lme4 party mgcv rlang ];
+  };
+
+  # conting has been removed from CRAN
+  conting' = buildRPackage {
+    name = "conting";
+    src = fetchFromGitHub {
+      owner = "vandenman";
+      repo = "conting";
+      rev = "03a4eb9a687e015d602022a01d4e638324c110c8";
+      hash = "sha256-Sp09YZz1WGyefn31Zy1qGufoKjtuEEZHO+wJvoLArf0=";
+    };
+    propagatedBuildInputs = [ mvtnorm gtools tseries coda ];
+  };
+
+  buildJaspModule = name: deps: buildRPackage {
+    name = "${name}-${jasp-version}";
+    version = jasp-version;
+    src = jasp-src;
+    sourceRoot = "${jasp-src.name}/Modules/${name}";
+    propagatedBuildInputs = deps;
+  };
+in
+{
+  engine = { inherit jaspBase jaspGraphs; };
+  modules = rec {
+    jaspAcceptanceSampling = buildJaspModule "jaspAcceptanceSampling" [ abtest BayesFactor conting' ggplot2 jaspBase jaspGraphs plyr stringr vcd vcdExtra AcceptanceSampling ];
+    jaspAnova = buildJaspModule "jaspAnova" [ afex BayesFactor boot car colorspace emmeans ggplot2 jaspBase jaspDescriptives jaspGraphs jaspTTests KernSmooth matrixStats multcomp onewaytests plyr stringi stringr restriktor ];
+    jaspAudit = buildJaspModule "jaspAudit" [ bstats extraDistr ggplot2 ggrepel jaspBase jaspGraphs jfa ];
+    jaspBain = buildJaspModule "jaspBain" [ bain lavaan ggplot2 semPlot stringr jaspBase jaspGraphs jaspSem ];
+    jaspBsts = buildJaspModule "jaspBsts" [ Boom bsts ggplot2 jaspBase jaspGraphs matrixStats reshape2 ];
+    jaspCircular = buildJaspModule "jaspCircular" [ jaspBase jaspGraphs circular ggplot2 ];
+    jaspCochrane = buildJaspModule "jaspCochrane" [ jaspBase jaspGraphs jaspDescriptives jaspMetaAnalysis ];
+    jaspDescriptives = buildJaspModule "jaspDescriptives" [ ggplot2 ggrepel jaspBase jaspGraphs ];
+    jaspDistributions = buildJaspModule "jaspDistributions" [ car fitdistrplus ggplot2 goftest gnorm jaspBase jaspGraphs MASS sgt sn ];
+    jaspEquivalenceTTests = buildJaspModule "jaspEquivalenceTTests" [ BayesFactor ggplot2 jaspBase jaspGraphs metaBMA TOSTER jaspTTests ];
+    jaspFactor = buildJaspModule "jaspFactor" [ ggplot2 jaspBase jaspGraphs jaspSem lavaan psych qgraph reshape2 semPlot GPArotation Rcsdp semTools ];
+    jaspFrequencies = buildJaspModule "jaspFrequencies" [ abtest BayesFactor conting' multibridge ggplot2 jaspBase jaspGraphs plyr stringr vcd vcdExtra ];
+    jaspJags = buildJaspModule "jaspJags" [ coda ggplot2 ggtext hexbin jaspBase jaspGraphs rjags scales stringr ];
+    jaspLearnBayes = buildJaspModule "jaspLearnBayes" [ extraDistr ggplot2 HDInterval jaspBase jaspGraphs MASS MCMCpack MGLM scales ggalluvial ragg runjags ggdist png posterior ];
+    jaspLearnStats = buildJaspModule "jaspLearnStats" [ extraDistr ggplot2 jaspBase jaspGraphs jaspDistributions jaspDescriptives jaspTTests ggforce tidyr igraph ];
+    jaspMachineLearning = buildJaspModule "jaspMachineLearning" [ kknn AUC cluster colorspace DALEX dbscan e1071 fpc gbm Gmedian ggparty ggdendro ggnetwork ggplot2 ggrepel ggridges glmnet jaspBase jaspGraphs MASS mvnormalTest neuralnet network partykit plyr randomForest rpart ROCR Rtsne signal ];
+    jaspMetaAnalysis = buildJaspModule "jaspMetaAnalysis" [ dplyr ggplot2 jaspBase jaspGraphs MASS metaBMA metafor psych purrr rstan stringr tibble tidyr weightr BayesTools RoBMA metamisc ggmcmc pema ];
+    jaspMixedModels = buildJaspModule "jaspMixedModels" [ afex emmeans ggplot2 ggpol jaspBase jaspGraphs lme4 loo mgcv rstan rstanarm stanova withr ];
+    jaspNetwork = buildJaspModule "jaspNetwork" [ bootnet BDgraph corpcor dplyr foreach ggplot2 gtools HDInterval huge IsingSampler jaspBase jaspGraphs mvtnorm qgraph reshape2 snow stringr ];
+    jaspPower = buildJaspModule "jaspPower" [ pwr jaspBase jaspGraphs ];
+    jaspPredictiveAnalytics = buildJaspModule "jaspPredictiveAnalytics" [ jaspBase jaspGraphs bsts bssm precrec reshape2 Boom lubridate prophet BART EBMAforecast imputeTS ];
+    jaspProcess = buildJaspModule "jaspProcess" [ dagitty ggplot2 ggraph jaspBase jaspGraphs ];
+    jaspProphet = buildJaspModule "jaspProphet" [ rstan ggplot2 jaspBase jaspGraphs prophet scales ];
+    jaspQualityControl = buildJaspModule "jaspQualityControl" [ car cowplot daewr desirability DoE_base EnvStats FAdist fitdistrplus FrF2 ggplot2 ggrepel goftest ggpp irr jaspBase jaspDescriptives jaspGraphs mle_tools psych qcc rsm Rspc tidyr tibble vipor weibullness ];
+    jaspRegression = buildJaspModule "jaspRegression" [ BAS boot bstats combinat emmeans ggplot2 ggrepel hmeasure jaspAnova jaspBase jaspDescriptives jaspGraphs jaspTTests lmtest logistf MASS matrixStats mdscore ppcor purrr Rcpp statmod VGAM ];
+    jaspReliability = buildJaspModule "jaspReliability" [ Bayesrel coda ggplot2 ggridges irr jaspBase jaspGraphs LaplacesDemon lme4 MASS psych ];
+    jaspRobustTTests = buildJaspModule "jaspRobustTTests" [ RoBTT ggplot2 jaspBase jaspGraphs ];
+    jaspSem = buildJaspModule "jaspSem" [ forcats ggplot2 jaspBase jaspGraphs lavaan cSEM reshape2 semPlot semTools stringr tibble tidyr ];
+    jaspSummaryStatistics = buildJaspModule "jaspSummaryStatistics" [ BayesFactor bstats jaspBase jaspFrequencies jaspGraphs jaspRegression jaspTTests jaspAnova jaspDescriptives SuppDists bayesplay ];
+    jaspSurvival = buildJaspModule "jaspSurvival" [ survival survminer jaspBase jaspGraphs ];
+    jaspTTests = buildJaspModule "jaspTTests" [ BayesFactor car ggplot2 jaspBase jaspGraphs logspline plotrix plyr ];
+    jaspTimeSeries = buildJaspModule "jaspTimeSeries" [ jaspBase jaspGraphs forecast ];
+    jaspVisualModeling = buildJaspModule "jaspVisualModeling" [ flexplot jaspBase jaspGraphs ];
+  };
+}

--- a/pkgs/by-name/ja/jasp-desktop/package.nix
+++ b/pkgs/by-name/ja/jasp-desktop/package.nix
@@ -1,0 +1,121 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, callPackage
+, buildEnv
+, linkFarm
+, substituteAll
+, R
+, rPackages
+, cmake
+, ninja
+, pkg-config
+, boost
+, libarchive
+, readstat
+, qt6
+}:
+
+let
+  version = "0.18.2";
+
+  src = fetchFromGitHub {
+    owner = "jasp-stats";
+    repo = "jasp-desktop";
+    rev = "v${version}";
+    hash = "sha256-W0wYvk5T9srE1cOyGgahfGxEookdOgVcnzqH9SkFyo8=";
+    fetchSubmodules = true;
+  };
+
+  inherit (callPackage ./modules.nix {
+    jasp-src = src;
+    jasp-version = version;
+  }) engine modules;
+
+  # Merges ${R}/lib/R with all used R packages (even propagated ones)
+  customREnv = buildEnv {
+    name = "jasp-${version}-env";
+    paths = [
+      "${R}/lib/R"
+      rPackages.RInside
+      engine.jaspBase # Should already be propagated from modules, but include it again, just in case
+    ] ++ lib.attrValues modules;
+  };
+
+  modulesDir = linkFarm "jasp-${version}-modules"
+    (lib.mapAttrsToList (name: drv: { name = name; path = "${drv}/library"; }) modules);
+in
+stdenv.mkDerivation {
+  pname = "jasp-desktop";
+  inherit version src;
+
+  patches = [
+    # remove unused cmake deps, ensure boost is dynamically linked, patch readstat path
+    (substituteAll {
+      src = ./cmake.patch;
+      inherit readstat;
+    })
+  ];
+
+  cmakeFlags = [
+    "-DGITHUB_PAT=dummy"
+    "-DGITHUB_PAT_DEF=dummy"
+    "-DINSTALL_R_FRAMEWORK=OFF"
+    "-DLINUX_LOCAL_BUILD=OFF"
+    "-DINSTALL_R_MODULES=OFF"
+    "-DCUSTOM_R_PATH=${customREnv}"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    customREnv
+    boost
+    libarchive
+    readstat
+  ] ++ (with qt6; [
+    qtbase
+    qtdeclarative
+    qtwebengine
+    qtsvg
+    qt5compat
+  ]);
+
+  env.NIX_LDFLAGS = "-L${rPackages.RInside}/library/RInside/lib";
+
+  postInstall = ''
+    # Remove unused cache locations
+    rm -r $out/lib64 $out/Modules
+
+    # Remove flatpak proxy script
+    rm $out/bin/org.jaspstats.JASP
+    substituteInPlace $out/share/applications/org.jaspstats.JASP.desktop \
+        --replace "Exec=org.jaspstats.JASP" "Exec=JASP"
+
+    # symlink modules from the store
+    ln -s ${modulesDir} $out/Modules
+  '';
+
+  passthru = {
+    inherit modules engine;
+    env = customREnv;
+  };
+
+  meta = {
+    changelog = "https://jasp-stats.org/release-notes";
+    description = "A complete statistical package for both Bayesian and Frequentist statistical methods";
+    homepage = "https://github.com/jasp-stats/jasp-desktop";
+    license = lib.licenses.agpl3;
+    mainProgram = "JASP";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    # JASP's cmake build steps are really different on Darwin
+    # Perhaps the Darwin-specific things could be changed to be the same as Linux
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -618,7 +618,7 @@ let
     LCMCR = [ pkgs.gsl ];
     BNSP = [ pkgs.gsl ];
     scModels = [ pkgs.mpfr.dev ];
-    multibridge = [ pkgs.mpfr.dev ];
+    multibridge = with pkgs; [ pkg-config mpfr.dev ];
     RcppCWB = with pkgs; [ pcre.dev glib.dev ];
     redux = [ pkgs.hiredis ];
     RmecabKo = [ pkgs.mecab ];


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/264279
Supersedes https://github.com/NixOS/nixpkgs/pull/264366

This PR adds the `jasp-desktop` package, alongside with all of its R modules.
`env`, `modules` and `engine` is exposed through `passthru` for debugging purposes.
There's a custom R environment, which simulates what a normal installation of R would look like.

The module loading logic requires the modules themselves to be in a special location, which I set up using `linkFarm`.

This PR also fixes the build of the `multibridge` R module.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
