### PR TITLE
toot: 0.38.1 -> 0.38.2

### DIFF
--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -25,18 +25,6 @@
 
 import ./make-test-python.nix ({ pkgs, ... }:
   let
-  # Fix for https://github.com/ihabunek/toot/pull/405. Includes
-  # https://github.com/ihabunek/toot/pull/405. TOREMOVE when
-  # toot > 0.38.1
-  patched-toot = pkgs.toot.overrideAttrs (old: {
-    version = "unstable-24-09-2023";
-    src = pkgs.fetchFromGitHub {
-      owner = "ihabunek";
-      repo = "toot";
-      rev = "30857f570d64a26da80d0024227a8259f7cb65b5";
-      sha256 = "sha256-BxrI7UY9bfqPzS+VLqCFSmu4PkIkvhntcEeNJb1AzOs=";
-    };
-  });
   send-toot = pkgs.writeScriptBin "send-toot" ''
     set -eux
     # toot is using the requests library internally. This library
@@ -195,7 +183,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
       networking.extraHosts = hosts nodes;
       environment.systemPackages = with pkgs; [
-        patched-toot
+        pkgs.toot
         send-toot
       ];
     };

--- a/pkgs/applications/misc/toot/default.nix
+++ b/pkgs/applications/misc/toot/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "toot";
-  version = "0.38.1";
+  version = "0.38.2";
 
   src = fetchFromGitHub {
     owner  = "ihabunek";
     repo   = "toot";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-gT9xKFanQhptt46nkdzYsZ6Vu0Nab0oRsvEHVRNf8DQ=";
+    sha256 = "sha256-0L/5i+m0rh1VjsZ0N2cshi+Nw951ASjMf5y6JxV53ko=";
   };
 
   nativeCheckInputs = with python3Packages; [ pytest ];
@@ -30,4 +30,3 @@ python3Packages.buildPythonApplication rec {
   };
 
 }
-


### PR DESCRIPTION
## Description of changes
```
commit c79cf2f6ab6f8fe49cac6ca256b9b4b01b49f060


    toot: 0.38.1 -> 0.38.2
    
    Changelog: https://github.com/ihabunek/toot/releases/tag/0.38.2

commit 7e7d40393950769de14a6d0e36ff0843af97703b 

    nixosTests.pleroma: un-vendor toot
    
    Upstream released 0.38.2. This new release contains the pleroma fix we
    previously were getting from master.
    
    We don't need this override anymore to get the test to succeed.
    
    https://github.com/ihabunek/toot/issues/399#issuecomment-1814712723
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
