### PR TITLE
nixos/slurm: use Type="simple" instead of "forking"

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -467,6 +467,7 @@ in
         Type = "simple";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         LimitNOFILE = 65536;
+        User = cfg.user;
       };
     };
 

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -400,8 +400,19 @@ in
         ++ lib.optional cfg.enableSrunX11 slurm-spank-x11;
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" "munged.service" ];
-      requires = [ "munged.service" ];
+      after = [
+        "network-online.target"
+        "munged.service"
+      ] ++ lib.optionals cfg.dbdserver.enable [
+        # If slurmdbd runs on the same server, start it first
+        "slurmdbd.service"
+      ];
+
+      requires = [
+        "munged.service"
+      ] ++ lib.optionals cfg.dbdserver.enable [
+        "slurmdbd.service"
+      ];
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/modules/services/security/munge.nix
+++ b/nixos/modules/services/security/munge.nix
@@ -45,7 +45,13 @@ in
 
     systemd.services.munged = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      wants = [
+        "network-online.target"
+      ];
+      after = [
+        "network-online.target"
+        "time-sync.target"
+      ];
 
       path = [ pkgs.munge pkgs.coreutils ];
 
@@ -58,6 +64,7 @@ in
         Group = "munge";
         StateDirectory = "munge";
         StateDirectoryMode = "0711";
+        Restart = "on-abort";
         RuntimeDirectory = "munge";
       };
 

--- a/nixos/modules/services/security/munge.nix
+++ b/nixos/modules/services/security/munge.nix
@@ -57,8 +57,7 @@ in
 
       serviceConfig = {
         ExecStartPre = "+${pkgs.coreutils}/bin/chmod 0400 ${cfg.password}";
-        ExecStart = "${pkgs.munge}/bin/munged --syslog --key-file ${cfg.password}";
-        PIDFile = "/run/munge/munged.pid";
+        ExecStart = "${pkgs.munge}/bin/munged --foreground --key-file ${cfg.password}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         User = "munge";
         Group = "munge";

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -126,6 +126,9 @@ in {
 
   testScript =
   ''
+  # There's currently no way for slurmdbd to signal its readyness to slurmctld.
+  # If slurmctld happens to start before slurmdbd, it errors out.
+  dbd.wait_for_unit("slurmdbd.service")
   control.wait_for_unit("slurmctld.service")
   submit.wait_for_unit("network-online.target")
 

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -155,6 +155,8 @@ in {
   with subtest("can_start_slurmd"):
       for node in [node1, node2, node3]:
           node.succeed("systemctl restart slurmd.service")
+
+      for node in [node1, node2, node3]:
           node.wait_for_unit("slurmd")
 
   # Test that the cluster works and can distribute jobs;

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -126,7 +126,13 @@ in {
 
   testScript =
   ''
+  control.wait_for_unit("slurmctld.service")
+  submit.wait_for_unit("network-online.target")
+
   start_all()
+
+  with subtest("run_PMIx_mpitest"):
+      submit.succeed("srun --wait=0 -N 3 --mpi=pmix mpitest | grep size=3")
 
   # Make sure DBD is up after DB initialzation
   with subtest("can_start_slurmdbd"):
@@ -136,9 +142,7 @@ in {
 
   # there needs to be an entry for the current
   # cluster in the database before slurmctld is restarted
-  with subtest("add_account"):
-      control.succeed("sacctmgr -i add cluster default")
-      # check for cluster entry
+  with subtest("default_account_exists"):
       control.succeed("sacctmgr list cluster | awk '{ print $1 }' | grep default")
 
   with subtest("can_start_slurmctld"):


### PR DESCRIPTION
## Description of changes

A bit of upkeep on the slurm module:

- Use "simple" instead of "forking": that's what upstream currently does, and that's more reliable anyway. In the future releases we can upgrade to "notify"
- nixosTests.slurm: test `srun` first, before we've manually restarted all of the daemons. This ensures we do test the (somewhat) unattended initialization (we still have to wait for slurmdbd explicitly, because slurmctld can't wait and errors out if it can't connect to slurmdbd right away)

Incorporates/depends on https://github.com/NixOS/nixpkgs/pull/267937/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC @markuskowa 