### PR TITLE
python3.pkgs.reuse: make a python library

### DIFF
--- a/pkgs/development/python-modules/reuse/default.nix
+++ b/pkgs/development/python-modules/reuse/default.nix
@@ -1,6 +1,16 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, binaryornot
+, boolean-py
+, debian
+, jinja2
+, license-expression
+, pytestCheckHook
+}:
 
-python3Packages.buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "reuse";
   version = "2.1.0";
   format = "pyproject";
@@ -12,11 +22,11 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-MEQiuBxe/ctHlAnmLhQY4QH62uAcHb7CGfZz+iZCRSk=";
   };
 
-  nativeBuildInputs = with python3Packages; [
+  nativeBuildInputs = [
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     binaryornot
     boolean-py
     debian
@@ -24,12 +34,14 @@ python3Packages.buildPythonApplication rec {
     license-expression
   ];
 
-  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTestPaths = [
     # pytest wants to execute the actual source files for some reason, which fails with ImportPathMismatchError()
     "src/reuse"
   ];
+
+  pythonImportsCheck = [ "reuse" ];
 
   meta = with lib; {
     description = "A tool for compliance with the REUSE Initiative recommendations";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12774,7 +12774,7 @@ with pkgs;
 
   restool = callPackage ../os-specific/linux/restool { };
 
-  reuse = callPackage ../tools/package-management/reuse { };
+  reuse = with python3.pkgs; toPythonApplication reuse;
 
   reveal-md = callPackage ../tools/text/reveal-md { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12486,6 +12486,8 @@ self: super: with self; {
 
   returns = callPackage ../development/python-modules/returns { };
 
+  reuse = callPackage ../development/python-modules/reuse { };
+
   rfc3339 = callPackage ../development/python-modules/rfc3339 { };
 
   rfc3339-validator = callPackage ../development/python-modules/rfc3339-validator { };


### PR DESCRIPTION
reuse actually can also be used as a python library: https://github.com/fsfe/reuse-tool/blob/main/src/reuse/__init__.py#L11-L12

This change allows composing a python with `reuse` in `PYTHONPATH`:

```
$(nix-build -E "with import ./. {}; (python3.withPackages (ps: [ps.reuse]))")/bin/python
Python 3.11.5 (main, Aug 24 2023, 12:23:19) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import reuse
>>> reuse.__doc__
'reuse is a tool for compliance with the REUSE recommendations.\n\nAlthough the API is documented, it is **NOT** guaranteed stable between minor or\neven patch releases. The semantic versioning of this program pertains\nexclusively to the reuse CLI command. If you want to use reuse as a Python\nlibrary, you should pin reuse to an exact version.\n\nHaving given the above disclaimer, the API has been relatively stable\nnevertheless, and we (the maintainers) do make some efforts to not needlessly\nchange the public API.\n'
```

vs before:
```
❯ $(nix-build -E "with import ./. {}; (python3.withPackages (_: [ reuse]))")/bin/python
Python 3.11.5 (main, Aug 24 2023, 12:23:19) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import reuse
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'reuse'
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
