### PR TITLE
protonvpn-gui: 1.12.0 -> 4.1.0-unstable-2023-10-25, protonvpn-gui_legacy: init at 1.12.0

### DIFF
--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -1,74 +1,103 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
-, wrapGAppsHook
-, gdk-pixbuf
-, glib-networking
 , gobject-introspection
-, imagemagick
-, librsvg
-, pango
-, webkitgtk
-# Python libs
-, protonvpn-nm-lib
-, psutil
-# Optionals
+, setuptools
+, wrapGAppsHook
+, dbus-python
+, packaging
+, proton-core
+, proton-keyring-linux
+, proton-keyring-linux-secretservice
+, proton-vpn-api-core
+, proton-vpn-connection
+, proton-vpn-killswitch
+, proton-vpn-killswitch-network-manager
+, proton-vpn-logger
+, proton-vpn-network-manager
+, proton-vpn-network-manager-openvpn
+, proton-vpn-session
+, pycairo
+, pygobject3
+, pytestCheckHook
 , withIndicator ? true
-, libappindicator-gtk3 }:
+, libappindicator-gtk3
+, libayatana-appindicator
+}:
 
 buildPythonApplication rec {
   pname = "protonvpn-gui";
-  version = "1.12.0";
+  version = "4.1.0-unstable-2023-10-25";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
-    repo = "linux-app";
-    rev = "refs/tags/${version}";
-    sha256 = "sha256-MPS4d/yNkccsc/j85h7/4k4xL8uSCvhj/9JWPa7ezLY=";
+    repo = "proton-vpn-gtk-app";
+    rev = "713324e9e4ee9f030c8115072cae379eb3340c42";
+    hash = "sha256-DfuM4b2cSIA8j9Ux3TzInRCvzQGb9LvJDSwRhfadBPY=";
   };
 
   nativeBuildInputs = [
-    gdk-pixbuf
+    # Needed for the NM namespace
     gobject-introspection
-    imagemagick
+    setuptools
     wrapGAppsHook
   ];
 
-  propagatedBuildInputs = [
-    glib-networking # needed for the login captcha
-    protonvpn-nm-lib
-    psutil
+  buildInputs = lib.optionals withIndicator [
+    # Adds AppIndicator3 namespace
+    libappindicator-gtk3
+    # Adds AyatanaAppIndicator3 namespace
+    libayatana-appindicator
   ];
 
-  buildInputs = [
-    librsvg
-    pango
-    webkitgtk
-  ] ++ lib.optionals withIndicator [ libappindicator-gtk3 ];
+  propagatedBuildInputs = [
+    dbus-python
+    packaging
+    proton-core
+    proton-keyring-linux
+    proton-keyring-linux-secretservice
+    proton-vpn-api-core
+    proton-vpn-connection
+    proton-vpn-killswitch
+    proton-vpn-killswitch-network-manager
+    proton-vpn-logger
+    proton-vpn-network-manager
+    proton-vpn-network-manager-openvpn
+    proton-vpn-session
+    pycairo
+    pygobject3
+  ];
 
-  postInstall = ''
-    # Setting icons
-    for size in 16 32 48 64 72 96 128 192 512 1024; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize $size'x'$size \
-        protonvpn_gui/assets/icons/protonvpn-logo.png \
-        $out/share/icons/hicolor/$size'x'$size/apps/protonvpn.png
-    done
-
-    install -Dm644 protonvpn.desktop -t $out/share/applications/
-    substituteInPlace $out/share/applications/protonvpn.desktop \
-      --replace 'protonvpn-logo' protonvpn
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton --cov-report=html --cov-report=term" ""
   '';
 
-  # Project has a dummy test
+  postInstall = ''
+    mkdir -p $out/share/{applications,pixmaps}
+    install -Dm 644 ${src}/rpmbuild/SOURCES/protonvpn-app.desktop $out/share/applications
+    install -Dm 644 ${src}/rpmbuild/SOURCES/proton-vpn-logo.svg $out/share/pixmaps
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # Needed for Permission denied: '/homeless-shelter'
+    export HOME=$(mktemp -d)
+  '';
+
+  # Gets a segmentation fault after the widgets test
   doCheck = false;
 
   meta = with lib; {
-    description = "Official ProtonVPN Linux app";
-    homepage = "https://github.com/ProtonVPN/linux-app";
-    maintainers = with maintainers; [ wolfangaukang ];
+    description = "Proton VPN GTK app for Linux";
+    homepage = "https://github.com/ProtonVPN/proton-vpn-gtk-app";
     license = licenses.gpl3Plus;
-    mainProgram = "protonvpn";
     platforms = platforms.linux;
+    mainProgram = "protonvpn-app";
+    maintainers = with maintainers; [ wolfangaukang ];
   };
 }

--- a/pkgs/applications/networking/protonvpn-gui/legacy.nix
+++ b/pkgs/applications/networking/protonvpn-gui/legacy.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, setuptools
+, wrapGAppsHook
+, gdk-pixbuf
+, glib-networking
+, gobject-introspection
+, imagemagick
+, librsvg
+, pango
+, python3
+, webkitgtk
+# Python libs
+, protonvpn-nm-lib
+, psutil
+# Optionals
+, withIndicator ? true
+, libappindicator-gtk3 }:
+
+buildPythonApplication rec {
+  pname = "protonvpn-gui";
+  version = "1.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "linux-app";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-MPS4d/yNkccsc/j85h7/4k4xL8uSCvhj/9JWPa7ezLY=";
+  };
+
+  nativeBuildInputs = [
+    gdk-pixbuf
+    gobject-introspection
+    imagemagick
+    setuptools
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    glib-networking # needed for the login captcha
+    protonvpn-nm-lib
+    psutil
+  ];
+
+  buildInputs = [
+    librsvg
+    pango
+    webkitgtk
+  ] ++ lib.optionals withIndicator [ libappindicator-gtk3 ];
+
+  postInstall = ''
+    # Setting icons
+    for size in 16 32 48 64 72 96 128 192 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize $size'x'$size \
+        protonvpn_gui/assets/icons/protonvpn-logo.png \
+        $out/share/icons/hicolor/$size'x'$size/apps/protonvpn.png
+    done
+
+    install -Dm644 protonvpn.desktop -t $out/share/applications/
+    chmod 644 $out/${python3.sitePackages}/protonvpn_gui/assets/icons/plus-server.png
+    substituteInPlace $out/share/applications/protonvpn.desktop \
+      --replace 'protonvpn-logo' protonvpn
+  '';
+
+  # Project has a dummy test
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Official ProtonVPN Linux app";
+    homepage = "https://github.com/ProtonVPN/linux-app";
+    maintainers = with maintainers; [ wolfangaukang ];
+    license = licenses.gpl3Plus;
+    mainProgram = "protonvpn";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/proton-core/default.nix
+++ b/pkgs/development/python-modules/proton-core/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, aiohttp
+, bcrypt
+, pyopenssl
+, python-gnupg
+, requests
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-core";
+  version = "0.1.15-unstable-2023-10-24";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-core";
+    rev = "5e795e04094dff67c03c56f2f3de03ff43514cc4";
+    hash = "sha256-hchwrolc65tVmSe2IzxwH2zDU2JZzXrCMzWaETWcMDI=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    bcrypt
+    aiohttp
+    pyopenssl
+    python-gnupg
+    requests
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Single test, requires internet connection
+    "tests/test_alternativerouting.py"
+  ];
+
+  disabledTests = [
+    # Invalid modulus
+    "test_modulus_verification"
+    # Permission denied: '/run'
+    "test_broken_data"
+    "test_broken_index"
+    "test_sessions"
+    # No working transports found
+    "test_auto_works_on_prod"
+    "test_ping"
+    "test_successful"
+    "test_without_pinning"
+    # Failed assertions
+    "test_bad_pinning_fingerprint_changed"
+    "test_bad_pinning_url_changed"
+  ];
+
+  meta = {
+    description = "Core logic used by the other Proton components";
+    homepage = "https://github.com/ProtonVPN/python-proton-core";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-keyring-linux-secretservice/default.nix
+++ b/pkgs/development/python-modules/proton-keyring-linux-secretservice/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, proton-keyring-linux
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-keyring-linux-secretservice";
+  version = "0.0.1-unstable-2023-04-14";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-keyring-linux-secretservice";
+    rev = "973d2646ec4d04bc270df53058df892950244e70";
+    hash = "sha256-JlhvJBpbewT2c8k31CPMUlvvo/orWW1qfylFZLnDxeY=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    proton-keyring-linux
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton.keyring_linux.secretservice --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.keyring_linux" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "ProtonVPN component to access Linux's keyring secret service API";
+    homepage = "https://github.com/ProtonVPN/python-proton-keyring-linux-secretservice";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-keyring-linux/default.nix
+++ b/pkgs/development/python-modules/proton-keyring-linux/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, keyring
+, proton-core
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-keyring-linux";
+  version = "0.0.1-unstable-2023-04-14";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-keyring-linux";
+    rev = "5ff3c7f9a1a162836649502dd23c2fbe1f487d73";
+    hash = "sha256-4d8ZePG8imURhdNtLbraMRisrTLoRvJ+L2UuuOo3MPM=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    keyring
+    proton-core
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton.keyring_linux.core --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.keyring_linux.core" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "ProtonVPN core component to access Linux's keyring";
+    homepage = "https://github.com/ProtonVPN/python-proton-keyring-linux";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-api-core/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-api-core/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, proton-core
+, proton-vpn-connection
+, proton-vpn-logger
+, proton-vpn-killswitch
+, proton-vpn-session
+, distro
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-api-core";
+  version = "0.20.1-unstable-2023-10-10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-api-core";
+    rev = "9c03fc30d3ff08559cab3644eadde027b029375d";
+    hash = "sha256-vnz1+NazQceAs9KA3Jq0tsJditRoG/LoBR+0wuDzzHk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    distro
+    proton-core
+    proton-vpn-connection
+    proton-vpn-logger
+    proton-vpn-killswitch
+    proton-vpn-session
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton/vpn/core/ --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.core" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # Needed for Permission denied: '/homeless-shelter'
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTestPaths = [
+    # Has a single test failing with Permission denied: '/run'
+    "tests/test_session.py"
+  ];
+
+  meta = with lib; {
+    description = "Acts as a facade to the other Proton VPN components, exposing a uniform API to the available Proton VPN services";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-api-core";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-connection/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-connection/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, proton-core
+, proton-vpn-killswitch
+, proton-vpn-logger
+, jinja2
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-connection";
+  version = "0.11.0-unstable-2023-09-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-connection";
+    rev = "747ccacb5350ad59f2a09953b8d20c5c161aab54";
+    hash = "sha256-WyMG0kmwBKoWc0mHnaop9E0upPAYHFwS/A9I1//WwlY=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    jinja2
+    proton-core
+    proton-vpn-killswitch
+    proton-vpn-logger
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton.vpn.connection --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.connection" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Permission denied: '/run'
+    "test_ensure_configuration_file_is_deleted"
+    "test_ensure_generate_is_returning_expected_content"
+    "test_ensure_same_configuration_file_in_case_of_duplicate"
+    "test_ensure_configuration_file_is_created"
+    "test_wireguard_config_content_generation"
+    "test_wireguard_with_malformed_credentials"
+    "test_wireguard_with_non_certificate"
+    "test_wireguard_without_settings"
+    # Neiter udp or tcp are working
+    "test_ovpnconfig_with_settings"
+    "test_ovpnconfig_with_missing_settings_applies_expected_defaults"
+    "test_ovpnconfig_with_malformed_params"
+    "test_ovpnconfig_with_certificate_and_malformed_credentials"
+    "test_ovpnconfig_with_malformed_server"
+    "test_ovpnconfig_with_malformed_server_and_credentials"
+  ];
+
+  meta = with lib; {
+    description = "Defines the interface that VPN connection backends should implement";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-connection";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-killswitch-network-manager/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-killswitch-network-manager/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, gobject-introspection
+, setuptools
+, networkmanager
+, proton-vpn-killswitch
+, proton-vpn-logger
+, pycairo
+, pygobject3
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-killswitch-network-manager";
+  version = "0.2.0-unstable-2023-09-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-killswitch-network-manager";
+    rev = "39d4398f169539e335c1f661e0dfc5551df0e6af";
+    hash = "sha256-vmTXMIhXZgRvXeUX/XslT+ShqY60w4P7kJBQzWhA66k=";
+  };
+
+  nativeBuildInputs = [
+    # Solves ImportError: cannot import name NM, introspection typelib not found
+    gobject-introspection
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    # Needed here for the NM namespace
+    networkmanager
+    proton-vpn-killswitch
+    proton-vpn-logger
+    pycairo
+    pygobject3
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton.vpn.killswitch.backend.linux.networkmanager --cov-report=html --cov-report=term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.killswitch.backend.linux.networkmanager" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Implementation of the proton-vpn-killswitch interface using Network Manager";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-killswitch-network-manager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-killswitch/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-killswitch/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, proton-core
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-killswitch";
+  version = "0.2.0-unstable-2023-09-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-killswitch";
+    rev = "6e84588ea6ae0946141d4b44b2cf5df8465d5eba";
+    hash = "sha256-eFwWN8E+nIDpbut8tkWqXucLhzm7HaLAMBIbAq/X2eo=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    proton-core
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton --cov-report=html --cov-report=term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.killswitch.interface" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Defines the ProtonVPN kill switch interface";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-killswitch";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-logger/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-logger/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, proton-core
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-logger";
+  version = "0.2.1-unstable-2023-05-10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-logger";
+    rev = "0acbc1ab41a65cbc9ceb340e3db011e6f89eb65a";
+    hash = "sha256-VIggBKopAAKiNdQ5ypG1qI74E2WMDwDSriSuka/DBKA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    proton-core
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton/vpn/logging/ --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.logging" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # Needed for Permission denied: '/homeless-shelter'
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "General purpose logging package for the entire ProtonVPN Linux client";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-logger";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-network-manager-openvpn/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager-openvpn/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, gobject-introspection
+, setuptools
+, proton-core
+, proton-vpn-network-manager
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-network-manager-openvpn";
+  version = "0.0.4-unstable-2023-07-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-network-manager-openvpn";
+    rev = "b79f6732646378ef1b92696de3665ff9560286d3";
+    hash = "sha256-Z5X8RRu+1KaZ0pnH7tzGhfeST2W8bxMZnuryLhFjG/g=";
+  };
+
+  nativeBuildInputs = [
+    # Solves Namespace NM not available
+    gobject-introspection
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    proton-core
+    proton-vpn-network-manager
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton.vpn.backend.linux.networkmanager.protocol.openvpn --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.backend.linux.networkmanager.protocol" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Adds support for the OpenVPN protocol using NetworkManager";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-network-manager-openvpn";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, gobject-introspection
+, setuptools
+, networkmanager
+, proton-core
+, proton-vpn-connection
+, pycairo
+, pygobject3
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-network-manager";
+  version = "0.3.0-unstable-2023-09-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-network-manager";
+    rev = "6ffd04fa0ae88a89d2b733443317066ef23b3ccd";
+    hash = "sha256-Bqlwo7U/mwodQarl30n3/BNETqit1MVQUJT+mAhC6AI=";
+  };
+
+  nativeBuildInputs = [
+    # Needed to recognize the NM namespace
+    gobject-introspection
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    # Needed here for the NM namespace
+    networkmanager
+    proton-core
+    proton-vpn-connection
+    pycairo
+    pygobject3
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton/vpn/backend/linux/networkmanager --cov-report html --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.backend.linux.networkmanager" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Provides the necessary functionality for other ProtonVPN components to interact with NetworkManager";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-network-manager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-session/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-session/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, cryptography
+, distro
+, proton-core
+, proton-vpn-logger
+, pynacl
+, aiohttp
+, pyopenssl
+, pytest-asyncio
+, requests
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "proton-vpn-session";
+  version = "0.6.2-unstable-2023-10-24";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-session";
+    rev = "419b25bd1823f78d1219dc4cc441eeaf37646068";
+    hash = "sha256-YPyNxbKxw+670bNQZ7U5nljyUjsNJ+k7eL+HpGiSCLk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    distro
+    proton-core
+    proton-vpn-logger
+    pynacl
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=proton.vpn.session --cov-report term" ""
+  '';
+
+  pythonImportsCheck = [ "proton.vpn.session" ];
+
+  postInstall = ''
+    # Needed for Permission denied: '/homeless-shelter'
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    aiohttp
+    pyopenssl
+    pytest-asyncio
+    requests
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Provides utility classes to manage VPN sessions";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-session";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34825,6 +34825,7 @@ with pkgs;
   protonvpn-cli_2 = python3Packages.callPackage ../applications/networking/protonvpn-cli/2.nix { };
 
   protonvpn-gui = python3Packages.callPackage ../applications/networking/protonvpn-gui { };
+  protonvpn-gui_legacy = python3Packages.callPackage ../applications/networking/protonvpn-gui/legacy.nix { };
 
   ps2client = callPackage ../applications/networking/ps2client { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9721,6 +9721,8 @@ self: super: with self; {
 
   proton-client = callPackage ../development/python-modules/proton-client { };
 
+  proton-core = callPackage ../development/python-modules/proton-core { };
+
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };
 
   protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ self: super: with self; {
 
   proton-core = callPackage ../development/python-modules/proton-core { };
 
+  proton-vpn-connection = callPackage ../development/python-modules/proton-vpn-connection { };
+
   proton-vpn-killswitch = callPackage ../development/python-modules/proton-vpn-killswitch { };
 
   proton-vpn-logger = callPackage ../development/python-modules/proton-vpn-logger { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ self: super: with self; {
 
   proton-core = callPackage ../development/python-modules/proton-core { };
 
+  proton-vpn-logger = callPackage ../development/python-modules/proton-vpn-logger { };
+
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };
 
   protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9735,6 +9735,8 @@ self: super: with self; {
 
   proton-vpn-network-manager = callPackage ../development/python-modules/proton-vpn-network-manager { };
 
+  proton-vpn-network-manager-openvpn = callPackage ../development/python-modules/proton-vpn-network-manager-openvpn { };
+
   proton-vpn-session = callPackage ../development/python-modules/proton-vpn-session { };
 
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ self: super: with self; {
 
   proton-core = callPackage ../development/python-modules/proton-core { };
 
+  proton-vpn-killswitch = callPackage ../development/python-modules/proton-vpn-killswitch { };
+
   proton-vpn-logger = callPackage ../development/python-modules/proton-vpn-logger { };
 
   proton-vpn-session = callPackage ../development/python-modules/proton-vpn-session { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ self: super: with self; {
 
   proton-core = callPackage ../development/python-modules/proton-core { };
 
+  proton-vpn-api-core = callPackage ../development/python-modules/proton-vpn-api-core { };
+
   proton-vpn-connection = callPackage ../development/python-modules/proton-vpn-connection { };
 
   proton-vpn-killswitch = callPackage ../development/python-modules/proton-vpn-killswitch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9725,6 +9725,8 @@ self: super: with self; {
 
   proton-vpn-logger = callPackage ../development/python-modules/proton-vpn-logger { };
 
+  proton-vpn-session = callPackage ../development/python-modules/proton-vpn-session { };
+
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };
 
   protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9725,6 +9725,8 @@ self: super: with self; {
 
   proton-keyring-linux = callPackage ../development/python-modules/proton-keyring-linux { };
 
+  proton-keyring-linux-secretservice = callPackage ../development/python-modules/proton-keyring-linux-secretservice { };
+
   proton-vpn-api-core = callPackage ../development/python-modules/proton-vpn-api-core { };
 
   proton-vpn-connection = callPackage ../development/python-modules/proton-vpn-connection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9731,6 +9731,8 @@ self: super: with self; {
 
   proton-vpn-logger = callPackage ../development/python-modules/proton-vpn-logger { };
 
+  proton-vpn-network-manager = callPackage ../development/python-modules/proton-vpn-network-manager { };
+
   proton-vpn-session = callPackage ../development/python-modules/proton-vpn-session { };
 
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ self: super: with self; {
 
   proton-core = callPackage ../development/python-modules/proton-core { };
 
+  proton-keyring-linux = callPackage ../development/python-modules/proton-keyring-linux { };
+
   proton-vpn-api-core = callPackage ../development/python-modules/proton-vpn-api-core { };
 
   proton-vpn-connection = callPackage ../development/python-modules/proton-vpn-connection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9729,6 +9729,8 @@ self: super: with self; {
 
   proton-vpn-killswitch = callPackage ../development/python-modules/proton-vpn-killswitch { };
 
+  proton-vpn-killswitch-network-manager = callPackage ../development/python-modules/proton-vpn-killswitch-network-manager { };
+
   proton-vpn-logger = callPackage ../development/python-modules/proton-vpn-logger { };
 
   proton-vpn-network-manager = callPackage ../development/python-modules/proton-vpn-network-manager { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #264004

Using commit hashes because of https://github.com/ProtonVPN/proton-vpn-gtk-app/issues/6

Using `pyproject = true` based on https://github.com/NixOS/nixpkgs/pull/254136

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
