### PR TITLE
amd-libflame: fix various build errors

### DIFF
--- a/pkgs/development/libraries/science/math/amd-libflame/default.nix
+++ b/pkgs/development/libraries/science/math/amd-libflame/default.nix
@@ -9,7 +9,7 @@
 
 , withOpenMP ? true
 , blas64 ? false
-, withAMDOpt ? false
+, withAMDOpt ? true
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/science/math/amd-libflame/default.nix
+++ b/pkgs/development/libraries/science/math/amd-libflame/default.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation rec {
     "-DENABLE_CBLAS_INTERFACES=ON"
     "-DENABLE_EXT_LAPACK_INTERFACE=ON"
   ]
-  ++ lib.optional (!withOpenMP) "ENABLE_MULTITHREADING=OFF"
-  ++ lib.optional blas64 "ENABLE_ILP64=ON"
-  ++ lib.optional withAMDOpt "ENABLE_AMD_OPT=ON";
+  ++ lib.optional (!withOpenMP) "-DENABLE_MULTITHREADING=OFF"
+  ++ lib.optional blas64 "-DENABLE_ILP64=ON"
+  ++ lib.optional withAMDOpt "-DENABLE_AMD_OPT=ON";
 
   postInstall = ''
     ln -s $out/lib/libflame.so $out/lib/liblapack.so.3

--- a/pkgs/development/libraries/science/math/amd-libflame/default.nix
+++ b/pkgs/development/libraries/science/math/amd-libflame/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ amd-blis aocl-utils ];
 
   cmakeFlags = [
-    "-DLIBAOCLUTILS_LIBRARY_PATH=${lib.getLib aocl-utils}/lib"
+    "-DLIBAOCLUTILS_LIBRARY_PATH=${lib.getLib aocl-utils}/lib/libaoclutils${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DLIBAOCLUTILS_INCLUDE_PATH=${lib.getDev aocl-utils}/include"
     "-DENABLE_BUILTIN_LAPACK2FLAME=ON"
     "-DENABLE_CBLAS_INTERFACES=ON"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes three issues when trying to build a package like `python311Packages.numpy`, e.g.

1. The optional `cmakeFlags` don't have a `-D`, so they don't actually work.

2. Missing symbols. Running 
```shell
nix build nixpkgs#amd-libflame
nm -ugD /lib/liblapack.so.3
```
shows the missing symbols
```text
U fla_dhrot3
U fla_drot
U fla_dscal
U fla_sger
U fla_sscal
U fla_zgetrf_small_avx2
```
(along with the missing `cblas` and `blas` symbols). These symbols are generated by `ENABLE_AMD_OPT`.

Without them, one gets a `undefined symbol: fla_sger` error like
```text
error: builder for '/nix/store/i1bqihxvgh7y918kh9djd1p7h239a8j6-python3.11-numpy-1.25.2.drv' failed with exit code 2;
       last 10 log lines:
       > lib/python3.11/site-packages/numpy/linalg/__init__.py:73: in <module>
       >     from . import linalg
       > lib/python3.11/site-packages/numpy/linalg/linalg.py:35: in <module>
       >     from numpy.linalg import _umath_linalg
       > E   ImportError: /nix/store/8wd7y7dndgpymcdrqaghkiimp7k5ii7b-lapack-3/lib/liblapack.so.3: undefined symbol: fla_sger
       > =========================== short test summary info ============================
       > ERROR  - ImportError: /nix/store/8wd7y7dndgpymcdrqaghkiimp7k5ii7b-lapack-3/lib/libla...
       > !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
       > =============================== 1 error in 0.15s ===============================
       > /nix/store/bbxdw4rgwwl3gnajri82yidr1nlsfskf-stdenv-linux/setup: line 1596: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix-store -l /nix/store/i1bqihxvgh7y918kh9djd1p7h239a8j6-python3.11-numpy-1.25.2.drv'.
```

3. The path of `aocl-utils` is specified incorrectly. During the configure phase, the following warning is shown.
```text
CMake Warning at CMakeLists.txt:994 (target_link_libraries):
  Target "flame" requests linking to directory
  "/nix/store/f4niv5r35s44lnn4l3f7ksznl4vlp2pm-aocl-utils-4.1/lib".  Targets
  may link only to libraries.  CMake is dropping the item.
```
That leads to an `undefined symbol: alcpu_flag_is_available` with trying to build `numpy`.
```
error: builder for '/nix/store/cc3bncprgggw1swbv9pn0pq5jqdi0ays-python3.11-numpy-1.25.2.drv' failed with exit code 2;
       last 10 log lines:
       > lib/python3.11/site-packages/numpy/linalg/__init__.py:73: in <module>
       >     from . import linalg
       > lib/python3.11/site-packages/numpy/linalg/linalg.py:35: in <module>
       >     from numpy.linalg import _umath_linalg
       > E   ImportError: /nix/store/wjnb49hlblsqc85cwjw5psqz5wcs29j4-lapack-3/lib/liblapack.so.3: undefined symbol: alcpu_flag_is_available
       > =========================== short test summary info ============================
       > ERROR  - ImportError: /nix/store/wjnb49hlblsqc85cwjw5psqz5wcs29j4-lapack-3/lib/libla...
       > !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
       > =============================== 1 error in 0.53s ===============================
       > /nix/store/bbxdw4rgwwl3gnajri82yidr1nlsfskf-stdenv-linux/setup: line 1596: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix-store -l /nix/store/cc3bncprgggw1swbv9pn0pq5jqdi0ays-python3.11-numpy-1.25.2.drv'.
```

Once all of these errors has been fixed, `numpy` builds but fails a few tests relating to the Cholesky factorization.
```
error: builder for '/nix/store/v2nw9i9q7f1qwvdzv9p853lg47irgp5m-python3.11-numpy-1.25.2.drv' failed with exit code 1;
       last 10 log lines:
       > FAILED lib/python3.11/site-packages/numpy/linalg/tests/test_linalg.py::TestCholesky::test_basic_property[float64-shape1] - AssertionError:
       > FAILED lib/python3.11/site-packages/numpy/linalg/tests/test_linalg.py::TestCholesky::test_basic_property[float64-shape2] - AssertionError:
       > FAILED lib/python3.11/site-packages/numpy/linalg/tests/test_linalg.py::TestCholesky::test_basic_property[float64-shape3] - AssertionError:
       > FAILED lib/python3.11/site-packages/numpy/linalg/tests/test_linalg.py::TestCholesky::test_basic_property[float64-shape4] - AssertionError:
       > FAILED lib/python3.11/site-packages/numpy/random/tests/test_generator_mt19937.py::TestRandomDist::test_multivariate_normal[svd] - AssertionError: LinAlgError not raised by multivariate_normal
       > FAILED lib/python3.11/site-packages/numpy/random/tests/test_generator_mt19937.py::TestRandomDist::test_multivariate_normal[eigh] - AssertionError: LinAlgError not raised by multivariate_normal
       > FAILED lib/python3.11/site-packages/numpy/random/tests/test_generator_mt19937.py::TestRandomDist::test_multivariate_normal[cholesky] - AssertionError: LinAlgError not raised by multivariate_normal
       > FAILED lib/python3.11/site-packages/numpy/random/tests/test_generator_mt19937.py::TestRandomDist::test_multivariate_normal_basic_stats[cholesky] - AssertionError: assert False
       > = 13 failed, 35331 passed, 1624 skipped, 1308 deselected, 31 xfailed, 4 xpassed, 618 warnings in 168.63s (0:02:48) =
       > /nix/store/bbxdw4rgwwl3gnajri82yidr1nlsfskf-stdenv-linux/setup: line 1596: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix-store -l /nix/store/v2nw9i9q7f1qwvdzv9p853lg47irgp5m-python3.11-numpy-1.25.2.drv'.
```
This is probably an upstream issue related to numerical instability (see https://github.com/flame/libflame/issues/26, e.g.).

@markuskowa

(n.b.: based on my understanding of the `CmakeLists.txt` I don't think `amd-blis` in the `buildInputs` is currently used. 
I tried playing around with specifying the flags related to blas
```nix
  cmakeFlags = [
    "-DCMAKE_EXT_BLAS_LIBRARY_DEPENDENCY_PATH=${lib.getLib amd-blis}/lib"
    "-DEXT_BLAS_LIBNAME=libcblas.so"
    ...
  ]
```
along with the following patch
```patch
diff --git a/CMakeLists.txt b/CMakeLists.txt
index ccec416d..99cb5143 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,12 +1021,11 @@ endif ()
 
 # TODO : enable this flag to build source supplied blas library
 # link externally built blas library
-if(WIN32)
-	if (NOT ENABLE_BUILTIN_BLAS)
-		target_link_libraries(${PROJECT_NAME} ${CMAKE_EXT_BLAS_LIBRARY_DEPENDENCY_PATH}/${EXT_BLAS_LIBNAME})
-		target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_EXT_BLAS_LIBRARY_DEPENDENCY_PATH})		
-	endif ()
-endif()
+if (NOT ENABLE_BUILTIN_BLAS)
+	target_link_libraries(${PROJECT_NAME} ${CMAKE_EXT_BLAS_LIBRARY_DEPENDENCY_PATH}/${EXT_BLAS_LIBNAME})
+	target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_EXT_BLAS_LIBRARY_DEPENDENCY_PATH})		
+	target_link_options(${PROJECT_NAME} PUBLIC "LINKER:-lcblas")
+endif ()
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-DEXPMODULE)
 add_subdirectory(src)
```
but the symbols still show up as missing; however, `amd-blis` has been added to the `rpath` and the `.so` is needed but I don't know if there's a difference. I'm not too familiar with the subtleties of linking so I left it at that.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
