### PR TITLE
texturepacker: init at 7.1.0

### DIFF
--- a/pkgs/applications/graphics/texturepacker/default.nix
+++ b/pkgs/applications/graphics/texturepacker/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, wrapQtAppsHook
+, qtbase
+, qtdeclarative
+, qtsvg
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "texturepacker";
+  version = "7.1.0";
+
+  src = fetchurl {
+    url = "https://www.codeandweb.com/download/texturepacker/${finalAttrs.version}/TexturePacker-${finalAttrs.version}.deb";
+    hash = "sha256-9HbmdMPTp6qZCEU/lIZv4HbjKUlEtPVval+y0tiYObc=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+    qtsvg
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    cp usr/lib/texturepacker/{libGrantlee_Templates.so.5,libHQX.so.1.0.0,libPVRTexLib.so} $out/lib
+    cp usr/lib/texturepacker/TexturePacker $out/bin
+    cp -r usr/share $out
+  '';
+
+  meta = {
+    changelog = "https://www.codeandweb.com/texturepacker/download";
+    description = "Sprite sheet creator and game graphics optimizer";
+    homepage = "https://www.codeandweb.com/texturepacker";
+    license = lib.licenses.unfree;
+    mainProgram = "TexturePacker";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35753,6 +35753,8 @@ with pkgs;
 
   texture-synthesis = callPackage ../tools/graphics/texture-synthesis { };
 
+  texturepacker = qt6.callPackage ../applications/graphics/texturepacker { };
+
   tty-solitaire = callPackage ../applications/misc/tty-solitaire { };
 
   termtosvg = callPackage ../tools/misc/termtosvg { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/81362

This PR adds 1 package: `texturepacker`
This software is proprietary

To get it to work, I used the published `.deb` package, removed most of the libraries packaged together with it. 
There were a few exceptions: two, which were not in nixpkgs, and one which, if replaced by the nixpkgs version of the lib, would not work

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
