### PR TITLE
fix python311Packages.pynndescent & .umap-learn

### DIFF
--- a/pkgs/development/python-modules/pynndescent/default.nix
+++ b/pkgs/development/python-modules/pynndescent/default.nix
@@ -25,14 +25,10 @@ buildPythonPackage rec {
   };
 
   patches = [
-    # Fix sklearn 1.2.0 compat; https://github.com/lmcinnes/pynndescent/issues/207
+    # https://github.com/lmcinnes/pynndescent/pull/224
     (fetchpatch {
-      url = "https://github.com/lmcinnes/pynndescent/commit/00444be2107b71169b853847e7b334623c58a4e3.patch";
-      hash = "sha256-mbe01BwroS5q6hENsj3NejmGGhmk2IeX4LD6Iq6PR0c=";
-    })
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/pynndescent/commit/e56b92776a4a05f2dabb80d25479bd37e7ebd88e.patch";
-      hash = "sha256-zVTaW4syGEHh2HAGPyBN3YXqUGe55v/LxKLX/zjXT5Y=";
+      url = "https://github.com/lmcinnes/pynndescent/commit/86e0d716a3a4d5f4e6a0a3c2952f6fe339524e96.patch";
+      hash = "sha256-dfnT5P9Qsn/nSAr4Ysqo/olbLLfoZXvBRz33yzhN3J4=";
     })
   ];
 

--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "umap-learn";
-  version = "0.5.3";
+  version = "0.5.4";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,39 +25,8 @@ buildPythonPackage rec {
     owner = "lmcinnes";
     repo = "umap";
     rev = version;
-    hash = "sha256-S2+k7Ec4AxsN6d0GUGnU81oLnBgmlZp8OmUFCNaUJYw=";
+    hash = "sha256-cvAq9b7xDowLIfIAzV+X08SUEL0QOisr/wBXMYeQ/8A=";
   };
-
-  patches = [
-    # Fix tests with sklearn>=1.2.0
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/umap/commit/a714b59bd9e2ca2e63312bc3491b2b037a42f2f2.patch";
-      hash = "sha256-WOSWNN5ewVTV7IEBEA7ZzgZYMZxctF1jAWs9ylKTyLs=";
-    })
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/umap/commit/c7d05683325589ad432a55e109cacb9d631cfaa9.patch";
-      hash = "sha256-hE2Svxf7Uja+DbCmTDCnd7mZynjNbC5GUjfqg4ZRO9Y=";
-    })
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/umap/commit/949abd082524fce8c45dfb147bcd8e8ef49eade3.patch";
-      hash = "sha256-8/1k8iYeF77FIaUApNtY07auPJkrt3vNRR/HTYRvq+0=";
-    })
-    # Fix tests with numpy>=1.24
-    # https://github.com/lmcinnes/umap/pull/952
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/umap/commit/588e1f724c9f5de528eb1500b0c85a1a609fe947.patch";
-      hash = "sha256-B50eyMs3CRuzOAq+jxz56XMJPdiUofUxCL0Vqolaafo=";
-    })
-    # https://github.com/lmcinnes/umap/pull/1010
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/umap/commit/848396c762c894e666aaf3d0bcfe1e041b529ea6.patch";
-      hash = "sha256-ir0Pxfr2c0oSuFGXQqHjkj7nzvlpTXCYbaI9qAiLun0=";
-    })
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/umap/commit/30e39938f4627f327223245dfe2c908af6b7e304.patch";
-      hash = "sha256-7Divrym05wIPa7evgrNYXGm44/EOWG8sIYV8fmtuzJ4=";
-    })
-  ];
 
   propagatedBuildInputs = [
     numba


### PR DESCRIPTION
## Description of changes

The package pynndescent received a version update without adjusting the list of patches. I found the PR #248481 which did the update correctly, but it was closed without merging, since there was already the faulty version update commit.

@natsukium created the PR mentioned above.

Edit: Also fixed the build of umap-learn, which depends on pynndescent, by updating from 0.5.3 to 0.5.4. This includes some fixes for tests that failed before and also got rid of all the patches we applied.

ZHF: #265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
