### PR TITLE
{tor,mullvad}-browser: add support for GPU acceleration

### DIFF
--- a/pkgs/applications/networking/browsers/mullvad-browser/default.nix
+++ b/pkgs/applications/networking/browsers/mullvad-browser/default.nix
@@ -6,12 +6,9 @@
 , makeWrapper
 , writeText
 , wrapGAppsHook
+, autoPatchelfHook
 , callPackage
 
-# Common run-time dependencies
-, zlib
-
-# libxul run-time dependencies
 , atk
 , cairo
 , dbus
@@ -30,19 +27,30 @@
 , mesa
 , pango
 , pciutils
+, zlib
 
 , libnotifySupport ? stdenv.isLinux
 , libnotify
 
+, waylandSupport ? stdenv.isLinux
+, libxkbcommon
+, libdrm
+
+, mediaSupport ? true
+, ffmpeg
+
 , audioSupport ? mediaSupport
-, pulseaudioSupport ? mediaSupport
+
+, pipewireSupport ? audioSupport
+, pipewire
+
+, pulseaudioSupport ? audioSupport
 , libpulseaudio
 , apulse
 , alsa-lib
 
-# Media support (implies audio support)
-, mediaSupport ? true
-, ffmpeg
+, libvaSupport ? mediaSupport
+, libva
 
 # Extra preferences
 , extraPrefs ? ""
@@ -74,7 +82,10 @@ let
       stdenv.cc.libc
       zlib
     ] ++ lib.optionals libnotifySupport [ libnotify ]
+      ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
+      ++ lib.optionals pipewireSupport [ pipewire ]
       ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
+      ++ lib.optionals libvaSupport [ libva ]
       ++ lib.optionals mediaSupport [ ffmpeg ]
   );
 
@@ -113,7 +124,13 @@ stdenv.mkDerivation rec {
 
   src = sources.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
-  nativeBuildInputs = [ copyDesktopItems makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper wrapGAppsHook autoPatchelfHook ];
+  buildInputs = [
+    gtk3
+    alsa-lib
+    dbus-glib
+    libXtst
+  ];
 
   preferLocalBuild = true;
   allowSubstitutes = false;


### PR DESCRIPTION
## Description of changes
Previously Tor/Mullvad Browser didn't have support for GPU acceleration.
On `about:support` under `Compositing` it would show `WebRender (Software)` and there were a lot of occurrences of `FEATURE_FAILURE_GLXTEST_FAILED`.

I've added neccessary dependencies for GPU acceleration as well as some new dependencies & options to better support Wayland, Pipewire & VA-API.

I also added `autoPatchelfHook` to fix `glxtest`, which threw an error before on startup of the browser, which could be seen in the console:
```console
❯ mullvad-browser
[GFX1-]: FireTestProcess failed: Failed to spawn child process “/nix/store/4irsfq4c6jhlvikr6i93gm0bq8q2nlrf-mullvad-browser-13.0.1/share/mullvad-browser/glxtest” (No such file or directory)

Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
 (t=0.246357) [GFX1-]: glxtest: ManageChildProcess failed

Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
 (t=0.246357) |[1][GFX1-]: No GPUs detected via PCI
 (t=0.246385) [GFX1-]: No GPUs detected via PCI
```

After these changes `Compositing` in `about:support` will show up as `WebRender` & all `FEATURE_FAILURE_GLXTEST_FAILED` (except for the `*.failureid` settings) are gone.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).