### PR TITLE
tika-server-standard: init at 2.9.0

### DIFF
--- a/pkgs/by-name/ti/tika-server-standard/package.nix
+++ b/pkgs/by-name/ti/tika-server-standard/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchurl
+, jre
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tika-server-standard";
+  version = "2.9.0";
+
+  src = fetchurl {
+    url = "https://dlcdn.apache.org/tika/${version}/tika-server-standard-${version}.jar";
+    hash = "sha256-7BoXwaI9cstYX/OGT8h1gYLfbobmNkRt7QIgeEvPhes=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+
+    cp ${src} "$out/share/tika-server-standard.jar"
+
+    makeWrapper ${jre}/bin/java $out/bin/tika-server-standard \
+      --add-flags "-jar $out/share/tika-server-standard.jar" \
+      --prefix PATH ":" ${ lib.makeBinPath [ jre ] }
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Detects and extracts metadata and text from over a thousand different file types";
+    homepage = "https://tika.apache.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elohmeier ];
+    platforms = jre.meta.platforms;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the tika package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
