### PR TITLE
eigenlayer: init at 0.5.0

### DIFF
--- a/pkgs/by-name/ei/eigenlayer/package.nix
+++ b/pkgs/by-name/ei/eigenlayer/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule rec {
+  pname = "eigenlayer";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "Layr-Labs";
+    repo = "eigenlayer-cli";
+    rev = "v${version}";
+    hash = "sha256-zLTzDVXj2XTjgMuTLXVQStzDkkOGU2kCgIvBmJKohY4";
+  };
+
+  vendorHash = "sha256-gAW+yEj4aRHTuuZLrqQs8lebs9/O0uGxkHRK3B1TG+Q=";
+
+  ldflags = ["-s" "-w"];
+  subPackages = ["cmd/eigenlayer"];
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = with lib; {
+    homepage = "https://www.eigenlayer.xyz/";
+    changelog = "https://github.com/Layr-Labs/eigenlayer-cli/releases/tag/${src.rev}";
+    description = "Utility that manages core operator functionalities like local keys, operator registration and updates";
+    mainProgram = "eigenlayer";
+    license = licenses.bsl11;
+    maintainers = with maintainers; [selfuryon];
+  };
+}


### PR DESCRIPTION
## Description of changes
[EigenLayer](https://www.eigenlayer.xyz/) has a [cli utility](https://github.com/NethermindEth/eigenlayer/tree/develop) to manage operators.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Merge after https://github.com/NixOS/nixpkgs/pull/265354 because I added myself to maintainer list there
