### PR TITLE
manim: 0.17.3 -> 0.18.0

### DIFF
--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchPypi
 
 , cairo
 , ffmpeg
@@ -43,39 +42,19 @@ let
     babel-english gnu-freefont mathastext cbfonts-fd
   ]);
 
-  python = python3.override {
-    packageOverrides = self: super: {
-      networkx = super.networkx.overridePythonAttrs (oldAttrs: rec {
-        pname = "networkx";
-        version = "2.8.8";
-        src = fetchPypi {
-          inherit pname version;
-          hash = "sha256-Iw04gRevhw/OVkejxSQB/PdT6Ucg5uprQZelNVZIiF4=";
-        };
-      });
-
-      watchdog = super.watchdog.overridePythonAttrs (oldAttrs: rec{
-        pname = "watchdog";
-        version = "2.3.1";
-        src = fetchPypi {
-          inherit pname version;
-          hash = "sha256-2fntJu0iqdMxggqEMsNoBwfqi1QSHdzJ3H2fLO6zaQY=";
-        };
-      });
-    };
-  };
+  python = python3;
 
 in python.pkgs.buildPythonApplication rec {
   pname = "manim";
   pyproject = true;
-  version = "0.17.3";
+  version = "0.18.0";
   disabled = python3.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner  = "ManimCommunity";
-    repo = pname;
+    repo = "manim";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-TU/b5nwk5Xc9wmFKAIMeBwC4YBy7HauGeGV9/n4Y64c=";
+    sha256 = "sha256-TI7O0b1JvUZAxTj6XfpAJKhbGqrGnhcrE9eRJUVx4GM=";
   };
 
   nativeBuildInputs = with python.pkgs; [

--- a/pkgs/applications/video/manim/failing_tests.nix
+++ b/pkgs/applications/video/manim/failing_tests.nix
@@ -71,4 +71,7 @@
   # mismatching expecation on the new commandline
   "test_manim_new_command"
 
+  # This tests checks if the manim executable is a python script. In our case it is not.
+  # It is a wrapper shell script instead.
+  "test_manim_checkhealth_subcommand"
 ]

--- a/pkgs/applications/video/manim/pytest-report-header.patch
+++ b/pkgs/applications/video/manim/pytest-report-header.patch
@@ -1,8 +1,8 @@
 diff --git a/conftest.py b/conftest.py
-index da37e19b..d9f850d8 100644
+index dacb730a..149c6702 100644
 --- a/conftest.py
 +++ b/conftest.py
-@@ -32,16 +32,3 @@ def temp_media_dir(tmpdir, monkeypatch, request):
+@@ -33,17 +33,3 @@ def temp_media_dir(tmpdir, monkeypatch, request):
          with tempconfig({"media_dir": str(tmpdir)}):
              assert config.media_dir == str(tmpdir)
              yield tmpdir
@@ -13,6 +13,7 @@ index da37e19b..d9f850d8 100644
 -    info = ctx.info
 -    ctx.release()
 -    return (
+-        f"\nCairo Version: {cairo.cairo_version()}",
 -        "\nOpenGL information",
 -        "------------------",
 -        f"vendor: {info['GL_VENDOR'].strip()}",


### PR DESCRIPTION
## Description of changes

Changelog: https://docs.manim.community/en/latest/changelog/0.18.0-changelog.html

Some changes worth noting:
- Removed a useless (empty) file named `conftest-` in the `manim` derivation folder
- Removed the version override for `networkx` and `watchdog` as the versions currently packaged in nixpkgs are supported by this version of `manim`.
- Disable a new test added in this new version which calls `manim checkhealth` and ensures that all the checks pass.
  This is not the case as one of those checks is about making sure that the `manim` executable is a python script (whereas for us is is a wrapper shell script).

cc @friedelino 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
