### PR TITLE
mpv: Set `meta.mainProgram`

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -256,6 +256,7 @@ in stdenv'.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/mpv-player/mpv/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl2Plus;
+    mainProgram = "mpv";
     maintainers = with maintainers; [ AndersonTorres fpletz globin ma27 tadeokondrak ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
 
   postPatch = ''
     substituteInPlace thumbfast.lua \
-      --replace 'mpv_path = "mpv"' 'mpv_path = "${lib.getBin mpv-unwrapped}/bin/mpv"'
+      --replace 'mpv_path = "mpv"' 'mpv_path = "${lib.getExe mpv-unwrapped}"'
   '';
 
   dontBuild = true;


### PR DESCRIPTION
## Description of changes

- `mpv`: Set `meta.mainProgram`
- `mpvScripts.thumbfast`: Simplify using `lib.getExe`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  Checked that no rebuild was necessary, hence this does not introduce functional changes.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
