### PR TITLE
easycrypt: fix runtest command

### DIFF
--- a/pkgs/applications/science/logic/easycrypt/default.nix
+++ b/pkgs/applications/science/logic/easycrypt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ocamlPackages, why3 }:
+{ lib, stdenv, fetchFromGitHub, ocamlPackages, why3, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "easycrypt";
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     findlib
     menhir
     ocaml
+    python3.pkgs.wrapPython
   ];
   buildInputs = with ocamlPackages; [
     batteries
@@ -33,10 +34,13 @@ stdenv.mkDerivation rec {
     substituteInPlace dune-project --replace '(name easycrypt)' '(name easycrypt)(version ${version})'
   '';
 
+  pythonPath = with python3.pkgs; [ pyyaml ];
+
   installPhase = ''
     runHook preInstall
     dune install --prefix $out ${pname}
     rm $out/bin/ec-runtest
+    wrapPythonProgramsIn "$out/lib/easycrypt/commands" "$pythonPath"
     runHook postInstall
   '';
 


### PR DESCRIPTION
The `ec-runtest` program is still available as a separate easycrypt-runtest package, but the `easycrypt runtest` command now also works out-of-the-box.

## Description of changes

Just wrap the python program.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
