### PR TITLE
sharedown: unbreak build

### DIFF
--- a/pkgs/tools/misc/sharedown/default.nix
+++ b/pkgs/tools/misc/sharedown/default.nix
@@ -6,7 +6,7 @@
 , libsecret
 , python3
 , pkg-config
-, nodejs
+, nodePackages
 , electron
 , makeWrapper
 , makeDesktopItem
@@ -63,6 +63,7 @@ stdenvNoCC.mkDerivation rec {
             nativeBuildInputs = [
               python3
               pkg-config
+              nodePackages.node-gyp
             ];
             buildInputs = [
               libsecret
@@ -74,17 +75,6 @@ stdenvNoCC.mkDerivation rec {
             '';
           };
         };
-
-        preBuild = ''
-          # Set up headers for node-gyp, which is needed to build keytar.
-          mkdir -p "$HOME/.cache/node-gyp/${nodejs.version}"
-
-          # Set up version which node-gyp checks in <https://github.com/nodejs/node-gyp/blob/4937722cf597ccd1953628f3d5e2ab5204280051/lib/install.js#L87-L96> against the version in <https://github.com/nodejs/node-gyp/blob/4937722cf597ccd1953628f3d5e2ab5204280051/package.json#L15>.
-          echo 9 > "$HOME/.cache/node-gyp/${nodejs.version}/installVersion"
-
-          # Link node headers so that node-gyp does not try to download them.
-          ln -sfv "${nodejs}/include" "$HOME/.cache/node-gyp/${nodejs.version}"
-        '';
 
         packageJSON = "${src}/package.json";
         yarnLock = ./yarn.lock;


### PR DESCRIPTION
## Description of changes

fixes the following error message:

```
$ node-gyp rebuild
info This package requires node-gyp, which is not currently installed. Yarn will attempt to automatically install it. If this fails, you can run "yarn global add node-gyp" to manually install it.
[1/4] Resolving packages...
error Failed to auto-install node-gyp. Please run "yarn global add node-gyp" manually. Error: "Couldn't find any versions for \"node-gyp\" that matches \"latest\" in our cache (possible versions are \"\"). This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue."
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

https://hydra.nixos.org/build/239684452

ZHF #265948

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
