### PR TITLE
himitsu: 0.3 -> 0.4

### DIFF
--- a/pkgs/tools/security/himitsu/default.nix
+++ b/pkgs/tools/security/himitsu/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "himitsu";
-  version = "0.3";
+  version = "0.4";
 
   src = fetchFromSourcehut {
     name = pname + "-src";
     owner = "~sircmpwn";
     repo = pname;
     rev = version;
-    hash = "sha256-HoAntg9aQhMmff3T3/xnor7Sf3yX9qBbZlpVfyac5o8=";
+    hash = "sha256-Y2QSzYfG1F9Z8MjeVvQ3+Snff+nqSjeK6VNzRaRDLYo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

[Changelog](https://git.sr.ht/~sircmpwn/himitsu/refs/0.4)

Related to: #266456 

<details>
<summary>
After applying the patch from #266456 [1], the package can be built:
</summary>

```
$ nix run nixpkgs#nixpkgs-review -- rev HEAD
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 12, done.
remote: Counting objects: 100% (12/12), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 12 (delta 3), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (12/12), 17.25 KiB | 321.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   e94bccefd06..54da2986be0  master     -> refs/nixpkgs-review/0
$ git worktree add /home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/nixpkgs 54da2986be07ad2ffbade0b3cefaf7f0c2553c88
Preparing worktree (detached HEAD 54da2986be0)
Updating files: 100% (37989/37989), done.
HEAD is now at 54da2986be0 Merge pull request #266989 from r-ryantm/auto-update/linux-wifi-hotspot
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/nixpkgs nixpkgs-overlays=/tmp/tmpy8nfjsgn -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 337b7fd01db98c65f17191efd954646ab2e8a05f
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/nixpkgs nixpkgs-overlays=/tmp/tmpy8nfjsgn -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
4 packages updated:
harePackages.hare (2023-04-23 → 2023-10-23) harePackages.harec (2023-04-25 → 2023-10-22) himitsu (0.3 → 0.4) himitsu-firefox

$ nix build --nix-path nixpkgs=/home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/nixpkgs nixpkgs-overlays=/tmp/tmpy8nfjsgn --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/build.nix
1 package marked as broken and skipped:
himitsu-firefox

3 packages built:
harePackages.hare harePackages.harec himitsu

$ /nix/store/11glc2yk4jmycvk42q6kikpdcpbnbf6w-nix-2.17.1/bin/nix-shell /home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/shell.nix --nix-path nixpkgs=/home/patwid/.cache/nixpkgs-review/rev-337b7fd01db98c65f17191efd954646ab2e8a05f/nixpkgs nixpkgs-overlays=/tmp/tmpy8nfjsgn
```
</details>

[1] https://github.com/NixOS/nixpkgs/commit/f9b3fbfdf931341961677234b4b888378bcaf7b0.diff

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
