### PR TITLE
avr-sim: init at 2.8

### DIFF
--- a/pkgs/by-name/av/avr-sim/package.nix
+++ b/pkgs/by-name/av/avr-sim/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  lazarus,
+  fpc,
+  pango,
+  cairo,
+  glib,
+  atk,
+  gtk2,
+  libX11,
+  gdk-pixbuf,
+}:
+stdenv.mkDerivation rec {
+  pname = "avr-sim";
+  version = "2.8";
+
+  # Unfortunately old releases get removed:
+  # http://www.avr-asm-tutorial.net/avr_sim/avr_sim-download.html
+  # Therefore, fallback to an archive.org snapshot
+  src = fetchzip {
+    urls = [
+      "http://www.avr-asm-tutorial.net/avr_sim/28/avr_sim_28_lin_src.zip"
+      "https://web.archive.org/web/20231129125754/http://www.avr-asm-tutorial.net/avr_sim/28/avr_sim_28_lin_src.zip"
+    ];
+    sha256 = "sha256-7MgUzMs+l+3RVUbORAWyU1OUpgrKIeWhS+ObgRJtOHc=";
+  };
+
+  nativeBuildInputs = [lazarus fpc];
+
+  buildInputs = [pango cairo glib atk gtk2 libX11 gdk-pixbuf];
+
+  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+
+  buildPhase = ''
+    runHook preBuild
+
+    lazbuild --lazarusdir=${lazarus}/share/lazarus --build-mode=Release avr_sim.lpi
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    cp avr_sim $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "AVR assembler simulator for the stepwise execution of assembler source code - with many extras";
+    homepage = "http://www.avr-asm-tutorial.net/avr_sim/index_en.html";
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ameer];
+  };
+}


### PR DESCRIPTION
## Description of changes

New Package: Gerd's AVR Simulator

Website: http://www.avr-asm-tutorial.net/avr_sim/index_en.html

AVR assembler simulator for the stepwise execution of assembler source code.

Some Features:

- Simulates AVR 8-bit microcontrollers of any type (ATtiny, ATmega, etc).
- Assembles the source code with the built-in assembler `gavrasm`.
- Allows control over registers, flags, memories, ports, timer/counters, AD converter, etc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
