### PR TITLE
makeOverridablePythonPackage: simplify implementation and make compatible with `<pkg>.overrideAttrs`

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -14,6 +14,9 @@ let
 
   # Derivations built with `buildPythonPackage` can already be overridden with `override`, `overrideAttrs`, and `overrideDerivation`.
   # This function introduces `overridePythonAttrs` and it overrides the call to `buildPythonPackage`.
+  #
+  # Overridings specified through `overridePythonAttrs` will always be applied
+  # before those specified by `overrideAttrs`, even if invoked after them.
   makeOverridablePythonPackage =
     f:
     lib.mirrorFunctionArgs f (
@@ -26,6 +29,8 @@ let
         result
         // {
           overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
+          overrideAttrs =
+            newArgs: makeOverridablePythonPackage (args: (f args).overrideAttrs newArgs) origArgs;
         }
       else
         result

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -19,22 +19,13 @@ let
     lib.mirrorFunctionArgs f (
       origArgs:
       let
-        args = lib.fix (
-          lib.extends (_: previousAttrs: {
-            passthru = (previousAttrs.passthru or { }) // {
-              overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
-            };
-          }) (_: origArgs)
-        );
-        result = f args;
-        overrideWith = newArgs: args // (if pkgs.lib.isFunction newArgs then newArgs args else newArgs);
+        result = f origArgs;
+        overrideWith = newArgs: origArgs // lib.toFunction newArgs origArgs;
       in
-      if builtins.isAttrs result then
+      if lib.isAttrs result then
         result
-      else if builtins.isFunction result then
-        {
+        // {
           overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
-          __functor = self: result;
         }
       else
         result

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -390,14 +390,33 @@ let
 
   tests-python =
     let
-      p = pkgs.python3Packages.xpybutil.overridePythonAttrs (_: {
-        dontWrapPythonPrograms = true;
-      });
+      python-package-stub = pkgs.python3Packages.callPackage (
+        {
+          buildPythonPackage,
+          emptyDirectory,
+        }:
+        buildPythonPackage {
+          pname = "python-package-stub";
+          version = "0.1.0";
+          pyproject = true;
+          src = emptyDirectory;
+        }
+      ) { };
+      applyOverridePythonAttrs =
+        p:
+        p.overridePythonAttrs (previousAttrs: {
+          overridePythonAttrsFlag = previousAttrs.overridePythonAttrsFlag or 0 + 1;
+        });
     in
     {
       overridePythonAttrs = {
-        expr = !lib.hasInfix "wrapPythonPrograms" p.postFixup;
-        expected = true;
+        expr = (applyOverridePythonAttrs python-package-stub).overridePythonAttrsFlag;
+        expected = 1;
+      };
+      overridePythonAttrs-nested = {
+        expr =
+          (applyOverridePythonAttrs (applyOverridePythonAttrs python-package-stub)).overridePythonAttrsFlag;
+        expected = 2;
       };
     };
 

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -407,6 +407,14 @@ let
         p.overridePythonAttrs (previousAttrs: {
           overridePythonAttrsFlag = previousAttrs.overridePythonAttrsFlag or 0 + 1;
         });
+      overrideAttrsFooBar =
+        drv:
+        drv.overrideAttrs (
+          finalAttrs: previousAttrs: {
+            FOO = "a";
+            BAR = finalAttrs.FOO;
+          }
+        );
     in
     {
       overridePythonAttrs = {
@@ -417,6 +425,37 @@ let
         expr =
           (applyOverridePythonAttrs (applyOverridePythonAttrs python-package-stub)).overridePythonAttrsFlag;
         expected = 2;
+      };
+      overrideAttrs-overridePythonAttrs-test-overrideAttrs = {
+        expr = {
+          inherit (applyOverridePythonAttrs (overrideAttrsFooBar python-package-stub))
+            FOO
+            BAR
+            ;
+        };
+        expected = {
+          FOO = "a";
+          BAR = "a";
+        };
+      };
+      overrideAttrs-overridePythonAttrs-test-overridePythonAttrs = {
+        expr =
+          (applyOverridePythonAttrs (overrideAttrsFooBar python-package-stub)) ? overridePythonAttrsFlag;
+        expected = true;
+      };
+      overrideAttrs-overridePythonAttrs-test-commutation = {
+        expr = overrideAttrsFooBar (applyOverridePythonAttrs python-package-stub);
+        expected = applyOverridePythonAttrs (overrideAttrsFooBar python-package-stub);
+      };
+      chain-of-overrides = rec {
+        expr = lib.pipe python-package-stub [
+          (p: p.overrideAttrs { inherit (expected) a; })
+          (p: p.overridePythonAttrs { inherit (expected) b; })
+          (p: p.overrideAttrs { inherit (expected) c; })
+          (p: p.overridePythonAttrs { inherit (expected) d; })
+          (builtins.intersectAttrs expected)
+        ];
+        expected = lib.genAttrs [ "a" "b" "c" "d" ] lib.id;
       };
     };
 


### PR DESCRIPTION
## Description of changes

This patch updates the `<pkg>.overrideAttrs` inside `makeOverridablePythonPackage` (the function that adds `<pkg>.overridePythonAttrs`). If applied, `<pkgs>.overridePythonAttrs` will work after applying `<pkg>.overrideAttrs` to override a Python package built with `buildPythonPackage` or `buildPythonApplication`.

This patch also adds corresponding test cases to `tests.overriding`.

Closes #267293.

Initial effort for #271387.

Cc: @FRidh 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
