### PR TITLE
s3proxy: init

### DIFF
--- a/pkgs/by-name/s3/s3proxy/package.nix
+++ b/pkgs/by-name/s3/s3proxy/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, jre
+, makeWrapper
+, maven
+}:
+
+let
+  pname = "s3proxy";
+  version = "2.1.0";
+in
+maven.buildMavenPackage {
+  inherit pname version;
+  mvnHash = "sha256-85mE/pZ0DXkzOKvTAqBXGatAt8gc4VPRCxmEyIlyVGI=";
+
+  src = fetchFromGitHub {
+    owner = "gaul";
+    repo = pname;
+    rev = "s3proxy-${version}";
+    hash = "sha256-GhZPvo8wlXInHwg8rSmpwMMkZVw5SMpnZyKqFUYLbrE=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -D --mode=644 --target-directory=$out/share/s3proxy target/s3proxy-${version}-jar-with-dependencies.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/s3proxy \
+      --add-flags "-jar $out/share/s3proxy/s3proxy-${version}-jar-with-dependencies.jar"
+  '';
+
+  meta = with lib; {
+    description = "Access other storage backends via the S3 API";
+    homepage = "https://github.com/gaul/s3proxy";
+    changelog = "https://github.com/gaul/s3proxy/releases/tag/s3proxy-${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ camelpunch ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes

S3Proxy allows you to access various storage backends using the AWS S3 API. It's very useful for nix users who want to use non-S3-compatible blobstores as a binary cache.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).