### PR TITLE
darwin.mDNSResponder: patch header to match SDK

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
@@ -21,7 +21,6 @@ appleDerivation' stdenv {
     NIX_CFLAGS_COMPILE = toString [
       "-ISystemConfiguration.framework/Headers"
       "-I${xnu}/Library/Frameworks/System.framework/Versions/B/PrivateHeaders"
-      "-D_DNS_SD_LIBDISPATCH" # Needed for DNSServiceSetDispatchQueue to be available
     ];
   };
 

--- a/pkgs/os-specific/darwin/apple-source-releases/mDNSResponder/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mDNSResponder/default.nix
@@ -4,6 +4,9 @@ appleDerivation' stdenvNoCC {
   dontBuild = true;
   installPhase = ''
     mkdir -p $out/include
-    cp mDNSShared/dns_sd.h $out/include
+    # TODO: Do this only for 765.50.9 once there is a way to apply version-specific
+    # logic in a source-release derivation.
+    substitute mDNSShared/dns_sd.h $out/include/dns_sd.h \
+      --replace '#define _DNS_SD_LIBDISPATCH 0' '#define _DNS_SD_LIBDISPATCH 1'
   '';
 }


### PR DESCRIPTION
## Description of changes

Fixes grpc on staging-next #263535.

* grpc: https://hydra.nixos.org/build/240673948

Note: This was tested by building up through configd in the stdenv bootstrap. configd also has the same problem, which was fixed in the same way grpc was going to be fixed (by defining `_DNS_SD_LIBDISPATCH`). The fix is being applied to mDNSResponder now because we are early in this round of rebuilds and to avoid other possible breakage due to this issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
