### PR TITLE
webtorrent_desktop: use electron 27

### DIFF
--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -1,15 +1,27 @@
-{ lib, stdenv, electron_22, buildNpmPackage, fetchFromGitHub }:
+{ lib, stdenv, electron, buildNpmPackage, fetchFromGitHub, fetchpatch }:
 
 buildNpmPackage {
   pname = "webtorrent-desktop";
-  version = "0.25-pre";
+  version = "0.25-pre-1eb612";
   src = fetchFromGitHub {
     owner = "webtorrent";
     repo = "webtorrent-desktop";
-    rev = "fce078defefd575cb35a5c79d3d9f96affc8a08f";
-    sha256 = "sha256-gXFiG36qqR0QHTqhaxgQKDO0UCHkJLnVwUTQB/Nct/c=";
+    rev = "1eb61201d6360698a2cc4ea72bf0fa7ee78b457c";
+    sha256 = "sha256-DBEFOamncyidMXypvKNnUmDIPUq1LzYjDgox7fa4+Gg=";
   };
-  npmDepsHash = "sha256-pEuvstrZ9oMdJ/iU6XwEQ1BYOyQp/ce6sYBTrMCjGMc=";
+  patches = [
+    # electron 27 fix
+    (fetchpatch {
+      url = "https://github.com/webtorrent/webtorrent-desktop/pull/2388.patch";
+      hash = "sha256-gam5oAZtsaiCNFwecA5ff0nhraySLx3SOHlb/js+cPM=";
+    })
+    # startup fix
+    (fetchpatch {
+      url = "https://github.com/webtorrent/webtorrent-desktop/pull/2389.patch";
+      hash = "sha256-hBJGLNNjcGRhYOFlLm/RL0po+70tEeJtR6Y/CfacPAI=";
+    })
+  ];
+  npmDepsHash = "sha256-tqhp3jDb1xtyV/n9kJtzkiznLQfqeYWeZiTnTVV0ibE=";
   makeCacheWritable = true;
   npmRebuildFlags = [ "--ignore-scripts" ];
   installPhase = ''
@@ -31,7 +43,7 @@ buildNpmPackage {
     cat > $out/bin/WebTorrent <<EOF
     #! ${stdenv.shell}
     set -eu
-    exec ${electron_22}/bin/electron --no-sandbox $out/lib/webtorrent-desktop "\$@"
+    exec ${electron}/bin/electron --no-sandbox $out/lib/webtorrent-desktop "\$@"
     EOF
     chmod +x $out/bin/WebTorrent
     cp -r static/linux/share/icons $out/share/

--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -56,7 +56,7 @@ buildNpmPackage {
     description = "Streaming torrent app for Mac, Windows, and Linux";
     homepage = "https://webtorrent.io/desktop";
     license = licenses.mit;
-    maintainers = [ maintainers.flokli maintainers.bendlas ];
+    maintainers = [ maintainers.bendlas ];
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36436,7 +36436,9 @@ with pkgs;
 
   webssh = with python3Packages; toPythonApplication webssh;
 
-  webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop { };
+  webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {
+    electron = electron_27;
+  };
 
   wrapWeechat = callPackage ../applications/networking/irc/weechat/wrapper.nix { };
 


### PR DESCRIPTION
## Description of changes

update and test with electron 27, as 22 is marked as insecure

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
