### PR TITLE
emacsPackages.el-easydraw: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2545,6 +2545,12 @@
     githubId = 4621;
     name = "Brad Ediger";
   };
+  brahyerr = {
+    name = "Bryant Pham";
+    email = "bp@1829847@gmail.com";
+    github = "brahyerr";
+    githubId = 120991075;
+  };
   brainrape = {
     email = "martonboros@gmail.com";
     github = "brainrake";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -23,6 +23,8 @@ in
 
   ebuild-mode = callPackage ./manual-packages/ebuild-mode { };
 
+  el-easydraw = callPackage ./manual-packages/el-easydraw { };
+
   elisp-ffi = callPackage ./manual-packages/elisp-ffi { };
 
   emacspeak = callPackage ./manual-packages/emacspeak { };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, melpaBuild
+, fetchFromGitHub
+, writeText
+, unstableGitUpdater
+, gzip
+}:
+
+let
+  rev = "de68851724072c6695e675f090b33a8abec040c9";
+in
+melpaBuild {
+  pname = "edraw";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "misohena";
+    repo = "el-easydraw";
+    inherit rev;
+    hash = "sha256-l9i+HCRKnKiDqID+bfAOPE7LpVBZp1AOPkceX8KbDXM=";
+  };
+
+  commit = rev;
+
+  packageRequires = [ gzip ];
+
+  recipe = writeText "recipe" ''
+    (edraw
+      :repo "misohena/el-easydraw"
+      :fetcher github
+      :files
+      ("*.el"
+       "msg"))
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/misohena/el-easydraw";
+    description = "Embedded drawing tool for Emacs";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ brahyerr ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Emacs Easy Draw is a drawing tool that runs inside Emacs.
https://github.com/misohena/el-easydraw

## Things done

Tested functionality of package (Creating sketches in edraw-mode, and creating/previewing sketches inline in org-mode).

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
