### PR TITLE
prefetch-npm-deps: add support for npm alias schema in version spec

### DIFF
--- a/pkgs/build-support/node/fetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/fetch-npm-deps/src/main.rs
@@ -241,7 +241,9 @@ fn main() -> anyhow::Result<()> {
     packages.into_par_iter().try_for_each(|package| {
         eprintln!("{}", package.name);
 
-        let tarball = package.tarball()?;
+        let tarball = package
+            .tarball()
+            .map_err(|e| anyhow!("couldn't fetch {} at {}: {e:?}", package.name, package.url))?;
         let integrity = package.integrity().map(ToString::to_string);
 
         cache


### PR DESCRIPTION
Before it would try to do Http request against "npm:string-width@4.2.3" which would fail after 15 minutes. While at it I improved errors.