### PR TITLE
mpvScripts.buildLua: Add `extraScripts` parameter, infer `scriptName` better

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -8,10 +8,17 @@ let
 in
 lib.makeOverridable (
   { pname
-  , scriptPath ? "${pname}.lua"
   , extraScripts ? []
   , ... }@args:
-
+  let
+    # either passthru.scriptName, inferred from scriptPath, or from pname
+    scriptName = (args.passthru or {}).scriptName or (
+      if args ? scriptPath
+      then fileName args.scriptPath
+      else "${pname}.lua"
+    );
+    scriptPath = args.scriptPath or "./${scriptName}";
+  in
   stdenvNoCC.mkDerivation (lib.attrsets.recursiveUpdate {
     dontBuild = true;
     preferLocalBuild = true;
@@ -24,7 +31,7 @@ lib.makeOverridable (
       runHook postInstall
     '';
 
-    passthru.scriptName = fileName scriptPath;
+    passthru = { inherit scriptName; };
     meta.platforms = lib.platforms.all;
   } args)
 )

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -15,8 +15,8 @@ buildLua rec {
     hash = "sha256-yrcTxqpLnOI1Tq3khhflO3wzhyeTPuvKifyH5/P57Ns=";
   };
 
-  passthru.scriptName = "quality-menu.lua";
-  scriptPath = if oscSupport then "*.lua" else passthru.scriptName;
+  scriptPath = "quality-menu.lua";
+  extraScripts = lib.optional oscSupport "quality-menu-osc.lua";
 
   meta = with lib; {
     description = "A userscript for MPV that allows you to change youtube video quality (ytdl-format) on the fly";

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -15,7 +15,9 @@ buildLua rec {
   postPatch = "patchShebangs concat_files.py";
   dontBuild = false;
 
-  scriptPath = "mpv_thumbnail_script_{client_osc,server}.lua";
+  scriptPath = "mpv_thumbnail_script_client_osc.lua";
+  extraScripts = [ "mpv_thumbnail_script_server.lua" ];
+  passthru.scriptName = "mpv_thumbnail_script_{client_osc,server}.lua";
 
   meta = with lib; {
     description = "A lua script to show preview thumbnails in mpv's OSC seekbar";


### PR DESCRIPTION
## Description of changes

In `mpvScripts`:
- `buildLua`
  - Add `extraScripts` parameter, don't expand globs in `scriptPath`.
   this makes extending `buildLua` to handle scripts packaged as directories a lot simpler.
  - Infer `scriptName` from `scriptPath` before falling back to `${pname}.lua`
- Update `quality-menu` and `thumbnail` in consequence  
  as a bonus, this made `quality-menu` a fair bit cleaner  <3


## Context

Mpv has well-defined expectations for where to find scripts: either `scripts/${name}.ext` or `scripts/${name}/main.ext`.

In an ideal world, this is what upstreams would use, and the packaging helper wouldn't need globs or `extraScripts`.
Unfortunately, a number of upstreams ship either a bunch of dependencies directly in `scripts/`, or in `script/${name}_external`.

I was previously using shell patterns in `scriptPath` to cope with those cases, but it got in the way of implementing directory-based scripts as needed for #266501 and #266505.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
