### PR TITLE
fix long error messages in nix-instantiate

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/default.nix
@@ -5,8 +5,10 @@
   rustfmt,
   clippy,
   mkShell,
+  makeWrapper,
 }:
 let
+  runtimeExprPath = "${./src/eval.nix}";
   package =
     rustPlatform.buildRustPackage {
       name = "nixpkgs-check-by-name";
@@ -16,7 +18,9 @@ let
         nix
         rustfmt
         clippy
+        makeWrapper
       ];
+      env.NIX_CHECK_BY_NAME_EXPR_PATH = runtimeExprPath;
       # Needed to make Nix evaluation work inside the nix build
       preCheck = ''
         export TEST_ROOT=$(pwd)/test-tmp
@@ -34,7 +38,12 @@ let
         cargo fmt --check
         cargo clippy -- -D warnings
       '';
+      postInstall = ''
+        wrapProgram $out/bin/nixpkgs-check-by-name \
+          --set NIX_CHECK_BY_NAME_EXPR_PATH "$NIX_CHECK_BY_NAME_EXPR_PATH"
+      '';
       passthru.shell = mkShell {
+        env.NIX_CHECK_BY_NAME_EXPR_PATH = runtimeExprPath;
         inputsFrom = [ package ];
       };
     };

--- a/pkgs/test/nixpkgs-check-by-name/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/default.nix
@@ -8,7 +8,7 @@
   makeWrapper,
 }:
 let
-  runtimeExprPath = "${./src/eval.nix}";
+  runtimeExprPath = ./src/eval.nix;
   package =
     rustPlatform.buildRustPackage {
       name = "nixpkgs-check-by-name";
@@ -20,7 +20,7 @@ let
         clippy
         makeWrapper
       ];
-      env.NIX_CHECK_BY_NAME_EXPR_PATH = runtimeExprPath;
+      env.NIX_CHECK_BY_NAME_EXPR_PATH = "${runtimeExprPath}";
       # Needed to make Nix evaluation work inside the nix build
       preCheck = ''
         export TEST_ROOT=$(pwd)/test-tmp
@@ -43,7 +43,7 @@ let
           --set NIX_CHECK_BY_NAME_EXPR_PATH "$NIX_CHECK_BY_NAME_EXPR_PATH"
       '';
       passthru.shell = mkShell {
-        env.NIX_CHECK_BY_NAME_EXPR_PATH = runtimeExprPath;
+        env.NIX_CHECK_BY_NAME_EXPR_PATH = toString runtimeExprPath;
         inputsFrom = [ package ];
       };
     };

--- a/pkgs/test/nixpkgs-check-by-name/src/eval.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/eval.rs
@@ -58,7 +58,8 @@ pub fn check_values(
         attrs_file_path.display()
     ))?;
 
-    let expr_path = std::env::var("NIX_CHECK_BY_NAME_EXPR_PATH")?;
+    let expr_path = std::env::var("NIX_CHECK_BY_NAME_EXPR_PATH")
+        .context("Could not get environment variable NIX_CHECK_BY_NAME_EXPR_PATH")?;
     // With restrict-eval, only paths in NIX_PATH can be accessed, so we explicitly specify the
     // ones needed needed
     let mut command = process::Command::new("nix-instantiate");

--- a/pkgs/test/nixpkgs-check-by-name/src/eval.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/eval.rs
@@ -35,8 +35,6 @@ enum AttributeVariant {
     Other,
 }
 
-const EXPR: &str = include_str!("eval.nix");
-
 /// Check that the Nixpkgs attribute values corresponding to the packages in pkgs/by-name are
 /// of the form `callPackage <package_file> { ... }`.
 /// See the `eval.nix` file for how this is achieved on the Nix side
@@ -60,9 +58,9 @@ pub fn check_values(
         attrs_file_path.display()
     ))?;
 
+    let expr_path = std::env::var("NIX_CHECK_BY_NAME_EXPR_PATH")?;
     // With restrict-eval, only paths in NIX_PATH can be accessed, so we explicitly specify the
     // ones needed needed
-
     let mut command = process::Command::new("nix-instantiate");
     command
         // Inherit stderr so that error messages always get shown
@@ -76,8 +74,6 @@ pub fn check_values(
             "--readonly-mode",
             "--restrict-eval",
             "--show-trace",
-            "--expr",
-            EXPR,
         ])
         // Pass the path to the attrs_file as an argument and add it to the NIX_PATH so it can be
         // accessed in restrict-eval mode
@@ -96,6 +92,8 @@ pub fn check_values(
         command.arg("-I");
         command.arg(path);
     }
+    command.args(["-I", &expr_path]);
+    command.arg(expr_path);
 
     let result = command
         .output()


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Passing nix-expression using CLI puts the whole nix-expression in the error message making it unnecessarily verbose
- We pass it using stdio now instead of directly passing the expression as arg, this simply prints the command that failed


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Steps done in testing
- `nix-build -A tests.nixpkgs-check-by-name` for building it after making the required edits
- First ran on a normal checkout of nixpkgs, output: `Validation successful` (run command: ./result/bin/nixpkgs-check-by-name .`)
- removed `default.nix` to trigger error and print the stack tracing
- got a stack trace without the expression
```
hariomnarang@QURELAP-148: ~/Desktop/nixpkgs hariom/257748/check-by-name-msg!
$ ./result/bin/nixpkgs-check-by-name .                                              [18:08:26]
error:
       … while calling anonymous lambda

         at «stdin»:9:1:

            8| # - is_derivation: The result of `lib.isDerivation <attr>`
            9| {
             | ^
           10|   attrsPath,

       error: getting status of '/Users/hariomnarang/Desktop/nixpkgs/default.nix': No such file or directory
I/O error:  Failed to run command "nix-instantiate" "--eval" "--json" "--strict" "--readonly-mode" "--restrict-eval" "--show-trace" "--arg" "attrsPath" "/private/var/folders/s0/xjqwn7_d6kg3y6dcjy2tzpn80000gp/T/.tmpKXlpN1" "-I" "/private/var/folders/s0/xjqwn7_d6kg3y6dcjy2tzpn80000gp/T/.tmpKXlpN1" "--arg" "nixpkgsPath" "/Users/hariomnarang/Desktop/nixpkgs" "-I" "/Users/hariomnarang/Desktop/nixpkgs" "-"
```
