### PR TITLE
ocamlPackages.zipc: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/zipc/default.nix
+++ b/pkgs/development/ocaml-modules/zipc/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl
+, ocaml, findlib, ocamlbuild, topkg, cmdliner
+}:
+
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.14")
+  "zipc is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-zipc";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://erratique.ch/software/zipc/releases/zipc-${version}.tbz";
+    hash = "sha256-vU4AGW1MjQ31xjwvyRKSn1AwS0X6gjLvaJGYKqzFRpk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    ocaml findlib ocamlbuild
+  ];
+
+  buildInputs = [ cmdliner topkg ];
+
+  inherit (topkg) buildPhase installPhase;
+
+  meta = {
+    description = "ZIP archive and deflate codec for OCaml";
+    homepage = "https://erratique.ch/software/zipc";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1892,6 +1892,8 @@ let
 
     zelus-gtk = callPackage ../development/ocaml-modules/zelus-gtk { };
 
+    zipc = callPackage ../development/ocaml-modules/zipc { };
+
     zmq = callPackage ../development/ocaml-modules/zmq { };
 
     zmq-lwt = callPackage ../development/ocaml-modules/zmq/lwt.nix { };


### PR DESCRIPTION
## Description of changes

Zipc is an in-memory [ZIP archive](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) and [deflate](https://www.rfc-editor.org/rfc/rfc1951) compression codec

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
