### PR TITLE
Bluesnooze: init at 1.2

### DIFF
--- a/pkgs/by-name/bl/bluesnooze/package.nix
+++ b/pkgs/by-name/bl/bluesnooze/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "bluesnooze";
+  version = "1.2";
+
+  src = fetchzip {
+    url = "https://github.com/odlp/${finalAttrs.pname}/releases/download/v${finalAttrs.version}/Bluesnooze.zip";
+    hash = "sha256-ROGYzErQH2eRli2ccxv/859wMBd4WncEonY+2QR/G7w=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r $src/Bluesnooze.app $out/Applications/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Bluesnooze prevents your sleeping Mac from connecting to Bluetooth accessories. Sleeping Mac = Bluetooth off";
+    homepage = "https://github.com/odlp/bluesnooze";
+    license = licenses.mit;
+    maintainers = [ maintainers.frogamic ];
+    platforms = platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description of changes

Bluesnooze is a MacOS system tray app that turns off the bluetooth radio when the Mac goes to sleep.
https://github.com/odlp/bluesnooze

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
