### PR TITLE
elmPackages.elm-i18next-gen: init at 1.1.0

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -142,6 +142,8 @@ in lib.makeScope pkgs.newScope (self: with self; {
 
   elm-test-rs = callPackage ./packages/elm-test-rs.nix { };
 
+  elm-i18next-gen = callPackage ./packages/elm-i18next-gen.nix { };
+
   elm-test = callPackage ./packages/elm-test.nix { };
 } // (hs810Pkgs self).elmPkgs // (hs92Pkgs self).elmPkgs // (with elmLib; with (hs810Pkgs self).elmPkgs; {
   elm-verify-examples = let

--- a/pkgs/development/compilers/elm/packages/elm-i18next-gen.nix
+++ b/pkgs/development/compilers/elm/packages/elm-i18next-gen.nix
@@ -1,0 +1,26 @@
+{ lib, buildNpmPackage, fetchFromGitHub }:
+
+buildNpmPackage rec {
+  pname = "elm-i18next-gen";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "yonigibbs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-RBBTJA3sEpI5nIqhifDZGldUnVvaGK2ZeYqgvccODQ0=";
+  };
+
+  npmDepsHash = "sha256-eXh73Wb5x/7DLJk5bcpn3EkCAj8of76DrRoCHNHdvxE=";
+
+  dontNpmBuild = true;
+  npmInstallFlags = "--omit=dev";
+
+  meta = with lib; {
+    description = "Code generation for elm-i18next";
+    homepage = "https://github.com/yonigibbs/elm-i18next-gen";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ilyakooo0 ];
+  };
+}
+

--- a/pkgs/development/compilers/elm/packages/elm-i18next-gen.nix
+++ b/pkgs/development/compilers/elm/packages/elm-i18next-gen.nix
@@ -6,7 +6,7 @@ buildNpmPackage rec {
 
   src = fetchFromGitHub {
     owner = "yonigibbs";
-    repo = pname;
+    repo = "elm-i18next-gen";
     rev = "v${version}";
     hash = "sha256-RBBTJA3sEpI5nIqhifDZGldUnVvaGK2ZeYqgvccODQ0=";
   };
@@ -14,12 +14,15 @@ buildNpmPackage rec {
   npmDepsHash = "sha256-eXh73Wb5x/7DLJk5bcpn3EkCAj8of76DrRoCHNHdvxE=";
 
   dontNpmBuild = true;
+
+  # we can't download Elm during npm install
   npmInstallFlags = "--omit=dev";
 
   meta = with lib; {
     description = "Code generation for elm-i18next";
     homepage = "https://github.com/yonigibbs/elm-i18next-gen";
     license = licenses.mit;
+    mainProgram = "elm-i18next-gen";
     maintainers = with maintainers; [ ilyakooo0 ];
   };
 }


### PR DESCRIPTION
## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).