### PR TITLE
alsa-utils: make `aplay` find pipewire's ALSA library

### DIFF
--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -1,5 +1,33 @@
-{lib, stdenv, fetchurl, fetchpatch, alsa-lib, gettext, makeWrapper, ncurses, libsamplerate, pciutils, which, fftw}:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, alsa-lib
+, alsa-plugins
+, gettext
+, makeWrapper
+, ncurses
+, libsamplerate
+, pciutils
+, which
+, fftw
+, pipewire
+, withPipewireLib ? true
+, symlinkJoin
+}:
 
+let
+  plugin-packages = [ alsa-plugins ] ++ lib.optional withPipewireLib pipewire.lib;
+
+  # Create a directory containing symlinks of all ALSA plugins.
+  # This is necessary because ALSA_PLUGIN_DIR must reference only one directory.
+  plugin-dir = symlinkJoin {
+    name = "all-plugins";
+    paths = map
+      (path: "${path}/lib/alsa-lib")
+      plugin-packages;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "alsa-utils";
   version = "1.2.10";
@@ -30,6 +58,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     mv $out/bin/alsa-info.sh $out/bin/alsa-info
     wrapProgram $out/bin/alsa-info --prefix PATH : "${lib.makeBinPath [ which pciutils ]}"
+    wrapProgram $out/bin/aplay --set-default ALSA_PLUGIN_DIR ${plugin-dir}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Without this, users of alsa-utils on non-NixOS systems using pipewire will get error messages such as:
```
ALSA lib dlmisc.c:337:(snd_dlobj_cache_get0) Cannot open shared library libasound_module_pcm_pipewire.so (/nix/store/4vp...ii-alsa-lib-1.2.9/lib/alsa-lib/libasound_module_pcm_pipewire.>Nov 09 16:22:12 luz5 safeeyes[1872081]: aplay: main:834: audio open error: No such device or address
```

This is related (and potentially fixes):
- https://github.com/NixOS/nixpkgs/issues/187308
- https://github.com/NixOS/nixpkgs/issues/212141
- https://github.com/NixOS/nixpkgs/issues/6860

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
