### PR TITLE
gdal: unbreak

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -233,6 +233,9 @@ stdenv.mkDerivation (finalAttrs: {
     "test_sentinel2_zipped"
     # tries to call unwrapped executable
     "test_SetPROJAuxDbPaths"
+    # fixed and renamed in 3.8.0RC1
+    # https://github.com/OSGeo/gdal/commit/c8b471ca1e6318866ff668d2b57bb6f076e3ae29
+    "test_visoss_6"
   ] ++ lib.optionals (!stdenv.isx86_64) [
     # likely precision-related expecting x87 behaviour
     "test_jp2openjpeg_22"


### PR DESCRIPTION
## Description of changes

Disables failing test. It was fixed upstream in https://github.com/OSGeo/gdal/commit/c8b471ca1e6318866ff668d2b57bb6f076e3ae29, tagged in 3.8.0RC1. It nor the whole PR can be cherry picked.

ZHF #265948:

<details><summary><tt><a href="https://hydra.nixos.org/build/240203404">x86_64-linux gdal-3.7.3</a></tt> dependents:</summary>

<ul>
<li>apacheHttpdPackages.mod_tile.x86_64-linux</li>
<li>apacheHttpdPackages_2_4.mod_tile.x86_64-linux</li>
<li>cloudcompare.x86_64-linux</li>
<li>entwine.x86_64-linux</li>
<li>gmt.x86_64-linux</li>
<li>gplates.x86_64-linux</li>
<li>haskellPackages.hgdal.x86_64-linux</li>
<li>mapcache.x86_64-linux</li>
<li>mapnik.x86_64-linux</li>
<li>mapproxy.x86_64-linux</li>
<li>mapserver.x86_64-linux</li>
<li>merkaartor.x86_64-linux</li>
<li>octavePackages.mapping.x86_64-linux</li>
<li>openorienteering-mapper.x86_64-linux</li>
<li>paraview.x86_64-linux</li>
<li>pdal.x86_64-linux</li>
<li>perl536Packages.Tirex.x86_64-linux</li>
<li>perl538Packages.Tirex.x86_64-linux</li>
<li>postgresql12JitPackages.postgis.x86_64-linux</li>
<li>postgresql12Packages.postgis.x86_64-linux</li>
<li>postgresql13JitPackages.postgis.x86_64-linux</li>
<li>postgresql13Packages.postgis.x86_64-linux</li>
<li>postgresql14JitPackages.postgis.x86_64-linux</li>
<li>postgresql14Packages.postgis.x86_64-linux</li>
<li>postgresql15JitPackages.postgis.x86_64-linux</li>
<li>postgresql15Packages.postgis.x86_64-linux</li>
<li>postgresql16JitPackages.postgis.x86_64-linux</li>
<li>postgresql16Packages.postgis.x86_64-linux</li>
<li>postgresqlJitPackages.postgis.x86_64-linux</li>
<li>postgresqlPackages.postgis.x86_64-linux</li>
<li>python310Packages.pygmt.x86_64-linux</li>
<li>python310Packages.python-mapnik.x86_64-linux</li>
<li>python311Packages.bsuite.x86_64-linux</li>
<li>python311Packages.cartopy.x86_64-linux</li>
<li>python311Packages.django-bootstrap4.x86_64-linux</li>
<li>python311Packages.fiona.x86_64-linux</li>
<li>python311Packages.folium.x86_64-linux</li>
<li>python311Packages.geopandas.x86_64-linux</li>
<li>python311Packages.osmnx.x86_64-linux</li>
<li>python311Packages.plotnine.x86_64-linux</li>
<li>python311Packages.pygmt.x86_64-linux</li>
<li>python311Packages.python-mapnik.x86_64-linux</li>
<li>python311Packages.rasterio.x86_64-linux</li>
<li>python311Packages.wktutils.x86_64-linux</li>
<li>qmapshack.x86_64-linux</li>
<li>saga.x86_64-linux</li>
<li>sumo.x86_64-linux</li>
<li>udig.x86_64-linux</li>
<li>vpv.x86_64-linux</li>
</ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


# 