### PR TITLE
maintainers-list.nix: Document (current) invitation process, add get-maintainer.sh

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -165,3 +165,10 @@ team after giving the existing members a few days to respond.
 
 *Important:* If a team says it is a closed group, do not merge additions
 to the team without an approval by at least one existing member.
+
+
+# Maintainer scripts
+
+Various utility scripts, which are mainly useful for nixpkgs maintainers,
+are available under `./scripts/`.  See its [README](./scripts/README.md)
+for further information.

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26,8 +26,10 @@
     - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
     - `keys` is a list of your PGP/GPG key fingerprints.
 
-    Specifying a GitHub account ensures that you automatically get a review request on
-    pull requests that modify a package for which you are a maintainer.
+    Specifying a GitHub account ensures that you automatically:
+    - get invited to the @NixOS/nixpkgs-maintainers team ;
+    - once you are part of the @NixOS org, OfBorg will request you review
+      pull requests that modify a package for which you are a maintainer.
 
     `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
 

--- a/maintainers/scripts/README.md
+++ b/maintainers/scripts/README.md
@@ -18,6 +18,37 @@ This allows looking up a maintainer's attrset (including GitHub and Matrix
 handles, email address etc.) based on any of their handles, more correctly and
 robustly than text search through `maintainers-list.nix`.
 
+```
+❯ ./get-maintainer.sh nicoo
+{
+  "email": "nicoo@debian.org",
+  "github": "nbraud",
+  "githubId": 1155801,
+  "keys": [
+    {
+      "fingerprint": "E44E 9EA5 4B8E 256A FB73 49D3 EC9D 3708 72BC 7A8C"
+    }
+  ],
+  "name": "nicoo",
+  "handle": "nicoo"
+}
+
+❯ ./get-maintainer.sh name 'Silvan Mosberger'
+{
+  "email": "contact@infinisil.com",
+  "github": "infinisil",
+  "githubId": 20525370,
+  "keys": [
+    {
+      "fingerprint": "6C2B 55D4 4E04 8266 6B7D  DA1A 422E 9EDA E015 7170"
+    }
+  ],
+  "matrix": "@infinisil:matrix.org",
+  "name": "Silvan Mosberger",
+  "handle": "infinisil"
+}
+```
+
 The maintainer is designated by a `selector` which must be one of:
 - `handle` (default): the maintainer's attribute name in `lib.maintainers`;
 - `email`, `name`, `github`, `githubId`, `matrix`, `name`:

--- a/maintainers/scripts/README.md
+++ b/maintainers/scripts/README.md
@@ -1,0 +1,26 @@
+# Maintainer scripts
+
+This folder contains various executable scripts for nixpkgs maintainers,
+and supporting data or nixlang files as needed.
+
+What follows is a (very incomplete) overview of available scripts.
+
+
+## Metadata
+
+### `get-maintainer.sh`
+
+`get-maintainer.sh [selector] value` returns a JSON object describing
+a given nixpkgs maintainer, equivalent to `lib.maintainers.${x} // { handle = x; }`.
+
+This allows looking up a maintainer's attrset (including GitHub and Matrix
+handles, email address etc.) based on any of their handles, more correctly and
+robustly than text search through `maintainers-list.nix`.
+
+The maintainer is designated by a `selector` which must be one of:
+- `handle` (default): the maintainer's attribute name in `lib.maintainers`;
+- `email`, `name`, `github`, `githubId`, `matrix`, `name`:
+  attributes of the maintainer's object, matched exactly;
+  see [`maintainer-list.nix`] for the fields' definition.
+
+[`maintainer-list.nix`]: ../maintainer-list.nix

--- a/maintainers/scripts/README.md
+++ b/maintainers/scripts/README.md
@@ -2,6 +2,7 @@
 
 This folder contains various executable scripts for nixpkgs maintainers,
 and supporting data or nixlang files as needed.
+These scripts generally aren't a stable interface and may changed or be removed.
 
 What follows is a (very incomplete) overview of available scripts.
 

--- a/maintainers/scripts/get-maintainer.sh
+++ b/maintainers/scripts/get-maintainer.sh
@@ -2,9 +2,21 @@
 #!nix-shell -i bash -p jq ncurses
 # shellcheck shell=bash
 
+# Get a nixpkgs maintainer's metadata as a JSON object
+#  see HELP_MESSAGE just below, or README.md.
+
 set -euo pipefail
 
 declare -A SELECTORS=( [handle]= [email]= [github]= [githubId]= [matrix]= [name]= )
+HELP_MESSAGE="usage: '$0' [selector] value
+examples:
+  get-maintainer.sh nicoo
+  get-maintainer.sh githubId 1155801
+
+\`selector\` defaults to 'handle', can be one of:
+  ${!SELECTORS[*]}
+"
+
 MAINTAINERS_DIR="$(dirname "$0")/.."
 
 die() {
@@ -20,7 +32,7 @@ listAsJSON() {
 
 parseArgs() {
   [ $# -gt 0 -a $# -lt 3 ] || {
-      usage
+      echo "$HELP_MESSAGE"
       die "invalid number of arguments (must be 1 or 2)"
   }
 
@@ -37,17 +49,6 @@ parseArgs() {
 
   value="$1"
   shift
-}
-
-usage() {
-    local name="$(basename "$0")"
-    cat <<MSG
-usage: '$0' [selector] value
-example: $name nicoo; $name githubId 1155801
-
-selector defaults to 'handle', can be one of:
-  ${!SELECTORS[*]}
-MSG
 }
 
 query() {

--- a/maintainers/scripts/get-maintainer.sh
+++ b/maintainers/scripts/get-maintainer.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq ncurses
+# shellcheck shell=bash
+
+set -euo pipefail
+
+declare -A SELECTORS=( [handle]= [email]= [github]= [githubId]= [matrix]= [name]= )
+MAINTAINERS_DIR="$(dirname $0)/.."
+
+die() {
+  tput setaf 1 # red
+  echo "$@"
+  tput setaf 0 # back to black
+  exit 1
+}
+
+listAsJSON() {
+  nix-instantiate --eval --strict --json "${MAINTAINERS_DIR}/maintainer-list.nix"
+}
+
+parseArgs() {
+  [ $# -gt 0 -a $# -lt 3 ] || \
+    die "usage: '$0' [selector] value"
+
+  if [ $# -eq 1 ]; then
+    selector=handle
+  else
+    selector="$1"
+    shift
+  fi
+  [ -z "${SELECTORS[$selector]-n}" ] || {
+    echo "Valid selectors are: ${!SELECTORS[@]}" >&2
+    die "'$0': invalid selector '$selector'"
+  }
+
+  value="$1"
+  shift
+}
+
+query() {
+  # explode { a: A, b: B, ... } into A + {handle: a}, B + {handle: b}, ...
+  local explode="to_entries[] | .value + { \"handle\": .key }"
+
+  # select matching items from the list
+  # TODO(nicoo): Support approximate matching for `name` ?
+  local select
+  case "$selector" in
+    githubId)
+      select="select(.${selector} == $value)"
+      ;;
+    *)
+      select="select(.${selector} == \"$value\")"
+  esac
+
+  echo "$explode | $select"
+}
+
+parseArgs "$@"
+listAsJSON | jq -e "$(query)"

--- a/maintainers/scripts/get-maintainer.sh
+++ b/maintainers/scripts/get-maintainer.sh
@@ -9,7 +9,7 @@ MAINTAINERS_DIR="$(dirname $0)/.."
 
 die() {
   tput setaf 1 # red
-  echo "$@"
+  echo "'$0': $*"
   tput setaf 0 # back to black
   exit 1
 }
@@ -19,8 +19,10 @@ listAsJSON() {
 }
 
 parseArgs() {
-  [ $# -gt 0 -a $# -lt 3 ] || \
-    die "usage: '$0' [selector] value"
+  [ $# -gt 0 -a $# -lt 3 ] || {
+      usage
+      die "invalid number of arguments (must be 1 or 2)"
+  }
 
   if [ $# -eq 1 ]; then
     selector=handle
@@ -30,11 +32,22 @@ parseArgs() {
   fi
   [ -z "${SELECTORS[$selector]-n}" ] || {
     echo "Valid selectors are: ${!SELECTORS[@]}" >&2
-    die "'$0': invalid selector '$selector'"
+    die "invalid selector '$selector'"
   }
 
   value="$1"
   shift
+}
+
+usage() {
+    local name="$(basename "$0")"
+    cat <<MSG
+usage: '$0' [selector] value
+example: $name nicoo; $name githubId 1155801
+
+selector defaults to 'handle', can be one of:
+  ${!SELECTORS[*]}
+MSG
 }
 
 query() {

--- a/maintainers/scripts/get-maintainer.sh
+++ b/maintainers/scripts/get-maintainer.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 declare -A SELECTORS=( [handle]= [email]= [github]= [githubId]= [matrix]= [name]= )
-MAINTAINERS_DIR="$(dirname $0)/.."
+MAINTAINERS_DIR="$(dirname "$0")/.."
 
 die() {
   tput setaf 1 # red
@@ -31,7 +31,7 @@ parseArgs() {
     shift
   fi
   [ -z "${SELECTORS[$selector]-n}" ] || {
-    echo "Valid selectors are: ${!SELECTORS[@]}" >&2
+    echo "Valid selectors are:" "${!SELECTORS[@]}" >&2
     die "invalid selector '$selector'"
   }
 


### PR DESCRIPTION
## Description of changes

- Add `maintainers/scripts/get-maintainer.sh` to query `maintainers-list.nix`
  It supports querying by exact match against a maintainer's handle or any of the documented attributes of `maintainers.${handle}`.

- Document the [RFC 39] invitation process to [nixpkgs-maintainers] as it stands now.

- ~~Add new `reinvite-maintainers.yml` workflow, which:~~
  - triggers on comments on #234293, from non-bot users, that contain “invite me” ;
  - checks whether the GitHub user is present in `maintainers-list.nix` (taken from branch `master`) ;
  - invites the user to the [nixpkgs-maintainers] team, created by [RFC 39] ;
  - replies (if successful) to the user, informing them they were invited to the team.

[nixpkgs-maintainers]: https://github.com/orgs/NixOS/teams/nixpkgs-maintainers
[RFC 39]: https://github.com/NixOS/rfcs/blob/master/rfcs/0039-unprivileged-maintainer-teams.md#summary


## Things done

- Tested `get-maintainer.nix`
  - [x] all selectors work, on both existing maintainers and negative queries ;
  - [x] the script always exits with a non-zero exit code when no match was found.
  The latter allows the workflow to more-easily check whether a match exists.

- ~~`reinvite-maintainers.yml` isn't tested yet~~
  I guess the only way to do so would be to test it on a dummy org?
