### PR TITLE
p4d: 2022.1.2305383 -> 2023.1.2513900

### DIFF
--- a/pkgs/applications/version-management/p4d/default.nix
+++ b/pkgs/applications/version-management/p4d/default.nix
@@ -7,23 +7,19 @@
 let
   # Upstream replaces minor versions, so use cached URLs.
   srcs = {
-    "i686-linux" = fetchurl {
-      url = "https://web.archive.org/web/20220907001049/https://ftp.perforce.com/perforce/r22.1/bin.linux26x86/helix-core-server.tgz";
-      sha256 = "e9cf27c9dd2fa6432745058a93896d151543aff712fce9f7322152d6ea88a12a";
-    };
     "x86_64-linux" = fetchurl {
-      url = "https://web.archive.org/web/20220907001202/https://ftp.perforce.com/perforce/r22.1/bin.linux26x86_64/helix-core-server.tgz";
-      sha256 = "9c272b67574264a4f49fe846ccda24fbd4baeb282665af74b6fbccff26a43558";
+      url = "https://web.archive.org/web/20231109221336id_/https://ftp.perforce.com/perforce/r23.1/bin.linux26x86_64/helix-core-server.tgz";
+      sha256 = "b68c4907cf9258ab47102e8f0e489c11d528a8f614bfa45e3a2fa198639e2362";
     };
     "x86_64-darwin" = fetchurl {
-      url = "https://web.archive.org/web/20220907001334/https://ftp.perforce.com/perforce/r22.1/bin.macosx1015x86_64/helix-core-server.tgz";
-      sha256 = "2500a23fe482a303bd400f0de460b7624ad3f940fef45246004b9f956e90ea45";
+      url = "https://web.archive.org/web/20231109221937id_/https://ftp.perforce.com/perforce/r23.1/bin.macosx1015x86_64/helix-core-server.tgz";
+      sha256 = "fcbf09787ffc29f7237839711447bf19a37ae18a8a7e19b2d30deb3715ae2c11";
     };
   };
 in
 stdenv.mkDerivation {
   pname = "p4d";
-  version = "2022.1.2305383";
+  version = "2023.1.2513900";
 
   src =
     assert lib.assertMsg (builtins.hasAttr stdenv.hostPlatform.system srcs) "p4d is not available for ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
## Description of changes

Release notes: https://www.perforce.com/perforce/doc.current/user/relnotes.txt

i686-linux is no longer supported from upstream, and so has been removed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
