### PR TITLE
the-powder-toy: unstable-2022-08-30 -> 97.0.352

### DIFF
--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -38,8 +38,9 @@ stdenv.mkDerivation rec {
     install -Dm 755 powder $out/bin/powder
 
     mkdir -p $out/share/applications
-    mv ./resources/powder.desktop $out/share/applications
     mv ../resources $out/share
+  '' + lib.optionalString stdenv.isLinux ''
+    mv ./resources/powder.desktop $out/share/applications
   '';
 
   meta = with lib; {

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -12,29 +12,33 @@
 , lua
 , luajit
 , zlib
+, jsoncpp
+, libpng
 , Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "the-powder-toy";
-  version = "unstable-2022-08-30";
+  version = "97.0.352";
 
   src = fetchFromGitHub {
     owner = "The-Powder-Toy";
     repo = "The-Powder-Toy";
-    rev = "9e712eba080e194fc162b475f58aaed8f4ea008e";
-    sha256 = "sha256-44xUfif1E+T9jzixWgnBxOWmzPPuVZy7rf62ig/CczA=";
+    rev = "v${version}";
+    sha256 = "sha256-LYohsqFU9LBgTXMaV6cf8/zf3fBvT+s5A1JBpPHekH8=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config python3 ];
 
-  buildInputs = [ SDL2 bzip2 curl fftwFloat lua luajit zlib ]
+  buildInputs = [ SDL2 bzip2 curl fftwFloat lua luajit zlib jsoncpp libpng ]
   ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+
+  mesonFlags = [ "-Dworkaround_elusive_bzip2=false" ];
 
   installPhase = ''
     install -Dm 755 powder $out/bin/powder
 
     mkdir -p $out/share/applications
-    mv ../resources/powder.desktop $out/share/applications
+    mv ./resources/powder.desktop $out/share/applications
     mv ../resources $out/share
   '';
 


### PR DESCRIPTION


## Description of changes

https://powdertoy.co.uk/Download/Changelog.html (no stable per-version link seems to exist, from what I can tell? GitHub Releases' changelogs are based on changes from the previous snapshot, not the previous stable version)

Added new build dependencies `jsoncpp` and `libpng`. Add `-Dworkaround_elusive_bzip2=false` (incorrectly hardcodes the include path of bzip2 to /usr/include and other FHS-assuming paths) to mesonFlags. 

`powder.desktop` is now generated inside the build directory from a template in `resources/powder.template.desktop`, so adjust the path in installPhase to reflect that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
