### PR TITLE
rustc,cargo: 1.73.0 -> 1.74.0

### DIFF
--- a/pkgs/development/compilers/rust/1_74.nix
+++ b/pkgs/development/compilers/rust/1_74.nix
@@ -20,8 +20,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.73.0";
-  rustcSha256 = "sha256-ltYubR8tId96yKyzuYgkEfnnxwNhc/fy7enh8faxuzo=";
+  rustcVersion = "1.74.0";
+  rustcSha256 = "sha256-iCtYS8Mhxdz+d82qafJ3kGuTYlXveAj81cdJKSXPEEk=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_16.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_16.libllvm.override { enableSharedLibraries = true; };
@@ -35,24 +35,24 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.72.1";
+  bootstrapVersion = "1.73.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "a2a849a701dfd6643aaaa27e1ed5ac56aea00f7dee26c00d81c520808efd8911";
-    x86_64-unknown-linux-gnu = "4fbd8df2000cf73c632d67a219a7fc153537ceffa2e6474491e3db71fdd5a410";
-    x86_64-unknown-linux-musl = "94eddc044868a944a887d0b0375e393cb3acc6ebc034e3eac2ef2890ec7c0eac";
-    arm-unknown-linux-gnueabihf = "a4d90538882181722d3e7cb8d7f021770e29e6b6d28375452e31a98049600110";
-    armv7-unknown-linux-gnueabihf = "4c8e6b3c705a84d17894d3a1cfe744fb6083dd57c61868e67aac8b8512640ecb";
-    aarch64-unknown-linux-gnu = "190d0473cbe619f163d33a6c4e2ef982abdd4178f73abc3194631cd2d5c8ed8b";
-    aarch64-unknown-linux-musl = "c83778d1a95f6604bc3610a9070e8a8435c60a8bca5117aad71ffab36dea020f";
-    x86_64-apple-darwin = "d01e7e9a7482f88a51b4fd888f06234274b49f51b5476c2d14fd46fd6e99ba9e";
-    aarch64-apple-darwin = "42b0aaf269b6d9c60db13a64a920336d6064ab11d0c7043c9deeb9d4f67b3983";
-    powerpc64le-unknown-linux-gnu = "9310df247efc072f2ca27354a875c4989cf3c29c9e545255a7472895d830163c";
-    riscv64gc-unknown-linux-gnu = "1e08cd3ecd29d5bf247e3f7f4bc97318b439f0443dd9c99c36edcfa717d55101";
+    i686-unknown-linux-gnu = "6a088acbbda734d27e8b431499f1d746de7781673b88fead3aeae072be1d1a5a";
+    x86_64-unknown-linux-gnu = "aa4cf0b7e66a9f5b7c623d4b340bb1ac2864a5f2c2b981f39f796245dc84f2cb";
+    x86_64-unknown-linux-musl = "c888457d106ccd40288ca8db1cb966b23d719c9a128daca701ecc574c53773d4";
+    arm-unknown-linux-gnueabihf = "9c29bb42786aedbb16ea71564eb06068a8b01cca6c6b8857f0c37f91dfba7134";
+    armv7-unknown-linux-gnueabihf = "092b32b82c602c18279d76d9a96763e85030aa62cda64c1bc73fc1f6355bb99c";
+    aarch64-unknown-linux-gnu = "e54d7d886ba413ae573151f668e76ea537f9a44406d3d29598269a4a536d12f6";
+    aarch64-unknown-linux-musl = "f4e9ff895aa55558777585ad4debe2ccf3c0298cb5d65db67814f62428de4a5b";
+    x86_64-apple-darwin = "ece9646bb153d4bc0f7f1443989de0cbcd8989a7d0bf3b7fb9956e1223954f0c";
+    aarch64-apple-darwin = "9c96e4c57328fb438ee2d87aa75970ce89b4426b49780ccb3c16af0d7c617cc6";
+    powerpc64le-unknown-linux-gnu = "8fa215ee3e274fb64364e7084613bc570369488fa22cf5bc8e0fe6dc810fe2b9";
+    riscv64gc-unknown-linux-gnu = "381379a2381835428b2e7a396b3046581517356b7cc851e39e385aebd5700623";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_73;
+  selectRustPackage = pkgs: pkgs.rust_1_74;
 
   rustcPatches = [ ];
 }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -81,6 +81,7 @@ in stdenv.mkDerivation (finalAttrs: {
     ccForTarget  = ccPrefixForStdenv pkgsBuildTarget.targetPackages.stdenv;
     cxxForTarget  = cxxPrefixForStdenv pkgsBuildTarget.targetPackages.stdenv;
   in [
+    "--sysconfdir=${placeholder "out"}/etc"
     "--release-channel=stable"
     "--set=build.rustc=${rustc}/bin/rustc"
     "--set=build.cargo=${cargo}/bin/cargo"
@@ -177,14 +178,6 @@ in stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '' else null;
-
-  # The bootstrap.py will generated a Makefile that then executes the build.
-  # The BOOTSTRAP_ARGS used by this Makefile must include all flags to pass
-  # to the bootstrap builder.
-  postConfigure = ''
-    substituteInPlace Makefile \
-      --replace 'BOOTSTRAP_ARGS :=' 'BOOTSTRAP_ARGS := --jobs $(NIX_BUILD_CORES)'
-  '';
 
   # the rust build system complains that nix alters the checksums
   dontFixLibtool = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16939,11 +16939,11 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
-  rust_1_73 = callPackage ../development/compilers/rust/1_73.nix {
+  rust_1_74 = callPackage ../development/compilers/rust/1_74.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_16 = llvmPackages_16.libllvm;
   };
-  rust = rust_1_73;
+  rust = rust_1_74;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -16951,8 +16951,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_73 = rust_1_73.packages.stable;
-  rustPackages = rustPackages_1_73;
+  rustPackages_1_74 = rust_1_74.packages.stable;
+  rustPackages = rustPackages_1_74;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 


### PR DESCRIPTION
The BOOTSTRAP_ARGS patch is no longer necessary since rust-lang/rust@863d2fddd79 ("Pass `-jN` from Make to `BOOTSTRAP_ARGS`").

We now have to set sysconfdir, because since
rust-lang/rust@350ead87205 ("add sanity checks for user write access on `x install`"), the build system will check it can write there, even though nothing actually gets installed there.  (Previously it defaulted to /etc.)

Built:

- [x] thunderbird on x86_64-linux
- [x] firefox on x86_64-linux 
- [x] fd on aarch64-linux

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
