### PR TITLE
dmodman: init at 0.2.3

### DIFF
--- a/pkgs/by-name/dm/dmodman/package.nix
+++ b/pkgs/by-name/dm/dmodman/package.nix
@@ -43,11 +43,11 @@ rustPlatform.buildRustPackage rec {
       --replace 'Exec=dmodman' "Exec=$out/bin/dmodman"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "TUI downloader and update checker for Nexusmods.com";
     homepage = "https://github.com/dandels/dmodman";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "dmodman";
-    maintainers = [ maintainers.schnusch ];
+    maintainers = [ lib.maintainers.schnusch ];
   };
 }

--- a/pkgs/by-name/dm/dmodman/package.nix
+++ b/pkgs/by-name/dm/dmodman/package.nix
@@ -38,9 +38,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postInstall = lib.optionalString nxmUrlHandler ''
-    mkdir -p $out/share/applications
-    substitute dmodman.desktop $out/share/applications/dmodman.desktop \
-      --replace 'Exec=dmodman' "Exec=$out/bin/dmodman"
+    install -Dm 644 dmodman.desktop out/share/applications/
   '';
 
   meta = {

--- a/pkgs/by-name/dm/dmodman/package.nix
+++ b/pkgs/by-name/dm/dmodman/package.nix
@@ -1,10 +1,11 @@
-{ lib
-, fetchFromGitHub
-, fetchpatch
-, openssl
-, pkg-config
-, rustPlatform
-, nxmUrlHandler ? true
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  nxmUrlHandler ? true,
 }:
 
 rustPlatform.buildRustPackage rec {

--- a/pkgs/by-name/dm/dmodman/package.nix
+++ b/pkgs/by-name/dm/dmodman/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, openssl
+, pkg-config
+, rustPlatform
+, nxmUrlHandler ? true
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dmodman";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "dandels";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-SpfQzL9bFW/hvYSTBy+sI8FsywbohyvT2ZgpMl6KuEg=";
+  };
+
+  patches = [
+    # fix test that broke when a field became optional
+    (fetchpatch {
+      url = "https://github.com/dandels/dmodman/commit/dad568ddc121172c47807dcb39534becaba98684.diff";
+      hash = "sha256-W/XlYYtT0vr1QjSixG75Q+Y+XNjOK6jSqvBMB1qbqvk=";
+    })
+  ];
+
+  cargoHash = "sha256-ecchFPJBVsJZZ5rVYsjiJUrgm3rBdO+iU8JtuQ4PTN0=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  postInstall = lib.optionalString nxmUrlHandler ''
+    mkdir -p $out/share/applications
+    substitute dmodman.desktop $out/share/applications/dmodman.desktop \
+      --replace 'Exec=dmodman' "Exec=$out/bin/dmodman"
+  '';
+
+  meta = with lib; {
+    description = "TUI downloader and update checker for Nexusmods.com";
+    homepage = "https://github.com/dandels/dmodman";
+    license = licenses.mit;
+    mainProgram = "dmodman";
+    maintainers = [ maintainers.schnusch ];
+  };
+}


### PR DESCRIPTION
## Description of changes

TUI downloader and update checker for Nexusmods.com.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
