### PR TITLE
Add `splice` to splice a single derivation

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -146,6 +146,8 @@ with pkgs;
 
   cross = recurseIntoAttrs (callPackage ./cross { });
 
+  splicing = callPackage ./splicing { };
+
   php = recurseIntoAttrs (callPackages ./php { });
 
   pkg-config = recurseIntoAttrs (callPackage ../top-level/pkg-config/tests.nix { }) // {

--- a/pkgs/test/splicing/default.nix
+++ b/pkgs/test/splicing/default.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  stdenvNoCC,
+  lib,
+}:
+let
+  pkgsCross =
+    pkgs.pkgsCross.${
+      if stdenvNoCC.buildPlatform.isAarch64 then "gnu64" else "aarch64-multiplatform"
+    }.__splicedPackages;
+  tests = [
+    ({
+      name = "spliceSingle";
+      expr = (pkgsCross.splice { drv = pkgsCross.zsh; }).__spliced == pkgsCross.zsh.__spliced;
+      expected = true;
+    })
+    ({
+      name = "spliceSingleOverride";
+      expr =
+        (pkgsCross.splice { drv = pkgsCross.zsh.override { pcre2 = pkgsCross.pcre-cpp; }; })
+        == (pkgsCross.zsh.override { pcre2 = pkgsCross.pcre-cpp; });
+      expected = true;
+    })
+  ];
+in
+{
+  test-splicing = stdenvNoCC.mkDerivation {
+    name = "test-splicing";
+    passthru = {
+      inherit tests;
+    };
+    buildCommand =
+      ''
+        touch $out
+      ''
+      + lib.concatMapStringsSep "\n" (
+        t:
+        "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${t.name} success') || (echo '${t.name} fail' && exit 1)"
+      ) tests;
+  };
+}

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -159,15 +159,41 @@ let
 
   pkgsForCall = if actuallySplice then splicedPackagesWithXorg else packagesWithXorg;
 
+  splice =
+    { drv }:
+    let
+      calls = {
+        buildBuild = splicedPackages.pkgsBuildBuild.callPackage;
+        buildHost = splicedPackages.pkgsBuildHost.callPackage;
+        buildTarget = splicedPackages.pkgsBuildTarget.callPackage;
+        hostHost = splicedPackages.pkgsHostHost.callPackage;
+        hostTarget = splicedPackages.pkgsHostTarget.callPackage;
+        targetTarget = pkgs.pkgsTargetTarget.callPackage or { };
+      };
+    in
+    if actuallySplice then
+      (
+        (callPackage drv.origF drv.untouchedArgs)
+        // {
+          __spliced =
+            { }
+            // (lib.mapAttrs (_: v: v drv.origF drv.untouchedArgs) (lib.filterAttrs (_: v: v != { }) calls));
+        }
+      )
+    else
+      drv;
+
+  callPackage = pkgs.newScope { };
+
 in
 
 {
-  inherit splicePackages;
+  inherit splice splicePackages;
 
   # We use `callPackage' to be able to omit function arguments that can be
   # obtained `pkgs` or `buildPackages` and their `xorg` package sets. Use
   # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
-  callPackage = pkgs.newScope { };
+  inherit callPackage;
 
   callPackages = lib.callPackagesWith pkgsForCall;
 


### PR DESCRIPTION
And with some changes it should be able to splice a set

Just a test to see it's possible and if adding the `origF` and `untouchedArgs` will hurt the performance a lot 

Would be useful for splicing attributes that aren't reachable from `pkgs` 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
