### PR TITLE
authenticator-rs: init at 0.7.6

### DIFF
--- a/pkgs/by-name/au/authenticator-rs/package.nix
+++ b/pkgs/by-name/au/authenticator-rs/package.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, rustPlatform
+, glib
+, gtk3
+, meson
+, ninja
+, openssl
+, pkg-config
+, sqlite
+, libxml2 # for xmllint
+, wrapGAppsHook
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "authenticator-rs";
+  version = "0.7.6";
+
+  src = fetchFromGitHub {
+    owner = "grumlimited";
+    repo = "authenticator-rs";
+    rev = version;
+    sha256 = "sha256-zof+RMjp1y8pizWgBm+GYrHOyvAe2et3nGLO4hZ8/+o=";
+  };
+
+  cargoSha256 = "sha256-RWT60myX3kX8xdeMLueSec3tcle/OB/Qy/QI0yZ/xYQ=";
+
+  nativeBuildInputs = [ meson pkg-config glib libxml2 ninja wrapGAppsHook ];
+  buildInputs = [ gtk3 openssl sqlite ];
+
+  postUnpack = ''
+    # The build version is actually ${version}; the source is wrong.
+    # https://github.com/grumlimited/authenticator-rs/pull/139
+    sed -i "s,0\.0\.1,${version}," source/meson.build source/Cargo.{toml,lock}
+
+    # Fix paths to load from the Nix store.
+    substituteInPlace source/src/main.rs --replace /usr/share $out/share
+  '';
+
+  patches = [
+    # Fix Makefile to allow installing into the Nix store
+    # https://github.com/grumlimited/authenticator-rs/pull/138
+    (fetchpatch {
+      url = "https://github.com/grumlimited/authenticator-rs/commit/42500547753cb82bea060139cd79bae96b4ffa50.patch";
+      sha256 = "sha256-OPmNLM1CLS1zYxQfRDp4Tg5K3SxaOJvS1DO8F9tVAiU=";
+    })
+  ];
+
+  preInstall = ''
+    make install-gresource bindir=$out/bin sharedir=$out/share PREFIX=/ DESTDIR=$out
+  '';
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  # `authenticator-rs` only needs Ninja for the Meson build, not for anything else.
+  dontUseNinjaBuild = true;
+  dontUseNinjaCheck = true;
+  dontUseNinjaInstall = true;
+
+  # Skip tests which need a network connection to download assets from the BBC (!)
+  checkFlags = [
+    "--skip helpers::icon_parser::tests::download"
+    "--skip helpers::icon_parser::tests::html"
+  ];
+
+  meta = with lib; {
+    maintainers = with maintainers; [ philiptaron ];
+    description = "TOTP MFA/2FA application written in Rust and GTK3";
+    license = licenses.gpl3Plus;
+    homepage = "https://github.com/grumlimited/authenticator-rs";
+    mainProgram = "authenticator-rs";
+  };
+}


### PR DESCRIPTION
## Description of changes

[authenticator-rs](https://github.com/grumlimited/authenticator-rs) is a TOTP-MFA application written in Rust and GTK3.

It is currently packaged as a .deb, an .rpm, and is in the [AUR](https://aur.archlinux.org/packages/authenticator-rs-bin).

### Main view

![authenticator-rs](https://github.com/grumlimited/authenticator-rs/blob/master/data/screenshots/screenshot1.png?raw=true "Main view")
![authenticator-rs](https://github.com/grumlimited/authenticator-rs/blob/master/data/screenshots/screenshot2.png?raw=true "Main view")

### Group editing

![authenticator-rs](https://github.com/grumlimited/authenticator-rs/blob/master/data/screenshots/screenshot3.png?raw=true "Group editing")

### Account editing

![authenticator-rs](https://github.com/grumlimited/authenticator-rs/blob/master/data/screenshots/screenshot4.png?raw=true "Account editing")

### Importing and exporting

Using `yaml` format

    ---
    - name: group name
      url: bbc.co.uk
      entries:
        - label: Account 1
          secret: secret code

![authenticator-rs](https://github.com/grumlimited/authenticator-rs/blob/master/data/screenshots/screenshot5.png?raw=true "Importing")

## Things done

Packaging this application was a little more challenging than I expected.

* The version numbers in the repository didn't match the version numbers in the metadata. The metadata was 0.1 and 0.0.1; the repository is 0.7.6.

* Two tests make use of the network.

* The install process uses a hand-written Makefile that baked in assumptions about `/usr`. It also re-compiled the source.

I also decided to strip "RS" from the `.desktop` name, as it didn't add anything to the functionality of the application.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
