### PR TITLE
djview: 4.10.6 -> 4.12

### DIFF
--- a/pkgs/applications/graphics/djview/default.nix
+++ b/pkgs/applications/graphics/djview/default.nix
@@ -1,6 +1,9 @@
 { lib, stdenv
 , mkDerivation
 , fetchurl
+, autoconf
+, automake
+, libtool
 , pkg-config
 , djvulibre
 , qtbase
@@ -12,14 +15,19 @@
 
 mkDerivation rec {
   pname = "djview";
-  version = "4.10.6";
+  version = "4.12";
+
+  outputs = [ "out" "man" ];
 
   src = fetchurl {
     url = "mirror://sourceforge/djvu/${pname}-${version}.tar.gz";
-    sha256 = "08bwv8ppdzhryfcnifgzgdilb12jcnivl4ig6hd44f12d76z6il4";
+    hash = "sha256-VnPGqLfhlbkaFyCyQJGRW4FF3jSHnbEVi8k2sQDq8+M=";
   };
 
   nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
     pkg-config
     qttools
   ];
@@ -31,24 +39,24 @@ mkDerivation rec {
     libtiff
   ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.AGL;
 
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
+
   configureFlags = [
     "--disable-silent-rules"
     "--disable-dependency-tracking"
     "--with-x"
     "--with-tiff"
-    # NOTE: 2019-09-19: experimental "--enable-npdjvu" fails
+    "--disable-nsdejavu" # 2023-11-14: modern browsers have dropped support for NPAPI
   ] ++ lib.optional stdenv.isDarwin "--enable-mac";
-
-  passthru = {
-    mozillaPlugin = "/lib/mozilla/plugins";
-  };
 
   meta = with lib; {
     broken = stdenv.isDarwin;
     description = "Portable DjVu viewer (Qt5) and browser (nsdejavu) plugin";
     mainProgram = "djview";
     homepage = "https://djvu.sourceforge.net/djview4.html";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ Anton-Latukha ];
     longDescription = ''


### PR DESCRIPTION
## Description of changes

Changelog: https://sourceforge.net/p/djvu/djview-git/ci/release.4.12/tree/NEWS

The release tarball no longer contains a configure script, so pull in the necessary dependencies to generate it here.

Disable building the `nsdejavu` plugin as modern browsers have dropped support for NPAPI. The `npdjvu` plugin is based on NPAPI too, so remove the respective note.

Split `man` output from `out`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
