### PR TITLE
teleport: 14.0.3 -> 14.1.1, teleport_13: 13.4.3 -> 13.4.5, teleport_12: 12.4.22 -> 12.4.23

### DIFF
--- a/pkgs/servers/teleport/12/default.nix
+++ b/pkgs/servers/teleport/12/default.nix
@@ -1,9 +1,9 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "12.4.22";
-  hash = "sha256-UEiS+GiderYTU34GHsQr4G8XrasV5ewmPcdrec4v5B4=";
-  vendorHash = "sha256-etutgK/5u+e86kx7ha3x+di9np7Tcr7hpGUMKZxJNT4=";
-  yarnHash = "sha256-MBTElkMH5rb33l+AYWH+zguSLQf+ntXpOkHZpjLAx/Q=";
+  version = "12.4.23";
+  hash = "sha256-kCHRBa9rdwfcb98XG/08ZaJmI1NhEiSCoXuH8/3xJlk=";
+  vendorHash = "sha256-yOvQQHjtDSLqQZcw2OIOy6CDqwYSgMpL2Rxlk2u//OE=";
+  yarnHash = "sha256-beHCg9qUSisYMJ/9eeqWmbc9+V9YGgXBheZSFpbqoPY=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/servers/teleport/13/Cargo.lock
+++ b/pkgs/servers/teleport/13/Cargo.lock
@@ -451,17 +451,6 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
@@ -713,7 +702,7 @@ checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
- "rustix 0.36.5",
+ "rustix 0.36.16",
  "windows-sys 0.42.0",
 ]
 
@@ -1363,16 +1352,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.2.8",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1382,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.0",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.0",

--- a/pkgs/servers/teleport/13/default.nix
+++ b/pkgs/servers/teleport/13/default.nix
@@ -1,9 +1,9 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "13.4.3";
-  hash = "sha256-x8G94jKycK3nYwqDA5RPc63GHIk9y4pHfSwSBqGBINk=";
-  vendorHash = "sha256-Pb3eO9zqLgTD7otM7yGRWicQjvpIXg7xKV8Oc4yh8PA=";
-  yarnHash = "sha256-GnoiLqzqGV0UZm5zePCDBUUX63NTIIo1dcxtiWQDPqc=";
+  version = "13.4.5";
+  hash = "sha256-uZolRnESFP65Xgvr29laEok2kBbm7G2qY9j8yKRrUdo=";
+  vendorHash = "sha256-Bkr6R9P2YTqvTEQkHvVdsRmWp6pv3Qg0WaQ+pERclWc=";
+  yarnHash = "sha256-60k4LRHpX4rYXZZ0CC44PqzL3PDu8PadV0kwXatnByI=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/servers/teleport/14/Cargo.lock
+++ b/pkgs/servers/teleport/14/Cargo.lock
@@ -451,17 +451,6 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
@@ -708,7 +697,7 @@ checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
- "rustix 0.36.5",
+ "rustix 0.36.16",
  "windows-sys 0.42.0",
 ]
 
@@ -1356,16 +1345,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.2.8",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1375,7 +1364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.4.0",
- "errno 0.3.1",
+ "errno",
  "libc",
  "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
@@ -1845,11 +1834,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/pkgs/servers/teleport/14/default.nix
+++ b/pkgs/servers/teleport/14/default.nix
@@ -1,9 +1,9 @@
 { callPackage, ... }@args:
 callPackage ../generic.nix ({
-  version = "14.0.3";
-  hash = "sha256-X+vekYmuTE7n22SH/z2GWO3wnBsIef1GEjR7WOJpjc8=";
-  vendorHash = "sha256-+R6f2HrlN/RLec83YutccDFJW6gq6HXbxoJVtxMgdp8=";
-  yarnHash = "sha256-udM4DNaTGiMkqfkllJjmT+Nk6PNbGUzT34ixQOhmScw=";
+  version = "14.1.1";
+  hash = "sha256-xdJBl5imHuo1IP0ja33eaaE4i/sSP3kg/wQwehC1Hao=";
+  vendorHash = "sha256-+kCns/xHUfUOW2xBk6CaPZYWe/vcEguz2/4lqaJEbFc=";
+  yarnHash = "sha256-fWBMeat1bSIEMSADn8oDVfQtnUBojjy5ZCdVhw8PGMs=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {


### PR DESCRIPTION
## Description of changes

New upstream versions, including security fixes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
