### PR TITLE
liquidsoap: 2.1.4 -> 2.2.2, update dependencies, clean up

### DIFF
--- a/pkgs/development/ocaml-modules/cry/default.nix
+++ b/pkgs/development/ocaml-modules/cry/default.nix
@@ -2,18 +2,20 @@
 
 buildDunePackage rec {
   pname = "cry";
-  version = "0.6.7";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-cry";
     rev = "v${version}";
-    sha256 = "sha256-1Omp3LBKGTPVwEBd530H0Djn3xiEjOHLqso6S8yIJSQ=";
+    sha256 = "sha256-wn9hLqbydzFTdYsJ1e76dmDLtwcZ7CGjbzFe5o9veYQ=";
   };
 
   postPatch = ''
     substituteInPlace src/dune --replace bytes ""
   '';
+
+  minimalOCamlVersion = "4.12";
 
   meta = with lib; {
     homepage = "https://github.com/savonet/ocaml-cry";

--- a/pkgs/development/ocaml-modules/ffmpeg/base.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/base.nix
@@ -1,15 +1,13 @@
 { lib, fetchFromGitHub }:
 
 rec {
-  version = "1.1.7";
-
-  duneVersion = "3";
+  version = "1.1.8";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-ffmpeg";
     rev = "v${version}";
-    sha256 = "sha256-0QDy0ZUAtojYIuNliiDV2uywBnWxtKUhZ/LPqkfSOZ4=";
+    sha256 = "sha256-XqZATaxpW0lEdrRTXVTc0laQAx437+eoa/zOzZV1kHk=";
   };
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/ffmpeg/default.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/default.nix
@@ -14,7 +14,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   propagatedBuildInputs = [
     ffmpeg-avutil

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
@@ -11,7 +11,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ AudioToolbox VideoToolbox ];

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
@@ -11,7 +11,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ]

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
@@ -17,7 +17,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ]

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
@@ -13,7 +13,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ]

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
@@ -9,7 +9,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ AudioToolbox VideoToolbox ];

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
@@ -10,7 +10,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
@@ -10,7 +10,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "4.08";
 
-  inherit (ffmpeg-base) version src duneVersion;
+  inherit (ffmpeg-base) version src;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];

--- a/pkgs/development/ocaml-modules/flac/default.nix
+++ b/pkgs/development/ocaml-modules/flac/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "flac";
-  version = "0.3.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-flac";
     rev = "v${version}";
-    sha256 = "sha256-oMmxZtphEX/OPfyTumjkWQJidAjSRqriygaTjVJTCG0=";
+    sha256 = "sha256-HRRQd//e6Eh2HuyO+U00ILu5FoBT9jf/nRJzDOie70A=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/ocaml-modules/metadata/default.nix
+++ b/pkgs/development/ocaml-modules/metadata/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, ogg, flac }:
+
+buildDunePackage rec {
+  pname = "metadata";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-metadata";
+    rev = "v${version}";
+    sha256 = "sha256-sSekkyJ8D6mCCmxIyd+pBk/khaehA3BcpUQl2Gln+Ic=";
+  };
+
+  minimalOCamlVersion = "4.14";
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-metadata";
+    description = "Library to read metadata from files in various formats. ";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -1,35 +1,68 @@
-{ lib, stdenv, makeWrapper, fetchurl, which, pkg-config
+{ lib, stdenv, makeWrapper, fetchFromGitHub, which, pkg-config
 , libjpeg
 , ocamlPackages
-, awscli2, curl, ffmpeg, youtube-dl
-, runtimePackages ? [ awscli2 curl ffmpeg youtube-dl ]
+, awscli2, bubblewrap, curl, ffmpeg, yt-dlp
+, runtimePackages ? [ awscli2 bubblewrap curl ffmpeg yt-dlp ]
 }:
 
 let
   pname = "liquidsoap";
-  version = "2.1.4";
+  version = "2.2.2";
 in
 stdenv.mkDerivation {
   inherit pname version;
 
-  src = fetchurl {
-    url = "https://github.com/savonet/${pname}/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-GQuG7f9U+/HqPcuj6hnBoH5mWEhxSwWgBnkCuLqHTAc=";
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "liquidsoap";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-t7rkWHSAd3DaTCXaGfL9NcIQYT+f4Od9D6huuZlwhWk=";
   };
 
-  postFixup = ''
+  postPatch = ''
+    substituteInPlace src/lang/dune \
+      --replace "(run git rev-parse --short HEAD)" "(run echo -n nixpkgs)"
+  '';
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    dune build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dune install --prefix "$out"
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
     wrapProgram $out/bin/liquidsoap \
       --set LIQ_LADSPA_PATH /run/current-system/sw/lib/ladspa \
       --prefix PATH : ${lib.makeBinPath runtimePackages}
-  '';
 
+    runHook postFixup
+  '';
 
   strictDeps = true;
 
-  nativeBuildInputs =
-    [ makeWrapper pkg-config which
-      ocamlPackages.ocaml ocamlPackages.findlib ocamlPackages.menhir
-    ];
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+    which
+    ocamlPackages.ocaml
+    ocamlPackages.dune_3
+    ocamlPackages.findlib
+    ocamlPackages.menhir
+  ];
 
   buildInputs = [
     libjpeg
@@ -38,29 +71,36 @@ stdenv.mkDerivation {
     ocamlPackages.dtools
     ocamlPackages.duppy
     ocamlPackages.mm
-    ocamlPackages.ocaml_pcre
-    ocamlPackages.menhir ocamlPackages.menhirLib
-    (ocamlPackages.camomile.override { version = "1.0.2"; })
     ocamlPackages.ocurl
+    ocamlPackages.cry
+    ocamlPackages.camomile
     ocamlPackages.uri
-    ocamlPackages.sedlex
+    ocamlPackages.fileutils
+    ocamlPackages.menhir # liquidsoap-lang
+    ocamlPackages.menhirLib
+    ocamlPackages.metadata
+    ocamlPackages.dune-build-info
+    ocamlPackages.re
+    ocamlPackages.sedlex # liquidsoap-lang
+    ocamlPackages.ppx_string
 
     # Recommended dependencies
     ocamlPackages.ffmpeg
 
     # Optional dependencies
-    ocamlPackages.camlimages
-    ocamlPackages.gd4o
     ocamlPackages.alsa
     ocamlPackages.ao
     ocamlPackages.bjack
-    ocamlPackages.cry
+    ocamlPackages.camlimages
     ocamlPackages.dssi
     ocamlPackages.faad
     ocamlPackages.fdkaac
     ocamlPackages.flac
     ocamlPackages.frei0r
+    ocamlPackages.gd4o
+    ocamlPackages.graphics
     ocamlPackages.gstreamer
+    ocamlPackages.imagelib
     ocamlPackages.inotify
     ocamlPackages.ladspa
     ocamlPackages.lame
@@ -72,25 +112,22 @@ stdenv.mkDerivation {
     ocamlPackages.ogg
     ocamlPackages.opus
     ocamlPackages.portaudio
+    ocamlPackages.posix-time2
     ocamlPackages.pulseaudio
-    ocamlPackages.shine
     ocamlPackages.samplerate
+    ocamlPackages.shine
     ocamlPackages.soundtouch
     ocamlPackages.speex
     ocamlPackages.srt
     ocamlPackages.ssl
     ocamlPackages.taglib
     ocamlPackages.theora
-    ocamlPackages.vorbis
-    ocamlPackages.xmlplaylist
-    ocamlPackages.posix-time2
     ocamlPackages.tsdl
     ocamlPackages.tsdl-image
     ocamlPackages.tsdl-ttf
-
-    # Undocumented dependencies
-    ocamlPackages.graphics
-    ocamlPackages.cohttp-lwt-unix
+    ocamlPackages.vorbis
+    ocamlPackages.xmlplaylist
+    ocamlPackages.yaml
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1046,6 +1046,8 @@ let
 
     merlin-lib = callPackage ../development/tools/ocaml/merlin/lib.nix { };
 
+    metadata = callPackage ../development/ocaml-modules/metadata { };
+
     metrics = callPackage ../development/ocaml-modules/metrics { };
 
     metrics-influx = callPackage ../development/ocaml-modules/metrics/influx.nix { };


### PR DESCRIPTION
## Description of changes

This PR updates liquidsoap to 2.2.2 and updates its dependencies

liquidsoap has switched build system to dune, so a PR moving to using our dune infrastructure might come later.

Dependencies packaged are now as follows:
<details>

* [ ] liquidsoap-libs-extra
* [ ] liquidsoap-libs
### liquidsoap-core
#### Required
* [x] ocaml
* [x] dtools
* [x] duppy
* [x] mm
* [x] re
* [x] ocurl
* [x] cry
* [x] camomile
* [x] uri
* [x] fileutils
* [x] menhirLib
* [x] metadata
* [x] dune-build-info
* [ ] liquidsoap-lang
* [x] ppx_string
#### Optional
* [x] alsa
* [x] ao
* [x] bjack
* [x] camlimages
* [ ] ctypes-foreign
* [x] dssi
* [x] faad
* [x] fdkaac
* [x] ffmpeg
* [x] flac
* [x] frei0r
* [x] gd
* [x] graphics
* [x] gstreamer
* [x] imagelib
* [x] inotify
* [ ] irc-client-unix
* [ ] jemalloc
* [x] ladspa
* [x] lame
* [x] lastfm
* [x] lilv
* [x] lo
* [x ]mad
* [x] magic
* [ ] memtrace
* [ ] mem_usage
* [x] ogg
* [x] opus
* [ ] osc-unix
* [x] portaudio
* [x] posix-time2
* [x] pulseaudio
* [ ] prometheus-liquidsoap
* [x] samplerate
* [x] shine
* [x] soundtouch
* [x] speex
* [x] srt
* [x] ssl
* [x] taglib
* [ ] tls-liquidsoap
* [x] theora
* [ ] sdl-liquidsoap
* [x] vorbis
* [x] yaml
* [x] xmlplaylist
### liquidsoap-lang Required
* [ ] dune-site
* [x] sedlex
* [x] menhir
### tls-liquidsoap
* [ ] tls
* [ ] ca-certs
### prometheus-liquidsoap
* [ ] prometheus-app
* [ ] cohttp-lwt-unix
### sdl-liquidsoap
* [x] tsdl
* [x] tsdl-image
* [x] tsdl-ttf
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
