### PR TITLE
xscreensaver: Add service module and suid wrapper patch

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18776,6 +18776,12 @@
     githubId = 223408;
     name = "Varun Madiath";
   };
+  vancluever = {
+    email = "chrism@vancluevertech.com";
+    github = "vancluever";
+    githubId = 10704423;
+    name = "Chris Marchesi";
+  };
   vandenoever = {
     email = "jos@vandenoever.info";
     github = "vandenoever";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1406,6 +1406,7 @@
   ./services/x11/xautolock.nix
   ./services/x11/xbanish.nix
   ./services/x11/xfs.nix
+  ./services/x11/xscreensaver.nix
   ./services/x11/xserver.nix
   ./system/activation/activatable-system.nix
   ./system/activation/activation-script.nix

--- a/nixos/modules/services/x11/xscreensaver.nix
+++ b/nixos/modules/services/x11/xscreensaver.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.xscreensaver;
+in
+{
+  options.services.xscreensaver = {
+    enable = lib.mkEnableOption "xscreensaver user service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.xscreensaver;
+      defaultText = lib.literalExpression "pkgs.xscreensaver";
+      description = "Which xscreensaver package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Make xscreensaver-auth setuid root so that it can (try to) prevent the OOM
+    # killer from unlocking the screen.
+    security.wrappers.xscreensaver-auth = {
+      setuid = true;
+      owner = "root";
+      group = "root";
+      source = "${pkgs.xscreensaver}/libexec/xscreensaver/xscreensaver-auth";
+    };
+
+    systemd.user.services.xscreensaver = {
+      enable = true;
+      description = "XScreenSaver";
+      after = [ "graphical-session-pre.target" ];
+      partOf = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      path = [ cfg.package ];
+      serviceConfig.ExecStart = "${cfg.package}/bin/xscreensaver -no-splash";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ vancluever AndersonTorres ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -927,6 +927,7 @@ in {
   xmonad-xdg-autostart = handleTest ./xmonad-xdg-autostart.nix {};
   xpadneo = handleTest ./xpadneo.nix {};
   xrdp = handleTest ./xrdp.nix {};
+  xscreensaver = handleTest ./xscreensaver.nix {};
   xss-lock = handleTest ./xss-lock.nix {};
   xterm = handleTest ./xterm.nix {};
   xxh = handleTest ./xxh.nix {};

--- a/nixos/tests/xscreensaver.nix
+++ b/nixos/tests/xscreensaver.nix
@@ -1,0 +1,64 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "pass-secret-service";
+  meta.maintainers = with lib.maintainers; [ vancluever AndersonTorres ];
+
+  nodes = {
+    ok = { nodes, pkgs, ... }:
+      {
+        imports = [ ./common/x11.nix ./common/user-account.nix ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver.enable = true;
+      };
+
+    empty_wrapperPrefix = { nodes, pkgs, ... }:
+      {
+        imports = [ ./common/x11.nix ./common/user-account.nix ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver.enable = true;
+        nixpkgs.overlays = [
+          (self: super: {
+            xscreensaver = super.xscreensaver.override {
+              wrapperPrefix = "";
+            };
+          })
+        ];
+      };
+
+    bad_wrapperPrefix = { nodes, pkgs, ... }:
+      {
+        imports = [ ./common/x11.nix ./common/user-account.nix ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver.enable = true;
+        nixpkgs.overlays = [
+          (self: super: {
+            xscreensaver = super.xscreensaver.override {
+              wrapperPrefix = "/a/bad/path";
+            };
+          })
+        ];
+      };
+  };
+
+  testScript = ''
+    ok.wait_for_x()
+    ok.wait_for_unit("xscreensaver", "alice")
+    _, output_ok = ok.systemctl("status xscreensaver", "alice")
+    assert 'To prevent the kernel from randomly unlocking' not in output_ok
+    assert 'your screen via the out-of-memory killer' not in output_ok
+    assert '"xscreensaver-auth" must be setuid root' not in output_ok
+
+    empty_wrapperPrefix.wait_for_x()
+    empty_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
+    _, output_empty_wrapperPrefix = empty_wrapperPrefix.systemctl("status xscreensaver", "alice")
+    assert 'To prevent the kernel from randomly unlocking' in output_empty_wrapperPrefix
+    assert 'your screen via the out-of-memory killer' in output_empty_wrapperPrefix
+    assert '"xscreensaver-auth" must be setuid root' in output_empty_wrapperPrefix
+
+    bad_wrapperPrefix.wait_for_x()
+    bad_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
+    _, output_bad_wrapperPrefix = bad_wrapperPrefix.systemctl("status xscreensaver", "alice")
+    assert 'To prevent the kernel from randomly unlocking' in output_bad_wrapperPrefix
+    assert 'your screen via the out-of-memory killer' in output_bad_wrapperPrefix
+    assert '"xscreensaver-auth" must be setuid root' in output_bad_wrapperPrefix
+  '';
+})

--- a/pkgs/by-name/xs/xscreensaver/xscreensaver-wrapper-prefix.patch
+++ b/pkgs/by-name/xs/xscreensaver/xscreensaver-wrapper-prefix.patch
@@ -1,0 +1,37 @@
+--- a/driver/xscreensaver.c
++++ b/driver/xscreensaver.c
+@@ -253,6 +253,8 @@
+ #undef MAX
+ #define MAX(x,y)((x)>(y)?(x):(y))
+ 
++/* Define the default wrapper prefix here, for NixOS */
++#define NIXOS_WRAPPER_PREFIX "@wrapperPrefix@"
+ 
+ /* Globals used in this file.
+  */
+@@ -632,12 +634,24 @@ handle_sigchld (Display *dpy, Bool blanked_p)
+ static void
+ hack_environment (void)
+ {
++  static const char *wrapper_path = NIXOS_WRAPPER_PREFIX;
+   static const char *def_path = DEFAULT_PATH_PREFIX;
+   const char *opath = getenv("PATH");
+   char *npath;
+   if (! opath) opath = "/bin:/usr/bin";  /* WTF */
+-  npath = (char *) malloc(strlen(def_path) + strlen(opath) + 20);
++  /* NOTE: The NixOS patch adds extra margin than what would be expected for a
++     single extra ":" PATH separator to account for UTF-32 encoding. The
++     original 20 bytes would have only accounted for UTF-16 safely (the path
++     concatenation would have needed 28 bytes of margin at minimum for UTF-32).
++   */
++  npath = (char *) malloc(strlen(wrapper_path) + strlen(def_path) + strlen(opath) + 32);
+   strcpy (npath, "PATH=");
++  if (wrapper_path && *wrapper_path)
++    {
++      strcat (npath, wrapper_path);
++      strcat (npath, ":");
++    }
++
+   strcat (npath, def_path);
+   strcat (npath, ":");
+   strcat (npath, opath);


### PR DESCRIPTION
## Description of changes

This adds the NixOS module (from @aidalgol) and a patch for XScreenSaver that ensures that the suid wrapper for xscreensaver-auth is run correctly.

The patch is a simple update to drivers/xscreensaver.c that inserts /run/wrappers/bin before the `DEFAULT_PATH_PREFIX`, which is the directory for xscreensaver hacks/demos, and should be preserved.

The wrapper directory can be modified in the derivation, or even disabled.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes #130218.