### PR TITLE
trivy: add shell completions

### DIFF
--- a/pkgs/tools/admin/trivy/default.nix
+++ b/pkgs/tools/admin/trivy/default.nix
@@ -67,6 +67,7 @@ buildGoModule rec {
       vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and
       application dependencies (Bundler, Composer, npm, yarn, etc.).
     '';
+    mainProgram = "trivy";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab jk ];
   };

--- a/pkgs/tools/admin/trivy/default.nix
+++ b/pkgs/tools/admin/trivy/default.nix
@@ -1,6 +1,9 @@
 { lib
+, stdenv
+, buildPackages
 , buildGoModule
 , fetchFromGitHub
+, installShellFiles
 , testers
 , trivy
 }:
@@ -29,8 +32,21 @@ buildGoModule rec {
     "-X=github.com/aquasecurity/trivy/pkg/version.ver=v${version}"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # Tests require network access
   doCheck = false;
+
+  postInstall =
+    let
+      trivy = if stdenv.buildPlatform.canExecute stdenv.hostPlatform then placeholder "out" else buildPackages.trivy;
+    in
+    ''
+      installShellCompletion --cmd trivy \
+        --bash <(${trivy}/bin/trivy completion bash) \
+        --fish <(${trivy}/bin/trivy completion fish) \
+        --zsh <(${trivy}/bin/trivy completion zsh)
+    '';
 
   doInstallCheck = true;
 


### PR DESCRIPTION
## Description of changes

Add shell completions.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A trivy
/nix/store/r6dz10rxdh8aga8hb1lmk9zr8s8gmj6g-trivy-0.47.0

$ find /nix/store/r6dz10rxdh8aga8hb1lmk9zr8s8gmj6g-trivy-0.47.0 -type f
/nix/store/r6dz10rxdh8aga8hb1lmk9zr8s8gmj6g-trivy-0.47.0/bin/trivy
/nix/store/r6dz10rxdh8aga8hb1lmk9zr8s8gmj6g-trivy-0.47.0/share/bash-completion/completions/trivy.bash
/nix/store/r6dz10rxdh8aga8hb1lmk9zr8s8gmj6g-trivy-0.47.0/share/fish/vendor_completions.d/trivy.fish
/nix/store/r6dz10rxdh8aga8hb1lmk9zr8s8gmj6g-trivy-0.47.0/share/zsh/site-functions/_trivy

$ nix-build --attr pkgs.trivy.passthru.tests
this derivation will be built:
  /nix/store/spamk6mm1sggkr4prsjs88z2klp39h6f-trivy-0.47.0-test-version.drv
building '/nix/store/spamk6mm1sggkr4prsjs88z2klp39h6f-trivy-0.47.0-test-version.drv'...
Version: v0.47.0
/nix/store/avdfvkv1b9m634d8sigir9351f9javjh-trivy-0.47.0-test-version

$ nix-build --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' -A trivy
/nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0

$ find /nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0 -type f
/nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0/bin/trivy
/nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0/share/bash-completion/completions/trivy.bash
/nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0/share/fish/vendor_completions.d/trivy.fish
/nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0/share/zsh/site-functions/_trivy

$ file /nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0/bin/trivy
/nix/store/6zxjbgzhi1g5b1m04hxmj7axl4ad4sbb-trivy-aarch64-unknown-linux-gnu-0.47.0/bin/trivy: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/m477n4gfp2kmw637q0swbpcz2cj6d78g-glibc-aarch64-unknown-linux-gnu-2.38-27/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, Go BuildID=XRYjWHLfqX44FkLf7GA1/vMCs4EnmApVl1Njrp-GH/nWkmKYQEG-3nt_klVJM4/jjaDL6TxzK4k86mM_q27, stripped
```