### PR TITLE
python311Packages.zope-exceptions: 4.6 -> 5.0.1; rename from zope_exceptions

### DIFF
--- a/pkgs/development/python-modules/zope-exceptions/default.nix
+++ b/pkgs/development/python-modules/zope-exceptions/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "zope-exceptions";
-  version = "4.6";
+  version = "5.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "zope.exceptions";
     inherit version;
-    hash = "sha256-YZ0kpMZb7Zez3QUV5zLoK2nxVdQsyUlV0b6MKCiGg80=";
+    hash = "sha256-MPxT5TOfX72dEzXg97afd/FePwbisXt/t++SXMJP3ZY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/zope-exceptions/default.nix
+++ b/pkgs/development/python-modules/zope-exceptions/default.nix
@@ -5,11 +5,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zope.exceptions";
+  pname = "zope-exceptions";
   version = "4.6";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "zope.exceptions";
+    inherit version;
     hash = "sha256-YZ0kpMZb7Zez3QUV5zLoK2nxVdQsyUlV0b6MKCiGg80=";
   };
 

--- a/pkgs/development/python-modules/zope-exceptions/default.nix
+++ b/pkgs/development/python-modules/zope-exceptions/default.nix
@@ -1,12 +1,17 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
+, setuptools
 , zope_interface
 }:
 
 buildPythonPackage rec {
   pname = "zope-exceptions";
   version = "4.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "zope.exceptions";
@@ -14,15 +19,24 @@ buildPythonPackage rec {
     hash = "sha256-YZ0kpMZb7Zez3QUV5zLoK2nxVdQsyUlV0b6MKCiGg80=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [ zope_interface ];
 
   # circular deps
   doCheck = false;
 
+  pythonImportsCheck = [
+    "zope.exceptions"
+  ];
+
   meta = with lib; {
     description = "Exception interfaces and implementations";
     homepage = "https://pypi.python.org/pypi/zope.exceptions";
-    license = licenses.zpl20;
+    changelog = "https://github.com/zopefoundation/zope.exceptions/blob/${version}/CHANGES.rst";
+    license = licenses.zpl21;
     maintainers = with maintainers; [ goibhniu ];
   };
 

--- a/pkgs/development/python-modules/zope_testrunner/default.nix
+++ b/pkgs/development/python-modules/zope_testrunner/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , zope_interface
-, zope_exceptions
+, zope-exceptions
 , zope-testing
 , six
 }:
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     hash = "sha256-1r1y9E6jLKpBW5bP4UFSsnhjF67xzW9IqCe2Le8Fj9Q=";
   };
 
-  propagatedBuildInputs = [ zope_interface zope_exceptions zope-testing six ];
+  propagatedBuildInputs = [ zope_interface zope-exceptions zope-testing six ];
 
   doCheck = false; # custom test modifies sys.path
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -476,6 +476,7 @@ mapAliases ({
   zope_contenttype = zope-contenttype; # added 2023-10-11
   zope_deprecation = zope-deprecation; # added 2023-10-07
   zope_dottedname = zope-dottedname; # added 2023-11-12
+  zope_exceptions = zope-exceptions; # added 2023-10-11
   zope_i18nmessageid = zope-i18nmessageid; # added 2023-07-29
   zope_lifecycleevent = zope-lifecycleevent; # added 2023-10-11
   zope_proxy = zope-proxy; # added 2023-10-07

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16439,7 +16439,7 @@ self: super: with self; {
 
   zope_event = callPackage ../development/python-modules/zope_event { };
 
-  zope_exceptions = callPackage ../development/python-modules/zope_exceptions { };
+  zope-exceptions = callPackage ../development/python-modules/zope-exceptions { };
 
   zope_filerepresentation = callPackage ../development/python-modules/zope_filerepresentation { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/zopefoundation/zope.exceptions/blob/5.0.1/CHANGES.rst

part of #245383 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
