### PR TITLE
vips: 8.14.5 -> 8.15.0

### DIFF
--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
 , pytestCheckHook
 , glib
@@ -12,6 +13,8 @@
 buildPythonPackage rec {
   pname = "pyvips";
   version = "2.2.1";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "libvips";

--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -44,6 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A python wrapper for libvips";
     homepage = "https://github.com/libvips/pyvips";
+    changelog = "https://github.com/libvips/pyvips/blob/v${version}/CHANGELOG.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ ccellado anthonyroussel ];
   };

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -112,8 +112,14 @@ stdenv.mkDerivation (finalAttrs: {
   ;
 
   passthru = {
-    tests.pkg-config = testers.hasPkgConfigModules {
-      package = finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "vips --version";
+      };
     };
     updateScript = nix-update-script {
       extraArgs = [ "--version-regex" "v([0-9.]+)" ];

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -18,7 +18,6 @@
 , libexif
 , librsvg
 , poppler
-, libgsf
 , libtiff
 , fftw
 , lcms2
@@ -26,7 +25,6 @@
 , libimagequant
 , imagemagick
 , pango
-, orc
 , matio
 , cfitsio
 , libwebp
@@ -36,13 +34,15 @@
 , openslide
 , libheif
 , cgif
+, libarchive
+, libhwy
 , testers
 , nix-update-script
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vips";
-  version = "8.14.5";
+  version = "8.15.0";
 
   outputs = [ "bin" "out" "man" "dev" ] ++ lib.optionals (!stdenv.isDarwin) [ "devdoc" ];
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libvips";
     repo = "libvips";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-fG3DTP+3pO7sbqR/H9egJHU3cLKPU4Jad6qxcQ9evNw=";
+    hash = "sha256-WfKq+maLcAXyjk1sq66wSU92ALv4MfRDPKe4Mki0KRQ=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     postFetch = ''
@@ -78,7 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     libexif
     librsvg
     poppler
-    libgsf
     libtiff
     fftw
     lcms2
@@ -86,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     libimagequant
     imagemagick
     pango
-    orc
     matio
     cfitsio
     libwebp
@@ -96,6 +94,8 @@ stdenv.mkDerivation (finalAttrs: {
     openslide
     libheif
     cgif
+    libarchive
+    libhwy
   ] ++ lib.optionals stdenv.isDarwin [ ApplicationServices Foundation ];
 
   # Required by .pc file

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -37,6 +37,7 @@
 , libheif
 , cgif
 , testers
+, nix-update-script
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -110,8 +111,13 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (imagemagick == null) "-Dmagick=disabled"
   ;
 
-  passthru.tests.pkg-config = testers.hasPkgConfigModules {
-    package = finalAttrs.finalPackage;
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex" "v([0-9.]+)" ];
+    };
   };
 
   meta = with lib; {

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     changelog = "https://github.com/libvips/libvips/blob/${finalAttrs.src.rev}/ChangeLog";
-    homepage = "https://libvips.github.io/libvips/";
+    homepage = "https://www.libvips.org/";
     description = "Image processing system for large images";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ kovirobi ];

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -36,9 +36,10 @@
 , openslide
 , libheif
 , cgif
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vips";
   version = "8.14.5";
 
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libvips";
     repo = "libvips";
-    rev = "v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-fG3DTP+3pO7sbqR/H9egJHU3cLKPU4Jad6qxcQ9evNw=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
@@ -109,14 +110,18 @@ stdenv.mkDerivation rec {
   ++ lib.optional (imagemagick == null) "-Dmagick=disabled"
   ;
 
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+  };
+
   meta = with lib; {
-    changelog = "https://github.com/libvips/libvips/blob/${src.rev}/ChangeLog";
+    changelog = "https://github.com/libvips/libvips/blob/${finalAttrs.src.rev}/ChangeLog";
     homepage = "https://libvips.github.io/libvips/";
     description = "Image processing system for large images";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ kovirobi ];
-    pkgConfigModules = [ "vips" ];
+    pkgConfigModules = [ "vips" "vips-cpp" ];
     platforms = platforms.unix;
     mainProgram = "vips";
   };
-}
+})

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.libvips.org/";
     description = "Image processing system for large images";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ kovirobi ];
+    maintainers = with maintainers; [ kovirobi anthonyroussel ];
     pkgConfigModules = [ "vips" "vips-cpp" ];
     platforms = platforms.unix;
     mainProgram = "vips";

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation rec {
     description = "Image processing system for large images";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ kovirobi ];
+    pkgConfigModules = [ "vips" ];
     platforms = platforms.unix;
     mainProgram = "vips";
   };


### PR DESCRIPTION
## Description of changes

https://github.com/libvips/libvips/releases/tag/v8.15.0
https://github.com/libvips/libvips/compare/v8.14.5...v8.15.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
