### PR TITLE
hoppscotch: init at 23.12.1

### DIFF
--- a/pkgs/by-name/ho/hoppscotch/package.nix
+++ b/pkgs/by-name/ho/hoppscotch/package.nix
@@ -1,0 +1,56 @@
+{ appimageTools
+, fetchurl
+, lib
+, makeDesktopItem
+}:
+
+let
+  name = "hoppscotch";
+  version = "23.12.1";
+
+  desktopItem = makeDesktopItem {
+    categories = [ "Development" ];
+    desktopName = "Hoppscotch";
+    exec = "hoppscotch";
+    icon = name;
+    name = name;
+  };
+
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/hoppscotch/hoppscotch/20${version}/packages/hoppscotch-common/public/logo.svg";
+    hash = "sha256-Njbc+RTKSOziXo0H2Mv7RyNI5CLZNkJLUr/PatyrK9E=";
+  };
+in
+appimageTools.wrapType1 {
+  inherit name version;
+
+  src = fetchurl {
+    url = "https://github.com/hoppscotch/releases/releases/download/v${version}-1/Hoppscotch_linux_x64.AppImage";
+    hash = "sha256-lIfBmdyFRb+akkQkomfAyVLZnN10YoZXw/NJpNgk1/I=";
+  };
+
+  extraInstallCommands = ''
+    install -D ${icon} $out/share/icons/hicolor/scalable/apps/${name}.svg
+
+    mkdir -p $out/share/applications
+    cp -r ${desktopItem} $out/share/applications/${name}.desktop
+  '';
+
+  meta = with lib; {
+    description = "👽 Open-source API development ecosystem";
+    longDescription = ''
+      Hoppscotch is a lightweight, web-based API development suite. It was built
+      from the ground up with ease of use and accessibility in mind providing
+      all the functionality needed for API developers with minimalist,
+      unobtrusive UI.
+    '';
+    homepage = "https://hoppscotch.com";
+    downloadPage = "https://hoppscotch.com/downloads";
+    changelog = "https://hoppscotch.com/changelog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ getpsyched ];
+    mainProgram = "hoppscotch";
+    platforms = platforms.linux;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Similar to Postman in terms of core functionality.

Copied from upstream: Hoppscotch is a lightweight, web-based API development suite. It was built the ground up with ease of use and accessibility in mind providing the functionality needed for API developers with minimalist, UI.

Closes #267059

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).