### PR TITLE
rustc: add a compiler wrapper

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -963,7 +963,7 @@ repository:
      lib.updateManyAttrsByPath [{
        path = [ "packages" "stable" ];
        update = old: old.overrideScope(final: prev: {
-         rustc = prev.rustc.overrideAttrs (_: {
+         rustc-unwrapped = prev.rustc-unwrapped.overrideAttrs (_: {
            src = lib.cleanSource /git/scratch/rust;
            # do *not* put passthru.isReleaseTarball=true here
          });
@@ -1003,4 +1003,3 @@ nix-build $NIXPKGS -A package-broken-by-rust-changes
 The `git submodule update --init` and `cargo vendor` commands above
 require network access, so they can't be performed from within the
 `rustc` derivation, unfortunately.
-

--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, rustc-unwrapped }:
+{ lib, runCommand, rustc-unwrapped, sysroot ? null }:
 
 runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
   preferLocalBuild = true;
@@ -7,6 +7,7 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
 
   env = {
     prog = "${rustc-unwrapped}/bin/rustc";
+    sysroot = lib.optionalString (sysroot != null) "--sysroot ${sysroot}";
   };
 
   passthru = {

--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -1,0 +1,29 @@
+{ lib, runCommand, rustc-unwrapped }:
+
+runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
+  preferLocalBuild = true;
+  strictDeps = true;
+  inherit (rustc-unwrapped) outputs;
+
+  env = {
+    prog = "${rustc-unwrapped}/bin/rustc";
+  };
+
+  passthru = {
+    inherit (rustc-unwrapped) pname version src llvm llvmPackages;
+    unwrapped = rustc-unwrapped;
+  };
+
+  meta = rustc-unwrapped.meta // {
+    description = "${rustc-unwrapped.meta.description} (wrapper script)";
+    priority = 10;
+  };
+} ''
+  mkdir -p $out/bin
+  ln -s ${rustc-unwrapped}/bin/* $out/bin
+  rm $out/bin/rustc
+  substituteAll ${./rustc-wrapper.sh} $out/bin/rustc
+  chmod +x $out/bin/rustc
+  ${lib.concatMapStrings (output: "ln -s ${rustc-unwrapped.${output}} \$${output}\n")
+    (lib.remove "out" rustc-unwrapped.outputs)}
+''

--- a/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
+++ b/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
@@ -1,11 +1,16 @@
 #!@shell@
 
+extraBefore=(@sysroot@)
+extraAfter=($NIX_RUSTFLAGS)
+
 # Optionally print debug info.
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
+    echo "extra flags before to @prog@:" >&2
+    printf "  %q\n" "${extraBefore[@]}" >&2
     echo "original flags to @prog@:" >&2
     printf "  %q\n" "$@" >&2
     echo "extra flags after to @prog@:" >&2
-    printf "  %q\n" $NIX_RUSTFLAGS >&2
+    printf "  %q\n" "${extraAfter[@]}" >&2
 fi
 
-exec @prog@ "$@" $NIX_RUSTFLAGS
+exec @prog@ "${extraBefore[@]}" "$@" "${extraAfter[@]}"

--- a/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
+++ b/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
@@ -1,0 +1,11 @@
+#!@shell@
+
+# Optionally print debug info.
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
+    echo "original flags to @prog@:" >&2
+    printf "  %q\n" "$@" >&2
+    echo "extra flags after to @prog@:" >&2
+    printf "  %q\n" $NIX_RUSTFLAGS >&2
+fi
+
+exec @prog@ "$@" $NIX_RUSTFLAGS

--- a/pkgs/build-support/setup-hooks/separate-debug-info.sh
+++ b/pkgs/build-support/setup-hooks/separate-debug-info.sh
@@ -1,7 +1,7 @@
 export NIX_SET_BUILD_ID=1
 export NIX_LDFLAGS+=" --compress-debug-sections=zlib"
 export NIX_CFLAGS_COMPILE+=" -ggdb -Wa,--compress-debug-sections"
-export RUSTFLAGS+=" -g"
+export NIX_RUSTFLAGS+=" -g"
 
 fixupOutputHooks+=(_separateDebugInfo)
 

--- a/pkgs/development/compilers/rust/1_74.nix
+++ b/pkgs/development/compilers/rust/1_74.nix
@@ -16,6 +16,7 @@
 , CoreFoundation, Security, SystemConfiguration
 , pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
+, wrapRustc
 , llvmPackages_16, llvm_16
 } @ args:
 

--- a/pkgs/development/compilers/rust/1_74.nix
+++ b/pkgs/development/compilers/rust/1_74.nix
@@ -16,7 +16,7 @@
 , CoreFoundation, Security, SystemConfiguration
 , pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
-, wrapRustc
+, wrapRustcWith
 , llvmPackages_16, llvm_16
 } @ args:
 

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeWrapper, bash, curl, darwin, zlib
+{ lib, stdenv, makeWrapper, wrapRustc, bash, curl, darwin, zlib
 , autoPatchelfHook, gcc
 , version
 , src
@@ -19,7 +19,7 @@ let
 in
 
 rec {
-  rustc = stdenv.mkDerivation {
+  rustc-unwrapped = stdenv.mkDerivation {
     pname = "rustc-${versionType}";
 
     inherit version;
@@ -60,6 +60,8 @@ rec {
 
     setupHooks = ./setup-hook.sh;
   };
+
+  rustc = wrapRustc rustc-unwrapped;
 
   cargo = stdenv.mkDerivation {
     pname = "cargo-${versionType}";

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage.override {
   cargo-auditable = cargo-auditable.bootstrap;
 } ({
   pname = "cargo";
-  inherit (rustc) version src;
+  inherit (rustc.unwrapped) version src;
 
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again
   cargoVendorDir = "vendor";

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -18,6 +18,7 @@
 , CoreFoundation, Security, SystemConfiguration
 , pkgsBuildBuild
 , makeRustPlatform
+, wrapRustc
 }:
 
 let
@@ -64,7 +65,7 @@ in
       buildRustPackages = (selectRustPackage buildPackages).packages.stable;
       # Analogous to stdenv
       rustPlatform = makeRustPlatform self.buildRustPackages;
-      rustc = self.callPackage ./rustc.nix ({
+      rustc-unwrapped = self.callPackage ./rustc.nix ({
         version = rustcVersion;
         sha256 = rustcSha256;
         inherit enableRustcDev;
@@ -75,6 +76,7 @@ in
         # Use boot package set to break cycle
         inherit (bootstrapRustPackages) cargo rustc rustfmt;
       });
+      rustc = wrapRustc self.rustc-unwrapped;
       rustfmt = self.callPackage ./rustfmt.nix {
         inherit Security;
         inherit (self.buildRustPackages) rustc;

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -18,7 +18,7 @@
 , CoreFoundation, Security, SystemConfiguration
 , pkgsBuildBuild
 , makeRustPlatform
-, wrapRustc
+, wrapRustcWith
 }:
 
 let
@@ -76,7 +76,10 @@ in
         # Use boot package set to break cycle
         inherit (bootstrapRustPackages) cargo rustc rustfmt;
       });
-      rustc = wrapRustc self.rustc-unwrapped;
+      rustc = wrapRustcWith {
+        inherit (self) rustc-unwrapped;
+        sysroot = if fastCross then self.rustc-unwrapped else null;
+      };
       rustfmt = self.callPackage ./rustfmt.nix {
         inherit Security;
         inherit (self.buildRustPackages) rustc;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -154,9 +154,9 @@ in stdenv.mkDerivation (finalAttrs: {
     runHook preBuild
 
     mkdir -p build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-{std,rustc}/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/
-    ln -s ${rustc}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/libstd-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/libstd.so
-    ln -s ${rustc}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/librustc_driver-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/librustc.so
-    ln -s ${rustc}/bin/rustc build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/rustc-main
+    ln -s ${rustc.unwrapped}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/libstd-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/libstd.so
+    ln -s ${rustc.unwrapped}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/librustc_driver-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/librustc.so
+    ln -s ${rustc.unwrapped}/bin/rustc build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/rustc-main
     touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.libstd.stamp
     touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.librustc.stamp
     python ./x.py --keep-stage=0 --stage=1 build library/std
@@ -169,9 +169,9 @@ in stdenv.mkDerivation (finalAttrs: {
 
     python ./x.py --keep-stage=0 --stage=1 install library/std
     mkdir -v $out/bin $doc $man
-    makeWrapper ${rustc}/bin/rustc $out/bin/rustc --add-flags "--sysroot $out"
-    makeWrapper ${rustc}/bin/rustdoc $out/bin/rustdoc --add-flags "--sysroot $out"
-    ln -s ${rustc}/lib/rustlib/{manifest-rust-std-,}${stdenv.hostPlatform.rust.rustcTargetSpec} $out/lib/rustlib/
+    makeWrapper ${rustc.unwrapped}/bin/rustc $out/bin/rustc --add-flags "--sysroot $out"
+    makeWrapper ${rustc.unwrapped}/bin/rustdoc $out/bin/rustdoc --add-flags "--sysroot $out"
+    ln -s ${rustc.unwrapped}/lib/rustlib/{manifest-rust-std-,}${stdenv.hostPlatform.rust.rustcTargetSpec} $out/lib/rustlib/
     echo rust-std-${stdenv.hostPlatform.rust.rustcTargetSpec} >> $out/lib/rustlib/components
     lndir ${rustc.doc} $doc
     lndir ${rustc.man} $man

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -169,7 +169,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
     python ./x.py --keep-stage=0 --stage=1 install library/std
     mkdir -v $out/bin $doc $man
-    makeWrapper ${rustc.unwrapped}/bin/rustc $out/bin/rustc --add-flags "--sysroot $out"
+    ln -s ${rustc.unwrapped}/bin/rustc $out/bin
     makeWrapper ${rustc.unwrapped}/bin/rustdoc $out/bin/rustdoc --add-flags "--sysroot $out"
     ln -s ${rustc.unwrapped}/lib/rustlib/{manifest-rust-std-,}${stdenv.hostPlatform.rust.rustcTargetSpec} $out/lib/rustlib/
     echo rust-std-${stdenv.hostPlatform.rust.rustcTargetSpec} >> $out/lib/rustlib/components

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16933,6 +16933,9 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
+  wrapRustcWith = { rustc-unwrapped, ... } @ args: callPackage ../build-support/rust/rustc-wrapper args;
+  wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
+
   rust_1_74 = callPackage ../development/compilers/rust/1_74.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_16 = llvmPackages_16.libllvm;
@@ -16951,7 +16954,7 @@ with pkgs;
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 
   # https://github.com/NixOS/nixpkgs/issues/89426
-  rustc-wasm32 = (rustc.override {
+  rustc-wasm32 = wrapRustc ((rustc.unwrapped.override {
     stdenv = stdenv.override {
       targetPlatform = stdenv.targetPlatform // {
         parsed = {
@@ -16964,7 +16967,7 @@ with pkgs;
     };
   }).overrideAttrs (old: {
     configureFlags = old.configureFlags ++ ["--set=build.docs=false"];
-  });
+  }));
 
   makeRustPlatform = callPackage ../development/compilers/rust/make-rust-platform.nix { };
 


### PR DESCRIPTION
## Description of changes

We [keep](https://github.com/NixOS/nixpkgs/pull/220660#issuecomment-1519530817) [running into](https://github.com/NixOS/nixpkgs/pull/261727) [situations](https://github.com/NixOS/nixpkgs/pull/221413#issuecomment-1471628464) where we can't get the right combination of rustc flags through build systems into rustc. `RUSTFLAGS` is the only variable supported across build systems, but if `RUSTFLAGS` is set, Cargo will ignore all other ways of specifying rustc flags, including the target-specific ones, which we need to make dynamic musl builds work.  (This is why `pkgsCross.musl64.crosvm` is currently broken — it works if you unset `separateDebugInfo`, which causes `RUSTFLAGS` not to be set.)

So, we need to do the same thing we do for C and C++ compilers, and add a compiler wrapper so we can inject the flags we need, regardless of the build system.

Currently the wrapper only supports a single mechanism for injecting flags — the `NIX_RUSTFLAGS` environment variable.  As time goes on, we'll probably want to add additional features, like target-specific environment variables.

This fixes https://github.com/NixOS/nixpkgs/pull/261727, and `pkgsCross.musl64.crosvm`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
