### PR TITLE
gcc6: don’t link libstdc++ to CoreFoundation

### DIFF
--- a/pkgs/development/compilers/gcc/patches/6/libstdc++-disable-flat_namespace.patch
+++ b/pkgs/development/compilers/gcc/patches/6/libstdc++-disable-flat_namespace.patch
@@ -1,0 +1,26 @@
+Backported from GCC 7.
+
+diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
+index 304a7f5aff6..d1a189d93d0 100644
+--- a/libstdc++-v3/configure.host
++++ b/libstdc++-v3/configure.host
+@@ -234,7 +234,7 @@ case "${host_os}" in
+     os_include_dir="os/newlib"
+     OPT_LDFLAGS="${OPT_LDFLAGS} \$(lt_host_flags)"
+     ;;
+-  darwin | darwin[1-7] | darwin[1-7].*)
++  darwin[1-7] | darwin[1-7].*)
+     # On Darwin, performance is improved if libstdc++ is single-module.
+     # Up to at least 10.3.7, -flat_namespace is required for proper
+     # treatment of coalesced symbols.
+@@ -252,6 +252,10 @@ case "${host_os}" in
+     esac
+     os_include_dir="os/bsd/darwin"
+     ;;
++  darwin*)
++    # Post Darwin8, defaults should be sufficient.
++    os_include_dir="os/bsd/darwin"
++    ;;
+   *djgpp*)      # leading * picks up "msdosdjgpp"
+     os_include_dir="os/djgpp"
+     error_constants_dir="os/djgpp"

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -259,6 +259,9 @@ in
 # This patch can be dropped should darwin.cctools-llvm ever implement support.
 ++ optional (!atLeast7 && hostPlatform.isDarwin && lib.versionAtLeast (lib.getVersion stdenv.cc) "12") ./4.9/darwin-clang-as.patch
 
+# Building libstdc++ with flat namespaces results in trying to link CoreFoundation, which
+# defaults to the impure, system location and causes the build to fail.
+++ optional (is6 && hostPlatform.isDarwin) ./6/libstdc++-disable-flat_namespace.patch
 
 ## gcc 4.9 and older ##############################################################################
 


### PR DESCRIPTION
## Description of changes

Fixes the build failure of GCC 6 on x86_64-darwin on staging-next #263535. Targeting master because this causes a limited number of rebuilds, and the patch also applies there.

https://hydra.nixos.org/build/240799330

Using flat namespaces causes libstdc++ to link CoreFoundation, but that fails after #265102. Since CoreFoundation is not actually needed, disable flat namespaces to avoid linking it unnecessarily.

Disabling flat namespaces matches the behavior of newer versions of libstdc++ (GCC 7+) when building for newer Darwin hosts (10.5+).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
