### PR TITLE
python311Packages.pyperf: from 2.6.1 -> 2.6.2

### DIFF
--- a/pkgs/development/python-modules/pyperf/default.nix
+++ b/pkgs/development/python-modules/pyperf/default.nix
@@ -5,26 +5,23 @@
 , pythonOlder
 , psutil
 , unittestCheckHook
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "pyperf";
-  version = "2.6.1";
-  format = "setuptools";
+  version = "2.6.2";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Fxrqabjv3mEhDlEhZth2Tndlqcdni3aAUhdLAfNJ8kc=";
+    hash = "sha256-ZNj63OanT0ePKYMsHqoqBIVmVev/FyktUjf8gxfDo8U=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-pythonpath-in-tests.patch";
-      url = "https://github.com/psf/pyperf/commit/d373c5e56c0257d2d7abd705b676bea25cf66566.patch";
-      hash = "sha256-2q1fTf+uU3qj3BG8P5otX4f7mSTnQxm4sfmmgIUuszA=";
-    })
+  nativeBuildInputs = [
+    setuptools
   ];
 
   propagatedBuildInputs = [
@@ -41,6 +38,6 @@ buildPythonPackage rec {
     description = "Python module to generate and modify perf";
     homepage = "https://pyperf.readthedocs.io/";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
___
Notes from previous [PR](https://github.com/NixOS/nixpkgs/pull/267236)
If I remove  **format = "pyproject";** 
I get:
```
Executing setuptoolsBuildPhase
Traceback (most recent call last):
  File "/build/pyperf-2.6.1/nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "/nix/store/c3cjxhn73xa5s8fm79w95d0879bijp04-python3-3.10.13/lib/python3.10/tokenize.py", line 394, in open
    buffer = _builtin_open(filename, 'rb')
**FileNotFoundError: [Errno 2] No such file or directory: 'setup.py'**
/nix/store/gv2cl6qvvslz5h15vqd89f1rpvrdg5yc-stdenv-linux/setup: line 1604: pop_var_context: head of shell_variables not a function context
error: builder for '/nix/store/m0q6lsar8nxa9lvvndl21d9jcsnlra7b-python3.10-pyperf-2.6.1.drv' failed with exit code 1;
       last 10 log lines:
       > no configure script, doing nothing
       > building
       > Executing setuptoolsBuildPhase
       > Traceback (most recent call last):
       >   File "/build/pyperf-2.6.1/nix_run_setup", line 8, in <module>
       >     exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
       >   File "/nix/store/c3cjxhn73xa5s8fm79w95d0879bijp04-python3-3.10.13/lib/python3.10/tokenize.py", line 394, in open
       >     buffer = _builtin_open(filename, 'rb')
       > FileNotFoundError: [Errno 2] No such file or directory: 'setup.py'
       > /nix/store/gv2cl6qvvslz5h15vqd89f1rpvrdg5yc-stdenv-linux/setup: line 1604: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix-store -l /nix/store/m0q6lsar8nxa9lvvndl21d9jcsnlra7b-python3.10-pyperf-2.6.1.drv'.
```
___

If I leave out `setuptools-scm`
I get:
```
Processing /build/pyperf-2.6.1
  Running command Preparing metadata (pyproject.toml)
  Preparing metadata (pyproject.toml) ... done
ERROR: Exception:
Traceback (most recent call last):
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/cli/base_command.py", line 160, in exc_logging_wrapper
    status = run_func(*args)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/cli/req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/commands/wheel.py", line 170, in run
    requirement_set = resolver.resolve(reqs, check_supported_wheels=True)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 73, in resolve
    collected = self.factory.collect_root_requirements(root_reqs)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 491, in collect_root_requirements
    req = self._make_requirement_from_install_req(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 453, in _make_requirement_from_install_req
    cand = self._make_candidate_from_link(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 206, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 297, in __init__
    super().__init__(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 162, in __init__
    self.dist = self._prepare()
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 231, in _prepare
    dist = self._prepare_distribution()
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 308, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 491, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 577, in _prepare_linked_requirement
    dist = _get_prepared_distribution(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 69, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 61, in prepare_distribution_metadata
    self.req.prepare_metadata()
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 539, in prepare_metadata
    self.metadata_directory = generate_metadata(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/operations/build/metadata.py", line 35, in generate_metadata
    distinfo_dir = backend.prepare_metadata_for_build_wheel(metadata_dir)
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_internal/utils/misc.py", line 722, in prepare_metadata_for_build_wheel
    return super().prepare_metadata_for_build_wheel(
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_impl.py", line 186, in prepare_metadata_for_build_wheel
    return self._call_hook('prepare_metadata_for_build_wheel', {
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_impl.py", line 321, in _call_hook
    raise BackendUnavailable(data.get('traceback', ''))
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Traceback (most recent call last):
  File "/nix/store/rdsbyvrlv3glqz7w6np2y3m78cqn7d1w-python3.10-pip-23.0.1/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 77, in _build_backend
    obj = import_module(mod_path)
  File "/nix/store/c3cjxhn73xa5s8fm79w95d0879bijp04-python3-3.10.13/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
**ModuleNotFoundError: No module named 'setuptools'**
error: builder for '/nix/store/lr2kr8nrvkpwkysan2awk9m7w6lv0gpj-python3.10-pyperf-2.6.1.drv' failed with exit code 2;
       last 10 log lines:
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
       > ModuleNotFoundError: No module named 'setuptools'
       For full logs, run 'nix-store -l /nix/store/lr2kr8nrvkpwkysan2awk9m7w6lv0gpj-python3.10-pyperf-2.6.1.drv'.
```