### PR TITLE
rr debugger: remove redundant line in buildInputs from rr's derivation

### DIFF
--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config which makeWrapper ];
   buildInputs = [
     libpfm zlib python3Packages.python python3Packages.pexpect procps gdb capnproto
-    libpfm zlib python3Packages.python python3Packages.pexpect procps capnproto
   ];
   cmakeFlags = [
     "-Ddisable32bit=ON"


### PR DESCRIPTION
Some `buildInputs` are repeated in rr debugger's derivation. Remove them.
