### PR TITLE
qt5: cross compile with a clean separation of build and host binaries

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -16,17 +16,7 @@
   fetchpatch,
   fetchFromGitHub,
   makeSetupHook,
-  makeWrapper,
-  bison,
-  cups ? null,
-  harfbuzz,
-  libGL,
-  perl,
   python3,
-  gstreamer,
-  gst-plugins-base,
-  gtk3,
-  dconf,
   llvmPackages_19,
   darwin,
 
@@ -282,14 +272,7 @@ let
       qtbase = callPackage ../modules/qtbase.nix {
         inherit (srcs.qtbase) src version;
         patches = patches.qtbase;
-        inherit
-          bison
-          cups
-          harfbuzz
-          libGL
-          ;
         withGtk3 = !stdenv.hostPlatform.isDarwin;
-        inherit dconf gtk3;
         inherit developerBuild decryptSslTraffic;
       };
 
@@ -305,9 +288,7 @@ let
       qtlocation = callPackage ../modules/qtlocation.nix { };
       qtlottie = callPackage ../modules/qtlottie.nix { };
       qtmacextras = callPackage ../modules/qtmacextras.nix { };
-      qtmultimedia = callPackage ../modules/qtmultimedia.nix {
-        inherit gstreamer gst-plugins-base;
-      };
+      qtmultimedia = callPackage ../modules/qtmultimedia.nix { };
       qtnetworkauth = callPackage ../modules/qtnetworkauth.nix { };
       qtpim = callPackage ../modules/qtpim.nix { };
       qtpositioning = callPackage ../modules/qtpositioning.nix { };

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -49,6 +49,10 @@ let
         url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/81b14ae4eed038662b53cd20786fd5e0816279ec/community/qt5-qtbase/loongarch64.patch";
         hash = "sha256-BnpejF6/L73kVVts0R0/OMbVN8G4DXVFwBMJPLU9QbE=";
       })
+      (fetchpatch {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtbase/-/raw/6910758e1141f8ea65a8f2359ac30163d65bf6e2/debian/patches/cross_build_mysql.diff";
+        hash = "sha256-tzmmLmMXmeDwRVjdpWekDJvSkrIIlslC12HP7XPcm3E=";
+      })
     ];
     qtdeclarative = [
       ./qtdeclarative.patch

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -368,9 +368,9 @@ let
         }:
         makeSetupHook {
           name = "wrap-qt5-apps-hook";
-          propagatedBuildInputs = [
+          propagatedBuildInputs = [ makeBinaryWrapper ];
+          depsTargetTargetPropagated = [
             qtbase.dev
-            makeBinaryWrapper
           ]
           ++ lib.optional stdenv.hostPlatform.isLinux qtwayland.dev;
         } ../hooks/wrap-qt-apps-hook.sh

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -198,6 +198,7 @@ let
       # See: https://bugreports.qt.io/browse/QTBUG-124375
       # Backport of: https://code.qt.io/cgit/qt/qtwebengine-chromium.git/commit/?id=a766045f65f934df3b5f1aa63bc86fbb3e003a09
       ./qtwebengine-ninja-1.12.patch
+      ./qtwebengine-cross-build.patch
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       ./qtwebengine-darwin-no-platform-check.patch
@@ -337,7 +338,6 @@ let
         stdenv = if stdenv.cc.isClang then llvmPackages_19.stdenv else stdenv;
         inherit (srcs.qtwebengine) version;
         inherit (darwin) bootstrap_cmds;
-        python = python3;
       };
       qtwebglplugin = callPackage ../modules/qtwebglplugin.nix { };
       qtwebkit = callPackage ../modules/qtwebkit.nix { };

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -53,6 +53,7 @@ let
         url = "https://salsa.debian.org/qt-kde-team/qt/qtbase/-/raw/6910758e1141f8ea65a8f2359ac30163d65bf6e2/debian/patches/cross_build_mysql.diff";
         hash = "sha256-tzmmLmMXmeDwRVjdpWekDJvSkrIIlslC12HP7XPcm3E=";
       })
+      ./qtbase.patch.d/0015-qtbase-cross-build.patch
     ];
     qtdeclarative = [
       ./qtdeclarative.patch

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -18,6 +18,7 @@
   python3,
   llvmPackages_19,
   darwin,
+  buildPackages,
 
   # options
   developerBuild ? false,
@@ -260,14 +261,15 @@ let
         mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
       };
 
-      callPackage = self.newScope {
-        inherit
-          qtCompatVersion
-          qtModule
-          srcs
-          stdenv
-          ;
+      qtbase-bootstrap = buildPackages.qt5.qtbase.override { bootstrapBuild = true; };
+      # qtbase won't be spliced here, but that's fine as it's only a buildInput
+      qttools-bootstrap = buildPackages.qt5.qttools.override {
+        qtbase = qtbase-bootstrap;
+        qtdeclarative = null;
       };
+
+      #                              ↓Things available only to packages in the scope↓
+      callPackage = self.newScope { inherit qtbase-bootstrap qttools-bootstrap stdenv; };
     in
     {
 
@@ -342,16 +344,10 @@ let
       env = callPackage ../qt-env.nix { };
 
       qmake = callPackage (
-        { qtbase }:
+        { qtbase-bootstrap }:
         makeSetupHook {
           name = "qmake-hook";
-          ${
-            if stdenv.buildPlatform == stdenv.hostPlatform then
-              "propagatedBuildInputs"
-            else
-              "depsTargetTargetPropagated"
-          } =
-            [ qtbase.dev ];
+          propagatedBuildInputs = [ qtbase-bootstrap.qmake ];
           substitutions = {
             inherit debug;
             fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
@@ -379,25 +375,10 @@ let
       full = throw "libsForQt5.full has been removed. Please use individual packages instead."; # Added 2025-10-18
     };
 
-  baseScope = makeScopeWithSplicing' {
+  finalScope = makeScopeWithSplicing' {
     otherSplices = generateSplicesForMkScope "qt5";
     f = addPackages;
   };
 
-  bootstrapScope = baseScope.overrideScope (
-    final: prev: {
-      qtbase = prev.qtbase.override { qttranslations = null; };
-      qtdeclarative = null;
-    }
-  );
-
-  finalScope = baseScope.overrideScope (
-    final: prev: {
-      # qttranslations causes eval-time infinite recursion when
-      # cross-compiling; disabled for now.
-      qttranslations =
-        if stdenv.buildPlatform == stdenv.hostPlatform then bootstrapScope.qttranslations else null;
-    }
-  );
 in
 finalScope

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -10,7 +10,6 @@
   generateSplicesForMkScope,
   lib,
   stdenv,
-  gcc14Stdenv,
   fetchurl,
   fetchgit,
   fetchpatch,
@@ -254,15 +253,12 @@ let
   addPackages =
     self:
     let
-      qtModuleWithStdenv =
-        stdenv:
-        callPackage ../qtModule.nix {
-          inherit patches;
-          # Use a variant of mkDerivation that does not include wrapQtApplications
-          # to avoid cyclic dependencies between Qt modules.
-          mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
-        };
-      qtModule = qtModuleWithStdenv stdenv;
+      qtModule = callPackage ../qtModule.nix {
+        inherit patches;
+        # Use a variant of mkDerivation that does not include wrapQtApplications
+        # to avoid cyclic dependencies between Qt modules.
+        mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
+      };
 
       callPackage = self.newScope {
         inherit
@@ -328,22 +324,14 @@ let
       qtvirtualkeyboard = callPackage ../modules/qtvirtualkeyboard.nix { };
       qtwayland = callPackage ../modules/qtwayland.nix { };
       qtwebchannel = callPackage ../modules/qtwebchannel.nix { };
-      qtwebengine =
-        # Actually propagating stdenv change
-        let
-          # Won’t build with Clang 20, as `-Wenum-constexpr-conversion`
-          # was made a hard error.
-          # qt5webengine no longer maintained, FTBFS with GCC 15
-          stdenv' = if stdenv.cc.isClang then llvmPackages_19.stdenv else gcc14Stdenv;
-          qtModule' = qtModuleWithStdenv stdenv';
-        in
-        callPackage ../modules/qtwebengine.nix {
-          inherit (srcs.qtwebengine) version;
-          inherit (darwin) bootstrap_cmds;
-          stdenv = stdenv';
-          qtModule = qtModule';
-          python = python3;
-        };
+      qtwebengine = callPackage ../modules/qtwebengine.nix {
+        # Won’t build with Clang 20, as `-Wenum-constexpr-conversion`
+        # was made a hard error.
+        stdenv = if stdenv.cc.isClang then llvmPackages_19.stdenv else stdenv;
+        inherit (srcs.qtwebengine) version;
+        inherit (darwin) bootstrap_cmds;
+        python = python3;
+      };
       qtwebglplugin = callPackage ../modules/qtwebglplugin.nix { };
       qtwebkit = callPackage ../modules/qtwebkit.nix { };
       qtwebsockets = callPackage ../modules/qtwebsockets.nix { };

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -62,6 +62,7 @@ let
       # add version specific QML import path
       ./qtdeclarative-qml-paths.patch
       ./qtdeclarative-gcc15.patch
+      ./qtdeclarative-cross-build.patch
     ];
     qtlocation = lib.optionals stdenv.cc.isClang [
       # Fix build with Clang 16

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -60,6 +60,7 @@ let
       ./qtdeclarative-default-disable-qmlcache.patch
       # add version specific QML import path
       ./qtdeclarative-qml-paths.patch
+      ./qtdeclarative-gcc15.patch
     ];
     qtlocation = lib.optionals stdenv.cc.isClang [
       # Fix build with Clang 16

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -250,7 +250,10 @@ let
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch
     ];
-    qttools = [ ./qttools.patch ];
+    qttools = [
+      ./qttools.patch
+      ./qttools-cross-build.patch
+    ];
   };
 
   addPackages =

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -231,6 +231,18 @@ let
       ./qtwebkit.patch
       ./qtwebkit-icu68.patch
       ./qtwebkit-cstdint.patch
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/84f3c61c46bce99bfbd70d8c202e022d62f2ea9a/f/qtwebkit-icu76.patch";
+        sha256 = "sha256-Z+ot7R5Dy+F08FbcXzN4MB2ttxLg0I0P8uVErpbFiu4=";
+      })
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/84f3c61c46bce99bfbd70d8c202e022d62f2ea9a/f/webkit-offlineasm-warnings-ruby27.patch";
+        sha256 = "sha256-g+qkAJD78lPdZzZZ910SZqk0yJlJIBZh9ue4ClRD5L4=";
+      })
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/84f3c61c46bce99bfbd70d8c202e022d62f2ea9a/f/qtwebkit-fix-build-gcc14.patch";
+        sha256 = "sha256-K7TgGux34dMN0Mnm4EsJhNKLdy1VdKTAE3HGRD8KARU=";
+      })
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       ./qtwebkit-darwin-no-readline.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0015-qtbase-cross-build.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0015-qtbase-cross-build.patch
@@ -1,0 +1,197 @@
+diff --git a/mkspecs/features/device_config.prf b/mkspecs/features/device_config.prf
+index c15559e174..023a4bcb35 100644
+--- a/mkspecs/features/device_config.prf
++++ b/mkspecs/features/device_config.prf
+@@ -1,9 +1,5 @@
+ # This file is loaded by some qmakespecs to get early configuration data.
+ 
+-# Some of these qmakespecs can be used also in host mode, but they are not
+-# supposed to be influenced by -device-option then.
+-host_build: return()
+-
+ DEVICE_PRI = $$[QT_HOST_DATA/get]/mkspecs/qdevice.pri
+ exists($$DEVICE_PRI):include($$DEVICE_PRI)
+ unset(DEVICE_PRI)
+diff --git a/mkspecs/features/qt_build_config.prf b/mkspecs/features/qt_build_config.prf
+index 511b158b91..70d1e10611 100644
+--- a/mkspecs/features/qt_build_config.prf
++++ b/mkspecs/features/qt_build_config.prf
+@@ -15,6 +15,13 @@
+         debug(1, "Cannot load qmodule.pri!")
+     } else {
+         debug(1, "Loaded qmodule.pri from ($$QMAKE_QT_MODULE)")
++
++        # Yeah, there are multiple pkg-config related varialbes and functions
++        # that are used throughout QT modules somewhat interchangeably.
++        # As we're now trying to build all packaged binaries for the hostPlatform
++        # only, let's not create even more confusion and just follow a simple rule:
++        # always get pkg-config from the PKG_CONFIG env variable.
++        PKG_CONFIG_EXECUTABLE = $$(PKG_CONFIG)
+     }
+ } else {
+     debug(1, "Not loading qmodule.pri twice")
+diff --git a/mkspecs/features/qt_configure.prf b/mkspecs/features/qt_configure.prf
+index 6537d98c5d..19ed05db61 100644
+--- a/mkspecs/features/qt_configure.prf
++++ b/mkspecs/features/qt_configure.prf
+@@ -423,16 +423,7 @@ defineReplace(qtConfPkgConfigEnv) {
+ }
+ 
+ defineReplace(qtConfPkgConfig) {
+-    host = $$1
+-    isEmpty(host): host = false
+-
+-    $$host {
+-        pkg_config = $$qtConfFindInPath("pkg-config")
+-    } else {
+-        pkg_config = "$$qtConfPkgConfigEnv()$$PKG_CONFIG_EXECUTABLE"
+-    }
+-
+-    return($$pkg_config)
++    return($$getenv("PKG_CONFIG"))
+ }
+ 
+ defineTest(qtConfPkgConfigPackageExists) {
+diff --git a/mkspecs/features/qt_tool.prf b/mkspecs/features/qt_tool.prf
+index a8d589f0fa..3d0f832a6b 100644
+--- a/mkspecs/features/qt_tool.prf
++++ b/mkspecs/features/qt_tool.prf
+@@ -18,7 +18,7 @@ DEFINES *= QT_USE_QSTRINGBUILDER
+ # If we are doing a prefix build, create a "module" pri which enables
+ # qtPrepareTool() to work with the non-installed build.
+ # Non-bootstrapped tools always need this because of the environment setup.
+-!build_pass:if(!host_build|!force_bootstrap|force_independent|!isEmpty(HOST_QT_TOOLS)) {
++!build_pass:if(!host_build|!force_bootstrap|force_independent|cross_compile) {
+     isEmpty(MODULE):MODULE = $$TARGET
+ 
+     load(qt_build_paths)
+@@ -27,7 +27,7 @@ DEFINES *= QT_USE_QSTRINGBUILDER
+ 
+     vars = binary depends
+ 
+-    !host_build|isEmpty(HOST_QT_TOOLS) {
++    !host_build|!cross_compile {
+         load(resolve_target)
+ 
+         !host_build|!force_bootstrap: MODULE_DEPENDS = $$replace(QT, -private$, _private)
+@@ -55,6 +55,10 @@ DEFINES *= QT_USE_QSTRINGBUILDER
+         bin = $${HOST_QT_TOOLS}/$${TARGET}
+         equals(QMAKE_HOST.os, Windows): bin = $${bin}.exe
+         bin = $$system_path($$bin)
++        !exists($$bin) {
++            # search in PATH as a fallback
++            bin = $$system("command -v $${TARGET}")
++        }
+     }
+ 
+     TOOL_PRI_CONT = \
+diff --git a/src/corelib/Qt5CoreConfigExtras.cmake.in b/src/corelib/Qt5CoreConfigExtras.cmake.in
+index be07a2e1e8..0b9c425ec8 100644
+--- a/src/corelib/Qt5CoreConfigExtras.cmake.in
++++ b/src/corelib/Qt5CoreConfigExtras.cmake.in
+@@ -5,30 +5,20 @@ endif()
+ if (NOT TARGET Qt5::qmake)
+     add_executable(Qt5::qmake IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Core_check_file_exists(${imported_location})
++    find_program(qmake_imported_location \"qmake$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qmake PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qmake_imported_location}
+     )
+ endif()
+ 
+ if (NOT TARGET Qt5::moc)
+     add_executable(Qt5::moc IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Core_check_file_exists(${imported_location})
++    find_program(moc_imported_location \"moc$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::moc PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${moc_imported_location}
+     )
+     # For CMake automoc feature
+     get_target_property(QT_MOC_EXECUTABLE Qt5::moc LOCATION)
+@@ -37,15 +27,10 @@ endif()
+ if (NOT TARGET Qt5::rcc)
+     add_executable(Qt5::rcc IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Core_check_file_exists(${imported_location})
++    find_program(rcc_imported_location \"rcc$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::rcc PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${rcc_imported_location}
+     )
+ endif()
+ 
+diff --git a/src/dbus/Qt5DBusConfigExtras.cmake.in b/src/dbus/Qt5DBusConfigExtras.cmake.in
+index b13b964ec8..f4b7109037 100644
+--- a/src/dbus/Qt5DBusConfigExtras.cmake.in
++++ b/src/dbus/Qt5DBusConfigExtras.cmake.in
+@@ -2,22 +2,20 @@
+ if (NOT TARGET Qt5::qdbuscpp2xml)
+     add_executable(Qt5::qdbuscpp2xml IMPORTED)
+ 
+-    set(imported_location \"$$NIX_OUTPUT_DEV/bin/qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+-    _qt5_DBus_check_file_exists(${imported_location})
++    find_program(qdbuscpp2xml_imported_location \"qdbuscpp2xml$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qdbuscpp2xml PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qdbuscpp2xml_imported_location}
+     )
+ endif()
+ 
+ if (NOT TARGET Qt5::qdbusxml2cpp)
+     add_executable(Qt5::qdbusxml2cpp IMPORTED)
+ 
+-    set(imported_location \"$$NIX_OUTPUT_DEV/bin/qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+-    _qt5_DBus_check_file_exists(${imported_location})
++    find_program(qdbusxml2cpp_imported_location \"qdbusxml2cpp$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qdbusxml2cpp PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qdbusxml2cpp_imported_location}
+     )
+ endif()
+ 
+diff --git a/src/widgets/Qt5WidgetsConfigExtras.cmake.in b/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+index ca0b8e4bfb..f49f09fed2 100644
+--- a/src/widgets/Qt5WidgetsConfigExtras.cmake.in
++++ b/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+@@ -2,15 +2,10 @@
+ if (NOT TARGET Qt5::uic)
+     add_executable(Qt5::uic IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Widgets_check_file_exists(${imported_location})
++    find_program(uic_imported_location \"uic$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::uic PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${uic_imported_location}
+     )
+ endif()
+ 

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0016-qtbase-cross-build-postFixup.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0016-qtbase-cross-build-postFixup.patch
@@ -1,0 +1,40 @@
+diff --git a/mkspecs/features/qt_build_config.prf b/mkspecs/features/qt_build_config.prf
+index 70d1e10611..ce8b9383eb 100644
+--- a/mkspecs/features/qt_build_config.prf
++++ b/mkspecs/features/qt_build_config.prf
+@@ -16,6 +16,12 @@
+     } else {
+         debug(1, "Loaded qmodule.pri from ($$QMAKE_QT_MODULE)")
+ 
++        # detect cross compilation status dynamically for the case of
++        # switching cross and natively built qtbase
++        _crossComp = $$(XQMAKESPEC)
++        isEmpty(_crossComp): CONFIG -= cross_compile
++        else: CONFIG += cross_compile
++
+         # Yeah, there are multiple pkg-config related varialbes and functions
+         # that are used throughout QT modules somewhat interchangeably.
+         # As we're now trying to build all packaged binaries for the hostPlatform
+diff --git a/mkspecs/features/qt_config.prf b/mkspecs/features/qt_config.prf
+index 93c54e3010..65552276ac 100644
+--- a/mkspecs/features/qt_config.prf
++++ b/mkspecs/features/qt_config.prf
+@@ -5,6 +5,18 @@ QMAKE_QT_CONFIG = $$[QT_HOST_DATA/get]/mkspecs/qconfig.pri
+    debug(1, "Cannot load qconfig.pri!")
+ } else {
+    debug(1, "Loaded .qconfig.pri from ($$QMAKE_QT_CONFIG)")
++
++   # detect cross compilation status dynamically for the case of
++   # switching cross and natively built qtbase
++   _crossComp = $$(XQMAKESPEC)
++   isEmpty(_crossComp) {
++      QT.global.enabled_features -= cross_compile
++      CONFIG -= cross_compile
++   } else {
++      QT.global.enabled_features += cross_compile
++      CONFIG += cross_compile
++   }
++
+    dirs = $$(QMAKEMODULES)
+    QMAKE_MODULE_PATH = $$split(dirs, $$DIRLIST_SEPARATOR)
+    QMAKE_MODULE_PATH += $$QMAKEMODULES

--- a/pkgs/development/libraries/qt-5/5.15/qtdeclarative-cross-build.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtdeclarative-cross-build.patch
@@ -1,0 +1,38 @@
+diff --git a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in
+index 8a91fb8b87..b0f7cac849 100644
+--- a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in
++++ b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in
+@@ -18,11 +18,8 @@ function(QTQUICK_COMPILER_ADD_RESOURCES outfiles)
+ 
+     find_package(Qt5 COMPONENTS Qml Core)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(compiler_path \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmlcachegen$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(compiler_path \"$${CMAKE_BIN_DIR}qmlcachegen$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    find_program(compiler_path \"qmlcachegen$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
++
+     if(NOT EXISTS \"${compiler_path}\" )
+         message(FATAL_ERROR \"The package \\\"Qt5QuickCompilerConfig\\\" references the file
+    \\\"${compiler_path}\\\"
+diff --git a/tools/qmlimportscanner/Qt5QmlImportScannerConfig.cmake.in b/tools/qmlimportscanner/Qt5QmlImportScannerConfig.cmake.in
+index f92b8d295d..c85ec4d206 100644
+--- a/tools/qmlimportscanner/Qt5QmlImportScannerConfig.cmake.in
++++ b/tools/qmlimportscanner/Qt5QmlImportScannerConfig.cmake.in
+@@ -13,12 +13,9 @@ function(QT5_IMPORT_QML_PLUGINS target)
+ 
+     # Find location of qmlimportscanner.
+     find_package(Qt5 COMPONENTS Core)
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(tool_path
+-        \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmlimportscanner$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(tool_path \"$${CMAKE_BIN_DIR}qmlimportscanner$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++
++    find_program(tool_path \"qmlimportscanner$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
++
+     if(NOT EXISTS \"${tool_path}\" )
+         message(FATAL_ERROR \"The package \\\"Qt5QmlImportScannerConfig\\\" references the file
+    \\\"${tool_path}\\\"

--- a/pkgs/development/libraries/qt-5/5.15/qtdeclarative-gcc15.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtdeclarative-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/src/qml/compiler/qv4compiler.cpp b/src/qml/compiler/qv4compiler.cpp
+index 18e19cf01c..13934eebb5 100644
+--- a/src/qml/compiler/qv4compiler.cpp
++++ b/src/qml/compiler/qv4compiler.cpp
+@@ -47,6 +47,7 @@
+ #include <private/qml_compile_hash_p.h>
+ #include <private/qqmlirbuilder_p.h>
+ #include <QCryptographicHash>
++#include <cstdint>
+ 
+ // Efficient implementation that takes advantage of powers of two.
+ static inline size_t roundUpToMultipleOf(size_t divisor, size_t x)

--- a/pkgs/development/libraries/qt-5/5.15/qttools-cross-build.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qttools-cross-build.patch
@@ -1,0 +1,139 @@
+diff --git a/src/assistant/help/Qt5HelpConfigExtras.cmake.in b/src/assistant/help/Qt5HelpConfigExtras.cmake.in
+index 1f7544b62..bd18710f9 100644
+--- a/src/assistant/help/Qt5HelpConfigExtras.cmake.in
++++ b/src/assistant/help/Qt5HelpConfigExtras.cmake.in
+@@ -2,30 +2,20 @@
+ if (NOT TARGET Qt5::qcollectiongenerator)
+     add_executable(Qt5::qcollectiongenerator IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Help_check_file_exists(${imported_location})
++    find_program(qcollectiongenerator_imported_location \"qcollectiongenerator$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qcollectiongenerator PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qcollectiongenerator_imported_location}
+     )
+ endif()
+ 
+ if (NOT TARGET Qt5::qhelpgenerator)
+     add_executable(Qt5::qhelpgenerator IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Help_check_file_exists(${imported_location})
++    find_program(qhelpgenerator_imported_location \"qhelpgenerator$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qhelpgenerator PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qhelpgenerator_imported_location}
+     )
+ endif()
+ 
+diff --git a/src/linguist/Qt5LinguistToolsConfig.cmake.in b/src/linguist/Qt5LinguistToolsConfig.cmake.in
+index 2e99bc762..36af1a596 100644
+--- a/src/linguist/Qt5LinguistToolsConfig.cmake.in
++++ b/src/linguist/Qt5LinguistToolsConfig.cmake.in
+@@ -44,45 +44,30 @@ endmacro()
+ if (NOT TARGET Qt5::lrelease)
+     add_executable(Qt5::lrelease IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lrelease$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_LinguistTools_check_file_exists(${imported_location})
++    find_program(lrelease_imported_location \"lrelease$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::lrelease PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${lrelease_imported_location}
+     )
+ endif()
+ 
+ if (NOT TARGET Qt5::lupdate)
+     add_executable(Qt5::lupdate IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lupdate$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_LinguistTools_check_file_exists(${imported_location})
++    find_program(lupdate_imported_location \"lupdate$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::lupdate PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${lupdate_imported_location}
+     )
+ endif()
+ 
+ if (NOT TARGET Qt5::lconvert)
+     add_executable(Qt5::lconvert IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_linguisttools_install_prefix}/$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}lconvert$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_LinguistTools_check_file_exists(${imported_location})
++    find_program(lconvert_imported_location \"lconvert$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::lconvert PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${lconvert_imported_location}
+     )
+ endif()
+ 
+diff --git a/src/qdoc/Qt5DocToolsConfig.cmake.in b/src/qdoc/Qt5DocToolsConfig.cmake.in
+index 2a252bb31..6b2555c4d 100644
+--- a/src/qdoc/Qt5DocToolsConfig.cmake.in
++++ b/src/qdoc/Qt5DocToolsConfig.cmake.in
+@@ -43,15 +43,10 @@ endmacro()
+ if (NOT TARGET Qt5::qdoc)
+     add_executable(Qt5::qdoc IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_qdoctools_install_prefix}/$${CMAKE_BIN_DIR}qdoc$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qdoc$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_DocTools_check_file_exists(${imported_location})
++    find_program(qdoc_imported_location \"qdoc$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qdoc PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qdoc_imported_location}
+     )
+ endif()
+ 
+diff --git a/src/qtattributionsscanner/Qt5AttributionsScannerTools.cmake.in b/src/qtattributionsscanner/Qt5AttributionsScannerTools.cmake.in
+index e99540bfa..85171c76b 100644
+--- a/src/qtattributionsscanner/Qt5AttributionsScannerTools.cmake.in
++++ b/src/qtattributionsscanner/Qt5AttributionsScannerTools.cmake.in
+@@ -43,15 +43,10 @@ endmacro()
+ if (NOT TARGET Qt5::qtattributionsscanner)
+     add_executable(Qt5::qtattributionsscanner IMPORTED)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5_qattributionsscannertools_install_prefix}/$${CMAKE_BIN_DIR}qtattributionsscanner$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qtattributionsscanner$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_AttributionsScannerTools_check_file_exists(${imported_location})
++    find_program(qtattributionsscanner_imported_location \"qtattributionsscanner$$CMAKE_BIN_SUFFIX\" PATHS ENV PATH NO_DEFAULT_PATH)
+ 
+     set_target_properties(Qt5::qtattributionsscanner PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
++        IMPORTED_LOCATION ${qtattributionsscanner_imported_location}
+     )
+ endif()
+ 

--- a/pkgs/development/libraries/qt-5/5.15/qtwebengine-cross-build.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebengine-cross-build.patch
@@ -1,0 +1,149 @@
+commit 8d8892f237a510a614311e37ebcc4d70b71b7924
+Author:     eryngion <eryngion@protonmail.com>
+AuthorDate: Fri Dec 1 10:59:02 2023 +0300
+
+    Use buildBuld version of stdenv.cc in the "host" toolchain for chromium
+    
+    Chromium builds some tools for itself as a part of its build process.
+    Those tools don't end up in outputs of Nix packages, so we can actually
+    just compile them for the buildPlatform.
+    
+    It is mostly a Nixified version of this patch
+    https://github.com/meta-qt5/meta-qt5/raw/9537acc9fdd07f2dae6ea562eed34ba41ccde39d/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
+    Plus a small change that allows v8_snapshot_toolchain to properly find ICU
+    on the buildPlatform instead of resorting to the bundled ICU as done in
+    https://github.com/meta-qt5/meta-qt5/blob/9537acc9fdd07f2dae6ea562eed34ba41ccde39d/recipes-qt/qt5/qtwebengine/chromium/0010-chromium-icu-use-system-library-only-targets.patch
+    
+    The original commentary of the first patch is below:
+    
+    From: Samuli Piippo <samuli.piippo@qt.io>
+    Date: Wed, 15 Mar 2017 13:53:28 +0200
+    Subject: [PATCH] Force host toolchain configuration
+    
+    Force gcc/g++ to be used for parts using host toolchain, since
+    the option(host_build) does not work in yocto builds.
+    
+    Don't use QT_ARCH for the host architecture, since that's always
+    the target architecture in bitbake builds, instead ask specifically
+    for the qmakes's host architecture.
+    
+    Upstream-Status: Inappropriate [OE specific]
+    Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>
+
+diff --git a/mkspecs/features/functions.prf b/mkspecs/features/functions.prf
+index 7f63058..6b658e8 100644
+--- a/mkspecs/features/functions.prf
++++ b/mkspecs/features/functions.prf
+@@ -109,6 +109,7 @@ defineReplace(gnArch) {
+     contains(qtArch, "x86_64"): return(x64)
+     contains(qtArch, "arm"): return(arm)
+     contains(qtArch, "arm64"): return(arm64)
++    contains(qtArch, "aarch64"): return(arm64)
+     contains(qtArch, "mips"): return(mipsel)
+     contains(qtArch, "mips64"): return(mips64el)
+     contains(qtArch, "mips64el"): return(mips64el)
+diff --git a/src/buildtools/config/linux.pri b/src/buildtools/config/linux.pri
+index 7507d51..5bc9c1b 100644
+--- a/src/buildtools/config/linux.pri
++++ b/src/buildtools/config/linux.pri
+@@ -118,7 +118,7 @@ contains(QT_ARCH, "mips") {
+ 
+ host_build {
+     gn_args += custom_toolchain=\"$$QTWEBENGINE_OUT_ROOT/src/toolchain:host\"
+-    GN_HOST_CPU = $$gnArch($$QT_ARCH)
++    GN_HOST_CPU = $$gnArch($$QMAKE_HOST.arch)
+     gn_args += host_cpu=\"$$GN_HOST_CPU\"
+     # Don't bother trying to use system libraries in this case
+     gn_args += use_glib=false
+@@ -138,7 +138,7 @@ host_build {
+         # Strip '>2 /dev/null' from $$pkgConfigExecutable()
+         PKGCONFIG = $$first($$list($$pkgConfigExecutable()))
+         gn_args += pkg_config=\"$$PKGCONFIG\"
+-        PKG_CONFIG_HOST = $$(GN_PKG_CONFIG_HOST)
++        PKG_CONFIG_HOST = $$(PKG_CONFIG_FOR_BUILD)
+         pkgConfigLibDir = $$(PKG_CONFIG_LIBDIR)
+         pkgConfigSysrootDir = $$(PKG_CONFIG_SYSROOT_DIR)
+         isEmpty(PKG_CONFIG_HOST): cross_compile {
+diff --git a/src/buildtools/configure_host.pro b/src/buildtools/configure_host.pro
+index dd0d3e3..8703801 100644
+--- a/src/buildtools/configure_host.pro
++++ b/src/buildtools/configure_host.pro
+@@ -4,7 +4,7 @@ TEMPLATE = aux
+ # Pick up the host toolchain
+ option(host_build)
+ 
+-GN_HOST_CPU = $$gnArch($$QT_ARCH)
++GN_HOST_CPU = $$gnArch($$QMAKE_HOST.arch)
+ !isEmpty(QT_TARGET_ARCH): GN_TARGET_CPU = $$gnArch($$QT_TARGET_ARCH)
+ else: GN_TARGET_CPU = $$GN_HOST_CPU
+ GN_OS = $$gnOS()
+@@ -23,20 +23,17 @@ contains(GN_TARGET_CPU, "arm")|contains(GN_TARGET_CPU, "mipsel")|contains(GN_TAR
+     else: contains(GN_V8_HOST_CPU, mips64el): GN_V8_HOST_CPU = "mipsel"
+ }
+ 
+-GN_HOST_EXTRA_CPPFLAGS = $$(GN_HOST_TOOLCHAIN_EXTRA_CPPFLAGS)
+-
+ # We always use the gcc_toolchain, because clang_toolchain is just
+ # a broken wrapper around it for Google's custom clang binaries.
+ GN_CONTENTS = \
+ "import(\"//build/config/sysroot.gni\")" \
+ "import(\"//build/toolchain/gcc_toolchain.gni\")" \
+ "gcc_toolchain(\"host\") {" \
+-"  cc = \"$$which($$QMAKE_CC)\" " \
+-"  cxx = \"$$which($$QMAKE_CXX)\" " \
+-"  ld = \"$$which($$QMAKE_LINK)\" " \
+-"  ar = \"$$which(ar)\" " \
+-"  nm = \"$$which(nm)\" " \
+-"  extra_cppflags = \"$$GN_HOST_EXTRA_CPPFLAGS\" " \
++"  cc = \"$$which($$(CC_FOR_BUILD))\" " \
++"  cxx = \"$$which($$(CXX_FOR_BUILD))\" " \
++"  ld = \"$$which($$(CXX_FOR_BUILD))\" " \
++"  ar = \"$$which($$(AR_FOR_BUILD))\" " \
++"  nm = \"$$which($$(NM_FOR_BUILD))\" " \
+ "  toolchain_args = { " \
+ "    current_os = \"$$GN_OS\" " \
+ "    current_cpu = \"$$GN_HOST_CPU\" " \
+@@ -45,11 +42,11 @@ GN_CONTENTS = \
+ "  } " \
+ "}" \
+ "gcc_toolchain(\"v8_snapshot\") {" \
+-"  cc = \"$$which($$QMAKE_CC)\" " \
+-"  cxx = \"$$which($$QMAKE_CXX)\" " \
+-"  ld = \"$$which($$QMAKE_LINK)\" " \
+-"  ar = \"$$which(ar)\" " \
+-"  nm = \"$$which(nm)\" " \
++"  cc = \"$$which($$(CC_FOR_BUILD))\" " \
++"  cxx = \"$$which($$(CXX_FOR_BUILD))\" " \
++"  ld = \"$$which($$(CXX_FOR_BUILD))\" " \
++"  ar = \"$$which($$(AR_FOR_BUILD))\" " \
++"  nm = \"$$which($$(NM_FOR_BUILD))\" " \
+ "  toolchain_args = { " \
+ "    current_os = \"$$GN_OS\" " \
+ "    current_cpu = \"$$GN_V8_HOST_CPU\" " \
+diff --git a/src/buildtools/gn.pro b/src/buildtools/gn.pro
+index f94694d..8035d5a 100644
+--- a/src/buildtools/gn.pro
++++ b/src/buildtools/gn.pro
+@@ -19,9 +19,8 @@ build_pass|!debug_and_release {
+             gn_bootstrap = $$system_path($$absolute_path(gn/build/gen.py, $$src_3rd_party_dir))
+ 
+             gn_gen_args = --no-last-commit-position --out-path $$out_path \
+-                          --cc \"$$which($$QMAKE_CC)\" --cxx \"$$which($$QMAKE_CXX)\" \
+-                          --ld \"$$which($$QMAKE_LINK)\"
+-            !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
++                          --cc \"$$which($$(CC_FOR_BUILD))\" --cxx \"$$which($$(CXX_FOR_BUILD))\" \
++                          --ld \"$$which($$(CXX_FOR_BUILD))\" --ar \"$$which($$(AR_FOR_BUILD))\"
+ 
+             msvc:!clang_cl: gn_gen_args += --use-lto
+ 
+--- a/src/3rdparty/chromium/build/config/linux/pkg_config.gni
++++ b/src/3rdparty/chromium/build/config/linux/pkg_config.gni
+@@ -91,7 +91,7 @@
+   assert(defined(invoker.packages),
+          "Variable |packages| must be defined to be a list in pkg_config.")
+   config(target_name) {
+-    if (host_toolchain == current_toolchain) {
++    if (default_toolchain != current_toolchain) {
+       args = host_pkg_config_args + invoker.packages
+     } else {
+       args = pkg_config_args + invoker.packages

--- a/pkgs/development/libraries/qt-5/hooks/fix-qt-module-paths.sh
+++ b/pkgs/development/libraries/qt-5/hooks/fix-qt-module-paths.sh
@@ -4,6 +4,15 @@
 #
 # Find Qt module definitions in directory _dir_ and patch the module paths.
 #
+
+lndir() {
+    local link_to_dir=$(realpath "$1")
+    local link_from_dir=$(realpath "$2")
+    for f in $(ls "$link_to_dir"); do
+        ln -s "$link_to_dir/$f" "$link_from_dir/$f"
+    done
+}
+
 fixQtModulePaths () {
     local dir="$1"
     local bin="${!outputBin}"
@@ -30,7 +39,7 @@ fixQtModulePaths () {
     if [ "z$bin" != "z$dev" ]; then
         if [ -d "$bin/bin" ]; then
             mkdir -p "$dev/bin"
-            lndir -silent "$bin/bin" "$dev/bin"
+            lndir "$bin/bin" "$dev/bin"
         fi
     fi
 }

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -1,5 +1,15 @@
 . @fix_qmake_libtool@
 
+# Split qmakeFlags if it's not an array already (i.e. comes from a derivation
+# with __structuredAttrs disabled). This will be important later when we pass
+# it to qmake: qmakeFlags can contain file names and other options that must
+# be separate words in the command.
+local type=$(declare -p qmakeFlags)
+local typeArray='declare -a'
+if [[ "${type:0:${#typeArray}}" == "$typeArray" ]]; then
+    qmakeFlags=( ${qmakeFlags-} )
+fi
+
 qmakePrePhase() {
     # These flags must be added _before_ the flags specified in the derivation.
     prependToVar qmakeFlags \

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -30,12 +30,24 @@ else
     cmakeBuildType="Release"
 fi
 
-if [[ -n "@qtPlatformCross@" ]]; then
+isCrossBuild() {
+    # Check if the tool is prefixed. Will probably break on Windows.
+    # Maybe we should have a standard variable for this?
+    [[ -v AS ]] && [[ "${#AS}" -gt 2 ]]
+}
+
+if isCrossBuild; then
     # When cross compiling we're using a native-built qmake binary and
     # it will need a little help finding the target of cross compilation.
+    if [[ "$(uname)" == 'Linux' ]]; then
+       qtPlatformCross="linux-generic-g++"
+    else
+        echo "Please add a qtPlatformCross entry for $(uname)" >&2
+        exit 1
+    fi
 
     # Enable cross-compilation in qmake
-    export "XQMAKESPEC=devices/@qtPlatformCross@"
+    export "XQMAKESPEC=devices/$qtPlatformCross"
     # Use the same config for tools marked with host_build
     export "QMAKESPEC=$XQMAKESPEC"
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -39,17 +39,16 @@ isCrossBuild() {
 if isCrossBuild; then
     # When cross compiling we're using a native-built qmake binary and
     # it will need a little help finding the target of cross compilation.
-    if [[ "$(uname)" == 'Linux' ]]; then
-       qtPlatformCross="linux-generic-g++"
+    if nixCrossConf="$(basename $(ls -d @dev@/mkspecs/*-nix-cross))"; then
+        # Force qmake to use this config as the target instead of QMAKE_XSPEC
+        # that was baked into it at compile time.
+        export "XQMAKESPEC=$nixCrossConf"
+        # Use the same config for tools marked with host_build
+        export "QMAKESPEC=$XQMAKESPEC"
     else
-        echo "Please add a qtPlatformCross entry for $(uname)" >&2
+        echo "Please add a qtPlatformCross entry for $($CC -dumpmachine)" >&2
         exit 1
     fi
-
-    # Enable cross-compilation in qmake
-    export "XQMAKESPEC=devices/$qtPlatformCross"
-    # Use the same config for tools marked with host_build
-    export "QMAKESPEC=$XQMAKESPEC"
 fi
 
 providesQtRuntime() {

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -30,12 +30,25 @@ else
     cmakeBuildType="Release"
 fi
 
+if [[ -n "@qtPlatformCross@" ]]; then
+    # When cross compiling we're using a native-built qmake binary and
+    # it will need a little help finding the target of cross compilation.
+
+    # Enable cross-compilation in qmake
+    export "XQMAKESPEC=devices/@qtPlatformCross@"
+    # Use the same config for tools marked with host_build
+    export "QMAKESPEC=$XQMAKESPEC"
+fi
+
 providesQtRuntime() {
     [ -d "$1/$qtPluginPrefix" ] || [ -d "$1/$qtQmlPrefix" ]
 }
 
+if ! QMAKE="$(PATH="$_PATH" command -v qmake)"; then
+    echo "FYI: can't find a runnable qmake in PATH. If nothing breaks than it's perfectly fine."
+    echo "Otherwise you should add qmake or qtbase.qmake to nativeBuildInputs."
+fi
 # Build tools are often confused if QMAKE is unset.
-QMAKE=@dev@/bin/qmake
 export QMAKE
 
 QMAKEPATH=

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -77,7 +77,7 @@ qmakePathHook() {
         QMAKEPATH="${QMAKEPATH}${QMAKEPATH:+:}$1"
     fi
 }
-envBuildHostHooks+=(qmakePathHook)
+envHostTargetHooks+=(qmakePathHook)
 
 # Propagate any runtime dependency of the building package.
 # Each dependency is propagated to the user environment and as a build

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -41,9 +41,6 @@ export QMAKE
 QMAKEPATH=
 export QMAKEPATH
 
-QMAKEMODULES=
-export QMAKEMODULES
-
 declare -Ag qmakePathSeen=()
 qmakePathHook() {
     # Skip this path if we have seen it before.
@@ -52,7 +49,6 @@ qmakePathHook() {
     qmakePathSeen[$1]=1
     if [ -d "$1/mkspecs" ]
     then
-        QMAKEMODULES="${QMAKEMODULES}${QMAKEMODULES:+:}/mkspecs"
         QMAKEPATH="${QMAKEPATH}${QMAKEPATH:+:}$1"
     fi
 }

--- a/pkgs/development/libraries/qt-5/hooks/qttools-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qttools-setup-hook.sh
@@ -1,1 +1,15 @@
-appendToVar qmakeFlags "QMAKE_LRELEASE=@dev@/bin/lrelease"
+# Nowadays lrelease feature in mkspecs of qtbase can automatically find the tool in PATH with qtPrepareTool
+# and process TRANSLATIONS if the pro file has CONFIG+=lrelease in it.
+# But for some reason QMAKE_LRELEASE from qtPrepareTool does not propagate to the pro file itself, and some
+# packages still use QMAKE_LRELEASE directly, so we'll need to pass it explicitly until there's a better
+# mkspecs based solution.
+# NB: this could be non-overridable via qmakeFlags attribute in a package due to hook ordering.
+
+if [[ -z "${__nix_qttoolsHook-}" ]]; then
+    __nix_qttoolsHook=1  # Don't run this hook more than once.
+
+    if ! appendToVar qmakeFlags "QMAKE_LRELEASE=$(PATH="$_PATH" command -v lrelease)" ; then
+        echo "FYI: can't find a runnable lrelease in PATH. If this package doesn't use it than it's perfectly fine."
+        echo "Otherwise you should add qttools to nativeBuildInputs."
+    fi
+fi

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -56,7 +56,6 @@
   withGtk3 ? false,
   dconf,
   gtk3,
-  withQttranslation ? true,
   qttranslations ? null,
   withLibinput ? false,
   libinput,
@@ -492,8 +491,7 @@ stdenv.mkDerivation (
             "-I"
             "${libmysqlclient}/include"
           ]
-          ++ lib.optional (withQttranslation && (qttranslations != null)) [
-            # depends on x11
+          ++ lib.optional (qttranslations != null) [
             "-translationdir"
             "${qttranslations}/translations"
           ]

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -78,13 +78,23 @@
 let
   debugSymbols = debug || developerBuild;
   isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
+
   qtPlatformCross =
-    plat:
-    with plat;
+    with stdenv.hostPlatform;
     if isLinux then
-      "linux-generic-g++"
+      "devices/linux-generic-g++"
+    else if isDarwin then
+      # the logic from the configure script
+      if isAarch64 then "macx-clang-arm64" else "macx-clang-x64"
+    else if isCrossBuild then
+      throw "Please add a qtPlatformCross entry for ${config}"
     else
-      throw "Please add a qtPlatformCross entry for ${plat.config}";
+      null;
+
+  # We need to keep the original mkspec name in the string for pyqt-builder to determine
+  # the target platform.
+  nixCrossConf = builtins.baseNameOf qtPlatformCross + "-nix-cross";
+
   postFixupPatch = ../${lib.versions.majorMinor version}/qtbase.patch.d/0016-qtbase-cross-build-postFixup.patch;
 
 in
@@ -292,20 +302,19 @@ stdenv.mkDerivation (
 
         ./bin/syncqt.pl -version $version
 
-        # generate a cross compilation config unconditionally so we can pass a natively-built qtbase
-        # as a build dependency for a cross build and to avoid specifying CROSS_COMPILE prefix for qmake later
-        sed -i '1 i CROSS_COMPILE=${
-          stdenv.hostPlatform.config + "-"
-        }' mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
-        echo 'QMAKE_PKG_CONFIG=''$''$(PKG_CONFIG)' >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
-
-        # does this flag propagation really do anything?
-        echo "QMAKE_LFLAGS=''${LDFLAGS}" >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
-        echo "QMAKE_CFLAGS=''${CFLAGS}" >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
-        echo "QMAKE_CXXFLAGS=''${CXXFLAGS}" >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
       ''
+      # generate a cross compilation config even for native builds so we can pass a natively-built qtbase
+      # as a build dependency for a cross build and to avoid specifying CROSS_COMPILE prefix for qmake later
+      + lib.optionalString (qtPlatformCross != null) ''
+        mkdir mkspecs/${nixCrossConf}
+        echo 'CROSS_COMPILE=${stdenv.hostPlatform.config + "-"}' > mkspecs/${nixCrossConf}/qmake.conf
+        echo 'QMAKE_PKG_CONFIG=''$''$(PKG_CONFIG)' >> mkspecs/${nixCrossConf}/qmake.conf
+        echo 'include(../${qtPlatformCross}/qmake.conf)' >> mkspecs/${nixCrossConf}/qmake.conf
+        echo '#include "../${qtPlatformCross}/qplatformdefs.h"' > mkspecs/${nixCrossConf}/qplatformdefs.h
+
+      ''
+      # QT's configure script will refuse to use pkg-config unless these two environment variables are set
       + lib.optionalString isCrossBuild ''
-        # QT's configure script will refuse to use pkg-config unless these two environment variables are set
         export PKG_CONFIG_SYSROOT_DIR=/
         export PKG_CONFIG_LIBDIR=${lib.getLib pkg-config}/lib
       '';
@@ -473,6 +482,10 @@ stdenv.mkDerivation (
               "-system-libpng"
 
             ]
+            ++ lib.optional (qttranslations != null) [
+              "-translationdir"
+              "${qttranslations}/translations"
+            ]
             ++ (
               # regular build, Darwin options
               # regular build, other Unixes options
@@ -513,10 +526,6 @@ stdenv.mkDerivation (
                 "-I"
                 "${libmysqlclient}/include/mysql"
               ]
-              ++ lib.optional (qttranslations != null) [
-                "-translationdir"
-                "${qttranslations}/translations"
-              ]
 
             )
           )
@@ -524,7 +533,7 @@ stdenv.mkDerivation (
 
       # cross compilation options
       ++ lib.optionals isCrossBuild [
-        "-device ${qtPlatformCross stdenv.hostPlatform}"
+        "-xplatform ${nixCrossConf}"
         "-external-hostbindir ${qtbase-bootstrap.qmake}/bin"
       ]
 

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -63,8 +63,7 @@
   # options
   libGLSupported ? !stdenv.hostPlatform.isDarwin,
   libGL,
-  # qmake detection for libmysqlclient does not seem to work when cross compiling
-  mysqlSupport ? stdenv.hostPlatform == stdenv.buildPlatform,
+  mysqlSupport ? true,
   libmysqlclient,
   buildExamples ? false,
   buildTests ? false,
@@ -487,9 +486,9 @@ stdenv.mkDerivation (
           ]
           ++ lib.optionals mysqlSupport [
             "-L"
-            "${libmysqlclient}/lib"
+            "${libmysqlclient}/lib/mysql"
             "-I"
-            "${libmysqlclient}/include"
+            "${libmysqlclient}/include/mysql"
           ]
           ++ lib.optional (qttranslations != null) [
             "-translationdir"

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -69,6 +69,7 @@
   buildTests ? false,
   debug ? false,
   developerBuild ? false,
+  bootstrapBuild ? false,
   decryptSslTraffic ? false,
   testers,
   buildPackages,
@@ -186,6 +187,7 @@ stdenv.mkDerivation (
         "bin"
         "dev"
         "out"
+        "qmake"
       ];
 
       inherit patches;
@@ -215,6 +217,10 @@ stdenv.mkDerivation (
         sed -i '/PATHS.*NO_DEFAULT_PATH/ d' src/corelib/Qt5CoreMacros.cmake
         sed -i 's/NO_DEFAULT_PATH//' src/gui/Qt5GuiConfigExtras.cmake.in
         sed -i '/PATHS.*NO_DEFAULT_PATH/ d' mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+
+        # Always build uic and qvkgen for qtbase-bootstrap
+        sed -i '/^TOOLS =/ s/$/ src_tools_qvkgen src_tools_uic/' src/src.pro
+        sed -i '/^SUBDIRS += src_corelib/ s/$/ src_tools_qvkgen src_tools_uic/' src/src.pro
 
         # https://bugs.gentoo.org/803470
         sed -i 's/-lpthread/-pthread/' mkspecs/common/linux.conf src/corelib/configure.json
@@ -350,37 +356,166 @@ stdenv.mkDerivation (
     // {
       # TODO Remove obsolete and useless flags once the build will be totally mastered
       configureFlags = [
-        "-plugindir $(out)/$(qtPluginPrefix)"
-        "-qmldir $(out)/$(qtQmlPrefix)"
-        "-docdir $(out)/$(qtDocPrefix)"
-
+        # common options for all types of builds
         "-verbose"
         "-confirm-license"
         "-opensource"
 
         "-release"
         "-shared"
-        "-accessibility"
-        "-optimized-qmake"
         # for separateDebugInfo
         "-no-strip"
-        "-system-proxies"
         "-pkg-config"
 
-        "-gui"
-        "-widgets"
-        "-opengl desktop"
+        "-make tools"
+        "-${lib.optionalString (!buildExamples || bootstrapBuild) "no"}make examples"
+        "-${lib.optionalString (!buildTests) "no"}make tests"
+
         "-icu"
         "-L"
         "${icu.out}/lib"
         "-I"
         "${icu.dev}/include"
         "-pch"
+        "-system-zlib"
+        "-L"
+        "${zlib.out}/lib"
+        "-I"
+        "${zlib.dev}/include"
+
       ]
+      ++ (
+        if stdenv.hostPlatform.isDarwin then
+          [
+            "-no-fontconfig"
+            "-no-framework"
+            "-no-rpath"
+          ]
+        else
+          [
+            "-rpath"
+          ]
+      )
+      # a bare bones build only to get build tools and mkspecs
+      ++ (
+        if bootstrapBuild then
+          [
+            # We probably can go slimmer than this with some patching and/or selective run of Makefiles
+            # but this is already good enough.
+            "-no-gui"
+            "-no-widgets"
+            "-no-feature-sqlmodel"
+            "-no-sql-sqlite"
+            "-no-feature-bearermanagement"
+            "-no-feature-netlistmgr"
+            "-no-feature-networkdiskcache"
+            "-no-feature-networkinterface"
+            "-no-feature-networkproxy"
+            "-no-feature-concurrent"
+            "-no-feature-dnslookup"
+            "-no-feature-dtls"
+            "-no-feature-ftp"
+            "-no-feature-http"
+            "-no-feature-gssapi"
+            "-no-feature-localserver"
+            "-no-feature-ocsp"
+            "-no-feature-socks5"
+            "-no-feature-sspi"
+            "-no-feature-udpsocket"
+          ]
+        else
+          (
+            # regular build, platform-independent options
+            [
+              "-gui"
+              "-widgets"
+              "-opengl desktop"
+              "-accessibility"
+              "-system-proxies"
+              "-make libs"
+
+              "-plugindir $(out)/$(qtPluginPrefix)"
+              "-qmldir $(out)/$(qtQmlPrefix)"
+              "-docdir $(out)/$(qtDocPrefix)"
+
+              "-system-libjpeg"
+              "-L"
+              "${libjpeg.out}/lib"
+              "-I"
+              "${libjpeg.dev}/include"
+              "-system-harfbuzz"
+              "-L"
+              "${harfbuzz.out}/lib"
+              "-I"
+              "${harfbuzz.dev}/include"
+              "-system-pcre"
+              "-openssl-linked"
+              "-L"
+              "${lib.getLib openssl}/lib"
+              "-I"
+              "${openssl.dev}/include"
+              "-system-sqlite"
+              "-${if mysqlSupport then "plugin" else "no"}-sql-mysql"
+              "-${if libpq != null then "plugin" else "no"}-sql-psql"
+              "-system-libpng"
+
+            ]
+            ++ (
+              # regular build, Darwin options
+              # regular build, other Unixes options
+              [
+                "-xcb"
+                "-qpa xcb"
+                "-L"
+                "${libX11.out}/lib"
+                "-I"
+                "${libX11.out}/include"
+                "-L"
+                "${libXext.out}/lib"
+                "-I"
+                "${libXext.out}/include"
+                "-L"
+                "${libXrender.out}/lib"
+                "-I"
+                "${libXrender.out}/include"
+
+                "-${lib.optionalString (cups == null) "no-"}cups"
+                "-dbus-linked"
+                "-glib"
+              ]
+              ++ lib.optional withGtk3 "-gtk"
+              ++ lib.optional withLibinput "-libinput"
+              ++ [
+                "-inotify"
+              ]
+              ++ lib.optionals (cups != null) [
+                "-L"
+                "${cups.lib}/lib"
+                "-I"
+                "${cups.dev}/include"
+              ]
+              ++ lib.optionals mysqlSupport [
+                "-L"
+                "${libmysqlclient}/lib/mysql"
+                "-I"
+                "${libmysqlclient}/include/mysql"
+              ]
+              ++ lib.optional (qttranslations != null) [
+                "-translationdir"
+                "${qttranslations}/translations"
+              ]
+
+            )
+          )
+      )
+
+      # cross compilation options
       ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
         "-device ${qtPlatformCross stdenv.hostPlatform}"
         "-device-option CROSS_COMPILE=${stdenv.cc.targetPrefix}"
       ]
+
+      # debugging options
       ++ lib.optional debugSymbols "-debug"
       ++ lib.optionals developerBuild [
         "-developer-build"
@@ -389,6 +524,8 @@ stdenv.mkDerivation (
       ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
         "-no-warnings-are-errors"
       ]
+
+      # CPU features support
       ++ (
         if (!stdenv.hostPlatform.isx86_64) then
           [
@@ -408,96 +545,24 @@ stdenv.mkDerivation (
       ++ [
         "-no-mips_dsp"
         "-no-mips_dspr2"
-      ]
-      ++ [
-        "-system-zlib"
-        "-L"
-        "${zlib.out}/lib"
-        "-I"
-        "${zlib.dev}/include"
-        "-system-libjpeg"
-        "-L"
-        "${libjpeg.out}/lib"
-        "-I"
-        "${libjpeg.dev}/include"
-        "-system-harfbuzz"
-        "-L"
-        "${harfbuzz.out}/lib"
-        "-I"
-        "${harfbuzz.dev}/include"
-        "-system-pcre"
-        "-openssl-linked"
-        "-L"
-        "${lib.getLib openssl}/lib"
-        "-I"
-        "${openssl.dev}/include"
-        "-system-sqlite"
-        "-${if mysqlSupport then "plugin" else "no"}-sql-mysql"
-        "-${if libpq != null then "plugin" else "no"}-sql-psql"
-        "-system-libpng"
-
-        "-make libs"
-        "-make tools"
-        "-${lib.optionalString (!buildExamples) "no"}make examples"
-        "-${lib.optionalString (!buildTests) "no"}make tests"
-      ]
-      ++ (
-        if stdenv.hostPlatform.isDarwin then
-          [
-            "-no-fontconfig"
-            "-no-framework"
-            "-no-rpath"
-          ]
-        else
-          [
-            "-rpath"
-          ]
-          ++ [
-            "-xcb"
-            "-qpa xcb"
-            "-L"
-            "${libX11.out}/lib"
-            "-I"
-            "${libX11.out}/include"
-            "-L"
-            "${libXext.out}/lib"
-            "-I"
-            "${libXext.out}/include"
-            "-L"
-            "${libXrender.out}/lib"
-            "-I"
-            "${libXrender.out}/include"
-
-            "-${lib.optionalString (cups == null) "no-"}cups"
-            "-dbus-linked"
-            "-glib"
-          ]
-          ++ lib.optional withGtk3 "-gtk"
-          ++ lib.optional withLibinput "-libinput"
-          ++ [
-            "-inotify"
-          ]
-          ++ lib.optionals (cups != null) [
-            "-L"
-            "${cups.lib}/lib"
-            "-I"
-            "${cups.dev}/include"
-          ]
-          ++ lib.optionals mysqlSupport [
-            "-L"
-            "${libmysqlclient}/lib/mysql"
-            "-I"
-            "${libmysqlclient}/include/mysql"
-          ]
-          ++ lib.optional (qttranslations != null) [
-            "-translationdir"
-            "${qttranslations}/translations"
-          ]
-      );
+      ];
 
       # Move selected outputs.
+      # I don't want to patch moveQtDevTools to support qmake output, so here's a bit of moving binaries around
       postInstall = ''
         moveToOutput "mkspecs" "$dev"
+
+        # Move development tools to $dev and update paths to them in mkspecs
+        moveQtDevTools
+
+        # Move all binaries to $qmake
+        mkdir -p "$qmake/bin"
+        mv "$dev"/bin/* "$qmake/bin/"
+        moveToOutput "bin" "$qmake"
+
+        # Symlinks from $dev to $qmake for backward compatibility
+        mkdir -p "$dev/bin"
+        lndir "$qmake/bin" "$dev/bin"
       '';
 
       devTools = [
@@ -517,10 +582,6 @@ stdenv.mkDerivation (
         sed '/QMAKE_DEFAULT_.*DIRS/ d' -i $dev/mkspecs/qconfig.pri
         fixQtModulePaths "''${!outputDev}/mkspecs/modules"
         fixQtBuiltinPaths "''${!outputDev}" '*.pr?'
-
-        # Move development tools to $dev
-        moveQtDevTools
-        moveToOutput bin "$dev"
 
         # fixup .pc file (where to find 'moc' etc.)
         sed -i "$dev/lib/pkgconfig/Qt5Core.pc" \

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -16,6 +16,8 @@
   pkg-config,
   python3,
   which,
+  distccMasquerade,
+  qtbase-bootstrap,
   # darwin support
   xcbuild,
 
@@ -72,11 +74,11 @@
   bootstrapBuild ? false,
   decryptSslTraffic ? false,
   testers,
-  buildPackages,
 }:
 
 let
   debugSymbols = debug || developerBuild;
+  isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   qtPlatformCross =
     plat:
     with plat;
@@ -140,7 +142,12 @@ stdenv.mkDerivation (
       );
 
       buildInputs = [
+        # We need python3 for hostPlatform to properly patch the shebang of the
+        # mkspecs/features/uikit/devices.py script that we're publishing.
         python3
+        # We need perl for hostPlatform to properly patch shebangs of the
+        # fixqt4headers.pl and syncqt.pl scripts that we're publishing.
+        perl
         at-spi2-core
       ]
       ++ lib.optionals (!stdenv.hostPlatform.isDarwin) (
@@ -160,18 +167,24 @@ stdenv.mkDerivation (
         pkg-config
         which
       ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ]
+      ++ lib.optionals isCrossBuild [
+        # `qtbase` expects to find `cc` (with no prefix) in the `$PATH` for qmake and host_build marked projects.
+        # And we need those to be built for the hostPlatform. So instead of patching configure and mkspeks even
+        # more I'm just masqurading the prefixed tools.
+        # I probably should be using the distccMasquerade._spliced.buildHost here, but it works as it is. It's magic!
+        # Pure wall-of-bash-code-directly-in-derivation-attribute magic!
+        (distccMasquerade.override {
+          gccRaw = stdenv.cc;
+          binutils = stdenv.cc.bintools;
+        })
+      ];
 
-    }
-    // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
-      # `qtbase` expects to find `cc` (with no prefix) in the
-      # `$PATH`, so the following is needed even if
-      # `stdenv.buildPlatform.canExecute stdenv.hostPlatform`
-      depsBuildBuild = [ buildPackages.stdenv.cc ];
-    }
-    // {
-
-      propagatedNativeBuildInputs = [ lndir ];
+      # qtbase needs a runnable qmake and the accompanying tools to build itself, and there are also packages
+      # out there that use cmake as their main configurator (i.e. don't depend on qmake-the-package) but
+      # still need qmake&co to be available at build time. In fact, cmake scripts provided by qtbase.dev
+      # itself look for those tools.
+      propagatedNativeBuildInputs = [ lndir ] ++ lib.optional isCrossBuild qtbase-bootstrap.qmake;
 
       strictDeps = true;
 
@@ -267,6 +280,7 @@ stdenv.mkDerivation (
       qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
       qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
       qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
+      qtPlatformCross = lib.optionalString isCrossBuild (qtPlatformCross stdenv.hostPlatform);
 
       setOutputFlags = false;
       preConfigure = ''
@@ -278,14 +292,23 @@ stdenv.mkDerivation (
         export MAKEFLAGS+=" -j$NIX_BUILD_CORES"
 
         ./bin/syncqt.pl -version $version
-      ''
-      + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-        # QT's configure script will refuse to use pkg-config unless these two environment variables are set
-        export PKG_CONFIG_SYSROOT_DIR=/
-        export PKG_CONFIG_LIBDIR=${lib.getLib pkg-config}/lib
+
+        # generate a cross compilation config unconditionally so we can pass a natively-built qtbase
+        # as a build dependency for a cross build and to avoid specifying CROSS_COMPILE prefix for qmake later
+        sed -i '1 i CROSS_COMPILE=${
+          stdenv.hostPlatform.config + "-"
+        }' mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
+        echo 'QMAKE_PKG_CONFIG=''$''$(PKG_CONFIG)' >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
+
+        # does this flag propagation really do anything?
         echo "QMAKE_LFLAGS=''${LDFLAGS}" >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
         echo "QMAKE_CFLAGS=''${CFLAGS}" >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
         echo "QMAKE_CXXFLAGS=''${CXXFLAGS}" >> mkspecs/devices/${qtPlatformCross stdenv.hostPlatform}/qmake.conf
+      ''
+      + lib.optionalString isCrossBuild ''
+        # QT's configure script will refuse to use pkg-config unless these two environment variables are set
+        export PKG_CONFIG_SYSROOT_DIR=/
+        export PKG_CONFIG_LIBDIR=${lib.getLib pkg-config}/lib
       '';
 
       postConfigure = ''
@@ -314,8 +337,6 @@ stdenv.mkDerivation (
         NIX_CFLAGS_COMPILE = toString (
           [
             "-Wno-error=sign-compare" # freetype-2.5.4 changed signedness of some struct fields
-          ]
-          ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
             "-Wno-warn=free-nonheap-object"
             "-Wno-free-nonheap-object"
             "-w"
@@ -333,13 +354,6 @@ stdenv.mkDerivation (
           ]
           ++ lib.optional decryptSslTraffic "-DQT_DECRYPT_SSL_TRAFFIC"
         );
-      }
-      // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
-        NIX_CFLAGS_COMPILE_FOR_BUILD = toString [
-          "-Wno-warn=free-nonheap-object"
-          "-Wno-free-nonheap-object"
-          "-w"
-        ];
       };
 
       prefixKey = "-prefix ";
@@ -350,7 +364,7 @@ stdenv.mkDerivation (
       PSQL_LIBS = lib.optionalString (libpq != null) "-L${libpq}/lib -lpq";
 
     }
-    // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    // lib.optionalAttrs isCrossBuild {
       configurePlatforms = [ ];
     }
     // {
@@ -510,18 +524,15 @@ stdenv.mkDerivation (
       )
 
       # cross compilation options
-      ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ++ lib.optionals isCrossBuild [
         "-device ${qtPlatformCross stdenv.hostPlatform}"
-        "-device-option CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "-external-hostbindir ${qtbase-bootstrap.qmake}/bin"
       ]
 
       # debugging options
       ++ lib.optional debugSymbols "-debug"
       ++ lib.optionals developerBuild [
         "-developer-build"
-        "-no-warnings-are-errors"
-      ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
         "-no-warnings-are-errors"
       ]
 
@@ -559,6 +570,9 @@ stdenv.mkDerivation (
         mkdir -p "$qmake/bin"
         mv "$dev"/bin/* "$qmake/bin/"
         moveToOutput "bin" "$qmake"
+        patchShebangs --host --update "$qmake"
+
+        patchShebangs --host --update "$dev"
 
         # Symlinks from $dev to $qmake for backward compatibility
         mkdir -p "$dev/bin"
@@ -580,6 +594,11 @@ stdenv.mkDerivation (
       postFixup = ''
         # Don't retain build-time dependencies like gdb.
         sed '/QMAKE_DEFAULT_.*DIRS/ d' -i $dev/mkspecs/qconfig.pri
+
+        # Don't propagate nativeBuildInputs
+        sed '/HOST_QT_TOOLS/ d' -i $dev/mkspecs/qmodule.pri
+        sed '/PKG_CONFIG_LIBDIR/ d' -i $dev/mkspecs/qconfig.pri
+
         fixQtModulePaths "''${!outputDev}/mkspecs/modules"
         fixQtBuiltinPaths "''${!outputDev}" '*.pr?'
 

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -11,7 +11,6 @@
   flex,
   gdb,
   gperf,
-  lndir,
   perl,
   pkg-config,
   python3,
@@ -86,6 +85,8 @@ let
       "linux-generic-g++"
     else
       throw "Please add a qtPlatformCross entry for ${plat.config}";
+  postFixupPatch = ../${lib.versions.majorMinor version}/qtbase.patch.d/0016-qtbase-cross-build-postFixup.patch;
+
 in
 
 stdenv.mkDerivation (
@@ -162,7 +163,6 @@ stdenv.mkDerivation (
         bison
         flex
         gperf
-        lndir
         perl
         pkg-config
         which
@@ -184,7 +184,7 @@ stdenv.mkDerivation (
       # out there that use cmake as their main configurator (i.e. don't depend on qmake-the-package) but
       # still need qmake&co to be available at build time. In fact, cmake scripts provided by qtbase.dev
       # itself look for those tools.
-      propagatedNativeBuildInputs = [ lndir ] ++ lib.optional isCrossBuild qtbase-bootstrap.qmake;
+      propagatedNativeBuildInputs = lib.optional isCrossBuild qtbase-bootstrap.qmake;
 
       strictDeps = true;
 
@@ -280,7 +280,6 @@ stdenv.mkDerivation (
       qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
       qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
       qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
-      qtPlatformCross = lib.optionalString isCrossBuild (qtPlatformCross stdenv.hostPlatform);
 
       setOutputFlags = false;
       preConfigure = ''
@@ -598,6 +597,9 @@ stdenv.mkDerivation (
         # Don't propagate nativeBuildInputs
         sed '/HOST_QT_TOOLS/ d' -i $dev/mkspecs/qmodule.pri
         sed '/PKG_CONFIG_LIBDIR/ d' -i $dev/mkspecs/qconfig.pri
+
+        # Dynamically detect cross-compilation. This patch breaks the build of qtbase itself, so we need to appy it late.
+        patch -p1 -d $dev < ${postFixupPatch}
 
         fixQtModulePaths "''${!outputDev}/mkspecs/modules"
         fixQtBuiltinPaths "''${!outputDev}" '*.pr?'

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -159,7 +159,6 @@ stdenv.mkDerivation (
         pkg-config
         which
       ]
-      ++ lib.optionals mysqlSupport [ libmysqlclient ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 
     }

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -2,14 +2,12 @@
   qtModule,
   python3,
   qtbase,
-  qtsvg,
 }:
 
 qtModule {
   pname = "qtdeclarative";
   propagatedBuildInputs = [
     qtbase
-    qtsvg
   ];
   nativeBuildInputs = [ python3 ];
   outputs = [

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -1,15 +1,23 @@
 {
+  lib,
+  stdenv,
   qtModule,
   python3,
   qtbase,
+  qtdeclarative,
 }:
+
+let
+  isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
+in
 
 qtModule {
   pname = "qtdeclarative";
-  propagatedBuildInputs = [
-    qtbase
-  ];
+  buildInputs = [ qtbase ];
   nativeBuildInputs = [ python3 ];
+  # We need a runnable qmlcachegen to build qtdeclarative itself, and some dependers
+  # of this package also expect to get runnable tools with it.
+  propagatedNativeBuildInputs = lib.optional isCrossBuild qtdeclarative;
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/qt-5/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdoc.nix
@@ -1,7 +1,14 @@
-{ qtModule, qtdeclarative }:
+{
+  qtModule,
+  qtbase,
+  qtdeclarative,
+}:
 
 qtModule {
   pname = "qtdoc";
-  propagatedBuildInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ];
   outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtgraphicaleffects.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtgraphicaleffects.nix
@@ -1,8 +1,15 @@
-{ qtModule, qtdeclarative }:
+{
+  qtModule,
+  qtbase,
+  qtdeclarative,
+}:
 
 qtModule {
   pname = "qtgraphicaleffects";
-  propagatedBuildInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ];
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -6,8 +6,7 @@
   qtdeclarative,
   pkg-config,
   alsa-lib,
-  gstreamer,
-  gst-plugins-base,
+  gst_all_1,
   libpulseaudio,
   wayland,
 }:
@@ -19,16 +18,18 @@ qtModule {
     qtdeclarative
   ];
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    gstreamer
-    gst-plugins-base
-  ]
-  # https://github.com/NixOS/nixpkgs/pull/169336 regarding libpulseaudio
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libpulseaudio
-    alsa-lib
-    wayland
-  ];
+  buildInputs =
+    with gst_all_1;
+    [
+      gstreamer
+      gst-plugins-base
+    ]
+    # https://github.com/NixOS/nixpkgs/pull/169336 regarding libpulseaudio
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libpulseaudio
+      alsa-lib
+      wayland
+    ];
   outputs = [
     "bin"
     "dev"

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols.nix
@@ -1,6 +1,13 @@
-{ qtModule, qtdeclarative }:
+{
+  qtModule,
+  qtbase,
+  qtdeclarative,
+}:
 
 qtModule {
   pname = "qtquickcontrols";
-  propagatedBuildInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -1,8 +1,15 @@
-{ qtModule, qtdeclarative }:
+{
+  qtModule,
+  qtbase,
+  qtdeclarative,
+}:
 
 qtModule {
   pname = "qtquickcontrols2";
-  propagatedBuildInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ];
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/qt-5/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsvg.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtsvg";
-  propagatedBuildInputs = [ qtbase ];
+  buildInputs = [ qtbase ];
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -4,9 +4,14 @@
   lib,
   qtbase,
   qtdeclarative,
+  qttools,
   replaceVars,
   llvmPackages,
 }:
+
+let
+  isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
+in
 
 qtModule {
   pname = "qttools";
@@ -20,12 +25,13 @@ qtModule {
   buildInputs = with llvmPackages; [
     libclang
     libllvm
-  ];
-
-  propagatedBuildInputs = [
     qtbase
     qtdeclarative
   ];
+
+  # We don't need this to build qttools itself, only for the packages that include qttools
+  # in their buildInputs and expect to get not only libs but also runnable tools.
+  propagatedNativeBuildInputs = lib.optional isCrossBuild qttools;
 
   patches = [
     # fixQtBuiltinPaths overwrites builtin paths we should keep

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -38,6 +38,9 @@ qtModule {
     })
   ];
 
+  # Bootstrap build produces no out, and that makes nix unhappy and results in an unannotated failure for remote builds.
+  postFixup = "[ -e $out ] || mkdir $out";
+
   devTools = [
     "bin/qcollectiongenerator"
     "bin/linguist"

--- a/pkgs/development/libraries/qt-5/modules/qttranslations.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttranslations.nix
@@ -1,7 +1,23 @@
-{ qtModule, qttools }:
+{
+  qtModule,
+  stdenv,
+  qtbase-bootstrap,
+  qttools-bootstrap,
+  buildPackages,
+}:
 
-qtModule {
-  pname = "qttranslations";
-  nativeBuildInputs = [ qttools ];
-  outputs = [ "out" ];
-}
+# I don't want to bother with cross compilation support for qttranslations
+# as the outputs are identical with a native-built one. It will require a small
+# fiddling with a native-built qtbase-bootstrap in buildInputs (it is there only
+# for a few configs in mkspecs) or an additional individual build of qtbase/mkspecs
+# just for the sake of this package. There's really just no point in it.
+if stdenv.hostPlatform != stdenv.buildPlatform then
+  buildPackages.qt5.qttranslations
+
+else
+  qtModule {
+    pname = "qttranslations";
+    buildInputs = [ qtbase-bootstrap.dev ];
+    nativeBuildInputs = [ qttools-bootstrap ];
+    outputs = [ "out" ];
+  }

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -1,24 +1,32 @@
 {
   qtModule,
   qtbase,
-  qtquickcontrols,
+  qtdeclarative,
+  qtwayland,
   wayland,
   wayland-scanner,
   pkg-config,
+  buildPackages,
+  stdenv,
   lib,
 }:
 
+let
+  isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
+in
+
 qtModule {
   pname = "qtwayland";
-  propagatedBuildInputs = [
-    qtbase
-    qtquickcontrols
+  propagatedBuildInputs = [ qtbase ];
+  buildInputs = [
+    wayland
+    qtdeclarative
   ];
-  buildInputs = [ wayland ];
   nativeBuildInputs = [
     pkg-config
     wayland-scanner
-  ];
+  ]
+  ++ lib.optional isCrossBuild qtwayland.bin;
   outputs = [
     "out"
     "dev"
@@ -30,5 +38,6 @@ qtModule {
     # context).
     ./qtwayland-app_id.patch
   ];
+  disallowedReferences = lib.optional isCrossBuild buildPackages.qt5.qtwayland.bin;
   meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
@@ -1,6 +1,4 @@
 {
-  lib,
-  stdenv,
   qtModule,
   qtbase,
   qtdeclarative,
@@ -15,6 +13,6 @@ qtModule {
   outputs = [
     "out"
     "dev"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "bin" ];
+    "bin"
+  ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -6,19 +6,17 @@
   qtwebchannel,
   fetchpatch,
   fetchpatch2,
+  srcs,
 
   bison,
   flex,
   gperf,
   ninja,
   pkg-config,
-  python,
   which,
   nodejs,
   perl,
   buildPackages,
-  pkgsBuildTarget,
-  pkgsBuildBuild,
 
   libxdamage,
   libxcomposite,
@@ -57,7 +55,6 @@
   pciutils,
   systemd,
   enableProprietaryCodecs ? true,
-  gn,
   cctools,
   cups,
   bootstrap_cmds,
@@ -71,27 +68,56 @@
   pipewireSupport ? stdenv.hostPlatform.isLinux,
   pipewire,
   postPatch ? "",
-  nspr,
-  lndir,
 }:
 
 let
-  # qtwebengine expects to find an executable in $PATH which runs on
-  # the build platform yet knows about the host `.pc` files.  Most
-  # configury allows setting $PKG_CONFIG to point to an
-  # arbitrarily-named script which serves this purpose; however QT
-  # insists that it is named `pkg-config` with no target prefix.  So
-  # we re-wrap the host platform's pkg-config.
-  pkg-config-wrapped-without-prefix = stdenv.mkDerivation {
-    name = "pkg-config-wrapper-without-target-prefix";
-    dontUnpack = true;
-    dontBuild = true;
-    installPhase = ''
-      mkdir -p $out/bin
-      ln -s '${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config' $out/bin/pkg-config
-    '';
-  };
+  isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
+  # qtwebengine requires its own very particular specially patched for qt version of gn
+  gnQtWebengine =
+    with srcs.qtwebengine;
+    buildPackages.gn.overrideAttrs {
+      pname = "gn-qtwebengine";
+      inherit src version;
+      sourceRoot = "${src.name}/src/3rdparty/gn";
+      configurePhase = ''
+        # using $CXX as ld because the script uses --gc-sections, and ld doesn't recognize it.
+        # on a related note, here we can see as QT developers intentionally de-standardize build tools:
+        # https://github.com/qt/qtwebengine-chromium/commit/0e7e61966f9215babb0d4b32d97b9c0b73db1ca9
+        python build/gen.py --no-last-commit-position --cc $CC --cxx $CXX --ld $CXX --ar $AR
+      '';
+      buildPhase = ''
+        ninja -j $NIX_BUILD_CORES -C out gn
+      '';
+    };
+
+  # Overriding stdenv seems to be a common thing for qt5 scope, so I'm using the
+  # "__spliced or" construction here instead of pkgsBuildBuild.
+  stdenvForBuildPlatform = stdenv.__spliced.buildBuild or stdenv;
+
+  cflagsForPlatform =
+    stdenv:
+    toString (
+      [ "-w " ]
+      ++ lib.optionals stdenv.cc.isGNU [
+        # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
+        "-Wno-class-memaccess"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.gcc.arch or "" == "sandybridge") [
+        # it fails when compiled with -march=sandybridge https://github.com/NixOS/nixpkgs/pull/59148#discussion_r276696940
+        # TODO: investigate and fix properly
+        "-march=westmere"
+      ]
+      ++ lib.optionals stdenv.cc.isClang [
+        "-Wno-elaborated-enum-base"
+        # 5.15.17: need to silence these two warnings
+        # https://trac.macports.org/ticket/70850
+        "-Wno-enum-constexpr-conversion"
+        "-Wno-unused-but-set-variable"
+        # Clang 19
+        "-Wno-error=missing-template-arg-list-after-template-kw"
+      ]
+    );
 in
 
 qtModule (
@@ -103,23 +129,52 @@ qtModule (
       gperf
       ninja
       pkg-config
-      (python.withPackages (ps: [ ps.html5lib ]))
+      (buildPackages.python3.withPackages (ps: [ ps.html5lib ]))
       which
-      gn
+      gnQtWebengine
       nodejs
-    ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-      perl
-      lndir
-      (lib.getDev pkgsBuildTarget.targetPackages.qt5.qtbase)
-      pkgsBuildBuild.pkg-config
-      (lib.getDev pkgsBuildTarget.targetPackages.qt5.qtquickcontrols)
-      pkg-config-wrapped-without-prefix
     ]
     ++ lib.optional stdenv.hostPlatform.isDarwin [
       bootstrap_cmds
       xcbuild
+
+      # FIXME These dependencies shouldn't be needed but can't find a way
+      # around it. Chromium pulls this in while bootstrapping GN.
+      cctools.libtool
+
+      # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`
+      # to get some information about the host platform.
+      (writeScriptBin "sw_vers" ''
+        #!${stdenv.shell}
+
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            -buildVersion) echo "17E199";;
+          *) break ;;
+
+          esac
+          shift
+        done
+      '')
     ];
+
+    # For "host" builds in chromium. Only cc in depsBuildBuild will produce
+    # _FOR_BUILD env variables that are used in qtwebengine-cross-build.patch.
+    depsBuildBuild = [
+      stdenvForBuildPlatform.cc
+      pkg-config
+      zlib
+      nss
+      icu
+      # apparently chromium doesn't care if these deps are non-functional on the buildPlatform
+      # but build fails if pkg-config can't find them
+      libjpeg
+      libpng
+      libwebp
+      freetype
+      harfbuzz
+    ];
+    strictDeps = true;
     doCheck = true;
     outputs = [
       "bin"
@@ -261,6 +316,9 @@ qtModule (
     postPatch = ''
       # Patch Chromium build tools
       (
+        # Force configure to accept qtwebengine's own version of gn when passed from outside
+        substituteInPlace configure.pri --replace 'qtLog("Gn version too old")' 'return(true)'
+
         cd src/3rdparty/chromium;
 
         # Manually fix unsupported shebangs
@@ -305,57 +363,24 @@ qtModule (
     + postPatch;
 
     env = {
-      NIX_CFLAGS_COMPILE = toString (
-        lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-          "-w "
-        ]
-        ++ lib.optionals stdenv.cc.isGNU [
-          # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
-          "-Wno-class-memaccess"
-        ]
-        ++ lib.optionals (stdenv.hostPlatform.gcc.arch or "" == "sandybridge") [
-          # it fails when compiled with -march=sandybridge https://github.com/NixOS/nixpkgs/pull/59148#discussion_r276696940
-          # TODO: investigate and fix properly
-          "-march=westmere"
-        ]
-        ++ lib.optionals stdenv.cc.isClang [
-          "-Wno-elaborated-enum-base"
-          # 5.15.17: need to silence these two warnings
-          # https://trac.macports.org/ticket/70850
-          "-Wno-enum-constexpr-conversion"
-          "-Wno-unused-but-set-variable"
-          # Clang 19
-          "-Wno-error=missing-template-arg-list-after-template-kw"
-        ]
-      );
-    }
-    // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
-      NIX_CFLAGS_LINK = "-Wl,--no-warn-search-mismatch";
-      "NIX_CFLAGS_LINK_${buildPackages.stdenv.cc.suffixSalt}" = "-Wl,--no-warn-search-mismatch";
+      NIX_CFLAGS_COMPILE = cflagsForPlatform stdenv;
+      NIX_CFLAGS_COMPILE_FOR_BUILD = cflagsForPlatform stdenvForBuildPlatform;
     };
 
     preConfigure = ''
       export NINJAFLAGS=-j$NIX_BUILD_CORES
-
-      if [ -d "$PWD/tools/qmake" ]; then
-          QMAKEPATH="$PWD/tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
-      fi
-    ''
-    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-      export QMAKE_CC=$CC
-      export QMAKE_CXX=$CXX
-      export QMAKE_LINK=$CXX
-      export QMAKE_AR=$AR
     '';
 
     qmakeFlags = [
       "--"
+      "-feature-webengine-system-gn"
       "-webengine-icu"
     ]
-    ++ lib.optional (
-      pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform
-    ) "-webengine-webrtc-pipewire"
+    # webengine-embedded-build disables WebRTC, "Printing and PDF" and breaks PyQtWebEngine build.
+    # It is automatically switched on for cross compilation. We probably always want it disabled.
+    ++ lib.optional stdenv.hostPlatform.isLinux "-no-webengine-embedded-build"
     ++ lib.optional (ffmpeg_7 != null) "-webengine-ffmpeg"
+    ++ lib.optional (pipewireSupport && !isCrossBuild) "-webengine-webrtc-pipewire"
     ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
 
     propagatedBuildInputs = [
@@ -430,7 +455,7 @@ qtModule (
       libxkbfile
 
     ]
-    ++ lib.optionals pipewireSupport [
+    ++ lib.optionals (pipewireSupport && !isCrossBuild) [
       # Pipewire
       pipewire
     ]
@@ -440,28 +465,18 @@ qtModule (
       cctools.libtool
 
       cups
-
-      # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`
-      # to get some information about the host platform.
-      (writeScriptBin "sw_vers" ''
-        #!${stdenv.shell}
-
-        while [ $# -gt 0 ]; do
-          case "$1" in
-            -buildVersion) echo "17E199";;
-          *) break ;;
-
-          esac
-          shift
-        done
-      '')
     ];
+
+    # to get progress output in `nix-build` and `nix build -L`
+    preBuild = ''
+      export TERM=dumb
+    '';
 
     dontUseNinjaBuild = true;
     dontUseNinjaInstall = true;
 
     postInstall =
-      lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+      lib.optionalString isCrossBuild ''
         mkdir -p $out/libexec
       ''
       + lib.optionalString stdenv.hostPlatform.isLinux ''
@@ -542,18 +557,7 @@ qtModule (
     };
 
   }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  // lib.optionalAttrs isCrossBuild {
     configurePlatforms = [ ];
-    # to get progress output in `nix-build` and `nix build -L`
-    preBuild = ''
-      export TERM=dumb
-    '';
-    depsBuildBuild = [
-      pkgsBuildBuild.stdenv
-      zlib
-      nss
-      nspr
-    ];
-
   }
 )

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -38,17 +38,19 @@
   zlib,
   minizip,
   libjpeg,
+  openjpeg,
   libpng,
   libtiff,
   libwebp,
   libopus,
-  jsoncpp,
-  protobuf,
   libvpx,
   srtp,
   snappy,
   nss,
   libevent,
+  lcms2,
+  libxml2,
+  libxslt,
   alsa-lib,
   pulseaudio,
   libcap,
@@ -224,21 +226,42 @@ qtModule (
 
       # Fix the build with gperf ≥ 3.2 and Clang 19.
       ./qtwebengine-gperf-3.2.patch
+
+      # Support building with gcc15
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/451b2e7a6a0ac2c6eb409b4e2c03dada141bcd7f/debian/patches/gcc-15.patch";
+        hash = "sha256-nOGntSYDwyYXZYb1/VQMJQDfvn2KbN5/Ok4rs/ZabdQ=";
+      })
+
+      # support for building with python 3.12
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/python3.12-six.patch";
+        hash = "sha256-gjc9sOPbcyHtJWnSHpkpupY6dIAODO20tiaTEtAfFr0=";
+      })
+
+      # Build with C++17, which is required by ICU 75
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/build-with-c++17.patch";
+        hash = "sha256-1fhkj50radAc3uG386UnS735+LRe0Xs8jQOJtMqE7hQ=";
+      })
+
+      # Use system openjpeg
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/system-openjpeg2.patch";
+        hash = "sha256-H3WwC40t0FRMGf1K2aXucrQjynMU/U/14goB4HK9/KM=";
+      })
+
+      # Use system lcms2
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/system-lcms2.patch";
+        hash = "sha256-ccEbt5T54uXTV1pJnHI12NfYJ+QdUSUJFj0xcKcmtIA=";
+      })
     ];
 
     postPatch = ''
       # Patch Chromium build tools
       (
         cd src/3rdparty/chromium;
-
-        patch -p1 < ${
-          (fetchpatch {
-            # support for building with python 3.12
-            name = "python312-six.patch";
-            url = "https://gitlab.archlinux.org/archlinux/packaging/packages/qt5-webengine/-/raw/6b0c0e76e0934db2f84be40cb5978cee47266e78/python3.12-six.patch";
-            hash = "sha256-YgP9Sq5+zTC+U7+0hQjZokwb+fytk0UEIJztUXFhTkI=";
-          })
-        }
 
         # Manually fix unsupported shebangs
         substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
@@ -327,11 +350,12 @@ qtModule (
 
     qmakeFlags = [
       "--"
-      "-system-ffmpeg"
+      "-webengine-icu"
     ]
     ++ lib.optional (
       pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform
     ) "-webengine-webrtc-pipewire"
+    ++ lib.optional (ffmpeg_7 != null) "-webengine-ffmpeg"
     ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
 
     propagatedBuildInputs = [
@@ -339,9 +363,14 @@ qtModule (
       qtquickcontrols
       qtlocation
       qtwebchannel
+    ];
 
+    # Optional dependency on system-provided re2 library is not used here because it activates
+    # some broken code paths in chromium.
+    buildInputs = [
       # Image formats
       libjpeg
+      openjpeg
       libpng
       libtiff
       libwebp
@@ -356,18 +385,20 @@ qtModule (
       # Text rendering
       harfbuzz
       icu
+      freetype
 
       libevent
       ffmpeg_7
+
+      lcms2
+
+      snappy
+      minizip
+      zlib
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       dbus
-      zlib
-      minizip
-      snappy
       nss
-      protobuf
-      jsoncpp
 
       # Audio formats
       alsa-lib
@@ -375,10 +406,16 @@ qtModule (
 
       # Text rendering
       fontconfig
-      freetype
 
       libcap
       pciutils
+
+      # there's an explicit check for LIBXML_ICU_ENABLED at configuraion time
+      # FIXME: still doesn't work because of the propagation of non-icu libxml2
+      # from qtbase. Not sure what is the right move here.
+      # FIXME: those could also be used on Darwin if we fix https://github.com/NixOS/nixpkgs/issues/272383
+      (libxml2.override { icuSupport = true; })
+      libxslt
 
       # X11 libs
       xrandr

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -397,12 +397,11 @@ qtModule (
       # Pipewire
       pipewire
     ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # FIXME This dependency shouldn't be needed but can't find a way
+      # around it. Chromium pulls this in while bootstrapping GN.
+      cctools.libtool
 
-    # FIXME These dependencies shouldn't be needed but can't find a way
-    # around it. Chromium pulls this in while bootstrapping GN.
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
-
-    buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
       cups
 
       # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -26,22 +26,10 @@
   pkg-config,
   python3,
   ruby,
+  hyphen,
+  woff2,
 }:
 
-let
-  hyphen = stdenv.mkDerivation rec {
-    pname = "hyphen";
-    version = "2.8.8";
-    src = fetchurl {
-      url = "http://dev-www.libreoffice.org/src/5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-${version}.tar.gz";
-      sha256 = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705";
-    };
-    postPatch = ''
-      patchShebangs tests
-    '';
-    buildInputs = [ perl ];
-  };
-in
 qtModule {
   pname = "qtwebkit";
   propagatedBuildInputs = [
@@ -62,6 +50,7 @@ qtModule {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     hyphen
+    woff2
   ];
   nativeBuildInputs = [
     bison

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -6,6 +6,7 @@
   qmake,
   patches,
   srcs,
+  qtbase-bootstrap,
 }:
 
 let
@@ -53,6 +54,7 @@ mkDerivation (
       ${args.preConfigure or ""}
 
       fixQtBuiltinPaths . '*.pr?'
+      fixQtBuiltinPaths . '*.cmake.in'
     ''
     +
       lib.optionalString (builtins.compareVersions "5.15.0" version <= 0)
@@ -90,6 +92,8 @@ mkDerivation (
 
       ${args.postFixup or ""}
     '';
+
+    disallowedReferences = (args.disallowedReferences or [ ]) ++ [ qtbase-bootstrap.qmake ];
 
     meta = {
       homepage = "https://www.qt.io";

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -1,13 +1,11 @@
 {
   lib,
   stdenv,
-  buildPackages,
   mkDerivation,
   perl,
   qmake,
   patches,
   srcs,
-  pkgsHostTarget,
 }:
 
 let
@@ -38,11 +36,6 @@ mkDerivation (
     propagatedBuildInputs =
       (lib.warnIf (args ? qtInputs) "qt5.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
       ++ (args.propagatedBuildInputs or [ ]);
-  }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
-    depsBuildBuild = [ buildPackages.stdenv.cc ] ++ (args.depsBuildBuild or [ ]);
-  }
-  // {
 
     outputs =
       args.outputs or [

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -30,15 +30,11 @@ mkDerivation (
 
     buildInputs = args.buildInputs or [ ];
 
-    nativeBuildInputs =
-      (args.nativeBuildInputs or [ ])
-      ++ [
-        perl
-        qmake
-      ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-        pkgsHostTarget.qt5.qtbase.dev
-      ];
+    nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+      perl
+      qmake
+    ];
+
     propagatedBuildInputs =
       (lib.warnIf (args ? qtInputs) "qt5.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
       ++ (args.propagatedBuildInputs or [ ]);

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -7,7 +7,6 @@
   fetchPypi,
   pkg-config,
   dbus,
-  lndir,
   dbus-python,
   sip,
   pyqt5-sip,
@@ -22,7 +21,6 @@
   withLocation ? false,
   withSerialPort ? false,
   withTools ? false,
-  pkgsBuildTarget,
   dbusSupport ? !stdenv.hostPlatform.isDarwin,
 }:
 
@@ -120,42 +118,22 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-  ]
-  ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ libsForQt5.qmake ]
-  ++ [
+    libsForQt5.qmake
     setuptools
-    lndir
     sip
-  ]
-  ++ (
-    with pkgsBuildTarget.targetPackages.libsForQt5;
-    [ ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ qmake ]
-    ++ [
-      qtbase
-      qtsvg
-      qtdeclarative
-      qtwebchannel
-    ]
-    ++ lib.optional withConnectivity qtconnectivity
-    ++ lib.optional withMultimedia qtmultimedia
-    ++ lib.optional withWebKit qtwebkit
-    ++ lib.optional withWebSockets qtwebsockets
-    ++ lib.optional withLocation qtlocation
-    ++ lib.optional withSerialPort qtserialport
-    ++ lib.optional withTools qttools
-  );
+  ];
 
   buildInputs =
     with libsForQt5;
-    [ dbus ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ qtbase ]
-    ++ [
+    [
+      dbus
+      qtbase
       qtsvg
       qtdeclarative
       pyqt-builder
     ]
     ++ lib.optional withConnectivity qtconnectivity
+    ++ lib.optional withMultimedia qtmultimedia
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -46,19 +46,13 @@ buildPythonPackage (
       pkg-config
       libsForQt5.qmake
       libsForQt5.wrapQtAppsHook
+      pyqt-builder
+      setuptools
     ]
     ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ sip ]
     ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
       python.pythonOnBuildForHost.pkgs.sip
     ]
-    ++ [
-      libsForQt5.qtbase
-      libsForQt5.qtsvg
-      libsForQt5.qtwebengine
-      pyqt-builder
-      setuptools
-    ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ libsForQt5.qtdeclarative ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
       autoSignDarwinBinariesHook
     ];
@@ -68,10 +62,6 @@ buildPythonPackage (
       libsForQt5.qtbase
       libsForQt5.qtsvg
       libsForQt5.qtwebengine
-    ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-      libsForQt5.qtwebchannel
-      libsForQt5.qtdeclarative
     ];
 
     propagatedBuildInputs = [ pyqt5 ];
@@ -101,12 +91,5 @@ buildPythonPackage (
       license = lib.licenses.gpl3;
       hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms mesa.meta.platforms;
     };
-  }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
-    # TODO: figure out why the env hooks aren't adding these inclusions automatically
-    env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
-      "-I${lib.getDev libsForQt5.qtbase}/include/QtPrintSupport/"
-      "-I${lib.getDev libsForQt5.qtwebchannel}/include/QtWebChannel/"
-    ];
   }
 )

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -18,78 +18,76 @@
 let
   inherit (darwin) autoSignDarwinBinariesHook;
 in
-buildPythonPackage (
-  rec {
-    pname = "pyqtwebengine";
-    version = "5.15.7";
-    pyproject = true;
+buildPythonPackage rec {
+  pname = "pyqtwebengine";
+  version = "5.15.7";
+  pyproject = true;
 
-    disabled = isPy27;
+  disabled = isPy27;
 
-    src = fetchPypi {
-      pname = "PyQtWebEngine";
-      inherit version;
-      hash = "sha256-8SGsbkovlqwolhm8/Df2Tmg2LySjRlU/XWxC76Qiik0=";
-    };
+  src = fetchPypi {
+    pname = "PyQtWebEngine";
+    inherit version;
+    hash = "sha256-8SGsbkovlqwolhm8/Df2Tmg2LySjRlU/XWxC76Qiik0=";
+  };
 
-    postPatch = ''
-      substituteInPlace pyproject.toml \
-        --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
-    '';
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+  '';
 
-    outputs = [
-      "out"
-      "dev"
-    ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-    nativeBuildInputs = [
-      pkg-config
-      libsForQt5.qmake
-      libsForQt5.wrapQtAppsHook
-      pyqt-builder
-      setuptools
-    ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ sip ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-      python.pythonOnBuildForHost.pkgs.sip
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-      autoSignDarwinBinariesHook
-    ];
+  nativeBuildInputs = [
+    pkg-config
+    libsForQt5.qmake
+    libsForQt5.wrapQtAppsHook
+    pyqt-builder
+    setuptools
+  ]
+  ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ sip ]
+  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    python.pythonOnBuildForHost.pkgs.sip
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    autoSignDarwinBinariesHook
+  ];
 
-    buildInputs = [
-      sip
-      libsForQt5.qtbase
-      libsForQt5.qtsvg
-      libsForQt5.qtwebengine
-    ];
+  buildInputs = [
+    sip
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
+    libsForQt5.qtwebengine
+  ];
 
-    propagatedBuildInputs = [ pyqt5 ];
+  propagatedBuildInputs = [ pyqt5 ];
 
-    dontWrapQtApps = true;
+  dontWrapQtApps = true;
 
-    # Avoid running qmake, which is in nativeBuildInputs
-    dontConfigure = true;
+  # Avoid running qmake, which is in nativeBuildInputs
+  dontConfigure = true;
 
-    # Checked using pythonImportsCheck
-    doCheck = false;
+  # Checked using pythonImportsCheck
+  doCheck = false;
 
-    pythonImportsCheck = [
-      "PyQt5.QtWebEngine"
-      "PyQt5.QtWebEngineWidgets"
-    ];
+  pythonImportsCheck = [
+    "PyQt5.QtWebEngine"
+    "PyQt5.QtWebEngineWidgets"
+  ];
 
-    enableParallelBuilding = true;
+  enableParallelBuilding = true;
 
-    passthru = {
-      inherit (libsForQt5) wrapQtAppsHook;
-    };
+  passthru = {
+    inherit (libsForQt5) wrapQtAppsHook;
+  };
 
-    meta = {
-      description = "Python bindings for Qt5";
-      homepage = "http://www.riverbankcomputing.co.uk";
-      license = lib.licenses.gpl3;
-      hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms mesa.meta.platforms;
-    };
-  }
-)
+  meta = {
+    description = "Python bindings for Qt5";
+    homepage = "http://www.riverbankcomputing.co.uk";
+    license = lib.licenses.gpl3;
+    hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms mesa.meta.platforms;
+  };
+}

--- a/pkgs/development/tools/misc/distcc/masq.nix
+++ b/pkgs/development/tools/misc/distcc/masq.nix
@@ -42,6 +42,14 @@ stdenv.mkDerivation {
         ln -sf $bbin/*-as $out/bin/as
       done
     fi
+
+    if [ -f $bbin/ar ]; then
+      ln -s $bbin/ar $out/bin
+    else
+      for a in $bbin/*-ar; do
+        ln -sf $bbin/*-ar $out/bin/ar
+      done
+    fi
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7484,35 +7484,7 @@ with pkgs;
     python3 = null;
   };
 
-  qt5 = recurseIntoAttrs (
-    makeOverridable (import ../development/libraries/qt-5/5.15) {
-      inherit (__splicedPackages)
-        makeScopeWithSplicing'
-        generateSplicesForMkScope
-        lib
-        stdenv
-        gcc14Stdenv
-        fetchurl
-        fetchpatch
-        fetchgit
-        fetchFromGitHub
-        makeSetupHook
-        makeWrapper
-        bison
-        cups
-        dconf
-        harfbuzz
-        libGL
-        perl
-        gtk3
-        python3
-        llvmPackages_19
-        darwin
-        ;
-      inherit (__splicedPackages.gst_all_1) gstreamer gst-plugins-base;
-      inherit config;
-    }
-  );
+  qt5 = recurseIntoAttrs (__splicedPackages.callPackage ../development/libraries/qt-5/5.15 { });
 
   libsForQt5 = recurseIntoAttrs (
     import ./qt5-packages.nix {


### PR DESCRIPTION
## Description of changes

By default when cross compiling QT builds all binaries that are marked in their .pro files with ```option(host_build)``` for the build platform instead of the host platform, and those binaries end up in the dev outputs (maybe not only there) of packages intended for the host platform. While there is some expectation of this situation in Nix [1], it prevents us from easily swapping natively and cross built dependencies, i.e. "lazy cross-compiling" and the host platform doesn't get the full set of binaries.

Here I'm attempting to have only host-targeted binaries in the cross-compiled packages and somehow live with this new situation. Even if this approach fails, I have here a couple of fixes that can helpful elsewhere.

I'll direct this PR to staging when we will be done discussing it.

[1] ```patchShebangs``` expects that binaries in dev outputs will be run on the build platform, and ```propagatedNativeBuildInputs```, being implemented as an in-store dependency, essentially adds the same hard dependency on the platform where the package was built.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
