### PR TITLE
init Modular Portable Service Layer, proof of concept

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,18 @@
+
+# Module Based Service Abstraction Layer usage example
+
+This directory demonstrates
+ - `configuration.nix`: How to use an abstract service module on NixOS
+ - `generic-python-http-server.nix`: A simple abstract service
+ - `nixos-test.nix`: Make it runnable
+    - `nix build example/nixos-test.nix`
+
+Mess around with the repl
+
+    nix repl -f example/nixos-test.nix
+    nix-repl> nodes.machine.services.abstract.<TAB>
+    args
+    daemon
+    ...
+
+Enjoy!

--- a/example/configuration.nix
+++ b/example/configuration.nix
@@ -1,0 +1,23 @@
+# A NixOS configuration
+{ pkgs, ... }: {
+
+  environment.systemPackages = [ pkgs.hello ]; # Truly NixOS
+
+  services.abstract."serve-nix-manual" = {
+    imports = [ ./generic-python-http-server.nix ];
+    # You could change the port, but the default is sweet
+    # service.port = 8080;
+    service.directory = pkgs.nix.doc;
+  };
+
+  # A service that's distributed with NixOS may look like this.
+  # Doesn't exists yet. Add to specialArgs in a submoduleWith.
+  #
+  # services.abstract."serve-nixpkgs-manual" = { serviceModules, ... }: {
+  #   imports = [ serviceModules.nginx ];
+  #   service.virtualHosts."/" = {
+  #     root = pkgs.nix.doc;
+  #   };
+  # };
+
+}

--- a/example/generic-python-http-server.nix
+++ b/example/generic-python-http-server.nix
@@ -1,0 +1,36 @@
+{ lib, config, options, pkgs, ... }:
+let
+  inherit (lib) mkOption types;
+  cfg = config.service;
+in
+{
+  # I think `service` could be the place where the service itself is configured.
+  # Alternatively, this could have been `pythonHttpServer`, but then over time
+  # we'd endup with a service module namespace where we don't really know which
+  # names will conflict, whenever we introduce a new generic top level option in
+  # the future.
+  options.service = {
+    port = lib.mkOption {
+      type = types.int;
+      default = 8080;
+      description = ''
+        Port number where the web server should listen.
+      '';
+    };
+    directory = lib.mkOption {
+      type = types.path;
+      description = ''
+        A path to serve over HTTP.
+      '';
+    };
+  };
+
+  config = {
+    # Obligatory relaying of: Warning http.server is not recommended for production. It only implements basic security checks.
+    process = "${pkgs.python3}/bin/python3";
+    args = [
+      "-m" "http.server" (toString cfg.port)
+      "--directory" cfg.directory
+    ];
+  };
+}

--- a/example/nixos-test.nix
+++ b/example/nixos-test.nix
@@ -1,0 +1,22 @@
+let
+  pkgs = import ../. { };
+  inherit (pkgs.testers) runNixOSTest;
+in
+
+runNixOSTest {
+  name = "abstract-service";
+
+  nodes.machine = { lib, options, ... }: {
+    imports = [
+      ./configuration.nix
+    ];
+
+    # Ignore this. It makes nodes.machine.options appear in
+    # nix repl -f example/nixos-test.nix
+    options.options = lib.mkOption { default = options; };
+  };
+
+  testScript = ''
+    machine.wait_for_open_port(8080);
+  '';
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -319,6 +319,8 @@
   ./security/systemd-confinement.nix
   ./security/tpm2.nix
   ./security/wrappers/default.nix
+  ./services/abstract/generic.nix
+  ./services/abstract/systemd.nix
   ./services/admin/meshcentral.nix
   ./services/admin/oxidized.nix
   ./services/admin/pgadmin.nix

--- a/nixos/modules/services/abstract/generic.nix
+++ b/nixos/modules/services/abstract/generic.nix
@@ -1,0 +1,23 @@
+# This module is valid for all implementations of the service abstraction layer,
+# and might even be vendored from another repo or moved outside of nixpkgs/nixos/
+# into nixpkgs/something.
+
+{ lib, config, options, pkgs, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+    services.abstract = mkOption {
+      type = types.lazyAttrsOf (types.submoduleWith {
+        modules = [
+          ./instance/generic.nix
+          { _module.args.pkgs = pkgs; }
+        ]; });
+      default = { };
+      description = ''
+        All services that are configured on the system.
+      '';
+    };
+  };
+}

--- a/nixos/modules/services/abstract/instance/generic.nix
+++ b/nixos/modules/services/abstract/instance/generic.nix
@@ -1,0 +1,65 @@
+# This corresponds to the arguments of createManagedProcess in svanderburg's proposal
+{ lib, config, options, ... }:
+let
+  inherit (lib) literalExpression mkOption types;
+  pathOrStr = types.coercedTo types.path (x: "${x}") types.str;
+in
+{
+  options = {
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to enable the service. A service is enabled by default, because you took the effort to import it.
+      '';
+    };
+    process = mkOption {
+      type = pathOrStr;
+      description = ''
+        When this property is specified, it translates both to: {option}`foreground.process` and {option}`daemon.process`.
+      '';
+    };
+    foreground = {
+      process = lib.mkOption {
+        type  = pathOrStr;
+        description = ''
+          Path to an executable that launches a process in foreground mode.
+        '';
+        default = config.process;
+      };
+      args = lib.mkOption {
+        type = types.listOf pathOrStr;
+        description = ''
+          Arguments to pass to the {option}`foreground.process`.
+        '';
+        default = config.args;
+        defaultText = literalExpression "config.args";
+      };
+    };
+    daemon = {
+      process = lib.mkOption {
+        type = pathOrStr;
+        description = ''
+          Path to an executable that launches a process in daemon mode.
+        '';
+        default = config.process;
+      };
+      args = lib.mkOption {
+        type = types.listOf pathOrStr;
+        description = ''
+          Arguments to pass to the {option}`daemon.process`.
+        '';
+        default = config.args;
+        defaultText = literalExpression "config.args";
+      };
+    };
+    args = lib.mkOption {
+      type = types.listOf pathOrStr;
+      description = ''
+        Arguments to pass to the `foreground.process` or `daemon.process`. In other words, these arguments are passed regardless of process manager choice.
+      '';
+      default = [];
+    };
+    # TODO more from svanderburg's proposal. Look for the list of properties after defining `createManagedProcess`
+  };
+}

--- a/nixos/modules/services/abstract/instance/generic.nix
+++ b/nixos/modules/services/abstract/instance/generic.nix
@@ -10,7 +10,7 @@ in
       type = types.bool;
       default = true;
       description = ''
-        Whether to enable the service. A service is enabled by default, because you took the effort to import it.
+        Whether to enable the service. A service is enabled by default, because you took the effort to define its attribute.
       '';
     };
     process = mkOption {
@@ -26,6 +26,7 @@ in
           Path to an executable that launches a process in foreground mode.
         '';
         default = config.process;
+        defaultText = literalExpression "config.process";
       };
       args = lib.mkOption {
         type = types.listOf pathOrStr;
@@ -43,6 +44,7 @@ in
           Path to an executable that launches a process in daemon mode.
         '';
         default = config.process;
+        defaultText = literalExpression "config.process";
       };
       args = lib.mkOption {
         type = types.listOf pathOrStr;

--- a/nixos/modules/services/abstract/instance/systemd.nix
+++ b/nixos/modules/services/abstract/instance/systemd.nix
@@ -1,0 +1,42 @@
+{ lib, config, options, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+    systemd.services = lib.mkOption {
+      description = ''
+        This module configures systemd services, with the notable difference that their unit names will be prefixed with the abstract service name.
+
+        This option's value is not suitable for reading, but you can define a module here that interacts with just the unit configuration in the host system configuration.
+      '';
+      # ^ if we don't want to support this, we can add the systemd options that 
+      # we care about here, and combine them into a host system definition
+      # outside the control of this module - in services/abstract/systemd.nix.
+
+      type = types.lazyAttrsOf (types.deferredModuleWith { staticModules = [
+        # TODO Add the modules from systemd? They'll be deduplicated, but
+        #      will generate docs in this part of the hierarchy. Is such duplication
+        #      desirable? Perhaps!
+      ]; });
+    };
+  };
+  config = {
+    # Empty string "" is ok, because it will be prefixed by the abstraction layer
+    # anyway. Actual names here are for when multiple systemd services are needed.
+    # I might have overengineered this for a demonstration :thinking_face:.
+    #
+    # Note that this is the systemd.services option above, not the system one.
+    # This pattern allows a module to do all sorts of systemd stuff if it needs to.
+    systemd.services."" = {
+      description = "TBD add an option for that";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = "5";
+        ExecStart = [ (lib.escapeShellArgs ([ config.foreground.process ] ++ config.foreground.args)) ];
+      };
+    };
+  };
+}

--- a/nixos/modules/services/abstract/systemd.nix
+++ b/nixos/modules/services/abstract/systemd.nix
@@ -1,0 +1,41 @@
+# This merges systemd support into the generic instance module.
+{ lib, config, options, ... }:
+let
+  inherit (lib) concatMapAttrs mkOption types;
+
+  dash = before: after:
+    # maybe add nice clever escaping?
+    if after == ""
+    then before
+    else "${before}-${after}";
+in
+{
+  # First half of the magic: mix systemd logic into the otherwise abstract services
+  options = {
+    services.abstract = mkOption {
+      type = types.lazyAttrsOf (types.submoduleWith { modules = [ ./instance/systemd.nix ]; });
+    };
+  };
+
+  # Second half of the magic: siphon units that were defined in isolation to the system
+  config = {
+    systemd.services =
+      concatMapAttrs
+        (abstractServiceName: abstractServiceConfig:
+          if abstractServiceConfig.enable
+          then
+            concatMapAttrs
+              (subServiceName: unitModule: {
+                "${dash abstractServiceName subServiceName}" = { ... }: {
+                  imports = [ unitModule ];
+                };
+              })
+              abstractServiceConfig.systemd.services
+          else {})
+        config.services.abstract;
+
+    # systemd.sockets = 
+    #   ... same ...
+
+  };
+}


### PR DESCRIPTION
## Description of changes

- A proof of concept to hopefully illustrate what I [had in mind](https://github.com/NixOS/rfcs/pull/163#discussion_r1347854623) for https://github.com/NixOS/rfcs/pull/163

It implements a bit more than necessary, allowing an abstract service to potentially create multiple systemd services, if it seeks out `options?systemd` to figure out the kind of process manager it's loaded into.
I think that's nice functionality, but the proof of concept could be changed to something more restrictive if that's the direction you want to take. (ie don't define process-manager specific options; only read the data from the abstract service)

I hope this gives some insight into what's possible with the module system.
Or maybe you can learn some useful techniques. This kind of module based infrastructure doesn't exist in NixOS yet. Closest thing would be flake-parts, for which I originally wrote `types.deferredModule`.

Anyway, a good starting point is the `example` directory. It's the closest thing to actual documentation.
(Again, sorry, proof of concept status, time, etc etc)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

