### PR TITLE
tiledb: fixup build by using cmake to 3.26 again

### DIFF
--- a/pkgs/by-name/cm/cmake_3_26/001-search-path.diff
+++ b/pkgs/by-name/cm/cmake_3_26/001-search-path.diff
@@ -1,0 +1,95 @@
+diff --git a/Modules/Platform/UnixPaths.cmake b/Modules/Platform/UnixPaths.cmake
+index b9381c3d7d..5e944640b5 100644
+--- a/Modules/Platform/UnixPaths.cmake
++++ b/Modules/Platform/UnixPaths.cmake
+@@ -26,9 +26,6 @@ get_filename_component(_CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" PATH)
+ # please make sure to keep Help/variable/CMAKE_SYSTEM_PREFIX_PATH.rst
+ # synchronized
+ list(APPEND CMAKE_SYSTEM_PREFIX_PATH
+-  # Standard
+-  /usr/local /usr /
+-
+   # CMake install location
+   "${_CMAKE_INSTALL_DIR}"
+   )
+@@ -47,48 +44,49 @@ endif()
+ 
+ # Non "standard" but common install prefixes
+ list(APPEND CMAKE_SYSTEM_PREFIX_PATH
+-  /usr/X11R6
+-  /usr/pkg
+-  /opt
+   )
+ 
+ # List common include file locations not under the common prefixes.
++if(DEFINED ENV{NIX_CC}
++  AND IS_DIRECTORY "$ENV{NIX_CC}"
++  AND EXISTS "$ENV{NIX_CC}/nix-support/orig-libc"
++  AND EXISTS "$ENV{NIX_CC}/nix-support/orig-libc-dev")
++  file(STRINGS "$ENV{NIX_CC}/nix-support/orig-libc" _nix_cmake_libc)
++  file(STRINGS "$ENV{NIX_CC}/nix-support/orig-libc-dev" _nix_cmake_libc_dev)
++else()
++  set(_nix_cmake_libc @libc_lib@)
++  set(_nix_cmake_libc_dev @libc_dev@)
++endif()
++
+ list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
+-  # X11
+-  /usr/include/X11
++  "${_nix_cmake_libc_dev}/include"
+   )
+ 
+ list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
+-  # X11
+-  /usr/lib/X11
++  "${_nix_cmake_libc}/lib"
+   )
+ 
+ list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+-  /lib /lib32 /lib64 /usr/lib /usr/lib32 /usr/lib64
++  "${_nix_cmake_libc}/lib"
+   )
+ 
+-if(CMAKE_SYSROOT_COMPILE)
+-  set(_cmake_sysroot_compile "${CMAKE_SYSROOT_COMPILE}")
+-else()
+-  set(_cmake_sysroot_compile "${CMAKE_SYSROOT}")
+-endif()
+-
+ # Default per-language values.  These may be later replaced after
+ # parsing the implicit directory information from compiler output.
+ set(_CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES_INIT
+   ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}
+-  "${_cmake_sysroot_compile}/usr/include"
++  "${_nix_cmake_libc_dev}/include"
+   )
+ set(_CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES_INIT
+   ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}
+-  "${_cmake_sysroot_compile}/usr/include"
++  "${_nix_cmake_libc_dev}/include"
+   )
+ set(_CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES_INIT
+   ${CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES}
+-  "${_cmake_sysroot_compile}/usr/include"
++  "${_nix_cmake_libc_dev}/include"
+   )
+ 
+-unset(_cmake_sysroot_compile)
++unset(_nix_cmake_libc)
++unset(_nix_cmake_libc_dev)
+ 
+ # Reminder when adding new locations computed from environment variables
+ # please make sure to keep Help/variable/CMAKE_SYSTEM_PREFIX_PATH.rst
+diff --git a/Modules/Platform/WindowsPaths.cmake b/Modules/Platform/WindowsPaths.cmake
+index b9e2f17979..ab517cd4a7 100644
+--- a/Modules/Platform/WindowsPaths.cmake
++++ b/Modules/Platform/WindowsPaths.cmake
+@@ -70,7 +70,7 @@ endif()
+ 
+ if(CMAKE_CROSSCOMPILING AND NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+   # MinGW (useful when cross compiling from linux with CMAKE_FIND_ROOT_PATH set)
+-  list(APPEND CMAKE_SYSTEM_PREFIX_PATH /)
++  # list(APPEND CMAKE_SYSTEM_PREFIX_PATH /)
+ endif()
+ 
+ list(APPEND CMAKE_SYSTEM_INCLUDE_PATH

--- a/pkgs/by-name/cm/cmake_3_26/002-application-services.diff
+++ b/pkgs/by-name/cm/cmake_3_26/002-application-services.diff
@@ -1,0 +1,39 @@
+diff -Naur cmake-3.25.1-old/Source/CMakeLists.txt cmake-3.25.1-new/Source/CMakeLists.txt
+--- cmake-3.25.1-old/Source/CMakeLists.txt	2022-11-30 10:57:03.000000000 -0300
++++ cmake-3.25.1-new/Source/CMakeLists.txt	2022-12-19 01:00:08.412064304 -0300
+@@ -916,7 +916,6 @@
+ # On Apple we need CoreFoundation and CoreServices
+ if(APPLE)
+   target_link_libraries(CMakeLib PUBLIC "-framework CoreFoundation")
+-  target_link_libraries(CMakeLib PUBLIC "-framework CoreServices")
+ endif()
+ 
+ if(WIN32 AND NOT UNIX)
+diff -Naur cmake-3.25.1-old/Source/cmGlobalXCodeGenerator.cxx cmake-3.25.1-new/Source/cmGlobalXCodeGenerator.cxx
+--- cmake-3.25.1-old/Source/cmGlobalXCodeGenerator.cxx	2022-11-30 10:57:03.000000000 -0300
++++ cmake-3.25.1-new/Source/cmGlobalXCodeGenerator.cxx	2022-12-19 01:00:56.065135169 -0300
+@@ -56,10 +56,6 @@
+ 
+ #if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
+ #  include <CoreFoundation/CoreFoundation.h>
+-#  if !TARGET_OS_IPHONE
+-#    define HAVE_APPLICATION_SERVICES
+-#    include <ApplicationServices/ApplicationServices.h>
+-#  endif
+ #endif
+ 
+ #if !defined(CMAKE_BOOTSTRAP)
+diff -Naur cmake-3.25.1-old/Utilities/cmlibarchive/CMakeLists.txt cmake-3.25.1-new/Utilities/cmlibarchive/CMakeLists.txt
+--- cmake-3.25.1-old/Utilities/cmlibarchive/CMakeLists.txt	2022-11-30 10:57:03.000000000 -0300
++++ cmake-3.25.1-new/Utilities/cmlibarchive/CMakeLists.txt	2022-12-19 01:01:43.392205981 -0300
+@@ -2041,10 +2041,6 @@
+   ADD_CUSTOM_TARGET(run_all_tests)
+ ENDIF(ENABLE_TEST)
+ 
+-# We need CoreServices on Mac OS.
+-IF(APPLE)
+-  LIST(APPEND ADDITIONAL_LIBS "-framework CoreServices")
+-ENDIF(APPLE)
+ 
+ add_subdirectory(libarchive)
+ IF(0) # CMake does not build libarchive's command-line tools.

--- a/pkgs/by-name/cm/cmake_3_26/003-libuv-application-services.diff
+++ b/pkgs/by-name/cm/cmake_3_26/003-libuv-application-services.diff
@@ -1,0 +1,55 @@
+diff --git a/Utilities/cmlibuv/CMakeLists.txt b/Utilities/cmlibuv/CMakeLists.txt
+index 7625cf65d9..167903e309 100644
+--- a/Utilities/cmlibuv/CMakeLists.txt
++++ b/Utilities/cmlibuv/CMakeLists.txt
+@@ -193,6 +193,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+     src/unix/kqueue.c
+     src/unix/proctitle.c
+     )
++
++  include(CheckIncludeFile)
++
++  check_include_file("ApplicationServices/ApplicationServices.h" HAVE_ApplicationServices)
++  if (HAVE_ApplicationServices)
++    list(APPEND uv_defines
++      HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H=1
++      )
++  endif()
++
++  check_include_file("CoreServices/CoreServices.h" HAVE_CoreServices)
++  if (HAVE_CoreServices)
++    list(APPEND uv_defines
++      HAVE_CORESERVICES_CORESERVICES_H=1
++      )
++  endif()
+ endif()
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+diff --git a/Utilities/cmlibuv/src/unix/fsevents.c b/Utilities/cmlibuv/src/unix/fsevents.c
+index a51f29b3f6..3f6bf01968 100644
+--- a/Utilities/cmlibuv/src/unix/fsevents.c
++++ b/Utilities/cmlibuv/src/unix/fsevents.c
+@@ -21,7 +21,7 @@
+ #include "uv.h"
+ #include "internal.h"
+ 
+-#if TARGET_OS_IPHONE || MAC_OS_X_VERSION_MAX_ALLOWED < 1070
++#if !HAVE_CORESERVICES_CORESERVICES_H || MAC_OS_X_VERSION_MAX_ALLOWED < 1070
+ 
+ /* iOS (currently) doesn't provide the FSEvents-API (nor CoreServices) */
+ /* macOS prior to 10.7 doesn't provide the full FSEvents API so use kqueue */
+@@ -39,7 +39,7 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
+ void uv__fsevents_loop_delete(uv_loop_t* loop) {
+ }
+ 
+-#else /* TARGET_OS_IPHONE */
++#else /* !HAVE_CORESERVICES_CORESERVICES_H */
+ 
+ #include "darwin-stub.h"
+ 
+@@ -920,4 +920,4 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
+   return 0;
+ }
+ 
+-#endif /* TARGET_OS_IPHONE */
++#endif /* !HAVE_CORESERVICES_CORESERVICES_H */

--- a/pkgs/by-name/cm/cmake_3_26/004-cygwin.diff
+++ b/pkgs/by-name/cm/cmake_3_26/004-cygwin.diff
@@ -1,0 +1,274 @@
+--- cmake-3.2.2/Source/cmFileCommand.cxx	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Source/ccmFileCommand.cxx	2015-06-10 11:02:27.345598700 +0200
+@@ -1179,7 +1179,7 @@
+   MatchProperties CollectMatchProperties(const char* file)
+     {
+     // Match rules are case-insensitive on some platforms.
+-#if defined(_WIN32) || defined(__APPLE__) || defined(__CYGWIN__)
++#if defined(_WIN32) || defined(__APPLE__)
+     std::string lower = cmSystemTools::LowerCase(file);
+     const char* file_to_match = lower.c_str();
+ #else
+--- cmake-3.2.2/Source/cmInstallCommand.cxx	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Source/cmInstallCommand.cxx	2015-06-10 11:04:19.257935200 +0200
+@@ -1138,7 +1138,7 @@
+       {
+       literal_args += " REGEX \"";
+     // Match rules are case-insensitive on some platforms.
+-#if defined(_WIN32) || defined(__APPLE__) || defined(__CYGWIN__)
++#if defined(_WIN32) || defined(__APPLE__)
+       std::string regex = cmSystemTools::LowerCase(args[i]);
+ #else
+       std::string regex = args[i];
+--- cmake-3.2.2/Source/kwsys/Glob.cxx	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Source/kwsys/Glob.cxx	2015-06-10 11:05:51.602674000 +0200
+@@ -37,7 +37,7 @@
+ #include <string.h>
+ namespace KWSYS_NAMESPACE
+ {
+-#if defined(_WIN32) || defined(__APPLE__) || defined(__CYGWIN__)
++#if defined(_WIN32) || defined(__APPLE__)
+ // On Windows and apple, no difference between lower and upper case
+ # define KWSYS_GLOB_CASE_INDEPENDENT
+ #endif
+--- cmake-3.2.2/Source/kwsys/SystemInformation.cxx	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Source/kwsys/SystemInformation.cxx	2015-06-10 11:13:00.308303500 +0200
+@@ -911,7 +911,7 @@
+ // Hide implementation details in an anonymous namespace.
+ namespace {
+ // *****************************************************************************
+-#if defined(__linux) || defined(__APPLE__)
++#if defined(__linux) || defined(__APPLE__) || defined(__CYGWIN__)
+ int LoadLines(
+       FILE *file,
+       kwsys_stl::vector<kwsys_stl::string> &lines)
+@@ -947,7 +947,7 @@
+   return nRead;
+ }
+ 
+-# if defined(__linux)
++# if defined(__linux) || defined(__CYGWIN__)
+ // *****************************************************************************
+ int LoadLines(
+       const char *fileName,
+@@ -986,7 +986,7 @@
+ }
+ #endif
+ 
+-#if defined(__linux)
++#if defined(__linux) || defined(__CYGWIN__)
+ // ****************************************************************************
+ template<typename T>
+ int GetFieldsFromFile(
+@@ -3132,7 +3132,6 @@
+     pos = buffer.find("processor\t",pos+1);
+     }
+ 
+-#ifdef __linux
+   // Find the largest physical id.
+   int maxId = -1;
+   kwsys_stl::string idc =
+@@ -3165,14 +3164,6 @@
+             atoi(this->ExtractValueFromCpuInfoFile(buffer,"ncpus active").c_str());
+     }
+ 
+-#else // __CYGWIN__
+-  // does not have "physical id" entries, neither "cpu cores"
+-  // this has to be fixed for hyper-threading.
+-  kwsys_stl::string cpucount =
+-    this->ExtractValueFromCpuInfoFile(buffer,"cpu count");
+-  this->NumberOfPhysicalCPU=
+-    this->NumberOfLogicalCPU = atoi(cpucount.c_str());
+-#endif
+   // gotta have one, and if this is 0 then we get a / by 0n
+   // better to have a bad answer than a crash
+   if(this->NumberOfPhysicalCPU <= 0)
+@@ -3370,7 +3361,7 @@
+   GlobalMemoryStatusEx(&statex);
+   return statex.ullTotalPhys/1024;
+ # endif
+-#elif defined(__linux)
++#elif defined(__linux) || defined(__CYGWIN__)
+   SystemInformation::LongLong memTotal=0;
+   int ierr=GetFieldFromFile("/proc/meminfo","MemTotal:",memTotal);
+   if (ierr)
+@@ -3501,7 +3492,7 @@
+   GlobalMemoryStatusEx(&statex);
+   return (statex.ullTotalPhys - statex.ullAvailPhys)/1024;
+ # endif
+-#elif defined(__linux)
++#elif defined(__linux) || defined(__CYGWIN__)
+   const char *names[3]={"MemTotal:","MemFree:",NULL};
+   SystemInformation::LongLong values[2]={SystemInformation::LongLong(0)};
+   int ierr=GetFieldsFromFile("/proc/meminfo",names,values);
+@@ -3560,7 +3551,7 @@
+     return -2;
+     }
+   return pmc.WorkingSetSize/1024;
+-#elif defined(__linux)
++#elif defined(__linux) || defined(__CYGWIN__)
+   SystemInformation::LongLong memUsed=0;
+   int ierr=GetFieldFromFile("/proc/self/status","VmRSS:",memUsed);
+   if (ierr)
+@@ -3612,7 +3603,7 @@
+ {
+ #if defined(_WIN32)
+   return GetCurrentProcessId();
+-#elif defined(__linux) || defined(__APPLE__)
++#elif defined(__linux) || defined(__APPLE__) || defined(__CYGWIN__)
+   return getpid();
+ #else
+   return -1;
+--- cmake-3.2.2/Source/kwsys/SystemTools.cxx	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Source/kwsys/SystemTools.cxx	2015-06-10 11:21:58.980443200 +0200
+@@ -93,19 +93,12 @@
+ # if defined(_MSC_VER) && _MSC_VER >= 1800
+ #  define KWSYS_WINDOWS_DEPRECATED_GetVersionEx
+ # endif
+-#elif defined (__CYGWIN__)
+-# include <windows.h>
+-# undef _WIN32
+ #endif
+ 
+ #if !KWSYS_CXX_HAS_ENVIRON_IN_STDLIB_H
+ extern char **environ;
+ #endif
+ 
+-#ifdef __CYGWIN__
+-# include <sys/cygwin.h>
+-#endif
+-
+ // getpwnam doesn't exist on Windows and Cray Xt3/Catamount
+ // same for TIOCGWINSZ
+ #if defined(_WIN32) || defined (__LIBCATAMOUNT__)
+@@ -1148,15 +1141,7 @@
+     {
+     return false;
+     }
+-#if defined(__CYGWIN__)
+-  // Convert filename to native windows path if possible.
+-  char winpath[MAX_PATH];
+-  if(SystemTools::PathCygwinToWin32(filename.c_str(), winpath))
+-    {
+-    return (GetFileAttributesA(winpath) != INVALID_FILE_ATTRIBUTES);
+-    }
+-  return access(filename.c_str(), R_OK) == 0;
+-#elif defined(_WIN32)
++#if defined(_WIN32)
+   return (GetFileAttributesW(
+             SystemTools::ConvertToWindowsExtendedPath(filename).c_str())
+           != INVALID_FILE_ATTRIBUTES);
+@@ -1190,28 +1175,6 @@
+ }
+ 
+ //----------------------------------------------------------------------------
+-#ifdef __CYGWIN__
+-bool SystemTools::PathCygwinToWin32(const char *path, char *win32_path)
+-{
+-  SystemToolsTranslationMap::iterator i =
+-    SystemTools::Cyg2Win32Map->find(path);
+-
+-  if (i != SystemTools::Cyg2Win32Map->end())
+-    {
+-    strncpy(win32_path, i->second.c_str(), MAX_PATH);
+-    }
+-  else
+-    {
+-    if(cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, win32_path, MAX_PATH) != 0)
+-      {
+-      win32_path[0] = 0;
+-      }
+-    SystemToolsTranslationMap::value_type entry(path, win32_path);
+-    SystemTools::Cyg2Win32Map->insert(entry);
+-    }
+-  return win32_path[0] != 0;
+-}
+-#endif
+ 
+ bool SystemTools::Touch(const kwsys_stl::string& filename, bool create)
+ {
+@@ -4307,7 +4270,7 @@
+ 
+ bool SystemTools::FileIsFullPath(const char* in_name, size_t len)
+ {
+-#if defined(_WIN32) || defined(__CYGWIN__)
++#if defined(_WIN32)
+   // On Windows, the name must be at least two characters long.
+   if(len < 2)
+     {
+@@ -5078,9 +5041,6 @@
+ static unsigned int SystemToolsManagerCount;
+ SystemToolsTranslationMap *SystemTools::TranslationMap;
+ SystemToolsTranslationMap *SystemTools::LongPathMap;
+-#ifdef __CYGWIN__
+-SystemToolsTranslationMap *SystemTools::Cyg2Win32Map;
+-#endif
+ 
+ // SystemToolsManager manages the SystemTools singleton.
+ // SystemToolsManager should be included in any translation unit
+@@ -5126,9 +5086,6 @@
+   // Allocate the translation map first.
+   SystemTools::TranslationMap = new SystemToolsTranslationMap;
+   SystemTools::LongPathMap = new SystemToolsTranslationMap;
+-#ifdef __CYGWIN__
+-  SystemTools::Cyg2Win32Map = new SystemToolsTranslationMap;
+-#endif
+ 
+   // Add some special translation paths for unix.  These are not added
+   // for windows because drive letters need to be maintained.  Also,
+@@ -5183,9 +5140,6 @@
+ {
+   delete SystemTools::TranslationMap;
+   delete SystemTools::LongPathMap;
+-#ifdef __CYGWIN__
+-  delete SystemTools::Cyg2Win32Map;
+-#endif
+ }
+ 
+ 
+--- cmake-3.2.2/Source/kwsys/SystemTools.hxx.in	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Source/kwsys/SystemTools.hxx.in	2015-06-10 11:24:24.271286600 +0200
+@@ -298,15 +298,6 @@
+   static bool FileExists(const kwsys_stl::string& filename);
+ 
+   /**
+-   * Converts Cygwin path to Win32 path. Uses dictionary container for
+-   * caching and calls to cygwin_conv_to_win32_path from Cygwin dll
+-   * for actual translation.  Returns true on success, else false.
+-   */
+-#ifdef __CYGWIN__
+-  static bool PathCygwinToWin32(const char *path, char *win32_path);
+-#endif
+-
+-  /**
+    * Return file length
+    */
+   static unsigned long FileLength(const kwsys_stl::string& filename);
+@@ -942,9 +933,6 @@
+    */
+   static SystemToolsTranslationMap *TranslationMap;
+   static SystemToolsTranslationMap *LongPathMap;
+-#ifdef __CYGWIN__
+-  static SystemToolsTranslationMap *Cyg2Win32Map;
+-#endif
+   friend class SystemToolsManager;
+ };
+ 
+--- cmake-3.2.2/Modules/FindCurses.cmake	2015-04-13 19:09:00.000000000 +0200
++++ cmake-3.2.2/Modules/FindCurses.cmake	2015-06-10 12:10:19.682030300 +0200
+@@ -60,15 +60,6 @@
+ if(CURSES_NCURSES_LIBRARY  AND ((NOT CURSES_CURSES_LIBRARY) OR CURSES_NEED_NCURSES))
+   set(CURSES_USE_NCURSES TRUE)
+ endif()
+-# http://cygwin.com/ml/cygwin-announce/2010-01/msg00002.html
+-# cygwin ncurses stopped providing curses.h symlinks see above
+-# message.  Cygwin is an ncurses package, so force ncurses on
+-# cygwin if the curses.h is missing
+-if(CYGWIN)
+-  if(NOT EXISTS /usr/include/curses.h)
+-    set(CURSES_USE_NCURSES TRUE)
+-  endif()
+-endif()
+ 
+ 
+ # Not sure the logic is correct here.

--- a/pkgs/by-name/cm/cmake_3_26/005-remove-systemconfiguration-dep.diff
+++ b/pkgs/by-name/cm/cmake_3_26/005-remove-systemconfiguration-dep.diff
@@ -1,0 +1,67 @@
+--- a/Utilities/cmcurl/CMakeLists.txt
++++ b/Utilities/cmcurl/CMakeLists.txt
+@@ -391,13 +391,6 @@ if(ENABLE_IPV6 AND NOT WIN32)
+ 
+   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT ENABLE_ARES)
+     set(use_core_foundation ON)
+-
+-    find_library(SYSTEMCONFIGURATION_FRAMEWORK "SystemConfiguration")
+-    if(NOT SYSTEMCONFIGURATION_FRAMEWORK)
+-      message(FATAL_ERROR "SystemConfiguration framework not found")
+-    endif()
+-
+-    list(APPEND CURL_LIBS "-framework SystemConfiguration")
+   endif()
+ endif()
+ 
+--- a/Utilities/cmcurl/lib/curl_setup.h
++++ b/Utilities/cmcurl/lib/curl_setup.h
+@@ -257,11 +257,7 @@
+  * performing this task will result in a synthesized IPv6 address.
+  */
+ #if defined(__APPLE__) && !defined(USE_ARES)
+-#include <TargetConditionals.h>
+ #define USE_RESOLVE_ON_IPS 1
+-#  if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+-#    define CURL_OSX_CALL_COPYPROXIES 1
+-#  endif
+ #endif
+ 
+ #ifdef USE_LWIPSOCK
+--- a/Utilities/cmcurl/lib/hostip.c
++++ b/Utilities/cmcurl/lib/hostip.c
+@@ -68,10 +68,6 @@
+ #include "curl_memory.h"
+ #include "memdebug.h"
+ 
+-#if defined(ENABLE_IPV6) && defined(CURL_OSX_CALL_COPYPROXIES)
+-#include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
+-#endif
+-
+ #if defined(CURLRES_SYNCH) && \
+     defined(HAVE_ALARM) && defined(SIGALRM) && defined(HAVE_SIGSETJMP)
+ /* alarm-based timeouts can only be used with all the dependencies satisfied */
+@@ -661,23 +657,6 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
+         return CURLRESOLV_ERROR;
+     }
+ 
+-#if defined(ENABLE_IPV6) && defined(CURL_OSX_CALL_COPYPROXIES)
+-    {
+-      /*
+-       * The automagic conversion from IPv4 literals to IPv6 literals only
+-       * works if the SCDynamicStoreCopyProxies system function gets called
+-       * first. As Curl currently doesn't support system-wide HTTP proxies, we
+-       * therefore don't use any value this function might return.
+-       *
+-       * This function is only available on a macOS and is not needed for
+-       * IPv4-only builds, hence the conditions above.
+-       */
+-      CFDictionaryRef dict = SCDynamicStoreCopyProxies(NULL);
+-      if(dict)
+-        CFRelease(dict);
+-    }
+-#endif
+-
+ #ifndef USE_RESOLVE_ON_IPS
+     /* First check if this is an IPv4 address string */
+     if(Curl_inet_pton(AF_INET, hostname, &in) > 0)

--- a/pkgs/by-name/cm/cmake_3_26/006-darwin-always-set-runtime-c-flag.diff
+++ b/pkgs/by-name/cm/cmake_3_26/006-darwin-always-set-runtime-c-flag.diff
@@ -1,0 +1,14 @@
+Revert of commit 1af23c4de2c7d58c06171d70b37794b5c860d5f4.
+--- b/Modules/Platform/Darwin.cmake
++++ a/Modules/Platform/Darwin.cmake
+@@ -47,9 +47,7 @@
+ set(CMAKE_SHARED_MODULE_SUFFIX ".so")
+ set(CMAKE_MODULE_EXISTS 1)
+ set(CMAKE_DL_LIBS "")
++set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
+-if(NOT "${_CURRENT_OSX_VERSION}" VERSION_LESS "10.5")
+-  set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
+-endif()
+ 
+ foreach(lang C CXX OBJC OBJCXX)
+   set(CMAKE_${lang}_OSX_COMPATIBILITY_VERSION_FLAG "-compatibility_version ")

--- a/pkgs/by-name/cm/cmake_3_26/check-pc-files-hook.sh
+++ b/pkgs/by-name/cm/cmake_3_26/check-pc-files-hook.sh
@@ -1,0 +1,18 @@
+cmakePcfileCheckPhase() {
+    while IFS= read -rd $'\0' file; do
+        grepout=$(grep --line-number '}//nix/store' "$file" || true)
+        if [ -n "$grepout" ]; then
+            {
+            echo "Broken paths found in a .pc file! $file"
+            echo "The following lines have issues (specifically '//' in paths)."
+            echo "$grepout"
+            echo "It is very likely that paths are being joined improperly."
+            echo 'ex: "${prefix}/@CMAKE_INSTALL_LIBDIR@" should be "@CMAKE_INSTALL_FULL_LIBDIR@"'
+            echo "Please see https://github.com/NixOS/nixpkgs/issues/144170 for more details."
+            exit 1
+            } 1>&2
+        fi
+    done < <(find "${!outputDev}" -iname "*.pc" -print0)
+}
+
+postFixupHooks+=(cmakePcfileCheckPhase)

--- a/pkgs/by-name/cm/cmake_3_26/package.nix
+++ b/pkgs/by-name/cm/cmake_3_26/package.nix
@@ -1,0 +1,181 @@
+{ lib
+, stdenv
+, fetchurl
+, buildPackages
+, bzip2
+, curlMinimal
+, expat
+, libarchive
+, libuv
+, ncurses
+, openssl
+, pkg-config
+, ps
+, rhash
+, sphinx
+, texinfo
+, xz
+, zlib
+, isBootstrap ? null
+, isMinimalBuild ? (
+  if isBootstrap != null
+  then lib.warn
+    "isBootstrap argument is deprecated and will be removed; use isMinimalBuild instead"
+    isBootstrap
+  else false)
+, useOpenSSL ? !isMinimalBuild
+, useSharedLibraries ? (!isMinimalBuild && !stdenv.isCygwin)
+, uiToolkits ? [] # can contain "ncurses" and/or "qt5"
+, buildDocs ? !(isMinimalBuild || (uiToolkits == []))
+, darwin
+, libsForQt5
+}:
+
+let
+  inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
+  inherit (libsForQt5) qtbase wrapQtAppsHook;
+  cursesUI = lib.elem "ncurses" uiToolkits;
+  qt5UI = lib.elem "qt5" uiToolkits;
+in
+# Accepts only "ncurses" and "qt5" as possible uiToolkits
+assert lib.subtractLists [ "ncurses" "qt5" ] uiToolkits == [];
+# Minimal, bootstrap cmake does not have toolkits
+assert isMinimalBuild -> (uiToolkits == []);
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cmake"
+    + lib.optionalString isMinimalBuild "-minimal"
+    + lib.optionalString cursesUI "-cursesUI"
+    + lib.optionalString qt5UI "-qt5UI";
+  version = "3.26.4";
+
+  src = fetchurl {
+    url = "https://cmake.org/files/v${lib.versions.majorMinor finalAttrs.version}/cmake-${finalAttrs.version}.tar.gz";
+    hash = "sha256-MTtogMKRvU/jHAqlHW5iZZKCpSHmlfMNXMDSWrvVwgg=";
+  };
+
+  patches = [
+    # Don't search in non-Nix locations such as /usr, but do search in our libc.
+    ./001-search-path.diff
+    # Don't depend on frameworks.
+    ./002-application-services.diff
+    # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
+    ./003-libuv-application-services.diff
+  ]
+  ++ lib.optional stdenv.isCygwin ./004-cygwin.diff
+  # Derived from https://github.com/curl/curl/commit/31f631a142d855f069242f3e0c643beec25d1b51
+  ++ lib.optional (stdenv.isDarwin && isMinimalBuild) ./005-remove-systemconfiguration-dep.diff
+  # On Darwin, always set CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG.
+  ++ lib.optional stdenv.isDarwin ./006-darwin-always-set-runtime-c-flag.diff;
+
+  outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" "info" ];
+  setOutputFlags = false;
+
+  setupHooks = [
+    ./setup-hook.sh
+    ./check-pc-files-hook.sh
+  ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = finalAttrs.setupHooks ++ [
+    pkg-config
+  ]
+  ++ lib.optionals buildDocs [ texinfo ]
+  ++ lib.optionals qt5UI [ wrapQtAppsHook ];
+
+  buildInputs = lib.optionals useSharedLibraries [
+    bzip2
+    curlMinimal
+    expat
+    libarchive
+    xz
+    zlib
+    libuv
+    rhash
+  ]
+  ++ lib.optional useOpenSSL openssl
+  ++ lib.optional cursesUI ncurses
+  ++ lib.optional qt5UI qtbase
+  ++ lib.optional (stdenv.isDarwin && !isMinimalBuild) SystemConfiguration;
+
+  propagatedBuildInputs = lib.optional stdenv.isDarwin ps;
+
+  preConfigure = ''
+    fixCmakeFiles .
+    substituteInPlace Modules/Platform/UnixPaths.cmake \
+      --subst-var-by libc_bin ${lib.getBin stdenv.cc.libc} \
+      --subst-var-by libc_dev ${lib.getDev stdenv.cc.libc} \
+      --subst-var-by libc_lib ${lib.getLib stdenv.cc.libc}
+    # CC_FOR_BUILD and CXX_FOR_BUILD are used to bootstrap cmake
+    configureFlags="--parallel=''${NIX_BUILD_CORES:-1} CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD $configureFlags"
+  '';
+
+  configureFlags = [
+    "CXXFLAGS=-Wno-elaborated-enum-base"
+    "--docdir=share/doc/${finalAttrs.pname}-${finalAttrs.version}"
+  ] ++ (if useSharedLibraries
+        then [ "--no-system-jsoncpp" "--system-libs" ]
+        else [ "--no-system-libs" ]) # FIXME: cleanup
+  ++ lib.optional qt5UI "--qt-gui"
+  ++ lib.optionals buildDocs [
+    "--sphinx-build=${sphinx}/bin/sphinx-build"
+    "--sphinx-info"
+    "--sphinx-man"
+  ]
+  # Workaround https://gitlab.kitware.com/cmake/cmake/-/issues/20568
+  ++ lib.optionals stdenv.hostPlatform.is32bit [
+    "CFLAGS=-D_FILE_OFFSET_BITS=64"
+    "CXXFLAGS=-D_FILE_OFFSET_BITS=64"
+  ]
+  ++ [
+    "--"
+    # We should set the proper `CMAKE_SYSTEM_NAME`.
+    # http://www.cmake.org/Wiki/CMake_Cross_Compiling
+    #
+    # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
+    # strip. Otherwise they are taken to be relative to the source root of the
+    # package being built.
+    (lib.cmakeFeature "CMAKE_CXX_COMPILER" "${stdenv.cc.targetPrefix}c++")
+    (lib.cmakeFeature "CMAKE_C_COMPILER" "${stdenv.cc.targetPrefix}cc")
+    (lib.cmakeFeature "CMAKE_AR"
+      "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar")
+    (lib.cmakeFeature "CMAKE_RANLIB"
+      "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib")
+    (lib.cmakeFeature "CMAKE_STRIP"
+      "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip")
+
+    (lib.cmakeBool "CMAKE_USE_OPENSSL" useOpenSSL)
+    (lib.cmakeBool "BUILD_CursesDialog" cursesUI)
+  ];
+
+  # make install attempts to use the just-built cmake
+  preInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    sed -i 's|bin/cmake|${buildPackages.cmakeMinimal}/bin/cmake|g' Makefile
+  '';
+
+  dontUseCmakeConfigure = true;
+  enableParallelBuilding = true;
+
+  # This isn't an autoconf configure script; triples are passed via
+  # CMAKE_SYSTEM_NAME, etc.
+  configurePlatforms = [ ];
+
+  doCheck = false; # fails
+
+  meta = {
+    homepage = "https://cmake.org/";
+    description = "Cross-platform, open-source build system generator";
+    longDescription = ''
+      CMake is an open-source, cross-platform family of tools designed to build,
+      test and package software. CMake is used to control the software
+      compilation process using simple platform and compiler independent
+      configuration files, and generate native makefiles and workspaces that can
+      be used in the compiler environment of your choice.
+    '';
+    changelog = "https://cmake.org/cmake/help/v${lib.versions.majorMinor finalAttrs.version}/release/${lib.versions.majorMinor finalAttrs.version}.html";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ttuegel lnl7 AndersonTorres ];
+    platforms = lib.platforms.all;
+    broken = (qt5UI && stdenv.isDarwin);
+  };
+})

--- a/pkgs/by-name/cm/cmake_3_26/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake_3_26/setup-hook.sh
@@ -1,0 +1,184 @@
+addCMakeParams() {
+    addToSearchPath CMAKE_PREFIX_PATH $1
+}
+
+fixCmakeFiles() {
+    # Replace occurences of /usr and /opt by /var/empty.
+    echo "fixing cmake files..."
+    find "$1" \( -type f -name "*.cmake" -o -name "*.cmake.in" -o -name CMakeLists.txt \) -print |
+        while read fn; do
+            sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
+            mv "$fn.tmp" "$fn"
+        done
+}
+
+cmakeConfigurePhase() {
+    runHook preConfigure
+
+    # default to CMake defaults if unset
+    : ${cmakeBuildDir:=build}
+
+    export CTEST_OUTPUT_ON_FAILURE=1
+    if [ -n "${enableParallelChecking-1}" ]; then
+        export CTEST_PARALLEL_LEVEL=$NIX_BUILD_CORES
+    fi
+
+    if [ -z "${dontFixCmake-}" ]; then
+        fixCmakeFiles .
+    fi
+
+    if [ -z "${dontUseCmakeBuildDir-}" ]; then
+        mkdir -p "$cmakeBuildDir"
+        cd "$cmakeBuildDir"
+        : ${cmakeDir:=..}
+    else
+        : ${cmakeDir:=.}
+    fi
+
+    if [ -z "${dontAddPrefix-}" ]; then
+        cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix $cmakeFlags"
+    fi
+
+    # We should set the proper `CMAKE_SYSTEM_NAME`.
+    # http://www.cmake.org/Wiki/CMake_Cross_Compiling
+    #
+    # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
+    # strip. Otherwise they are taken to be relative to the source root of the
+    # package being built.
+    cmakeFlags="-DCMAKE_CXX_COMPILER=$CXX $cmakeFlags"
+    cmakeFlags="-DCMAKE_C_COMPILER=$CC $cmakeFlags"
+    cmakeFlags="-DCMAKE_AR=$(command -v $AR) $cmakeFlags"
+    cmakeFlags="-DCMAKE_RANLIB=$(command -v $RANLIB) $cmakeFlags"
+    cmakeFlags="-DCMAKE_STRIP=$(command -v $STRIP) $cmakeFlags"
+
+    # on macOS we want to prefer Unix-style headers to Frameworks
+    # because we usually do not package the framework
+    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=LAST $cmakeFlags"
+
+    # we never want to use the global macOS SDK
+    cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
+
+    # correctly detect our clang compiler
+    cmakeFlags="-DCMAKE_POLICY_DEFAULT_CMP0025=NEW $cmakeFlags"
+
+    # This installs shared libraries with a fully-specified install
+    # name. By default, cmake installs shared libraries with just the
+    # basename as the install name, which means that, on Darwin, they
+    # can only be found by an executable at runtime if the shared
+    # libraries are in a system path or in the same directory as the
+    # executable. This flag makes the shared library accessible from its
+    # nix/store directory.
+    cmakeFlags="-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib $cmakeFlags"
+
+    # The docdir flag needs to include PROJECT_NAME as per GNU guidelines,
+    # try to extract it from CMakeLists.txt.
+    if [[ -z "$shareDocName" ]]; then
+        local cmakeLists="${cmakeDir}/CMakeLists.txt"
+        if [[ -f "$cmakeLists" ]]; then
+            local shareDocName="$(grep --only-matching --perl-regexp --ignore-case '\bproject\s*\(\s*"?\K([^[:space:]")]+)' < "$cmakeLists" | head -n1)"
+        fi
+        # The argument sometimes contains garbage or variable interpolation.
+        # When that is the case, let’s fall back to the derivation name.
+        if [[ -z "$shareDocName" ]] || echo "$shareDocName" | grep -q '[^a-zA-Z0-9_+-]'; then
+            if [[ -n "${pname-}" ]]; then
+                shareDocName="$pname"
+            else
+                shareDocName="$(echo "$name" | sed 's/-[^a-zA-Z].*//')"
+            fi
+        fi
+    fi
+
+    # This ensures correct paths with multiple output derivations
+    # It requires the project to use variables from GNUInstallDirs module
+    # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+    cmakeFlags="-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName} $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec $cmakeFlags"
+    cmakeFlags="-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale $cmakeFlags"
+
+    # Don’t build tests when doCheck = false
+    if [ -z "${doCheck-}" ]; then
+        cmakeFlags="-DBUILD_TESTING=OFF $cmakeFlags"
+    fi
+
+    # Always build Release, to ensure optimisation flags
+    cmakeFlags="-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release} $cmakeFlags"
+
+    # Disable user package registry to avoid potential side effects
+    # and unecessary attempts to access non-existent home folder
+    # https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#disabling-the-package-registry
+    cmakeFlags="-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON $cmakeFlags"
+    cmakeFlags="-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF $cmakeFlags"
+    cmakeFlags="-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF $cmakeFlags"
+
+    if [ "${buildPhase-}" = ninjaBuildPhase ]; then
+        cmakeFlags="-GNinja $cmakeFlags"
+    fi
+
+    echo "cmake flags: $cmakeFlags ${cmakeFlagsArray[@]}"
+
+    cmake "$cmakeDir" $cmakeFlags "${cmakeFlagsArray[@]}"
+
+    if ! [[ -v enableParallelBuilding ]]; then
+        enableParallelBuilding=1
+        echo "cmake: enabled parallel building"
+    fi
+
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "cmake: enabled parallel installing"
+    fi
+
+    runHook postConfigure
+}
+
+if [ -z "${dontUseCmakeConfigure-}" -a -z "${configurePhase-}" ]; then
+    setOutputFlags=
+    configurePhase=cmakeConfigurePhase
+fi
+
+addEnvHooks "$targetOffset" addCMakeParams
+
+makeCmakeFindLibs(){
+  isystem_seen=
+  iframework_seen=
+  for flag in ${NIX_CFLAGS_COMPILE-} ${NIX_LDFLAGS-}; do
+    if test -n "$isystem_seen" && test -d "$flag"; then
+      isystem_seen=
+      export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag}"
+    elif test -n "$iframework_seen" && test -d "$flag"; then
+      iframework_seen=
+      export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag}"
+    else
+      isystem_seen=
+      iframework_seen=
+      case $flag in
+        -I*)
+          export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag:2}"
+          ;;
+        -L*)
+          export CMAKE_LIBRARY_PATH="${CMAKE_LIBRARY_PATH-}${CMAKE_LIBRARY_PATH:+:}${flag:2}"
+          ;;
+        -F*)
+          export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag:2}"
+          ;;
+        -isystem)
+          isystem_seen=1
+          ;;
+        -iframework)
+          iframework_seen=1
+          ;;
+      esac
+    fi
+  done
+}
+
+# not using setupHook, because it could be a setupHook adding additional
+# include flags to NIX_CFLAGS_COMPILE
+postHooks+=(makeCmakeFindLibs)

--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, cmake
+, cmake_3_26
 , zlib
 , lz4
 , bzip2
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     clang-tools
-    cmake
+    cmake_3_26
     python3
     doxygen
   ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;


### PR DESCRIPTION
https://hydra.nixos.org/build/240530029

/cc target PR: #263535 and maintainer @Rakesh4G

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
