### PR TITLE
[pre-commit] Forward sys.path to pygrep via PYTHONPATH

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -32,6 +32,7 @@ buildPythonApplication rec {
   patches = [
     ./languages-use-the-hardcoded-path-to-python-binaries.patch
     ./hook-tmpl.patch
+    ./pygrep-pythonpath.patch
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/tools/misc/pre-commit/pygrep-pythonpath.patch
+++ b/pkgs/tools/misc/pre-commit/pygrep-pythonpath.patch
@@ -1,0 +1,13 @@
+diff --git a/pre_commit/languages/pygrep.py b/pre_commit/languages/pygrep.py
+index ec55560..44e08a1 100644
+--- a/pre_commit/languages/pygrep.py
++++ b/pre_commit/languages/pygrep.py
+@@ -98,7 +98,7 @@ def run_hook(
+         color: bool,
+ ) -> tuple[int, bytes]:
+     cmd = (sys.executable, '-m', __name__, *args, entry)
+-    return xargs(cmd, file_args, color=color)
++    return xargs(cmd, file_args, color=color, env={ "PYTHONPATH": ':'.join(sys.path) })
+ 
+ 
+ def main(argv: Sequence[str] | None = None) -> int:


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/173707

## Description of changes

Currently nix sets up a wrapper around the call to pre-commit. However, child python processes are not subject to that wrapper and therefore do not get the correct path to modules. This provides a correct PYTHON path to pygrep-based pre-commit hooks.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested in flakes:

```
patchedPrecommit = pkgsUnstable.pre-commit.overrideAttrs (oldAttrs:
  rec {
    patches = oldAttrs.patches ++ [ ./third_party/pre-commit_pygrep.patch ];
  }
);
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
