### PR TITLE
ncspot: install desktop file and add `updateScript`

### DIFF
--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -12,6 +12,7 @@
 , withPulseAudio ? false, libpulseaudio
 , withPortAudio ? false, portaudio
 , withMPRIS ? true, withNotify ? true, dbus
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -52,6 +53,10 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withPortAudio "portaudio_backend"
     ++ lib.optional withMPRIS "mpris"
     ++ lib.optional withNotify "notify";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Cross-platform ncurses Spotify client written in Rust, inspired by ncmpc and the likes";

--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -56,6 +56,11 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withMPRIS "mpris"
     ++ lib.optional withNotify "notify";
 
+  postInstall = ''
+    install -D --mode=444 $src/misc/ncspot.desktop $out/share/applications/${pname}.desktop
+    install -D --mode=444 $src/images/logo.svg $out/share/icons/hicolor/scalable/apps/${pname}.png
+  '';
+
   passthru = {
     updateScript = nix-update-script { };
     tests.version = testers.testVersion { package = ncspot; };

--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -13,6 +13,8 @@
 , withPortAudio ? false, portaudio
 , withMPRIS ? true, withNotify ? true, dbus
 , nix-update-script
+, testers
+, ncspot
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -56,6 +58,7 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = ncspot; };
   };
 
   meta = with lib; {

--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hrkfdn/ncspot";
     changelog = "https://github.com/hrkfdn/ncspot/releases/tag/v${version}";
     license = licenses.bsd2;
-    maintainers = [ maintainers.marsam ];
+    maintainers = with maintainers; [ marsam liff ];
     mainProgram = "ncspot";
   };
 }


### PR DESCRIPTION
## Description of changes

Upstream provides a [desktop file](https://github.com/hrkfdn/ncspot/tree/main/misc) and an [SVG logo](https://github.com/hrkfdn/ncspot/blob/main/images/logo.svg), so we might just as well make use of them.

Also added an update script and a very simple test for helping with automatic updates.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
