### PR TITLE
cargo-mommy: 0.1.1 → 0.2.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-mommy/default.nix
+++ b/pkgs/development/tools/rust/cargo-mommy/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-mommy";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-p1SAYUQu1HpYJ6TbLJ3lfA9VlKHvB7z5yiFXmTQOCXA=";
+    sha256 = "sha256-/f6jHXwUJqAlqmVvvxfB4tvKkYwCmqI8GgPBHf5Qg1E=";
   };
 
-  cargoSha256 = "sha256-5RidY+6EF23UNzz1suSdA4LL59FalipaJ+ISSsmiCXM=";
+  cargoSha256 = "sha256-hj6oRuTlCxGq5SosVBkVwrG0Sgv5iDz5naCXPueYFqM=";
 
   meta = with lib; {
     description = "Cargo wrapper that encourages you after running commands";


### PR DESCRIPTION
## Description of changes

Updated `cargo-mommy` from v0.1.1 to v0.2.0 ~~like a good girl / excellent enby.~~

cc @GoldsteinE


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
