### PR TITLE
blender: 3.6.5 -> 4.0.1

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -38,11 +38,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "blender";
-  version = "4.0.0";
+  version = "4.0.1";
 
   src = fetchurl {
     url = "https://download.blender.org/source/${pname}-${version}.tar.xz";
-    hash = "sha256-5aUjwUCC2uk3BvsAKxbnMfKrSyAvXoIzfWInLKSIRWk=";
+    hash = "sha256-/jLU0noX5RxhQ+26G16nGFylm65Lzfm9s11oCWCC43Q=";
   };
 
   patches = [

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -3,7 +3,7 @@
 , libjpeg, libpng, libsamplerate, libsndfile
 , libtiff, libwebp, libGLU, libGL, openal, opencolorio, openexr, openimagedenoise, openimageio, openjpeg, python310Packages
 , openvdb, libXxf86vm, tbb, alembic
-, zlib, zstd, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
+, zlib, zstd, fftw, fftwFloat, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
 , jackaudioSupport ? false, libjack2
 , cudaSupport ? config.cudaSupport, cudaPackages ? { }
 , hipSupport ? false, rocmPackages # comes with a significantly larger closure size
@@ -30,15 +30,19 @@ let
     url = "https://developer.download.nvidia.com/redist/optix/v7.3/OptiX-7.3.0-Include.zip";
     sha256 = "0max1j4822mchj0xpz9lqzh91zkmvsn4py0r174cvqfz8z8ykjk8";
   };
+  libdecor' = libdecor.overrideAttrs (old: {
+    # Blender uses private APIs, need to patch to expose them
+    patches = (old.patches or [ ]) ++ [ ./libdecor.patch ];
+  });
 
 in
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "blender";
-  version = "3.6.5";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "https://download.blender.org/source/${pname}-${version}.tar.xz";
-    hash = "sha256-QAHA/pn22HLsfH6VX4Sp7r25raFxAPS1Gergjez38kM=";
+    hash = "sha256-5aUjwUCC2uk3BvsAKxbnMfKrSyAvXoIzfWInLKSIRWk=";
   };
 
   patches = [
@@ -53,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff libwebp
-      opencolorio openexr openimageio openjpeg python zlib zstd fftw jemalloc
+      opencolorio openexr openimageio openjpeg python zlib zstd fftw fftwFloat jemalloc
       alembic
       (opensubdiv.override { inherit cudaSupport; })
       tbb
@@ -65,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: rec {
       openpgl
     ]
     ++ lib.optionals waylandSupport [
-      wayland wayland-protocols libffi libdecor libxkbcommon dbus
+      wayland wayland-protocols libffi libdecor' libxkbcommon dbus
     ]
     ++ lib.optionals (!stdenv.isAarch64) [
       openimagedenoise

--- a/pkgs/applications/misc/blender/libdecor.patch
+++ b/pkgs/applications/misc/blender/libdecor.patch
@@ -1,0 +1,34 @@
+diff --git a/src/libdecor-plugin.h b/src/libdecor-plugin.h
+index ba80ce6..59199dd 100644
+--- a/src/libdecor-plugin.h
++++ b/src/libdecor-plugin.h
+@@ -132,12 +132,6 @@ struct libdecor_plugin_interface {
+ struct wl_surface *
+ libdecor_frame_get_wl_surface(struct libdecor_frame *frame);
+ 
+-int
+-libdecor_frame_get_content_width(struct libdecor_frame *frame);
+-
+-int
+-libdecor_frame_get_content_height(struct libdecor_frame *frame);
+-
+ enum libdecor_window_state
+ libdecor_frame_get_window_state(struct libdecor_frame *frame);
+ 
+diff --git a/src/libdecor.h b/src/libdecor.h
+index af67e2f..b5eba41 100644
+--- a/src/libdecor.h
++++ b/src/libdecor.h
+@@ -532,6 +532,12 @@ bool
+ libdecor_configuration_get_window_state(struct libdecor_configuration *configuration,
+ 					enum libdecor_window_state *window_state);
+ 
++int
++libdecor_frame_get_content_width(struct libdecor_frame *frame);
++
++int
++libdecor_frame_get_content_height(struct libdecor_frame *frame);
++
+ #ifdef __cplusplus
+ }
+ #endif


### PR DESCRIPTION
## Description of changes

As noted in comment, Blender is now using private libdecor APIs not in the headers, so need to patch to build against it. I think it probably works when Blender does dynamic loading at runtime since it uses the fn defs it defines in that case, but we don’t want to do that, it seems (as we already set `-DWITH_GHOST_WAYLAND_DYNLOAD=OFF`).

## Things done

Tested pkg tests, basic UI functionality, CUDA build and OptiX render.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
