### PR TITLE
python311Packages.textual-dev: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19535,6 +19535,12 @@
     github = "yanganto";
     githubId = 10803111;
   };
+  yannip = {
+    email = "yPapandreou7@gmail.com";
+    github = "YanniPapandreou";
+    githubId = 15948162;
+    name = "Yanni Papandreou";
+  };
   yarny = {
     github = "Yarny0";
     githubId = 41838844;

--- a/pkgs/development/python-modules/textual-dev/default.nix
+++ b/pkgs/development/python-modules/textual-dev/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, msgpack
+, poetry-core
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+, textual
+, time-machine
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "textual-dev";
+  version = "1.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Textualize";
+    repo = "textual-dev";
+    # we use rev instead of tag since upstream doesn't use tags
+    rev = "6afa9013a42cb18e9105e49d6a56874097f7c812";
+    hash = "sha256-ef35389ZMU/zih7Se3KkMGECf5o2i5y6up64/1AECas=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    click
+    msgpack
+    textual
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytest-aiohttp
+    pytestCheckHook
+    time-machine
+  ];
+
+  pythonImportsCheck = [
+    "textual_dev"
+  ];
+
+  meta = with lib; {
+    description = "Development tools for Textual";
+    homepage = "https://github.com/Textualize/textual-dev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yannip ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13864,6 +13864,8 @@ self: super: with self; {
 
   textual = callPackage ../development/python-modules/textual { };
 
+  textual-dev = callPackage ../development/python-modules/textual-dev { };
+
   textual-universal-directorytree = callPackage ../development/python-modules/textual-universal-directorytree { };
 
   testbook = callPackage ../development/python-modules/testbook { };


### PR DESCRIPTION
## Description of changes

<!--
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the Python package `textual-dev` with homepage [here](https://github.com/Textualize/textual-dev). This Python package provides development tools for the Python package `textual` (homepage [here](https://github.com/Textualize/textual)) which is already packaged in nix (source [here](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/textual/default.nix#L80)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Notes:

This package also provides a cli binary `textual`. I am new to textual and only tested out a few commands with the resulting binary file in `./result/bin/`. I have not tested all of the functionality yet but not sure what is required; this is my first time contributing to nixpkgs.
