### PR TITLE
`fileset.fileFilter`: Don't run predicate unnecessarily

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -304,7 +304,7 @@ in {
       fileFilter (file: hasPrefix "." file.name) ./.
 
       # Include all regular files (not symlinks or others) in the current directory
-      fileFilter (file: file.type == "regular")
+      fileFilter (file: file.type == "regular") ./.
   */
   fileFilter =
     /*
@@ -325,7 +325,7 @@ in {
     fileset:
     if ! isFunction predicate then
       throw ''
-        lib.fileset.fileFilter: First argument is of type ${typeOf predicate}, but it should be a function.''
+        lib.fileset.fileFilter: First argument is of type ${typeOf predicate}, but it should be a function instead.''
     else
       _fileFilter predicate
         (_coerce "lib.fileset.fileFilter: Second argument" fileset);

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -728,8 +728,12 @@ rec {
         _differenceTree (path + "/${name}") lhsValue (rhs.${name} or null)
       ) (_directoryEntries path lhs);
 
+  # Filters all files in a file set based on a predicate
+  # Type: ({ name, type, ... } -> Bool) -> FileSet -> FileSet
   _fileFilter = predicate: fileset:
     let
+      # Check the predicate for a path and a filesetTree, returning a new filesetTree
+      # Type: Path -> filesetTree -> filesetTree
       recurse = path: tree:
         mapAttrs (name: subtree:
           if isAttrs subtree || subtree == "directory" then

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -857,6 +857,26 @@ checkFileset 'union ./c/a (fileFilter (file: assert file.name != "a"; true) ./.)
 # but here we need to use ./c
 checkFileset 'union (fileFilter (file: assert file.name != "a"; true) ./.) ./c'
 
+# Also lazy, the filter isn't called on a filtered out path
+tree=(
+    [a]=1
+    [b]=0
+    [c]=0
+)
+checkFileset 'fileFilter (file: assert file.name != "c"; file.name == "a") (difference ./. ./c)'
+
+# Make sure single files are filtered correctly
+tree=(
+    [a]=1
+    [b]=0
+)
+checkFileset 'fileFilter (file: assert file.name == "a"; true) ./a'
+tree=(
+    [a]=0
+    [b]=0
+)
+checkFileset 'fileFilter (file: assert file.name == "a"; false) ./a'
+
 ## Tracing
 
 # The second trace argument is returned

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -785,6 +785,13 @@ checkFileset 'difference ./. ./b'
 
 ## File filter
 
+# The first argument needs to be a function
+expectFailure 'fileFilter null (abort "this is not needed")' 'lib.fileset.fileFilter: First argument is of type null, but it should be a function instead.'
+
+# The second argument can be a file set or an existing path
+expectFailure 'fileFilter (file: abort "this is not needed") null' 'lib.fileset.fileFilter: Second argument is of type null, but it should be a file set or a path instead.'
+expectFailure 'fileFilter (file: abort "this is not needed") ./a' 'lib.fileset.fileFilter: Second argument \('"$work"'/a\) is a path that does not exist.'
+
 # The predicate is not called when there's no files
 tree=()
 checkFileset 'fileFilter (file: abort "this is not needed") ./.'


### PR DESCRIPTION
## Description of changes

Before:

    nix-repl> :a lib.fileset
    
    nix-repl> trace (fileFilter (file: builtins.trace file.name false) ./default.nix)
    trace: README.md
    trace: benchmark.sh
    trace: default.nix
    trace: internal.nix
    trace: mock-splitRoot.nix
    trace: tests.sh

After:

    nix-repl> trace (fileFilter (file: builtins.trace file.name false) ./default.nix)
    trace: default.nix

Note that even if the filter returned true before, the files weren't added to the store, so this is just a performance and laziness improvement and arguably not a bug fix.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done
- [x] Cleaned up surrounding code
- [x] Added tests