### PR TITLE
nix-web: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ni/nix-web/package.nix
+++ b/pkgs/by-name/ni/nix-web/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, rustPlatform
+, fetchFromGitea
+, pkg-config
+, openssl
+, nix
+}:
+
+let
+  cargoFlags = [ "-p" "nix-web" ];
+in
+rustPlatform.buildRustPackage rec {
+  pname = "nix-web";
+  version = "0.1.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "gorgon";
+    repo = "gorgon";
+    rev = "nix-web-v${version}";
+    hash = "sha256-+IDvoMRuMt1nS69yFhPPVs+s6Dj0dgXVdjjd9f3+spk=";
+  };
+  cargoHash = "sha256-uVBfIw++MRxgVAC+KzGVuMZra8oktUfHcZQk90FF1a8=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  postPatch = ''
+    substituteInPlace nix-web/nix-web.service \
+      --replace 'ExecStart=nix-web' "ExecStart=$out/bin/nix-web"
+  '';
+  postInstall = ''
+    install -m 644 -D nix-web/nix-web.service $out/lib/systemd/system/nix-web.service
+  '';
+
+  cargoBuildFlags = cargoFlags;
+  cargoTestFlags = cargoFlags;
+
+  NIX_WEB_BUILD_NIX_CLI_PATH = "${nix}/bin/nix";
+
+  meta = with lib; {
+    description = "Web interface for the Nix store";
+    homepage = "https://codeberg.org/gorgon/gorgon/src/branch/main/nix-web";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ embr ];
+    mainProgram = "nix-web";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
