### PR TITLE
python311Packages.langchain: 0.325 -> 0.0.334; python311Packages.langsmith: 0.0.57 -> 0.0.63

### DIFF
--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -42,7 +42,6 @@
 , librosa
 , lxml
 , manifest-ml
-, markdownify
 , neo4j
 , networkx
 , nlpcloud
@@ -76,7 +75,6 @@
 , pytest-asyncio
 , pytest-mock
 , pytest-socket
-, pytest-vcr
 , pytestCheckHook
 , requests-mock
 , responses
@@ -254,22 +252,22 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     freezegun
-    markdownify
+    lark
     pandas
     pytest-asyncio
     pytest-mock
     pytest-socket
-    pytest-vcr
     pytestCheckHook
     requests-mock
     responses
     syrupy
     toml
-  ] ++ passthru.optional-dependencies.all;
+  ];
 
   pytestFlagsArray = [
     # integration_tests have many network, db access and require `OPENAI_API_KEY`, etc.
     "tests/unit_tests"
+    "--only-core"
   ];
 
   disabledTests = [
@@ -279,6 +277,10 @@ buildPythonPackage rec {
 
     # these tests have network access
     "test_socket_disabled"
+  ];
+
+  pythonImportsCheck = [
+    "langchain"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -78,6 +78,7 @@
 , pytest-socket
 , pytest-vcr
 , pytestCheckHook
+, requests-mock
 , responses
 , syrupy
 , toml
@@ -85,7 +86,7 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.0.325";
+  version = "0.0.334";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -94,7 +95,7 @@ buildPythonPackage rec {
     owner = "hwchase17";
     repo = "langchain";
     rev = "refs/tags/v${version}";
-    hash = "sha256-/bk4RafDDL4nozyFOiikyU4auBSftej21m5/FnEtDog=";
+    hash = "sha256-mXPqc8wF9DhEtITm8h5R9kHBcMJ7AEK4kL5Z7V2p8NE=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";
@@ -260,6 +261,7 @@ buildPythonPackage rec {
     pytest-socket
     pytest-vcr
     pytestCheckHook
+    requests-mock
     responses
     syrupy
     toml

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "langsmith";
-  version = "0.0.57";
+  version = "0.0.63";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     rev = "refs/tags/v${version}";
-    hash = "sha256-3P0vB7wz/K3skejyPwtFZN17mFrOw9TGLHTJHvu4m7M=";
+    hash = "sha256-KE+WMnuWAq1stZuuwZkOPOKQ2lZNKtxzNbZMRoOdmz0=";
   };
 
   sourceRoot = "${src.name}/python";
@@ -59,6 +59,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "langsmith"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform";


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/langchain-ai/langchain/compare/refs/tags/v0.0.325...v0.0.334
Changelog: https://github.com/hwchase17/langchain/releases/tag/v0.0.334

Diff: https://github.com/langchain-ai/langsmith-sdk/compare/refs/tags/v0.0.57...v0.0.63
Changelog: https://github.com/langchain-ai/langsmith-sdk/releases/tag/v0.0.63

clean up the test dependencies and fix on darwin
https://hydra.nixos.org/build/240230505
ZHF: #265948

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
