### PR TITLE
pythonPackages.pyudev: Allow to install on darwin

### DIFF
--- a/pkgs/development/python-modules/pyudev/default.nix
+++ b/pkgs/development/python-modules/pyudev/default.nix
@@ -1,5 +1,13 @@
-{ lib, fetchPypi, buildPythonPackage
-, six, udev, pytest, mock, hypothesis, docutils
+{ lib
+, fetchPypi
+, buildPythonPackage
+, six
+, udev
+, pytest
+, mock
+, hypothesis
+, docutils
+, stdenvNoCC
 }:
 
 buildPythonPackage rec {
@@ -11,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-deVNNyGPWsRbDaHw/ZzF5SajysPvHPrUEM96sziwFHE=";
   };
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenvNoCC.isLinux ''
     substituteInPlace src/pyudev/_ctypeslib/utils.py \
       --replace "find_library(name)" "'${lib.getLib udev}/lib/libudev.so'"
     '';
@@ -27,9 +35,10 @@ buildPythonPackage rec {
   # https://github.com/pyudev/pyudev/issues/187
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://pyudev.readthedocs.org/";
     description = "Pure Python libudev binding";
-    license = lib.licenses.lgpl21Plus;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ frogamic ];
   };
 }


### PR DESCRIPTION
## Description of changes

Remove the dependency on `udev` (`systemdMinimal`) on darwin systems, to allow dependent applications and packages to install on darwin.

#### Justification
Some packages that depend on `pyudev` expect to install it even when on non-linux OSs. In the NixOS tree, 2 packages use pyudev in this way:
* [rshell](https://github.com/dhylands/rshell)
* [nitrokey-app2](https://github.com/Nitrokey/nitrokey-app2)

Both these packages include pyudev as a dependency yet work fine on darwin, the nitrokey-app2 readme explicitly includes instructions for installing on darwin, yet pyudev is a non-optional dependency.

This change allows both those packages to be used on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
