### PR TITLE
dxvk: rely on the cross support in nixpkgs

### DIFF
--- a/pkgs/by-name/dx/dxvk_1/package.nix
+++ b/pkgs/by-name/dx/dxvk_1/package.nix
@@ -9,9 +9,6 @@
 , enableMoltenVKCompat ? false
 }:
 
-let
-  isCross = stdenv.hostPlatform != stdenv.targetPlatform;
-in
 stdenv.mkDerivation (finalAttrs:  {
   pname = "dxvk";
   version = "1.10.3";
@@ -36,15 +33,10 @@ stdenv.mkDerivation (finalAttrs:  {
   nativeBuildInputs = [ glslang meson ninja ];
   buildInputs = [ windows.pthreads ];
 
-  mesonFlags =
-    let
-      arch = if stdenv.is32bit then "32" else "64";
-    in
-    [
-      "--buildtype" "release"
-      "--prefix" "${placeholder "out"}"
-    ]
-    ++ lib.optionals isCross [ "--cross-file" "build-win${arch}.txt" ];
+  mesonFlags = [
+    "--buildtype" "release"
+    "--prefix" "${placeholder "out"}"
+  ];
 
   meta = {
     description = "A Vulkan-based translation layer for Direct3D 9/10/11";

--- a/pkgs/by-name/dx/dxvk_2/package.nix
+++ b/pkgs/by-name/dx/dxvk_2/package.nix
@@ -19,7 +19,6 @@
 assert !sdl2Support || !glfwSupport;
 
 let
-  isCross = stdenv.hostPlatform != stdenv.targetPlatform;
   isWindows = stdenv.hostPlatform.uname.system == "Windows";
 in
 stdenv.mkDerivation (finalAttrs:  {
@@ -51,18 +50,12 @@ stdenv.mkDerivation (finalAttrs:  {
     mkdir -p include/spirv/include include/vulkan/include
   '';
 
-  mesonFlags =
-    let
-      arch = if stdenv.is32bit then "32" else "64";
-    in
-    [
-      "--buildtype" "release"
-      "--prefix" "${placeholder "out"}"
-    ]
-    ++ lib.optionals isCross [ "--cross-file" "build-win${arch}.txt" ]
-    ++ lib.optional glfwSupport "-Ddxvk_native_wsi=glfw";
+  mesonFlags = [
+    "--buildtype" "release"
+    "--prefix" "${placeholder "out"}"
+  ] ++ lib.optional glfwSupport "-Ddxvk_native_wsi=glfw";
 
-  doCheck = !isCross;
+  doCheck = true;
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 


### PR DESCRIPTION
## Description of changes

The `isCross` check is broken. When cross-compiling, it incorrectly evaluates to false. DXVK has been building using the Meson cross-compilation support in nixpkgs instead of with upstream’s cross file. Instead of fixing `isCross`, just drop it as unnecessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
