### PR TITLE
autoPatchelfHook: fix --extra-args parsing

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -20,7 +20,6 @@
 , runtimeShell
 , systemLocale ? config.i18n.defaultLocale or "en_US"
 , patchelfUnstable  # have to use patchelfUnstable to support --no-clobber-old-sections
-, makeWrapper
 }:
 
 let
@@ -58,20 +57,6 @@ let
   source = lib.findFirst (sourceMatches mozLocale) defaultSource sources;
 
   pname = "firefox-${channel}-bin-unwrapped";
-
-  # FIXME: workaround for not being able to pass flags to patchelf
-  # Remove after https://github.com/NixOS/nixpkgs/pull/256525
-  wrappedPatchelf = stdenv.mkDerivation {
-    pname = "patchelf-wrapped";
-    inherit (patchelfUnstable) version;
-
-    nativeBuildInputs = [ makeWrapper ];
-
-    buildCommand = ''
-      mkdir -p $out/bin
-      makeWrapper ${patchelfUnstable}/bin/patchelf $out/bin/patchelf --append-flags "--no-clobber-old-sections"
-    '';
-  };
 in
 
 stdenv.mkDerivation {
@@ -79,7 +64,7 @@ stdenv.mkDerivation {
 
   src = fetchurl { inherit (source) url sha256; };
 
-  nativeBuildInputs = [ wrapGAppsHook autoPatchelfHook wrappedPatchelf ];
+  nativeBuildInputs = [ wrapGAppsHook autoPatchelfHook patchelfUnstable ];
   buildInputs = [
     gtk3
     adwaita-icon-theme
@@ -95,6 +80,8 @@ stdenv.mkDerivation {
   appendRunpaths = [
     "${pipewire}/lib"
   ];
+  # Firefox uses "relrhack" to manually process relocations from a fixed offset
+  patchelfFlags = [ "--no-clobber-old-sections" ];
 
   installPhase =
     ''

--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -336,9 +336,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--extra-args",
-        nargs="*",
+        # Undocumented Python argparse feature: consume all remaining arguments
+        # as values for this one. This means this argument should always be passed
+        # last.
+        nargs="...",
         type=str,
-        help="Extra arguments to pass to patchelf"
+        help="Extra arguments to pass to patchelf. This argument should always come last."
     )
 
     print("automatically fixing dependencies for ELF files")


### PR DESCRIPTION
## Description of changes

For real this time. argparse y u so argparse.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
