### PR TITLE
pulumi: 3.90.1 -> 3.93.0

### DIFF
--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     cp ../../README.md .
     substituteInPlace setup.py \
       --replace "3.0.0" "${version}" \
-      --replace "grpcio~=1.59" "grpcio" \
+      --replace "grpcio==1.56.2" "grpcio" \
       --replace "semver~=2.13" "semver"
   '';
 

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-6JnRPns+qOLXP2RBjsgq4v6nuLn3uX8jF4+uinr2Wt8";
+  vendorHash = "sha256-mBK9VEatuxeoZtXXOKdwj7wtZ/lo4Bi2h7N00zK6Hpw=";
 
   ldflags = [
     "-s"

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-gbZoDUJCKb5wcLhJ7DRSGHT3Q0xUlptUeS6Wen4dle0";
+  vendorHash = "sha256-gEOVtAyn7v8tsRU11NgrD3swMFFBxOTIjMWCqSSvHlI=";
 
   postPatch = ''
     # Gives github.com/pulumi/pulumi/pkg/v3: is replaced in go.mod, but not marked as replaced in vendor/modules.txt etc

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-aLCgAcrgnNH/eYpGkr5Kj4xWjSgP76nz0YoV6998i9M=";
+  vendorHash = "sha256-upRXs8Bo0dpnANNetfXqkatip9bA+Fqhg72Cd60ltz8=";
 
   postPatch = ''
     substituteInPlace main_test.go \

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -14,7 +14,7 @@
 
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.90.1";
+  version = "3.93.0";
 
   # Used in pulumi-language packages, which inherit this prop
   sdkVendorHash = lib.fakeHash;
@@ -23,12 +23,12 @@ buildGoModule rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-dAQpQapkdccRr/O8XT8dHrLwPvIPqeV8f3HS+GtK2GM=";
+    hash = "sha256-EaYYIbV7IItnmVfyEHtaAbAXvrZ8CXMjW+yNXOBIxg8=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-ijFYlHVH0axDpFoPGvthGVRt8UIUZDsWv3vAOe0U4H4";
+  vendorHash = "sha256-G+LspC6b2TvboMU6rKB0qrhhMNaLPVt/nUYZzkiVr/Q=";
 
   sourceRoot = "${src.name}/pkg";
 


### PR DESCRIPTION
## Description of changes

New upstream releases:
* [3.91.0](https://github.com/pulumi/pulumi/releases/tag/v3.91.0)
* [3.91.1](https://github.com/pulumi/pulumi/releases/tag/v3.91.1)
* [3.92.0](https://github.com/pulumi/pulumi/releases/tag/v3.92.0)
* [3.93.0](https://github.com/pulumi/pulumi/releases/tag/v3.93.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
