### PR TITLE
pam: fix pam_unix autohentication failures when ran as user

### DIFF
--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" "man" /* "modules" */ ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  # autoreconfHook269 is needed for `bind-locales.patch` above
+  # autoreconfHook269 is needed for `suid-wrapper-path.patch` and
+  # `bind-locales.patch` above.
   # pkg-config-unwrapped is needed for `AC_CHECK_LIB` and `AC_SEARCH_LIBS`
   nativeBuildInputs = [ flex autoreconfHook269 pkg-config-unwrapped ]
     ++ lib.optional stdenv.buildPlatform.isDarwin gettext;

--- a/pkgs/os-specific/linux/pam/suid-wrapper-path.patch
+++ b/pkgs/os-specific/linux/pam/suid-wrapper-path.patch
@@ -1,6 +1,6 @@
 It needs the SUID version during runtime, and that can't be in /nix/store/**
---- a/modules/pam_unix/Makefile.in
-+++ b/modules/pam_unix/Makefile.in
-@@ -651 +651 @@
+--- a/modules/pam_unix/Makefile.am
++++ b/modules/pam_unix/Makefile.am
+@@ -21 +21 @@
 -	-DCHKPWD_HELPER=\"$(sbindir)/unix_chkpwd\" \
 +	-DCHKPWD_HELPER=\"/run/wrappers/bin/unix_chkpwd\" \


### PR DESCRIPTION
Commit d0c42dfa "pam: bind Linux-PAM locales from pam-specific folder (upstream patch)" added autoreconfHook269 into one of the postPatch phases.

This clobbered the change applied by `suid-wrapper-path.patch` as it was patching Makefile.in.

As a result `nixosTests.sway` test started failing as:

    check pass; user unknown

Running `swaylock` on real system exhibited the same result.

As `suid-wrapper-path.patch` is clobbered we were running non-suid version of `unix_chkpwd`:

    /nix/store/...-linux-pam-1.5.2/sbin/unix_chkpwd

instead of SUID-wrapped

    /run/wrappers/bin/unix_chkpw

The fix is trivial: move the patch from auto-generated file to `Makefile.am`.

Discovered-by: Yureka

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
