### PR TITLE
ktx-tools: init at 4.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2711,6 +2711,12 @@
     githubId = 150560585;
     name = "Dmitry Ivankov";
   };
+  bonsairobo = {
+    email = "duncanfairbanks6@gmail.com";
+    github = "bonsairobo";
+    githubId = 3229981;
+    name = "Duncan Fairbanks";
+  };
   booklearner = {
     name = "booklearner";
     email = "booklearner@proton.me";

--- a/pkgs/by-name/kt/ktx-tools/package.nix
+++ b/pkgs/by-name/kt/ktx-tools/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/KhronosGroup/KTX-Software";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = with maintainers; [ bonsairobo ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/kt/ktx-tools/package.nix
+++ b/pkgs/by-name/kt/ktx-tools/package.nix
@@ -1,0 +1,66 @@
+{
+  cmake,
+  doxygen,
+  fetchFromGitHub,
+  getopt,
+  ninja,
+  lib,
+  pkg-config,
+  stdenv,
+}:
+stdenv.mkDerivation rec {
+  pname = "ktx-tools";
+  version = "4.3.2";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "KTX-Software";
+    rev = "v${version}";
+    hash = "sha256-zjiJ8B8FEZUJ3iFTYXRmuIEtcaCWtBIbYwz0DwjTDFo";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    getopt
+    ninja
+    pkg-config
+  ];
+
+  cmakeBuildType = "RelWithDebInfo";
+
+  cmakeFlags = [ "-DKTX_FEATURE_DOC=ON" ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  meta = with lib; {
+    description = "KTX (Khronos Texture) Library and Tools";
+    longDescription = ''
+      KTX (Khronos Texture) is a lightweight container for textures for OpenGL®,
+      Vulkan® and other GPU APIs. KTX files contain all the parameters needed
+      for texture loading. A single file can contain anything from a simple
+      base-level 2D texture through to a cubemap array texture with mipmaps.
+
+      This software package contains:
+        - libktx: a small library of functions for writing and reading KTX
+          files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures
+          from them.
+        - ktx2check: a tool for validating KTX Version 2 format files.
+        - ktx2ktx2: a tool for converting a KTX Version 1 file to a KTX Version
+          2 file.
+        - ktxinfo: a tool to display information about a KTX file in human
+          readable form.
+        - ktxsc: a tool to supercompress a KTX Version 2 file that contains
+          uncompressed images.
+        - toktx: a tool to create KTX files from PNG, Netpbm or JPEG format
+          images. It supports mipmap generation, encoding to Basis Universal
+          formats and Zstd supercompression.
+    '';
+    homepage = "https://github.com/KhronosGroup/KTX-Software";
+    license = licenses.asl20;
+    maintainers = [ ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

KTX is a standard GPU texture container format. This package includes `libktx` and several CLI tools for creating KTX files.

Home Page: https://github.com/KhronosGroup/KTX-Software

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
