### PR TITLE
opentrack: 2022.3.0 -> 2023.3.0

### DIFF
--- a/pkgs/applications/misc/opentrack/0001-fix-wine-no-wrapper.patch
+++ b/pkgs/applications/misc/opentrack/0001-fix-wine-no-wrapper.patch
@@ -1,0 +1,24 @@
+From d501d7e0b237ed0c305525788b423d842ffa356d Mon Sep 17 00:00:00 2001
+From: Francesco Zanini <francesco@zanini.me>
+Date: Mon, 13 Nov 2023 08:59:42 +0100
+Subject: [PATCH] Fix build for wine without wrapper
+
+`connected_game` is only declared in a specific configuration.
+---
+ proto-wine/ftnoir_protocol_wine.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/proto-wine/ftnoir_protocol_wine.cpp b/proto-wine/ftnoir_protocol_wine.cpp
+index 75526c54a..c44cfc43b 100644
+--- a/proto-wine/ftnoir_protocol_wine.cpp
++++ b/proto-wine/ftnoir_protocol_wine.cpp
+@@ -137,7 +137,9 @@ module_status wine::initialize()
+         qDebug() << "proto/wine: shm success";
+ 
+         // display "waiting for game message" (overwritten once a game is detected)
++#ifndef OTR_WINE_NO_WRAPPER
+         connected_game = "waiting for game...";
++#endif
+     }
+     else {
+         qDebug() << "proto/wine: shm no success";

--- a/pkgs/applications/misc/opentrack/default.nix
+++ b/pkgs/applications/misc/opentrack/default.nix
@@ -18,14 +18,14 @@
   makeDesktopItem,
   fetchurl,
 }: let
-  version = "2022.3.0";
+  version = "2023.3.0";
 
   aruco = callPackage ./aruco.nix {};
 
   # license.txt inside the zip file is MIT
   xplaneSdk = fetchzip {
-    url = "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK303.zip";
-    sha256 = "11wqjsr996c5qhiv2djsd55gc373a9qcq30dvc6rhzm0fys42zba";
+    url = "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK401.zip";
+    hash = "sha256-tUT9yV1949QVr5VebU/7esg7wwWkyak2TSA/kQSrbeo=";
   };
 in
   mkDerivation {
@@ -36,8 +36,13 @@ in
       owner = "opentrack";
       repo = "opentrack";
       rev = "opentrack-${version}";
-      sha256 = "sha256-8gpNORTJclYUYp57Vw/0YO3XC9Idurt0a79fhqx0+mo=";
+      sha256 = "sha256-C0jLS55DcLJh/e5yM8kLG7fhhKvBNllv5HkfCWRIfc4=";
     };
+
+    patches = [
+      # https://github.com/opentrack/opentrack/pull/1754
+      ./0001-fix-wine-no-wrapper.patch
+    ];
 
     nativeBuildInputs = [cmake pkg-config ninja copyDesktopItems];
     buildInputs = [qtbase qttools opencv4 procps eigen libXdmcp libevdev aruco];


### PR DESCRIPTION
## Description of changes

- Update to [2023.3.0](https://github.com/opentrack/opentrack/releases/tag/opentrack-2023.3.0)
- Add patch for a specific configuration, tracked by upstream PR: https://github.com/opentrack/opentrack/pull/1754, as it's not NixOS specific.

Fixes #251257.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
