### PR TITLE
patool: 1.12 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -9,6 +9,7 @@
 , lzip
 , zpaq
 , gnutar
+, unar  # Free alternative to unrar
 , gnugrep
 , diffutils
 , file
@@ -17,13 +18,11 @@
 , xz
 }:
 
-# unrar is unfree, as well as 7z with unrar support, not including it (patool doesn't support unar)
-# it will still use unrar if present in the path
-
 let
   compression-utilities = [
     p7zip
     gnutar
+    unar
     cabextract
     zip
     lzip
@@ -38,7 +37,7 @@ let
 in
 buildPythonPackage rec {
   pname = "patool";
-  version = "1.12";
+  version = "2.0.0";
   format = "setuptools";
 
   #pypi doesn't have test data
@@ -46,23 +45,8 @@ buildPythonPackage rec {
     owner = "wummel";
     repo = pname;
     rev = "upstream/${version}";
-    hash = "sha256-Xv4aCUnLi+b1T29tuKRADTIWwK2dO8iDP/D7UfU5mWw=";
+    hash = "sha256-Hjpifsi5Q1eoe/MFWuQBDyjoXi/aUG4VN84yNMkAZaE=";
   };
-
-  patches = [
-    # https://github.com/wummel/patool/pull/63
-    (fetchpatch {
-      name = "apk-sometimes-has-mime-jar.patch";
-      url = "https://github.com/wummel/patool/commit/a9f3ee3d639a1065be024001e89c0b153511b16b.patch";
-      hash = "sha256-a4aWqHHc/cBs5T2QKZ08ky1K1tqKZEgqVmTmV11aTVE=";
-    })
-    # https://github.com/wummel/patool/pull/130
-    (fetchpatch {
-      name = "apk-sometimes-has-mime-android-package.patch";
-      url = "https://github.com/wummel/patool/commit/e8a1eea1d273b278a1b6f5029d2e21cb18bc9ffd.patch";
-      hash = "sha256-AVooVdU4FNIixUfwyrn39N2SDFHNs4CUYzS5Eey+DrU=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace patoolib/util.py \


### PR DESCRIPTION
## Description of changes

Add support for unar to extract rar files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
    ```
    18 packages built:
    bottles bottles-unwrapped datalad datalad.dist patool patool.dist portmod portmod.dist python310Packages.heudiconv python310Packages.heudiconv.dist python310Packages.patool python310Packages.patool.dist python310Packages.pyunpack python310Packages.pyunpack.dist python311Packages.heudiconv python311Packages.heudiconv.dist python311Packages.pyunpack python311Packages.pyunpack.dist
    ```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@marius851000 
