### PR TITLE
scram_2, scram_3: init

### DIFF
--- a/pkgs/by-name/sc/scram_2/package.nix
+++ b/pkgs/by-name/sc/scram_2/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  perl,
+}:
+let
+  escapeMakeFlag = builtins.replaceStrings [ "\$" ] [ "\$\$" ];
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "scram";
+  version = "2.2.9-pre14";
+
+  __structuredAttrs = true;
+
+  SCRAM_VERSION = "V${lib.replaceStrings [ "." "-" ] [ "_" "_" ] finalAttrs.version}";
+
+  src = fetchFromGitHub {
+    owner = "cms-sw";
+    repo = "SCRAM";
+    rev = finalAttrs.SCRAM_VERSION;
+    hash = "sha256-k5XoLNGIfFKWlYrZHFK9hrYojA8SsjSM650BQEgDtfQ=";
+  };
+
+  # Name of the environment variable to get CMS_PATH from.
+  # If null, get directly from CMS_PATH specified by overrideAttrs.
+  getCmsPathFromEnv = "CMS_PATH";
+
+  postPatch = lib.optionalString (finalAttrs.getCmsPathFromEnv != null) ''
+    substituteInPlace "bin/scram.in" --replace "'@CMS_PATH@'" "@CMS_PATH@"
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ perl ];
+
+  makeFlagAttrs = {
+    VERSION = finalAttrs.SCRAM_VERSION;
+    # The surrounding double-quotes ("...") is to get it out of the outer double-quotes
+    # Get from environment variable CMS_PATH if finalAttrs.getCmsPathFromEnv
+    # otherwise get from finalAttrs.CMS_PATH
+    INSTALL_BASE = escapeMakeFlag "\"${
+      lib.escapeShellArg (
+        if finalAttrs.getCmsPathFromEnv != null then
+          "\$ENV{'${finalAttrs.getCmsPathFromEnv}'}"
+        else
+          finalAttrs.CMS_PATH
+      )
+    }\"";
+    PREFIX = "${placeholder "out"}/libexec/scramv2";
+  };
+
+  makeFlags = lib.mapAttrsToList (name: value: "${name}=${value}") finalAttrs.makeFlagAttrs;
+
+  preBuild = ''
+    mkdir -p "''${makeFlagAttrs[PREFIX]}"
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/bin"
+    makeWrapper "''${makeFlagAttrs[PREFIX]}/bin/chktool" "$out/bin/chktool"
+    makeWrapper "''${makeFlagAttrs[PREFIX]}/bin/scram" "$out/bin/scramv2"
+    ln -s "$out/bin/scramv2" "$out/bin/scram"
+  '';
+
+  meta = with lib; {
+    description = "Software Configuration And Management - CMS internal build tool";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ShamrockLee ];
+    mainProgram = "scram";
+  };
+})

--- a/pkgs/by-name/sc/scram_3/package.nix
+++ b/pkgs/by-name/sc/scram_3/package.nix
@@ -1,0 +1,4 @@
+{ python3Packages }:
+
+with python3Packages;
+toPythonApplication scram

--- a/pkgs/development/python-modules/scram/default.nix
+++ b/pkgs/development/python-modules/scram/default.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch2,
+  gnumake,
+  mock,
+  pytestCheckHook,
+}:
+
+# The branches SCRAMV2 and SCRAMV3 in github:cms-sw/SCRAM belongs to different trees,
+# and the implementation is totally different -- SCRAMV2 is based on Perl scripts and Makefiles,
+# while SCRAMV3 is a Python package.
+# They just share the same CLI interface.
+
+# SCRAM relies on CernVM File System (CVMFS), a repository/database located at CMS_PATH.
+# The content of CVMFS contains a huge amount of hard-coded paths and is not relocatable.
+# Both packages, scram_2 and scram_3, are expected to be uesd inside a system where CVMFS is distributed,
+# or at least where /cvmfs is mounted.
+
+(buildPythonPackage {
+  pname = "scram";
+  # There's currently no version tag along the branch SCRAMV3.
+  # Since it's Python version is specified as 3.0.0, I hereby
+  # made up a previous version referencing the version format used on SCRAMV2.
+  version = "3.0.0-pre00-unstable-2023-10-27";
+
+  src = fetchFromGitHub {
+    owner = "cms-sw";
+    repo = "SCRAM";
+    # Reference "SCRAMV3"
+    rev = "49a36349e8482b5953e79b49352b80eb234c50e6";
+    hash = "sha256-rYFh11kLhVOzgLKYJXPHBf6bgsQqL7DB1ISsFWAJbPI=";
+  };
+
+  pythonRemoveDeps = [
+    # Don't run linters
+    "flake8"
+  ];
+
+  patches = [
+    # setup.py load_source fixes
+    # See https://github.com/cms-sw/SCRAM/issues/71
+
+    # https://github.com/cms-sw/SCRAM/pull/72
+    (fetchpatch2 {
+      url = "https://github.com/cms-sw/SCRAM/commit/14dad59735809a8a2d2136df479d914443a81047.patch?full_index=1";
+      hash = "sha256-n6qntZaPAdcR5XY+BDeeW5+DZyfL+OQ9uN5OSgbZFyc=";
+    })
+    # https://github.com/cms-sw/SCRAM/pull/73
+    (fetchpatch2 {
+      url = "https://github.com/cms-sw/SCRAM/commit/362a0f3b4184c6bd9f07b1b30b3338e9d0c0159e.patch?full_index=1";
+      hash = "sha256-OzdG2YFb90nKv7VVfDPekMZSPvNfiazH8bDkms6tftI=";
+    })
+  ];
+
+  postPatch = ''
+    # Use usual string literals instead of byte strings
+    substituteInPlace setup.py \
+      --replace-fail "filename.endswith(b'.py')" "filename.endswith('.py')"
+
+    # Fix argument changes
+    substituteInPlace "SCRAM/BuildSystem/MakeInterface.py" \
+      --replace-fail "def exec(self, args, opts):" "def exec(self, args=[], opts=__import__('argparse').Namespace(verbose=False)):" \
+      --replace-fail "execl(script, *gmake_arg)" "print('LOCALTOP:', environ['LOCALTOP'], 'SCRAM_CONFIGDIR:', environ['SCRAM_CONFIGDIR'], 'script:', script, 'gmake_arg:', gmake_arg); execl(script, *gmake_arg)"
+  '';
+
+  LOCALTOP = placeholder "out";
+
+  preConfigure = ''
+    SCRAM_CONFIGDIR=config
+    mkdir -p "$LOCALTOP/$SCRAM_CONFIGDIR/SCRAM"
+    cat <<EOF > "$LOCALTOP/$SCRAM_CONFIGDIR/SCRAM/run_gmake.sh"
+    #!/bin/sh
+    exec -a gmake ${gnumake}/bin/make "\$@"
+    EOF
+    chmod +x "$LOCALTOP/$SCRAM_CONFIGDIR/SCRAM/run_gmake.sh"
+    patchShebangs --host "$LOCALTOP/$SCRAM_CONFIGDIR/SCRAM/run_gmake.sh"
+  '';
+
+  # Run the check as a package test with CMS_PATH="" set.
+  doCheck = false;
+
+  postInstall = ''
+    rm -f "$out/bin/SCRAM"
+    cp cli/scram.py "$out/bin"
+  '';
+
+  postFixup = ''
+    ln -s "$out/bin/scram.py" "$out/bin/scram"
+  '';
+
+  meta = with lib; {
+    description = "Software Configuration And Management - CMS internal build tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ShamrockLee ];
+    mainProgram = "scram";
+  };
+  # Workaround buildPythonPackage's lack of finalAttrs support
+}).overrideAttrs
+  (
+    finalAttrs: previousAttrs: {
+      SCRAM_VERSION = "V3_0_0";
+
+      # Name of the environment variable to get CMS_PATH from.
+      # If null, get directly from CMS_PATH specified by overrideAttrs.
+      getCmsPathFromEnv = "CMS_PATH";
+
+      postPatch =
+        previousAttrs.postPatch or ""
+        + ''
+          substituteInPlace "SCRAM/__init__.py" \
+            --replace "@SCRAM_VERSION@" "$SCRAM_VERSION" \
+            --replace "'@CMS_PATH@'" ${
+              lib.escapeShellArg (
+                if finalAttrs.getCmsPathFromEnv != null then
+                  "environ['${finalAttrs.getCmsPathFromEnv}']"
+                else
+                  "r'${finalAttrs.CMS_PATH}'"
+              )
+            }
+        '';
+
+      passthru = previousAttrs.passthru or { } // {
+        tests = previousAttrs.passthru.tests or { } // {
+          with-checks = finalAttrs.finalPackage.overrideAttrs (
+            previousAttrs:
+            {
+              doCheck = true;
+
+              nativeCheckInputs = [
+                mock
+                pytestCheckHook
+              ];
+
+              pythonImportsCheck = [ "SCRAM" ];
+            }
+            // lib.optionalAttrs (previousAttrs.getCmsPathFromEnv != null) {
+              # For testing purpose
+              env.${previousAttrs.getCmsPathFromEnv} = "";
+            }
+          );
+        };
+      };
+    }
+  )

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13913,6 +13913,8 @@ self: super: with self; {
 
   scp = callPackage ../development/python-modules/scp { };
 
+  scram = callPackage ../development/python-modules/scram { };
+
   scramp = callPackage ../development/python-modules/scramp { };
 
   scrap-engine = callPackage ../development/python-modules/scrap-engine { };


### PR DESCRIPTION
## Description of changes

This PR adds [SCRAM](https://github.com/cms-sw/SCRAM), the development environment manager and build tool of the [CMS Experiment](https://www.home.cern/science/experiments/cms), into Nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
