### PR TITLE
ocamlPackages.syslog: 1.5 → 2.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/syslog/default.nix
+++ b/pkgs/development/ocaml-modules/syslog/default.nix
@@ -1,30 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, ocaml, findlib }:
+{ lib, fetchFromGitHub, buildDunePackage }:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "4.03.0";
+buildDunePackage rec {
+  pname = "syslog";
+  version = "2.0.2";
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-syslog";
-  version = "1.5";
+  minimalOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
-    owner = "rixed";
+    owner = "geneanet";
     repo = "ocaml-syslog";
     rev = "v${version}";
-    sha256 = "1kqpc55ppzv9n555qgqpda49n7nvkqimzisyjx2a7338r7q4r5bw";
+    hash = "sha256-WybNZBPhv4fhjzzb95E+6ZHcZUnfROLlNF3PMBGO9ys=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ];
-  strictDeps = true;
-
-  buildFlags = [ "all" "opt" ];
-
-  createFindlibDestdir = true;
-
   meta = with lib; {
-    homepage = "https://github.com/rixed/ocaml-syslog";
+    homepage = "https://github.com/geneanet/ocaml-syslog";
     description = "Simple wrapper to access the system logger from OCaml";
     license = licenses.lgpl21Plus;
-    inherit (ocaml.meta) platforms;
     maintainers = [ maintainers.rixed ];
   };
 }


### PR DESCRIPTION
## Description of changes

Support for recent versions of OCaml.

cc maintainer @rixed.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
