### PR TITLE
piper-tts, piper-phonemize: 2023.11.6-1 -> 2023.11.14-2

### DIFF
--- a/pkgs/development/libraries/piper-phonemize/default.nix
+++ b/pkgs/development/libraries/piper-phonemize/default.nix
@@ -28,13 +28,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "piper-phonemize";
-  version = "2023.11.6-1";
+  version = "2023.11.14-4";
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "piper-phonemize";
     rev = "refs/tags/${version}";
-    hash = "sha256-IRvuA03Z6r8Re/ocq2G/r28uwI9RU3xmmNI7S2G40rc=";
+    hash = "sha256-pj1DZUhy3XWGn+wNtxKKDWET9gsfofEB0NZ+EEQz9q0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/audio/piper/default.nix
+++ b/pkgs/tools/audio/piper/default.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "piper";
-  version = "2023.11.6-1";
+  version = "2023.11.14-2";
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "piper";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-9y7HuVgbI8if5XrgQGnEZV1lOw8oMXTFRUTvy/kTGfs=";
+    hash = "sha256-3ynWyNcdf1ffU3VoDqrEMrm5Jo5Zc5YJcVqwLreRCsI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

```
❯ time echo "The world has changed in the 23 years since the Chaos Computer Club stepped forward to keep an eye on the impact of technological advances on people and society. Technology and electronic communication are a driving force in companies, government, and entertainment and enable a lot of new developments in the first place." | ./result/bin/piper --model ./en_GB-semaine-medium.onnx
Playing raw data 'stdin' : Signed 16 bit Little Endian, Rate 22050 Hz, Mono
[2023-11-14 22:06:37.940] [piper] [info] Loaded voice in 0.152854908 second(s)
[2023-11-14 22:06:37.941] [piper] [info] Initialized piper
[2023-11-14 22:06:37.941] [piper] [info] Output directory: /home/hexa/git/nixos/master/.
/home/hexa/git/nixos/master/./1699995997941568252.wav
[2023-11-14 22:06:38.569] [piper] [info] Real-time factor: 0.03411016564639729 (infer=0.621748652 sec, audio=18.227664399092973 sec)
[2023-11-14 22:06:38.569] [piper] [info] Terminated piper
echo   0.00s user 0.00s system 35% cpu 0.001 total
./result/bin/piper --model ./en_GB-semaine-medium.onnx  5.94s user 0.48s system 795% cpu 0.806 total
```

Real time factor of 0.034 is really amazing :partying_face: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
