### PR TITLE
Use cuda_compat drivers when available

### DIFF
--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -1,6 +1,7 @@
 {
   # General callPackage-supplied arguments
   autoAddOpenGLRunpathHook,
+  autoAddCudaCompatRunpathHook,
   autoPatchelfHook,
   backendStdenv,
   fetchurl,
@@ -126,6 +127,14 @@ backendStdenv.mkDerivation (
       # Check e.g. with `patchelf --print-rpath path/to/my/binary
       autoAddOpenGLRunpathHook
       markForCudatoolkitRootHook
+    ]
+    # autoAddCudaCompatRunpathHook depends on cuda_compat and would cause
+    # infinite recursion if applied to `cuda_compat` itself (beside the fact
+    # that it doesn't make sense in the first place)
+    ++ lib.optionals (pname != "cuda_compat" && flags.isJetsonBuild) [
+      # autoAddCudaCompatRunpathHook must appear AFTER autoAddOpenGLRunpathHook.
+      # See its documentation in ./setup-hooks/extension.nix.
+      autoAddCudaCompatRunpathHook
     ];
 
     buildInputs =

--- a/pkgs/development/cuda-modules/setup-hooks/auto-add-cuda-compat-runpath.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/auto-add-cuda-compat-runpath.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+# Patch all dynamically linked, ELF files with the CUDA driver (libcuda.so)
+# coming from the cuda_compat package by adding it to the RUNPATH.
+echo "Sourcing auto-add-cuda-compat-runpath-hook"
+
+elfHasDynamicSection() {
+    patchelf --print-rpath "$1" >& /dev/null
+}
+
+autoAddCudaCompatRunpathPhase() (
+  local outputPaths
+  mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "${!o}"; done)
+  find "${outputPaths[@]}" -type f -executable -print0  | while IFS= read -rd "" f; do
+    if isELF "$f"; then
+      # patchelf returns an error on statically linked ELF files
+      if elfHasDynamicSection "$f" ; then
+        echo "autoAddCudaCompatRunpathHook: patching $f"
+        local origRpath="$(patchelf --print-rpath "$f")"
+        patchelf --set-rpath "@libcudaPath@:$origRpath" "$f"
+      elif (( "${NIX_DEBUG:-0}" >= 1 )) ; then
+        echo "autoAddCudaCompatRunpathHook: skipping a statically-linked ELF file $f"
+      fi
+    fi
+  done
+)
+
+postFixupHooks+=(autoAddCudaCompatRunpathPhase)

--- a/pkgs/development/cuda-modules/setup-hooks/extension.nix
+++ b/pkgs/development/cuda-modules/setup-hooks/extension.nix
@@ -44,4 +44,24 @@ final: _: {
           ./auto-add-opengl-runpath-hook.sh
       )
       {};
+
+  # autoAddCudaCompatRunpathHook hook must be added AFTER `setupCudaHook`. Both
+  # hooks prepend a path with `libcuda.so` to the `DT_RUNPATH` section of
+  # patched elf files, but `cuda_compat` path must take precedence (otherwise,
+  # it doesn't have any effect) and thus appear first. Meaning this hook must be
+  # executed last.
+  autoAddCudaCompatRunpathHook =
+    final.callPackage
+      (
+        {makeSetupHook, cuda_compat}:
+        makeSetupHook
+          {
+            name = "auto-add-cuda-compat-runpath-hook";
+            substitutions = {
+              libcudaPath = "${cuda_compat}/compat";
+            };
+          }
+          ./auto-add-cuda-compat-runpath.sh
+      )
+      {};
 }


### PR DESCRIPTION
## Description of changes

Some nvidia devices, such as the Jetson family, support a package called nvidia compatibility package (`cudaPackages.cuda_compat`) which allows to run executables built against a higher CUDA major version on a system with an older CUDA driver. On such platforms, the consensus among CUDA maintainers is that there is no downside in always enabling it by default.

This PR links to the relevant cuda_compat shared libraries when available by patching the executables' runpaths when cuda_compat is available, in the same way as we already do for OpenGL drivers.

We initially tried to upgrade and reuse `add-patch-opengl-driver` because the script does exactly what we want, excepted that we would like to add several paths, and not just one, to the `runpath` of concerned executables.

However, this derivation is used in many places (both the result but also the attrs such as `driverLink`), making it harder to reuse it or to make more generic without causing a mass rebuild and without breaking existing packages. Instead, we just override the `driverLink` attrs, which is small, localized, and what we want.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## TODO before merging

- [x] Test on the Nvidia Jetson

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


