### PR TITLE
openai-triton-llvm: fix aarch64 and cross-compilation

### DIFF
--- a/pkgs/by-name/op/openai-triton-llvm/package.nix
+++ b/pkgs/by-name/op/openai-triton-llvm/package.nix
@@ -1,27 +1,49 @@
-{ config
-, lib
+{ lib
 , stdenv
 , fetchFromGitHub
+, pkgsBuildBuild
 , pkg-config
 , cmake
 , ninja
 , git
-, doxygen
-, sphinx
 , libxml2
 , libxcrypt
 , libedit
 , libffi
+, libpfm
 , mpfr
 , zlib
 , ncurses
+, doxygen
+, sphinx
+, which
+, sysctl
 , python3Packages
 , buildDocs ? true
 , buildMan ? true
 , buildTests ? true
+, llvmTargetsToBuild ? [ "NATIVE" ] # "NATIVE" resolves into x86 or aarch64 depending on stdenv
+, llvmProjectsToBuild ? [ "llvm" "mlir" ]
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  llvmNativeTarget =
+    if stdenv.hostPlatform.isx86_64 then "X86"
+    else if stdenv.hostPlatform.isAarch64 then "AArch64"
+    else throw "Currently unsupported LLVM platform '${stdenv.hostPlatform.config}'";
+
+  inferNativeTarget = t: if t == "NATIVE" then llvmNativeTarget else t;
+  llvmTargetsToBuild' = [ "AMDGPU" "NVPTX" ] ++ builtins.map inferNativeTarget llvmTargetsToBuild;
+
+  # This LLVM version can't seem to find pygments/pyyaml,
+  # but a later update will likely fix this (openai-triton-2.1.0)
+  python =
+    if buildTests
+    then python3Packages.python.withPackages (p: with p; [ psutil pygments pyyaml ])
+    else python3Packages.python;
+
+  isNative = stdenv.hostPlatform == stdenv.buildPlatform;
+in stdenv.mkDerivation (finalAttrs: {
   pname = "openai-triton-llvm";
   version = "14.0.6-f28c006a5895";
 
@@ -33,7 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  # See https://github.com/openai/triton/blob/main/python/setup.py and https://github.com/ptillet/triton-llvm-releases/releases
+  # See https://github.com/openai/triton/blob/main/python/setup.py
+  # and https://github.com/ptillet/triton-llvm-releases/releases
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
@@ -46,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     git
-    python3Packages.python
+    python
   ] ++ lib.optionals (buildDocs || buildMan) [
     doxygen
     sphinx
@@ -58,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxcrypt
     libedit
     libffi
+    libpfm
     mpfr
   ];
 
@@ -69,37 +93,55 @@ stdenv.mkDerivation (finalAttrs: {
   sourceRoot = "${finalAttrs.src.name}/llvm";
 
   cmakeFlags = [
-    "-DLLVM_TARGETS_TO_BUILD=${
-      let
-        # Targets can be found in
-        # https://github.com/llvm/llvm-project/tree/f28c006a5895fc0e329fe15fead81e37457cb1d1/clang/lib/Basic/Targets
-        # NOTE: Unsure of how "host" would function, especially given that we might be cross-compiling.
-        llvmTargets = [ "AMDGPU" "NVPTX" ]
-        ++ lib.optionals stdenv.isAarch64 [ "AArch64" ]
-        ++ lib.optionals stdenv.isx86_64 [ "X86" ];
-      in
-      lib.concatStringsSep ";" llvmTargets
-    }"
-    "-DLLVM_ENABLE_PROJECTS=llvm;mlir"
-    "-DLLVM_INSTALL_UTILS=ON"
-  ] ++ lib.optionals (buildDocs || buildMan) [
-    "-DLLVM_INCLUDE_DOCS=ON"
-    "-DMLIR_INCLUDE_DOCS=ON"
-    "-DLLVM_BUILD_DOCS=ON"
-    # "-DLLVM_ENABLE_DOXYGEN=ON" Way too slow, only uses one core
-    "-DLLVM_ENABLE_SPHINX=ON"
-    "-DSPHINX_OUTPUT_HTML=ON"
-    "-DSPHINX_OUTPUT_MAN=ON"
-    "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-  ] ++ lib.optionals buildTests [
-    "-DLLVM_INCLUDE_TESTS=ON"
-    "-DMLIR_INCLUDE_TESTS=ON"
-    "-DLLVM_BUILD_TESTS=ON"
-  ];
+    (lib.cmakeFeature "LLVM_TARGETS_TO_BUILD" (lib.concatStringsSep ";" llvmTargetsToBuild'))
+    (lib.cmakeFeature "LLVM_ENABLE_PROJECTS" (lib.concatStringsSep ";" llvmProjectsToBuild))
+    (lib.cmakeFeature "LLVM_HOST_TRIPLE" stdenv.hostPlatform.config)
+    (lib.cmakeFeature "LLVM_DEFAULT_TARGET_TRIPLE" stdenv.hostPlatform.config)
+    (lib.cmakeBool "LLVM_INSTALL_UTILS" true)
+    (lib.cmakeBool "LLVM_INCLUDE_DOCS" (buildDocs || buildMan))
+    (lib.cmakeBool "MLIR_INCLUDE_DOCS" (buildDocs || buildMan))
+    (lib.cmakeBool "LLVM_BUILD_DOCS" (buildDocs || buildMan))
+    # Way too slow, only uses one core
+    # (lib.cmakeBool "LLVM_ENABLE_DOXYGEN" (buildDocs || buildMan))
+    (lib.cmakeBool "LLVM_ENABLE_SPHINX" (buildDocs || buildMan))
+    (lib.cmakeBool "SPHINX_OUTPUT_HTML" buildDocs)
+    (lib.cmakeBool "SPHINX_OUTPUT_MAN" buildMan)
+    (lib.cmakeBool "SPHINX_WARNINGS_AS_ERRORS" false)
+    (lib.cmakeBool "LLVM_INCLUDE_TESTS" buildTests)
+    (lib.cmakeBool "MLIR_INCLUDE_TESTS" buildTests)
+    (lib.cmakeBool "LLVM_BUILD_TESTS" buildTests)
+  # Cross compilation code taken/modified from LLVM 16 derivation
+  ] ++ lib.optionals (!isNative) (let
+    nativeToolchainFlags = let
+      nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
+      nativeBintools = nativeCC.bintools.bintools;
+    in [
+      (lib.cmakeFeature "CMAKE_C_COMPILER" "${nativeCC}/bin/${nativeCC.targetPrefix}cc")
+      (lib.cmakeFeature "CMAKE_CXX_COMPILER" "${nativeCC}/bin/${nativeCC.targetPrefix}c++")
+      (lib.cmakeFeature "CMAKE_AR" "${nativeBintools}/bin/${nativeBintools.targetPrefix}ar")
+      (lib.cmakeFeature "CMAKE_STRIP" "${nativeBintools}/bin/${nativeBintools.targetPrefix}strip")
+      (lib.cmakeFeature "CMAKE_RANLIB" "${nativeBintools}/bin/${nativeBintools.targetPrefix}ranlib")
+    ];
+
+    # We need to repass the custom GNUInstallDirs values, otherwise CMake
+    # will choose them for us, leading to wrong results in llvm-config-native
+    nativeInstallFlags = [
+      (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" (placeholder "out"))
+      (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "${placeholder "out"}/bin")
+      (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "${placeholder "out"}/include")
+      (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "${placeholder "out"}/lib")
+      (lib.cmakeFeature "CMAKE_INSTALL_LIBEXECDIR" "${placeholder "out"}/libexec")
+    ];
+  in [
+    (lib.cmakeBool "CMAKE_CROSSCOMPILING" true)
+    (lib.cmakeFeature "CROSS_TOOLCHAIN_FLAGS_NATIVE" (lib.concatStringsSep ";"
+      (lib.concatLists [ nativeToolchainFlags nativeInstallFlags ])))
+  ]);
 
   postPatch = ''
     # `CMake Error: cannot write to file "/build/source/llvm/build/lib/cmake/mlir/MLIRTargets.cmake": Permission denied`
     chmod +w -R ../mlir
+    patchShebangs ../mlir/test/mlir-reduce
 
     # FileSystem permissions tests fail with various special bits
     rm test/tools/llvm-objcopy/ELF/mirror-permissions-unix.test
@@ -107,9 +149,21 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "Path.cpp" ""
+  '' + lib.optionalString stdenv.isAarch64 ''
+    # Not sure why this fails
+    rm test/tools/llvm-exegesis/AArch64/latency-by-opcode-name.s
+  '';
+
+  postInstall = lib.optionalString (!isNative) ''
+    cp -a NATIVE/bin/llvm-config $out/bin/llvm-config-native
   '';
 
   doCheck = buildTests;
+
+  nativeCheckInputs = [ which ]
+    ++ lib.optionals stdenv.isDarwin [ sysctl ];
+
+  checkTarget = "check-all";
   requiredSystemFeatures = [ "big-parallel" ];
 
   meta = with lib; {
@@ -117,9 +171,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/llvm/llvm-project";
     license = with licenses; [ ncsa ];
     maintainers = with maintainers; [ SomeoneSerge Madouura ];
-    platforms = platforms.linux;
-    # Consider the derivation broken if we're not building for CUDA or ROCm, or if we're building for aarch64
-    # and ROCm is enabled. See https://github.com/RadeonOpenCompute/ROCm/issues/1831#issuecomment-1278205344.
-    broken = stdenv.isAarch64 && !config.cudaSupport;
+    platforms = with platforms; aarch64 ++ x86;
   };
 })

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -16,9 +16,10 @@
   filelock,
   jinja2,
   networkx,
-  openai-triton,
   sympy,
   numpy, pyyaml, cffi, click, typing-extensions,
+  # ROCm build and `torch.compile` requires `openai-triton`
+  tritonSupport ? (!stdenv.isDarwin), openai-triton,
 
   # Unit tests
   hypothesis, psutil,
@@ -377,12 +378,10 @@ in buildPythonPackage rec {
     # the following are required for tensorboard support
     pillow six future tensorboard protobuf
 
-    # ROCm build and `torch.compile` requires openai-triton
-    openai-triton
-
     # torch/csrc requires `pybind11` at runtime
     pybind11
   ]
+  ++ lib.optionals tritonSupport [ openai-triton ]
   ++ lib.optionals MPISupport [ mpi ]
   ++ lib.optionals rocmSupport [ rocmtoolkit_joined ];
 

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -304,12 +304,13 @@ in buildPythonPackage rec {
     "-Wno-pass-failed"
   ] ++ [
     "-Wno-unused-command-line-argument"
-    "-Wno-maybe-uninitialized"
     "-Wno-uninitialized"
     "-Wno-array-bounds"
-    "-Wno-stringop-overflow"
     "-Wno-free-nonheap-object"
     "-Wno-unused-result"
+  ] ++ lib.optionals stdenv.cc.isGNU [
+    "-Wno-maybe-uninitialized"
+    "-Wno-stringop-overflow"
   ]));
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes
Fixes this comment: https://github.com/NixOS/nixpkgs/pull/263048#issuecomment-1807824236
Unsure how to test darwin, since it won't cross-compile.
This is why we're guarding ``openai-triton`` in ``torch``: 8bb0f732cf7638a0749a26fe37b60db1032daf55
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
