### PR TITLE
edid-generator: 2018-03-15 -> 2023-11-15

### DIFF
--- a/pkgs/tools/misc/edid-generator/default.nix
+++ b/pkgs/tools/misc/edid-generator/default.nix
@@ -5,43 +5,63 @@
 , edid-decode
 , hexdump
 , zsh
-, modelines ? [ ] # Modeline "1280x800"   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync
-, clean ? false # should it skip all, but explicitly listed modelines?
 }:
 
 # Usage:
-#   (edid-generator.override {
+#   hardware.firmware = [(edid-generator.overrideAttrs {
 #     clean = true;
-#     modelines = [
-#       ''Modeline "PG278Q_2560x1440"       241.50   2560 2608 2640 2720   1440 1443 1448 1481   -hsync +vsync''
-#       ''Modeline "PG278Q_2560x1440@120"   497.75   2560 2608 2640 2720   1440 1443 1448 1525   +hsync -vsync''
-#       ''Modeline "U2711_2560x1440"        241.50   2560 2600 2632 2720   1440 1443 1448 1481   -hsync +vsync''
-#     ];
-#   })
+#     modelines = ''
+#       Modeline "PG278Q_60"      241.50   2560 2608 2640 2720   1440 1443 1448 1481   -hsync +vsync
+#       Modeline "PG278Q_120"     497.75   2560 2608 2640 2720   1440 1443 1448 1525   +hsync -vsync
+#       Modeline "U2711_60"       241.50   2560 2600 2632 2720   1440 1443 1448 1481   -hsync +vsync
+#     '';
+#   })];
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "edid-generator";
-  version = "unstable-2018-03-15";
+  version = "master-2023-11-20";
+
+  # so `hardware.firmware` doesn't compress it
+  compressFirmware = false;
 
   src = fetchFromGitHub {
     owner = "akatrevorjay";
     repo = "edid-generator";
-    rev = "31a6f80784d289d2faa8c4ca4788409c83b3ea14";
-    sha256 = "0j6wqzx5frca8b5i6812vvr5iwk7440fka70bmqn00k0vfhsc2x3";
+    rev = "476a016d8b488df749bf6d6efbf7b9fbfb2e3cb8";
+    sha256 = "sha256-UGxze273VB5cQDWrv9X/Lam6WbOu9U3bro8GcVbEvws=";
   };
 
   nativeBuildInputs = [ dos2unix edid-decode hexdump zsh ];
 
   postPatch = ''
     patchShebangs modeline2edid
-    # allows makefile to discover prefixes and suffixes in addition to just `[0-9]*x[0-9]*.S`
-    awk -i inplace '/^SOURCES\t/ { print "SOURCES\t:= $(wildcard *[0-9]*x[0-9]**.S)"; next; }; { print; }' Makefile
   '';
 
+  passAsFile = [ "modelines" ];
+  clean = false;
+  modelines = "";
+
   configurePhase = ''
-    test '${toString clean}' != 1 || rm *x*.S
-    ${lib.concatMapStringsSep "\n" (m: "./modeline2edid - <<<'${m}'") modelines}
-    make clean all
+    test "$clean" != 1 || rm *x*.S
+    ./modeline2edid - <"$modelinesPath"
+
+    for file in *.S ; do
+      echo "--- generated file: $file"
+      cat "$file"
+    done
+    make clean
+  '';
+
+  buildPhase = ''
+    make all
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    for file in *.bin ; do
+      echo "validating $file"
+      edid-decode <"$file"
+    done
   '';
 
   installPhase = ''
@@ -51,7 +71,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Hackerswork to generate an EDID blob from given Xorg Modelines";
     homepage = "https://github.com/akatrevorjay/edid-generator";
-    license = lib.licenses.mit;
+    license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ flokli nazarewk ];
     platforms = lib.platforms.all;
     broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/edid-generator.x86_64-darwin


### PR DESCRIPTION
## Description of changes

result of:
- suprise merge of https://github.com/akatrevorjay/edid-generator/pull/28
- temporarily builds off my fork until https://github.com/akatrevorjay/edid-generator/pull/29 is merged

also:
- fixes and gives actually working example of `overrideAttrs`
- ensures it works with `hardware.firmware` option
- split into phases
- adds `checkPhase`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
