### PR TITLE
texlive: fix compatibility with Nix 2.3

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -70,7 +70,7 @@ let
 
     # group the specified outputs
     specified = builtins.partition (p: p.outputSpecified or false) all;
-    specifiedOutputs = builtins.groupBy (p: p.tlOutputName or p.outputName) specified.right;
+    specifiedOutputs = lib.groupBy (p: p.tlOutputName or p.outputName) specified.right;
     otherOutputNames = builtins.catAttrs "key" (builtins.genericClosure {
       startSet = map (key: { inherit key; }) (lib.concatLists (builtins.catAttrs "outputs" specified.wrong));
       operator = _: [ ];


### PR DESCRIPTION
Uses the `lib.groupBy` compatibility shim to allow this package to work with the maintained, unflaked Nix 2.3 that many people use.

Tested on Nix 2.3.