### PR TITLE
python311Packages.pymc: 5.9.1 -> 5.9.2, python311Packages.pytensor: 2.17.3 -> 2.18.1

### DIFF
--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pymc";
-  version = "5.9.1";
+  version = "5.9.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "pymc-devs";
     repo = "pymc";
     rev = "refs/tags/v${version}";
-    hash = "sha256-yY8W3B1yqj0oOkR6+nMbFgCFmTStXkePWnEYPHI8Zto=";
+    hash = "sha256-fbS4JSbmdOGz570awEpT6ut0NJ8TbiAeJWaETMBeI3c=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -18,15 +18,13 @@
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
-# Tensorflow is currently (2023/10/04) broken.
-# Thus, we don't provide this optional test dependency.
-# , tensorflow-probability
+, tensorflow-probability
 , stdenv
 }:
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.17.3";
+  version = "2.18.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -35,7 +33,7 @@ buildPythonPackage rec {
     owner = "pymc-devs";
     repo = "pytensor";
     rev = "refs/tags/rel-${version}";
-    hash = "sha256-FufPCFzSjG8BrHes7t3XsdovX9gqUBG0gMDGKvkRkSA=";
+    hash = "sha256-8bt6ps5bwT+Atr6JgQMxe234bL/ZriYlURUdX0sC1kk=";
   };
 
   postPatch = ''
@@ -66,9 +64,7 @@ buildPythonPackage rec {
     numba-scipy
     pytest-mock
     pytestCheckHook
-    # Tensorflow is currently (2023/10/04) broken.
-    # Thus, we don't provide this optional test dependency.
-    # tensorflow-probability
+    tensorflow-probability
   ];
 
   preBuild = ''
@@ -86,8 +82,6 @@ buildPythonPackage rec {
     "test_logsumexp_benchmark"
     "test_scan_multiple_output"
     "test_vector_taps_benchmark"
-    # Temporarily disabled because of broken tensorflow-probability
-    "test_tfp_ops"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Description of changes

Changelog pymc: https://github.com/pymc-devs/pymc/releases/tag/v5.9.2
Changelog pytensor: https://github.com/pymc-devs/pytensor/releases/tag/rel-2.18.1

cc @nidabdella @bcdarwin 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
