### PR TITLE
ttfb: 1.7.0 -> 1.10.0

### DIFF
--- a/pkgs/development/tools/ttfb/default.nix
+++ b/pkgs/development/tools/ttfb/default.nix
@@ -1,40 +1,35 @@
 { darwin
 , fetchCrate
 , lib
-, openssl
-, pkg-config
 , rustPlatform
 , stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "ttfb";
-  version = "1.7.0";
+  version = "1.10.0";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-GxjG8pyE2rY0h1dpAo+HRUbP31I5Pm4h1fAb6R7V+qU=";
+    hash = "sha256-94gBofb7H7+qU50+cp+rq14Vtbk2vuXFQksNITvICm4=";
   };
 
-  cargoHash = "sha256-YdbVtVKt0bKb1R5IQxf9J/0ZA3ZHH+oZ8ryX6f4cGsY=";
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  cargoHash = "sha256-CUisxtUQXkStqSZikIoAN0GwpUjvQqon7KqI0beHL5U=";
 
   # The bin feature activates all dependencies of the binary. Otherwise,
   # only the library is build.
   buildFeatures = [ "bin" ];
 
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [
-    openssl
-  ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ];
-
   meta = {
     description = "CLI-Tool to measure the TTFB (time to first byte) of HTTP(S) requests";
     longDescription = ''
-      This crate measures the times of DNS lookup, TCP connect, TLS handshake, and HTTP's TTFB
-      for a given IP or domain.
+      ttfb measure the TTFB (time to first byte) of HTTP(S) requests. This includes data
+      of intermediate steps, such as the relative and absolute timings of DNS lookup, TCP
+      connect, and TLS handshake.
     '';
     homepage = "https://github.com/phip1611/ttfb";
     changelog = "https://github.com/phip1611/ttfb/blob/v${version}/CHANGELOG.md";


### PR DESCRIPTION

## Description of changes

bump `ttfb`. The new version doesn't need the openssl dependency anymore.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
