### PR TITLE
fonts: add githubnext monaspace

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19397,6 +19397,13 @@
     githubId = 3992240;
     name = "Elijah Rum";
   };
+  x0ba = {
+    email = "daniel.xu.dev@gmail.com";
+    name = "Daniel Xu";
+    github = "x0ba";
+    githubId = 64868985;
+  };
+
   x3ro = {
     name = "^x3ro";
     email = "nix@x3ro.dev";

--- a/pkgs/data/fonts/monaspace/default.nix
+++ b/pkgs/data/fonts/monaspace/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "monaspace";
+  version = "1.000";
+
+  src = fetchzip {
+    url = "https://github.com/githubnext/monaspace/releases/download/v${version}/monaspace-v${version}.zip";
+    sha256 = "sha256-0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+    stripRoot = false;
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/share/fonts/opentype/ *.otf
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An innovative superfamily of fonts for code";
+    homepage = "https://github.com/githubnext/monaspace";
+    license = [ licenses.sil ];
+    maintainers = [ maintainers.x0ba ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/monaspace/default.nix
+++ b/pkgs/data/fonts/monaspace/default.nix
@@ -6,20 +6,14 @@ stdenvNoCC.mkDerivation rec {
 
   src = fetchzip {
     url = "https://github.com/githubnext/monaspace/releases/download/v${version}/monaspace-v${version}.zip";
-    sha256 = "sha256-0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+    sha256 = "sha256-H8NOS+pVkrY9DofuJhPR2OlzkF4fMdmP2zfDBfrk83A=";
     stripRoot = false;
   };
-
-  dontPatch = true;
-  dontConfigure = true;
-  dontBuild = true;
-  doCheck = false;
-  dontFixup = true;
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 -t $out/share/fonts/opentype/ *.otf
+    install -D -t $out/share/fonts/opentype/ $(find $src -type f -name '*.otf')
 
     runHook postInstall
   '';
@@ -27,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "An innovative superfamily of fonts for code";
     homepage = "https://github.com/githubnext/monaspace";
-    license = [ licenses.sil ];
+    license = [ licenses.ofl ];
     maintainers = [ maintainers.x0ba ];
     platforms = platforms.all;
   };

--- a/pkgs/data/fonts/monaspace/default.nix
+++ b/pkgs/data/fonts/monaspace/default.nix
@@ -7,7 +7,6 @@ stdenvNoCC.mkDerivation rec {
   src = fetchzip {
     url = "https://github.com/githubnext/monaspace/releases/download/v${version}/monaspace-v${version}.zip";
     sha256 = "sha256-H8NOS+pVkrY9DofuJhPR2OlzkF4fMdmP2zfDBfrk83A=";
-    stripRoot = false;
   };
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Added the new Monaspace font from GitHubNext

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


