### PR TITLE
lib: init ansi module

### DIFF
--- a/lib/ansi.nix
+++ b/lib/ansi.nix
@@ -1,0 +1,60 @@
+# This exports a basic set of ANSI escape sequences to colorize terminal output.
+
+{ ... }:
+
+let
+  # Escape character. "\e" or similar encodings currently not supported by Nix.
+  esc = "";
+  reset = "${esc}[0m";
+  style = {
+    bold = "${esc}[1m";
+    italic = "${esc}[3m";
+  };
+  colorCode = {
+    black = 0;
+    red = 1;
+    green = 2;
+    yellow = 3;
+    blue = 4;
+    magenta = 5;
+    cyan = 6;
+    white = 7;
+  };
+  color = {
+    fg = builtins.mapAttrs (name: value: "${esc}[3${toString value}m") colorCode;
+    bg = builtins.mapAttrs (name: value: "${esc}[4${toString value}m") colorCode;
+  };
+
+  /*
+    Stylizes a string with ANSI escape sequences.
+
+    Type: stylize :: [String] -> String -> String
+  */
+  stylize =
+    # List of ANSI style attributes.
+    styles:
+    # Text to encapsulate by style.
+    text:
+    let
+      ansiBefore = builtins.concatStringsSep "" styles;
+    in
+    if text == "" then "" else "${ansiBefore}${text}${reset}";
+
+  /*
+    Stylizes a string as bold and red.
+
+    Type: stylizeError :: String -> String
+  */
+  stylizeError = text: stylize [ style.bold color.fg.red ] text;
+
+  /*
+    Stylizes a string as bold and yellow.
+
+    Type: stylizeWarn :: String -> String
+  */
+  stylizeWarn = text: stylize [ style.bold color.fg.yellow ] text;
+in
+{
+  inherit color style reset;
+  inherit stylize stylizeError stylizeWarn;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -83,6 +83,7 @@ let
       generators = callLibs ./generators.nix;
 
       # misc
+      ansi = callLibs ./ansi.nix;
       asserts = callLibs ./asserts.nix;
       debug = callLibs ./debug.nix;
       misc = callLibs ./deprecated/misc.nix;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -24,6 +24,7 @@ let
   inherit (lib)
     allUnique
     and
+    ansi
     attrNames
     attrsets
     attrsToList
@@ -2906,6 +2907,21 @@ runTests {
           }
         }
       }'';
+  };
+
+  # MISC
+
+  testAnsiStylizeEmptyInput = {
+    expr = ansi.stylize [ ansi.style.bold ansi.color.fg.red ] "";
+    expected = "";
+  };
+  testAnsiStylizeError = {
+    expr = ansi.stylizeError "ERROR";
+    expected = "[1m[31mERROR[0m";
+  };
+  testAnsiStylizeWarn = {
+    expr = ansi.stylizeWarn "WARN";
+    expected = "[1m[33mWARN[0m";
   };
 
   # CLI

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -790,11 +790,11 @@ in
       # `builtins.warn` requires a string message, so we enforce that in our implementation, so that callers aren't accidentally incompatible with newer Nix versions.
       assert isString msg;
       if mustAbort then
-        builtins.trace "[1;31mevaluation warning:[0m ${msg}" (
+        builtins.trace "${lib.ansi.stylizeError "evaluation warning:"} ${msg}" (
           abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors."
         )
       else
-        builtins.trace "[1;35mevaluation warning:[0m ${msg}" v
+        builtins.trace "${lib.ansi.stylizeError "evaluation warning:"} ${msg}" v
     );
 
   /**


### PR DESCRIPTION
The lib.ansi module provides a basic set of ANSI escape sequences to colorize and style text. The main purpose is to colorize trace messages (warnings, errors).

## Description of changes

Add `lib.ansi`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
