### PR TITLE
ocamlPackages.camlp5: 8.00.05 → 8.02.1

### DIFF
--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -12,10 +12,12 @@ let
     ''
       #!${runtimeShell}
       cd $out/lib/hol_light
+      export OCAMLPATH="''${OCAMLPATH-}''${OCAMLPATH:+:}${camlp5}/lib/ocaml/${ocaml.version}/site-lib/"
       exec ${ocaml}/bin/ocaml \
         -I \`${camlp5}/bin/camlp5 -where\` \
         ${load_num} \
-        -I ${camlp-streams}/lib/ocaml/${ocaml.version}/site-lib/camlp-streams camlp_streams.cma
+        -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ \
+        -I ${camlp-streams}/lib/ocaml/${ocaml.version}/site-lib/camlp-streams camlp_streams.cma \
         -init make.ml
     '';
 in
@@ -25,13 +27,13 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
 
 stdenv.mkDerivation {
   pname = "hol_light";
-  version = "unstable-2023-07-21";
+  version = "unstable-2023-11-03";
 
   src = fetchFromGitHub {
     owner = "jrh13";
     repo = "hol-light";
-    rev = "29b3e114f5c166584f4fbcfd1e1f9b13a25b7349";
-    hash = "sha256-Z5/4dCfLRwLMHBmth3xMdFW1M6NzUT/aPEEwSz1/S2E=";
+    rev = "dcd765c6032f52a0c0bf21fce5da4794a823e880";
+    hash = "sha256-k2RBNDo4tc3eobKB84Y2xr0UQJvef0hv6jyFCaDCQFM=";
   };
 
   patches = [

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, perl, makeWrapper
-, rresult, bos, ocaml_pcre, re, camlp-streams
+, rresult, bos, re, camlp-streams
 , legacy ? false
 }:
 
@@ -10,26 +10,19 @@ else
 let params =
   if lib.versionAtLeast ocaml.version "4.12" && !legacy
   then rec {
-    version = "8.00.05";
+    version = "8.02.01";
 
     src = fetchFromGitHub {
       owner = "camlp5";
       repo = "camlp5";
       rev = version;
-      hash = "sha256-Havr3RB6iUP7QzV+LUGwMHtGzmRdS5RqYsqJ0N5w6gE=";
+      hash = "sha256-qSA2559vqWLU+0ns7LPUGI2K5f8sfu+QQ0sCH8sR6To=";
     };
 
     nativeBuildInputs = [ makeWrapper ocaml findlib perl ];
-    buildInputs = [ bos ocaml_pcre re rresult ];
+    buildInputs = [ bos re rresult ];
     propagatedBuildInputs = [ camlp-streams ];
 
-    postFixup = ''
-      for p in camlp5 camlp5o camlp5r camlp5sch mkcamlp5 ocpp5
-      do
-        wrapProgram $out/bin/$p \
-        --suffix CAML_LD_LIBRARY_PATH : ${ocaml_pcre}/lib/ocaml/${ocaml.version}/site-lib/stublibs
-      done
-    '';
   } else rec {
     version = "7.14";
     src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34534,9 +34534,7 @@ with pkgs;
 
   opusTools = callPackage ../applications/audio/opus-tools { };
 
-  orpie = callPackage ../applications/misc/orpie {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_12;
-  };
+  orpie = callPackage ../applications/misc/orpie { };
 
   osmo = callPackage ../applications/office/osmo { };
 


### PR DESCRIPTION
## Description of changes

Support latest versions of OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
