### PR TITLE
mitmproxy: fix macos build

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2468,6 +2468,12 @@
     githubId = 50839;
     name = "Brian Jones";
   };
+  boltzmannrain = {
+    email = "boltzmannrain@gmail.com";
+    github = "boltzmannrain";
+    githubId = 150560585;
+    name = "Dmitry Ivankov";
+  };
   booklearner = {
     name = "booklearner";
     email = "booklearner@proton.me";

--- a/pkgs/development/python-modules/mitmproxy-macos/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-macos/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+}:
+
+buildPythonPackage rec {
+  pname = "mitmproxy-macos";
+  version = "0.3.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mitmproxy";
+    repo = "mitmproxy_rs";
+    rev = version;
+    hash = "sha256-V6LUr1jJiTo0+53jipkTyzG5JSw6uHaS6ziyBaFbETw=";
+  };
+
+  sourceRoot = "${src.name}/mitmproxy-macos";
+  pythonImportsCheck = [ "mitmproxy_macos" ];
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  meta = with lib; {
+    description = "The MacOS Rust bits in mitmproxy";
+    homepage = "https://github.com/mitmproxy/mitmproxy_rs/tree/main/mitmproxy-macos";
+    changelog = "https://github.com/mitmproxy/mitmproxy_rs/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ boltzmannrain ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/development/python-modules/mitmproxy-rs/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-rs/default.nix
@@ -4,6 +4,8 @@
 , fetchFromGitHub
 , rustPlatform
 , darwin
+, libiconv
+, mitmproxy-macos
 }:
 
 buildPythonPackage rec {
@@ -34,13 +36,15 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
+    libiconv
+    mitmproxy-macos
   ];
 
   pythonImportsCheck = [ "mitmproxy_rs" ];
 
   meta = with lib; {
     description = "The Rust bits in mitmproxy";
-    homepage = " https://github.com/mitmproxy/mitmproxy_rs";
+    homepage = "https://github.com/mitmproxy/mitmproxy_rs";
     changelog = "https://github.com/mitmproxy/mitmproxy_rs/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , pythonOlder
+, stdenv
   # Mitmproxy requirements
 , aioquic
 , asgiref
@@ -15,6 +16,7 @@
 , hyperframe
 , kaitaistruct
 , ldap3
+, mitmproxy-macos
 , mitmproxy-rs
 , msgpack
 , passlib
@@ -81,6 +83,8 @@ buildPythonPackage rec {
     urwid
     wsproto
     zstandard
+  ] ++ lib.optionals stdenv.isDarwin [
+    mitmproxy-macos
   ];
 
   nativeCheckInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6877,6 +6877,8 @@ self: super: with self; {
 
   mitmproxy = callPackage ../development/python-modules/mitmproxy { };
 
+  mitmproxy-macos = callPackage ../development/python-modules/mitmproxy-macos { };
+
   mitmproxy-rs = callPackage ../development/python-modules/mitmproxy-rs { };
 
   mitmproxy-wireguard = callPackage ../development/python-modules/mitmproxy-wireguard { };


### PR DESCRIPTION
## Description of changes

https://hydra.nixos.org/build/240114924/nixlog/1
```
error: linking with `/nix/store/sa6hywsm1mqfyd1xakyzv4ljjsb3hawh-clang-wrapper-11.1.0/bin/cc` failed: exit status: 1
  |
...
  = note: ld: library not found for -liconv
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

after adding libiconv it starts to fail with
```
  File "/nix/store/ncs3h7zqjl3cl2cwflka40rrirb6qg1m-python3.11-mitmproxy-rs-0.3.11/lib/python3.11/site-packages/mitmproxy_rs/__init__.py", line 1, in <module>
    from .mitmproxy_rs import *
ModuleNotFoundError: No module named 'mitmproxy_macos'
```
so it needs extra module
https://github.com/mitmproxy/mitmproxy_rs/tree/main/mitmproxy-macos

So the fixes are
- add `libiconv` dependency to mitmproxy-rs
- add `mitmproxy-macos` python package and add it to dependencies of `mitmproxy-rs` and `mitmproxy` itself (otherwise import fails, looks like the import is sneaky because it is platform-conditional)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

ZHF: #265948