### PR TITLE
python311Packages.xdg: fetch from PyPI instead of GitHub

### DIFF
--- a/pkgs/development/python-modules/xdg/default.nix
+++ b/pkgs/development/python-modules/xdg/default.nix
@@ -1,20 +1,23 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
 , clikit
 , poetry-core
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   version = "6.0.0";
   pname = "xdg";
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
   format = "pyproject";
 
-  src = fetchFromGitHub {
-    owner = "srstevenson";
-    repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-yVuruSKv99IZGNCpY9cKwAe6gJNAWjL+Lol2D1/0hiI=";
+  # the github source uses `xdg_base_dirs`, but pypi's sdist maintains `xdg` for compatibility.
+  # there are actually breaking changes in xdg_base_dirs,
+  # and libraries that want to support python 3.9 and below need to use xdg.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JCeAlPLUXoRtHrKKLruS17Z/wMq1JJ7jzojJX2SaHJI=";
   };
 
   nativeBuildInputs = [ poetry-core ];
@@ -23,7 +26,12 @@ buildPythonPackage rec {
     clikit
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  # sdist has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "xdg"
+  ];
 
   meta = with lib; {
     description = "XDG Base Directory Specification for Python";


### PR DESCRIPTION
the github source uses `xdg_base_dirs`, but pypi's sdist maintains `xdg` for compatibility. there are actually breaking changes in xdg_base_dirs, and libraries that want to support python 3.9 and below need to use xdg.
for example, https://github.com/Textualize/frogmouth/pull/59#issuecomment-1585504373

Because pythonImportsCheck was not set, hydra cannot detect a break in xdg itself, but it causes downstream packages to break. e.g. #267385 

ZHF: https://github.com/NixOS/nixpkgs/issues/265948
- python311Packages.rmcl: https://hydra.nixos.org/build/238937793
- python311Pacakges.rmrl: https://hydra.nixos.org/build/238900130
- rmfuse: https://hydra.nixos.org/build/238986343

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
