### PR TITLE
mnemonicode: 2015-11-30 -> 1.0.0

### DIFF
--- a/pkgs/misc/mnemonicode/default.nix
+++ b/pkgs/misc/mnemonicode/default.nix
@@ -1,20 +1,21 @@
 { stdenv, lib, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mnemonicode";
-  version = "2015-11-30";
+  version = "1.0.0";
   src = fetchFromGitHub {
     owner = "singpolyma";
     repo = "mnemonicode";
-    rev = "1687fabdf48acf68d4186f219bc20bffe02e8ee0";
-    sha256 = "0kp1jhhqfwfiqg9kx0mbyr4qh4yc4zg4szqk5fbf809nx2pvprm5";
+    rev = finalAttrs.version;
+    hash = "sha256-bGipPvLj6ig+lMLsl/Yve8PmuA93ETvhNKoMPh0JMBM=";
   };
   installPhase = ''
     mkdir -p $out/bin
-    cp mnencode $out/bin
-    cp mndecode $out/bin
+    mv mnencode $out/bin
+    mv mndecode $out/bin
   '';
   meta = with lib; {
+    homepage = "https://github.com/singpolyma/mnemonicode";
     description = ''
       Routines which implement a method for encoding binary data into a sequence
       of words which can be spoken over the phone, for example, and converted
@@ -22,6 +23,7 @@ stdenv.mkDerivation {
     '';
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ ];
+    maintainers = with maintainers; [ kirillrdy ];
+    mainProgram = "mnencode";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

latest stable version and added myself as maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
