### PR TITLE
awscli2: override version of old python pkgs too

### DIFF
--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -14,12 +14,14 @@ let
   py = python3 // {
     pkgs = python3.pkgs.overrideScope (final: prev: {
       ruamel-yaml = prev.ruamel-yaml.overridePythonAttrs (prev: {
+        version = "0.17.21";
         src = prev.src.override {
           version = "0.17.21";
           hash = "sha256-i3zml6LyEnUqNcGsQURx3BbEJMlXO+SSa1b/P10jt68=";
         };
       });
       urllib3 = prev.urllib3.overridePythonAttrs (prev: {
+        version = "1.26.18";
         format = "setuptools";
         src = prev.src.override {
           version = "1.26.18";


### PR DESCRIPTION
## Description of changes

This fixes the version in the store path of the overriden packages. No functional changes. Safe to merge.

Related #267864

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).