### PR TITLE
`lib.fileset`: Lazier path existence check

### DIFF
--- a/doc/functions/fileset.section.md
+++ b/doc/functions/fileset.section.md
@@ -15,7 +15,8 @@ Such path arguments are implicitly coerced to file sets containing all files und
 - A path to a file turns into a file set containing that single file.
 - A path to a directory turns into a file set containing all files _recursively_ in that directory.
 
-If the path points to a non-existent location, an error is thrown.
+If the path points to a non-existent location, an error is thrown
+only once/if either the file's type or contents are needed.
 
 ::: {.note}
 Just like in Git, file sets cannot represent empty directories.

--- a/lib/fileset/README.md
+++ b/lib/fileset/README.md
@@ -58,7 +58,8 @@ An attribute set with these values:
 
 - `_internalBase` (path):
   Any files outside of this path cannot influence the set of files.
-  This is always a directory and should be as long as possible.
+  This path should be as long as possible.
+  This may be a directory or a file.
   This is used by `lib.fileset.toSource` to check that all files are under the `root` argument
 
 - `_internalBaseRoot` (path):

--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -3,7 +3,7 @@ let
 
   inherit (import ./internal.nix { inherit lib; })
     _coerce
-    _singleton
+    _create
     _coerceMany
     _toSourceFilter
     _fromSourceFilter
@@ -262,7 +262,7 @@ in {
       _fromSourceFilter path source.filter
     else
       # If there's no filter, no need to run the expensive conversion, all subpaths will be included
-      _singleton path;
+      _create path (pathType path);
 
   /*
     The file set containing all files that are in either of two given file sets.

--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -257,7 +257,7 @@ in {
           lib.fileset.fromSource: The source origin of the argument is of type ${typeOf path}, but it should be a path instead.''
     else if ! pathExists path then
       throw ''
-        lib.fileset.fromSource: The source origin (${toString path}) of the argument does not exist.''
+        lib.fileset.fromSource: The source origin (${toString path}) of the argument is a path that does not exist.''
     else if isFiltered then
       _fromSourceFilter path source.filter
     else

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -381,7 +381,7 @@ rec {
 
   # Turn a fileset into a source filter function suitable for `builtins.path`
   # Only directories recursively containing at least one files are recursed into
-  # Type: Path -> fileset -> (String -> String -> Bool)
+  # Type: fileset -> (String -> String -> Bool)
   _toSourceFilter = fileset:
     let
       # Simplify the tree, necessary to make sure all empty directories are null
@@ -753,9 +753,9 @@ rec {
 
       resultingTree =
         _differenceTree
-        positive._internalBase
-        positive._internalTree
-        negativeTreeWithPositiveBase;
+          positive._internalBase
+          positive._internalTree
+          negativeTreeWithPositiveBase;
     in
     # If the first file set is empty, we can never have any files in the result
     if positive._internalIsEmptyWithoutBase then


### PR DESCRIPTION
## Description of changes
Allows things like `difference ./. ./a` even if `./a` doesn't exist.
Another case that's now doable is `intersection ./a (union ./a ./b)` even if `./b` doesn't exist.

This is an alternative to https://github.com/NixOS/nixpkgs/pull/265964 that doesn't require a new function and is more transparent to the user.

It's not perfect however, because `difference ./. (difference ./a ./a/b)`
doesn't give an error anymore if `./a/b` doesn't exist. We can maybe consider this an edge case. This could be fixed in the future, but would need a non-trivial change to the internal representation.

More problematic however is that you aren't protected against typos in the negative argument anymore: If you want to remove `./secret`, but you write `difference ./. ./sercet` instead, it would just fail silently and import the path into the store! This is making me think that we maybe shouldn't do this.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done
- [x] Extended tests
- [x] Updated documentation
- [x] Clean and commented code