### PR TITLE
sqlcl: change license to unfreeRedistributable

### DIFF
--- a/pkgs/development/tools/database/sqlcl/default.nix
+++ b/pkgs/development/tools/database/sqlcl/default.nix
@@ -1,37 +1,11 @@
-{ lib, stdenv, makeWrapper, requireFile, unzip, jdk }:
+{ lib, stdenv, makeWrapper, fetchurl, unzip, jdk }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sqlcl";
   version = "23.2.0.178.1027";
 
-  src = requireFile rec {
-    url = "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/";
-    name = "sqlcl-${version}.zip";
-    message = ''
-      This Nix expression requires that ${name} already be part of the store. To
-      obtain it you need to
-
-      - navigate to ${url}
-      - make sure that it says "Version ${version}" above the list of downloads
-        - if it does not, click on the "Previous Version" link below the
-          download and repeat until the version is correct. This is necessary
-          because as the time of this writing there exists no permanent link
-          for the current version yet.
-          Also consider updating this package yourself (you probably just need
-          to change the `version` variable and update the sha256 to the one of
-          the new file) or opening an issue at the nixpkgs repo.
-      - click "Download"
-      - sign in or create an oracle account if neccessary
-      - on the next page, click the "${name}" link
-
-      and then add the file to the Nix store using either:
-
-        nix-store --add-fixed sha256 ${name}
-
-      or
-
-        nix-prefetch-url --type sha256 file:///path/to/${name}
-    '';
+  src = fetchurl {
+    url = "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-${finalAttrs.version}.zip";
     hash = "sha256-wGqLlV88yYJrVblKzeG6VerfsEgCi1JQd49ONZmUB4Y=";
   };
 
@@ -58,8 +32,8 @@ stdenv.mkDerivation rec {
       also supporting your previously written SQL*Plus scripts.
     '';
     homepage = "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/";
-    license = licenses.unfree;
+    license = licenses.unfreeRedistributable;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ misterio77 ];
   };
-}
+})


### PR DESCRIPTION
SQLcL is actually unfreeRedistributable ([since 2021, it seems](https://blogs.oracle.com/database/post/sqlcl-now-under-the-oracle-free-use-terms-and-conditions-license)), under the https://www.oracle.com/downloads/licenses/oracle-free-license.html. Manually downloading the source is also not needed anymore.

Also switched to finalAttrs pattern instead of using rec.