### PR TITLE
ludtwig: init at 0.8.0

### DIFF
--- a/pkgs/by-name/lu/ludtwig/package.nix
+++ b/pkgs/by-name/lu/ludtwig/package.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ludtwig";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "MalteJanz";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-WF3tEf3SuXiH35Ny4RGLzvEW7yMsFcnVTX52e5qvK5g=";
+  };
+
+  checkType = "debug";
+
+  cargoHash = "sha256-AbT8Jv6v7EVPX5mIplKaBkGrVonA8YWlMvo46coFMzk=";
+
+  meta = with lib; {
+    description = "Linter / Formatter for Twig template files which respects HTML and your time.";
+    homepage = "https://github.com/MalteJanz/ludtwig";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shyim ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Ludtwig is fast Twig template linter written in Rust.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
