### PR TITLE
Revert "Revert "python310Packages.pillow: 10.0.1 -> 10.1.0""

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -133,6 +133,10 @@ buildPythonPackage rec {
     "test_auto_blocksize_csv"
     # AttributeError: 'str' object has no attribute 'decode'
     "test_read_dir_nometa"
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    # concurrent.futures.process.BrokenProcessPool: A process in the process pool terminated abpruptly...
+    "test_foldby_tree_reduction"
+    "test_to_bag"
   ] ++ [
     # https://github.com/dask/dask/issues/10347#issuecomment-1589683941
     "test_concat_categorical"

--- a/pkgs/development/python-modules/pillow-heif/default.nix
+++ b/pkgs/development/python-modules/pillow-heif/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
     hash = "sha256-GbOW29rGpLMS7AfShuO6UCzcspdHtFS7hyNKori0otI=";
   };
 
+  postPatch = ''
+    sed -i '/addopts/d' pyproject.toml
+  '';
+
   nativeBuildInputs = [
     cmake
     nasm
@@ -68,6 +72,15 @@ buildPythonPackage rec {
     # https://github.com/bigcat88/pillow_heif/issues/89
     # not reproducible in nixpkgs
     "test_opencv_crash"
+  ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+    # RuntimeError: Encoder plugin generated an error: Unsupported bit depth: Bit depth not supported by x265
+    "test_open_heif_compare_non_standard_modes_data"
+    "test_open_save_disable_16bit"
+    "test_save_bgr_16bit_to_10_12_bit"
+    "test_save_bgra_16bit_to_10_12_bit"
+    "test_premultiplied_alpha"
+    "test_hdr_save"
+    "test_I_color_modes_to_10_12_bit"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -12,7 +12,7 @@
 
 import ./generic.nix (rec {
   pname = "pillow";
-  version = "10.0.1";
+  version = "10.1.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ import ./generic.nix (rec {
   src = fetchPypi {
     pname = "Pillow";
     inherit version;
-    hash = "sha256-1ylnsGvpMA/tXPvItbr87sSL983H2rZrHSVJA1KHGR0=";
+    hash = "sha256-5r+N5sNu2WyG6jtuHVJzxT9G71GKBiRkzX713Sz5Ljg=";
   };
 
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

Was reverted because `python311Packages.imageio` hadn't caught up. Now there is a patch and it works.

Also did some light work on the imageio packaging in general.

Then some workarounds for aarch64-linux and aarch64-darwin, who failed a test here and there.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux 
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
