### PR TITLE
cppdap: init at 1.58.0-a

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13126,17 +13126,17 @@
     githubId = 20391;
     name = "Nahum Shalman";
   };
-  nsnelson = {
-    email = "noah.snelson@protonmail.com";
-    github = "peeley";
-    githubId = 30942198;
-    name = "Noah Snelson";
-  };
   nsidiropoulos = {
     email = "nikolaos@sidiropoulos.dev";
     github = "nsidiropoulos";
     githubId = 144605927;
     name = "Nikolaos Sidiropoulos";
+  };
+  nsnelson = {
+    email = "noah.snelson@protonmail.com";
+    github = "peeley";
+    githubId = 30942198;
+    name = "Noah Snelson";
   };
   nthorne = {
     email = "notrupertthorne@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13132,6 +13132,12 @@
     githubId = 30942198;
     name = "Noah Snelson";
   };
+  nsidiropoulos = {
+    email = "nikolaos@sidiropoulos.dev";
+    github = "nsidiropoulos";
+    githubId = 144605927;
+    name = "Nikolaos Sidiropoulos";
+  };
   nthorne = {
     email = "notrupertthorne@gmail.com";
     github = "nthorne";

--- a/pkgs/by-name/cp/cppdap/package.nix
+++ b/pkgs/by-name/cp/cppdap/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, buildTests ? false
+, buildFuzzer ? false
+, buildExamples ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cppdap";
+  version = "1.58.0-a";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "cppdap";
+    rev = "dap-${version}";
+    sha256 = "sha256-c7U8ItFmsh+PiFF/JK4gWTBhZn46CoOXI7Rl+50Uc3c=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = []
+    ++ lib.optionals buildTests [ "-DCPPDAP_BUILD_TESTS=ON" ]
+    ++ lib.optionals buildFuzzer [ "-DCPPDAP_BUILD_FUZZER=ON" ]
+    ++ lib.optionals buildExamples [ "-DCPPDAP_BUILD_EXAMPLES=ON" ];
+
+  # Temporary patch to satisfy this check "https://github.com/google/cppdap/blob/252b56807b532533ea7362a4d949758dcb481d2b/CMakeLists.txt#L63"
+  prePatch = ''
+    mkdir -p $TMP/source/third_party/googletest/.git
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+  '' + lib.optionalString buildTests ''
+    install -Dm755 "$TMP/source/build/cppdap-unittests" "$out/bin/cppdap-unittests"
+  '' + lib.optionalString buildFuzzer ''
+    install -Dm755 "$TMP/source/build/cppdap-fuzzer" "$out/bin/cppdap-fuzzer"
+  '' + lib.optionalString buildExamples ''
+    mkdir -p $out/bin/examples
+    install -Dm755 "$TMP/source/build/hello_debugger" "$out/bin/examples/hello_debugger"
+    install -Dm755 "$TMP/source/build/simple_net_client_server" "$out/bin/examples/simple_net_client_server"
+  '';
+  
+  meta = {
+    homepage = "https://github.com/google/cppdap";
+    description = "C++ library for the Debug Adapter Protocol";
+    license = lib.licenses.asl20;
+    # See "https://github.com/Kitware/CMake/blob/5e79703f93be8374efd8e9dfe570d03a6c48e4ab/CMakeLists.txt#L139-L143"
+    platforms = lib.flatten (with lib.platforms; [ linux darwin freebsd netbsd openbsd windows cygwin ]);
+    maintainers = with lib.maintainers; [ nsidiropoulos ];
+  };
+}

--- a/pkgs/by-name/cp/cppdap/package.nix
+++ b/pkgs/by-name/cp/cppdap/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     install -Dm755 "$TMP/source/build/hello_debugger" "$out/bin/examples/hello_debugger"
     install -Dm755 "$TMP/source/build/simple_net_client_server" "$out/bin/examples/simple_net_client_server"
   '';
-  
+
   meta = {
     homepage = "https://github.com/google/cppdap";
     description = "C++ library for the Debug Adapter Protocol";


### PR DESCRIPTION
This library is a dependency for the new CMake `3.27.x` debugger.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
