### PR TITLE
emacs: Add withCompressInstall flag

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -90,6 +90,7 @@
 , withXinput2 ? withX && lib.versionAtLeast version "29"
 , withXwidgets ? !stdenv.isDarwin && !noGui && (withGTK3 || withPgtk)
 , withSmallJaDic ? false
+, withCompressInstall ? true
 
 # Options
 , siteStart ? ./site-start.el
@@ -339,6 +340,7 @@ mkDerivation (finalAttrs: {
   ++ lib.optional withXinput2 "--with-xinput2"
   ++ lib.optional withXwidgets "--with-xwidgets"
   ++ lib.optional withSmallJaDic "--with-small-ja-dic"
+  ++ lib.optional (!withCompressInstall) "--without-compress-install"
   ;
 
   env = lib.optionalAttrs withNativeCompilation {


### PR DESCRIPTION
## Description of changes

When enabled (the default), Emacs compresses its files (.c, .el, .info, and so on) before installing them.

Disabling the option with `withCompressInstall = false` results in the suppression of that compression step. This increases disk space, but is slightly faster for some operations; Emacs does not have to decompress these files on the fly when, for example, jumping to the definition of a built-in function.

---

~~I've explicitly included gzip in the dependencies for the default case now. I assume that it was pulled in transitively before, but I figured being explicit here might be better. Feel free to disagree and I'll remove that again.~~ Removed now, see below.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
