### PR TITLE
Gnome extensions tophat pathfixes

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
@@ -1,7 +1,7 @@
 diff --git a/extension.js b/extension.js
 index 400a4cd..25b4456 100644
---- a/tophat@fflewddur.github.io/extension.js
-+++ b/tophat@fflewddur.github.io/extension.js
+--- a/extension.js
++++ b/extension.js
 @@ -20,6 +20,8 @@
  
  /* exported init, enable, disable */

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
@@ -1,7 +1,7 @@
-diff --git a/extension.js b/extension.js
-index 60396f8..b044872 100644
---- a/extension.js
-+++ b/extension.js
+diff --git a/tophat@fflewddur.github.io/extension.js b/tophat@fflewddur.github.io/extension.js
+index 400a4cd..25b4456 100644
+--- a/tophat@fflewddur.github.io/extension.js
++++ b/tophat@fflewddur.github.io/extension.js
 @@ -20,6 +20,8 @@
  
  /* exported init, enable, disable */
@@ -11,3 +11,29 @@ index 60396f8..b044872 100644
  let depFailures = [];
  let missingLibs = [];
  
+diff --git a/tophat@fflewddur.github.io/lib/shared.js b/tophat@fflewddur.github.io/lib/shared.js
+index 0f19efa..a3f6e02 100644
+--- a/tophat@fflewddur.github.io/lib/shared.js
++++ b/tophat@fflewddur.github.io/lib/shared.js
+@@ -21,6 +21,8 @@
+ /* exported getProcessList, getProcessName, bytesToHumanString, getPartitions */
+ /* exported roundMax */
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
++
+ const {Gio, GTop} = imports.gi;
+ const ExtensionUtils = imports.misc.extensionUtils;
+ const Me = ExtensionUtils.getCurrentExtension();
+diff --git a/tophat@fflewddur.github.io/prefs.js b/tophat@fflewddur.github.io/prefs.js
+index 4775e18..856545e 100644
+--- a/tophat@fflewddur.github.io/prefs.js
++++ b/tophat@fflewddur.github.io/prefs.js
+@@ -19,6 +19,8 @@
+ 
+ /* exported init, fillPreferencesWindow, buildPrefsWidget */
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
++
+ const {Gdk, Gio, Gtk} = imports.gi;
+ const gtkVersion = Gtk.get_major_version();
+ const ExtensionUtils = imports.misc.extensionUtils;

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
@@ -1,4 +1,4 @@
-diff --git a/tophat@fflewddur.github.io/extension.js b/tophat@fflewddur.github.io/extension.js
+diff --git a/extension.js b/extension.js
 index 400a4cd..25b4456 100644
 --- a/tophat@fflewddur.github.io/extension.js
 +++ b/tophat@fflewddur.github.io/extension.js
@@ -11,10 +11,10 @@ index 400a4cd..25b4456 100644
  let depFailures = [];
  let missingLibs = [];
  
-diff --git a/tophat@fflewddur.github.io/lib/shared.js b/tophat@fflewddur.github.io/lib/shared.js
+diff --git a/lib/shared.js b/lib/shared.js
 index 0f19efa..a3f6e02 100644
---- a/tophat@fflewddur.github.io/lib/shared.js
-+++ b/tophat@fflewddur.github.io/lib/shared.js
+--- a/lib/shared.js
++++ b/lib/shared.js
 @@ -21,6 +21,8 @@
  /* exported getProcessList, getProcessName, bytesToHumanString, getPartitions */
  /* exported roundMax */
@@ -24,10 +24,10 @@ index 0f19efa..a3f6e02 100644
  const {Gio, GTop} = imports.gi;
  const ExtensionUtils = imports.misc.extensionUtils;
  const Me = ExtensionUtils.getCurrentExtension();
-diff --git a/tophat@fflewddur.github.io/prefs.js b/tophat@fflewddur.github.io/prefs.js
+diff --git a/prefs.js b/prefs.js
 index 4775e18..856545e 100644
---- a/tophat@fflewddur.github.io/prefs.js
-+++ b/tophat@fflewddur.github.io/prefs.js
+--- a/prefs.js
++++ b/prefs.js
 @@ -19,6 +19,8 @@
  
  /* exported init, fillPreferencesWindow, buildPrefsWidget */


### PR DESCRIPTION
## Description of changes

The tophat gnome extension needs a few more search path patches for gtop to get settings to work.

## Things done

- Built on platform(s)
  - [*] x86_64-linux

- [*] Tested basic functionality of all binary files (usually in `./result/bin/`)

Add path fixes to prefs.js and lib/shared.js

Options are now available again in the extension.