### PR TITLE
e3-core: init at 22.3.1

### DIFF
--- a/pkgs/development/python-modules/e3-core/0001-use-distro-over-ld.patch
+++ b/pkgs/development/python-modules/e3-core/0001-use-distro-over-ld.patch
@@ -1,0 +1,42 @@
+From 189681bbfb703a7026ca7bbb3b21ef554807b144 Mon Sep 17 00:00:00 2001
+From: tali auster <taliauster@gmail.com>
+Date: Wed, 15 Nov 2023 12:15:34 -0700
+Subject: [PATCH] use distro over ld
+
+The `ld` module (linux distribution) was renamed to `distro`, presumably
+so as not to subsume binutils name.
+
+---
+ setup.py              | 2 +-
+ src/e3/os/platform.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index c32f46f..de1ada6 100644
+--- a/setup.py
++++ b/setup.py
+@@ -25,7 +25,7 @@ for p in ("darwin", "linux", "linux2", "win32"):
+     platform_string = ":sys_platform=='%s'" % p
+     extras_require[platform_string] = ["psutil"]
+     if p in ("linux", "linux2"):
+-        extras_require[platform_string].append("ld")
++        extras_require[platform_string].append("distro")
+ 
+ # Get e3 version from the VERSION file.
+ version_file = os.path.join(os.path.dirname(__file__), "VERSION")
+diff --git a/src/e3/os/platform.py b/src/e3/os/platform.py
+index 2d4e174..a9d12d3 100644
+--- a/src/e3/os/platform.py
++++ b/src/e3/os/platform.py
+@@ -78,7 +78,7 @@ class SystemInfo:
+ 
+         # Fetch linux distribution info on linux OS
+         if cls.uname.system == "Linux":  # linux-only
+-            import ld
++            import distro as ld
+ 
+             cls.ld_info = {
+                 "name": ld.name(),
+-- 
+2.40.1
+

--- a/pkgs/development/python-modules/e3-core/default.nix
+++ b/pkgs/development/python-modules/e3-core/default.nix
@@ -1,0 +1,65 @@
+{ buildPythonPackage
+, colorama
+, coverage
+, distro
+, fetchFromGitHub
+, httpretty
+, lib
+, mock
+, psutil
+, pytest
+, pytest-socket
+, python-dateutil
+, pyyaml
+, requests
+, requests-toolbelt
+, stdenv
+, setuptools
+, stevedore
+, tomlkit
+, tox
+, tqdm
+, typeguard
+}:
+
+buildPythonPackage rec {
+  pname = "e3-core";
+  version = "22.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "e3-core";
+    rev = "v${version}";
+    hash = "sha256-4StHOJldfeqApdF6D14Euzg9HvZ2e7G4/OQ0UrEbEIw=";
+  };
+
+  patches = [ ./0001-use-distro-over-ld.patch ];
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    colorama pyyaml python-dateutil requests requests-toolbelt tqdm stevedore
+  ] ++ lib.optional stdenv.isLinux [
+    # See setup.py:24. These are required only on Linux. Darwin has its own set
+    # of requirements.
+    psutil distro
+  ];
+
+  pythonImportsCheck = [ "e3" ];
+
+  # e3-core is tested with tox; it's hard to test without internet.
+  doCheck = false;
+
+  meta = with lib; {
+    changelog = "https://github.com/AdaCore/e3-core/releases/tag/${src.rev}";
+    homepage = "https://github.com/AdaCore/e3-core/";
+    description = "Core framework for developing portable automated build systems";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ atalii ];
+    mainProgram = "e3";
+    # See the comment regarding distro and psutil. Other platforms are supported
+    # upstream, but not by this package.
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3412,6 +3412,8 @@ self: super: with self; {
 
   dynd = callPackage ../development/python-modules/dynd { };
 
+  e3-core = callPackage ../development/python-modules/e3-core { };
+
   eagle100 = callPackage ../development/python-modules/eagle100 { };
 
   easydict = callPackage ../development/python-modules/easydict { };


### PR DESCRIPTION
## Description of changes

Adds the e3-core python library. This has some general utility, though it's primarily used by AdaCore for build automation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
