### PR TITLE
cargo-raze: increase open file descriptors limits for tests on darwin

### DIFF
--- a/pkgs/development/tools/rust/cargo-raze/default.nix
+++ b/pkgs/development/tools/rust/cargo-raze/default.nix
@@ -31,6 +31,12 @@ rustPlatform.buildRustPackage rec {
   ]
   ++ lib.optional stdenv.isDarwin Security;
 
+  preCheck = lib.optionalString stdenv.isDarwin ''
+    # Darwin issue: Os { code: 24, kind: Uncategorized, message: "Too many open files" }
+    # https://github.com/google/cargo-raze/issues/544
+    ulimit -n 1024
+  '';
+
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Bump file descriptor limit for tests on Darwin

https://hydra.nixos.org/build/239024688/nixlog/2
https://hydra.nixos.org/build/239009073/nixlog/2
```
thread '<unnamed>' panicked at 'Cannot build local tokio runtime: Os { code: 24, kind: Uncategorized, message: "Too many open files" }', /private/tmp/nix-build-cargo-raze-0.16.0.drv-0/cargo-raze-0.16.0-vendor.tar.gz/httpmock/src/lib.rs:1436:14
```

Seems to be a typical darwin failure, some packages already bump file descriptors limit to 1024 (same as default in some Linux distros, default darwin value seems to be 256 these days)

Also has a report upstream
https://github.com/google/cargo-raze/issues/544

ZHF: #265948

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
