### PR TITLE
monocypher: 3.1.3 -> 4.0.2

### DIFF
--- a/pkgs/development/libraries/monocypher/default.nix
+++ b/pkgs/development/libraries/monocypher/default.nix
@@ -2,22 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "monocypher";
-  version = "3.1.3";
+  version = "4.0.2";
 
   src = fetchurl {
     url = "https://monocypher.org/download/monocypher-${version}.tar.gz";
-    hash = "sha256-tEK1d98o+MNsqgHZrpARtd2ccX2UvlIBaKBONtf1AW4=";
+    hash = "sha256-ONBxeXOMDJBnfbo863p7hJa8/qdYuhpT6AP+0wrgh5w=";
   };
-
-  patches = [
-    # Fix cross-compilation
-    (fetchpatch {
-      url = "https://github.com/LoupVaillant/Monocypher/commit/376715e1c0ebb375e50dfa757bc89486c9a7b404.patch";
-      hash = "sha256-tuwSUaU4w+jkaj10ChMgUmOQmoKYnv5JgJ1og8EXxFk=";
-    })
-  ];
-
-  makeFlags = [ "AR:=$(AR)" "CC:=$(CC)" ];
 
   installFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
Changelog: https://monocypher.org/changelog

This package had a nixos specific patch, but I don't think it's still needed in this version.
I tested on x64, maybe it was needed for a different architecture?
@sikmir 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
