### PR TITLE
gdcm: unvendor some dependencies (openjpeg, zlib, uuid, expat)

### DIFF
--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -10,6 +10,11 @@
 , enablePython ? false
 , python ? null
 , swig
+, expat
+, libuuid
+, openjpeg
+, zlib
+, pkg-config
 }:
 
 stdenv.mkDerivation rec {
@@ -27,6 +32,10 @@ stdenv.mkDerivation rec {
     "-DGDCM_BUILD_APPLICATIONS=ON"
     "-DGDCM_BUILD_SHARED_LIBS=ON"
     "-DGDCM_BUILD_TESTING=ON"
+    "-DGDCM_USE_SYSTEM_EXPAT=ON"
+    "-DGDCM_USE_SYSTEM_ZLIB=ON"
+    "-DGDCM_USE_SYSTEM_UUID=ON"
+    "-DGDCM_USE_SYSTEM_OPENJPEG=ON"
     # hack around usual "`RUNTIME_DESTINATION` must not be an absolute path" issue:
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_BINDIR=bin"
@@ -38,9 +47,17 @@ stdenv.mkDerivation rec {
     "-DGDCM_INSTALL_PYTHONMODULE_DIR=${placeholder "out"}/${python.sitePackages}"
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  buildInputs = lib.optionals enableVTK [
+  buildInputs = [
+    expat
+    libuuid
+    openjpeg
+    zlib
+  ] ++ lib.optionals enableVTK [
     vtk
   ] ++ lib.optionals stdenv.isDarwin [
     ApplicationServices


### PR DESCRIPTION
## Description of changes

Unvendors all the "non-advanced" dependencies except openssh and poppler, which aren't vendored and hence not supported by this build.  There are still some minor "advanced" dependencies which are still vendored - I only tried unvendoring `charls` but wasn't immediately successful.

Results of `nixpkgs-review` on x86_64-NixOS:

```
8 packages built:
gdcm octavePackages.dicom python310Packages.dicom2nifti python310Packages.dicom2nifti.dist python310Packages.gdcm python311Packages.dicom2nifti python311Packages.dicom2nifti.dist python311Packages.gdcm
```

I also confirmed that ITK can be built against this GDCM on the branch in #265927 (but didn't run a full nixpkgs-review against the rebase).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).