### PR TITLE
python311Packages.zope-dottedname: 5.0 -> 6.0; rename from zope_dottedname

### DIFF
--- a/pkgs/development/python-modules/zope-dottedname/default.nix
+++ b/pkgs/development/python-modules/zope-dottedname/default.nix
@@ -1,11 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-dottedname";
   version = "5.0";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "zope.dottedname";
@@ -13,11 +16,31 @@ buildPythonPackage rec {
     hash = "sha256-mfWDqAKFhqtMIXlGE+QR0BDNCZF/RdqXa9/udI87++w=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "src/zope/dottedname/tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "zope.dottedname"
+  ];
+
+  pythonNamespaces = [
+    "zope"
+  ];
+
   meta = with lib; {
-    homepage = "http://pypi.python.org/pypi/zope.dottedname";
+    homepage = "https://github.com/zopefoundation/zope.dottedname";
     description = "Resolver for Python dotted names";
-    license = licenses.zpl20;
+    changelog = "https://github.com/zopefoundation/zope.dottedname/blob/${version}/CHANGES.rst";
+    license = licenses.zpl21;
     maintainers = with maintainers; [ goibhniu ];
   };
-
 }

--- a/pkgs/development/python-modules/zope-dottedname/default.nix
+++ b/pkgs/development/python-modules/zope-dottedname/default.nix
@@ -4,11 +4,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zope.dottedname";
+  pname = "zope-dottedname";
   version = "5.0";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "zope.dottedname";
+    inherit version;
     hash = "sha256-mfWDqAKFhqtMIXlGE+QR0BDNCZF/RdqXa9/udI87++w=";
   };
 

--- a/pkgs/development/python-modules/zope-dottedname/default.nix
+++ b/pkgs/development/python-modules/zope-dottedname/default.nix
@@ -1,19 +1,22 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , setuptools
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-dottedname";
-  version = "5.0";
+  version = "6.0";
   pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "zope.dottedname";
     inherit version;
-    hash = "sha256-mfWDqAKFhqtMIXlGE+QR0BDNCZF/RdqXa9/udI87++w=";
+    hash = "sha256-28S4W/vzSx74jasWJSrG7xbZBDnyIjstCiYs9Bnq6QI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -457,6 +457,7 @@ mapAliases ({
   zope_component = zope-component; # added 2023-07-28
   zope_contenttype = zope-contenttype; # added 2023-10-11
   zope_deprecation = zope-deprecation; # added 2023-10-07
+  zope_dottedname = zope-dottedname; # added 2023-11-12
   zope_i18nmessageid = zope-i18nmessageid; # added 2023-07-29
   zope_lifecycleevent = zope-lifecycleevent; # added 2023-10-11
   zope_proxy = zope-proxy; # added 2023-10-07

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16087,7 +16087,7 @@ self: super: with self; {
 
   zope-deprecation = callPackage ../development/python-modules/zope-deprecation { };
 
-  zope_dottedname = callPackage ../development/python-modules/zope_dottedname { };
+  zope-dottedname = callPackage ../development/python-modules/zope-dottedname { };
 
   zope_event = callPackage ../development/python-modules/zope_event { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/zopefoundation/zope.dottedname/blob/6.0/CHANGES.rst

part of #245383 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
