### PR TITLE
blisp: silence implicit-function-declaration on Darwin

### DIFF
--- a/pkgs/development/embedded/blisp/default.nix
+++ b/pkgs/development/embedded/blisp/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBLISP_USE_SYSTEM_LIBRARIES=ON"
   ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-error=implicit-function-declaration";
+
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
     version = "v${finalAttrs.version}";
@@ -42,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     mainProgram = "blisp";
     homepage = "https://github.com/pine64/blisp";
+    platforms = platforms.unix;
     maintainers = [ maintainers.bdd ];
   };
 })


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes
```
error: builder for '/nix/store/8931isfz18dsq13vqsmhj9sz61rnc5jp-blisp-0.0.4.drv' failed with exit code 2;
       last 10 log lines:
       > ^
       > /tmp/nix-build-blisp-0.0.4.drv-0/source/tools/blisp/src/util.c:21:8: error: call to undeclared function '_NSGetExecutablePath'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
       >   if (!_NSGetExecutablePath(raw_path_name, &raw_path_size)) {
       >        ^
       > 1 error generated.
       > make[2]: *** [tools/blisp/CMakeFiles/blisp.dir/build.make:104: tools/blisp/CMakeFiles/blisp.dir/src/util.c.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > 5 warnings generated.
       > make[1]: *** [CMakeFiles/Makefile2:200: tools/blisp/CMakeFiles/blisp.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
       For full logs, run 'nix log /nix/store/8931isfz18dsq13vqsmhj9sz61rnc5jp-blisp-0.0.4.drv'.
  ```
  
as including the right header as a patch causes non-deterministic builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
