### PR TITLE
cargo-mommy: 0.1.1 -> 0.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-mommy/default.nix
+++ b/pkgs/development/tools/rust/cargo-mommy/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-mommy";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-p1SAYUQu1HpYJ6TbLJ3lfA9VlKHvB7z5yiFXmTQOCXA=";
+    sha256 = "sha256-/f6jHXwUJqAlqmVvvxfB4tvKkYwCmqI8GgPBHf5Qg1E=";
   };
 
-  cargoSha256 = "sha256-5RidY+6EF23UNzz1suSdA4LL59FalipaJ+ISSsmiCXM=";
+  cargoSha256 = "sha256-hj6oRuTlCxGq5SosVBkVwrG0Sgv5iDz5naCXPueYFqM=";
 
   meta = with lib; {
     description = "Cargo wrapper that encourages you after running commands";


### PR DESCRIPTION
## Description of changes

No breaking changes. Improved performance, customizable emotes, fixed typos, and, uhm, [one other update](https://github.com/Gankra/cargo-mommy#configuration-kink).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (in CI)
  - [x] aarch64-darwin (in CI)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
