### PR TITLE
wxGTK32: 3.2.3 -> 3.2.4

### DIFF
--- a/pkgs/development/libraries/wxwidgets/wxGTK32.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK32.nix
@@ -50,13 +50,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wxwidgets";
-  version = "3.2.3";
+  version = "3.2.4";
 
   src = fetchFromGitHub {
     owner = "wxWidgets";
     repo = "wxWidgets";
     rev = "v${version}";
-    hash = "sha256-tuLNNhQA9HGax1aueZHQ+eB2dyIQnKjlmarp7e6Jplc=";
+    hash = "sha256-YkV150sDsfBEHvHne0GF6i8Y5881NrByPkLtPAmb24E=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37380,13 +37380,31 @@ with pkgs;
   rbdoom-3-bfg = callPackage ../games/doom-ports/rbdoom-3-bfg { };
 
   slade = callPackage ../games/doom-ports/slade {
-    wxGTK = wxGTK32.override {
+    wxGTK = (wxGTK32.overrideAttrs {
+      patches = [
+       (fetchpatch { # required to run slade 3.2.4 on wxGTK 3.2.4, see PR #266945
+         url = "https://github.com/wxWidgets/wxWidgets/commit/425d9455e8307c1267a79d47d77e3dafeb4d86de.patch";
+         excludes = [ "docs/changes.txt" ];
+         revert = true;
+         hash = "sha256-6LOYLDLtVCHxNdHAWv3zhlCsljIpi//RJb9XVLGD5hM=";
+       })
+     ];
+    }).override {
       withWebKit = true;
     };
   };
 
   sladeUnstable = callPackage ../games/doom-ports/slade/git.nix {
-    wxGTK = wxGTK32.override {
+    wxGTK = (wxGTK32.overrideAttrs {
+      patches = [
+       (fetchpatch { # required to run sladeUnstable unstable-2023-09-30 on wxGTK 3.2.4, see PR #266945
+         url = "https://github.com/wxWidgets/wxWidgets/commit/425d9455e8307c1267a79d47d77e3dafeb4d86de.patch";
+         excludes = [ "docs/changes.txt" ];
+         revert = true;
+         hash = "sha256-6LOYLDLtVCHxNdHAWv3zhlCsljIpi//RJb9XVLGD5hM=";
+       })
+     ];
+    }).override {
       withWebKit = true;
     };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30456,6 +30456,16 @@ with pkgs;
 
   audacity = callPackage ../applications/audio/audacity {
     inherit (darwin.apple_sdk.frameworks) AppKit CoreAudioKit;
+    wxGTK32 = wxGTK32.overrideAttrs {
+      patches = [
+       (fetchpatch { # required to run audacity 3.3.3 on wxGTK 3.2.4, see PR #266945
+         url = "https://github.com/wxWidgets/wxWidgets/commit/425d9455e8307c1267a79d47d77e3dafeb4d86de.patch";
+         excludes = [ "docs/changes.txt" ];
+         revert = true;
+         hash = "sha256-6LOYLDLtVCHxNdHAWv3zhlCsljIpi//RJb9XVLGD5hM=";
+       })
+     ];
+    };
   };
 
   audio-recorder = callPackage ../applications/audio/audio-recorder { };


### PR DESCRIPTION
## Description of changes

https://github.com/wxWidgets/wxWidgets/releases/tag/v3.2.4
https://github.com/wxWidgets/wxWidgets/compare/v3.2.3...v3.2.4

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### result of nixpkgs-review
```
1 package marked as broken and skipped:
springLobby

9 packages failed to build:
audacity displaycal displaycal.dist erlang-ls klipper-firmware klipper-flash slade sladeUnstable tenacity

195 packages built:
abracadabra aegisub akkoma amule amule-daemon amule-gui amule-web asc bochs boinc bossa bossa-arduino cemu chirp chirp.dist cl codeblocks codeblocksFull comical couchdb3 cqrlog cubicsdr diff-pdf digikam dump1090 dvdstyler easyabc ejabberd electricsheep elixir elixir-ls elixir_1_10 elixir_1_11 elixir_1_12 elixir_1_13 elixir_1_14 elvis-erlang erlang erlang_24 erlang_26 erlang_javac erlang_odbc erlang_odbc_javac erlfmt espanso espanso-wayland espeakedit far2l filezilla fityk flamerobin freedv freefilesync freqtweak fsg gnudatalanguage gnuradio3_8Packages.ais gnuradio3_8Packages.limesdr gnuradio3_8Packages.osmosdr gnuradio3_8Packages.osmosdr.dev gnuradio3_9Packages.osmosdr gnuradio3_9Packages.osmosdr.dev gnuradioPackages.osmosdr gnuradioPackages.osmosdr.dev golly gqrx gqrx-gr-audio gqrx-portaudio grandorgue grass hugin indi-full kicad kicad-small kicad-unstable kicad-unstable-small kstars lenmus lfe limesuite livebook loxodo loxodo.dist mavproxy mavproxy.dist mediainfo-gui meerk40t meerk40t.dist megaglest mercury metamorphose2 mix2nix mmex mobilizon mymcplus mymcplus.dist notmuch-bower odamex opencpn openwebrx openwebrx.dist pcem perl536Packages.AlienWxWidgets perl536Packages.AlienWxWidgets.devdoc perl536Packages.AppMusicChordPro perl536Packages.AppMusicChordPro.devdoc perl536Packages.Wx perl536Packages.Wx.devdoc perl536Packages.WxGLCanvas perl536Packages.WxGLCanvas.devdoc perl538Packages.AlienWxWidgets perl538Packages.AlienWxWidgets.devdoc perl538Packages.AppMusicChordPro perl538Packages.AppMusicChordPro.devdoc perl538Packages.Wx perl538Packages.Wx.devdoc perl538Packages.WxGLCanvas perl538Packages.WxGLCanvas.devdoc phd2 plausible playonlinux pleroma poedit pothos printrun printrun.dist pwsafe python310Packages.humblewx python310Packages.humblewx.dist python310Packages.kicad python310Packages.soapysdr-with-plugins python310Packages.wxPython_4_2 python311Packages.humblewx python311Packages.humblewx.dist python311Packages.kicad python311Packages.soapysdr-with-plugins python311Packages.wxPython_4_2 qgis qgis-ltr qradiolink quisk quisk.dist rabbitmq-server rabbitmq-server.doc rabbitmq-server.man radiotray-ng rapidsvn rebar rebar3 rehex rtl_433 saga scorched3d sdrangel sigdigger slic3r soapysdr-with-plugins sonic-pi sooperlooper sound-of-sorting spatialite_gui spek srsran survex suscan therion timeline tqsl treesheets tsung tunnelx urbackup-client urh urh.dist vbam veracrypt welle-io wings woeusb-ng woeusb-ng.dist wxGTK32 wxSVG wxformbuilder wxhexeditor wxmacmolplt wxmaxima wxsqlite3 wxsqliteplus xchm xmlcopyeditor xylib yaws zeroad zeroadPackages.zeroad-unwrapped zod
```
`kicad` seems to work with this update, but 

pinging maintainers of packages broken by this change:
`audacity`: @lheckemann @veprbl @wegank (note: `nix-update` to 3.4.1 didn't fix it)
`erlang-ls`: none available, @dlesl authored and `erlang` maintainer @happysalada seems involved (note: doesn't fail on my branch based on nixos-unstable)
`slade`: @ertes
`tenacity`: @IreneKnapp @lheckemann

`displaycal` and `klipper-firmware` currently fail on master anyway
but pinging their maintainers to make sure they're aware of that:
`displaycal`: @toastal
`klipper-firmware`: @vtuan10 (note: updating to 0.12.0 didn't fix it)