### PR TITLE
showdown: init at 2.1.0

### DIFF
--- a/pkgs/tools/text/showdown/default.nix
+++ b/pkgs/tools/text/showdown/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildNpmPackage, fetchFromGitHub }:
+
+buildNpmPackage rec {
+  pname = "showdown";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "showdownjs";
+    repo = "showdown";
+    rev = version;
+    hash = "sha256-MTnCKDKrJWoR7xaep+oaWbAAzBEnwiqHaiTsmfhEOXQ=";
+  };
+
+  npmDepsHash = "sha256-xEXygjJVJvfKIoH8DIbELq5vUig5vyboBK5QSV5Zq2M=";
+
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "JavaScript Markdown to HTML converter";
+    homepage = "https://showdownjs.com";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rhoriguchi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13181,6 +13181,8 @@ with pkgs;
 
   shout = nodePackages.shout;
 
+  showdown = callPackage ../tools/text/showdown { };
+
   showmethekey = callPackage ../applications/video/showmethekey { };
 
   shrikhand = callPackage ../data/fonts/shrikhand { };


### PR DESCRIPTION
## Description of changes

Replaces #196453

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
