### PR TITLE
discord-screenaudio: init at 1.9.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord-screenaudio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord-screenaudio/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeShellWrapper
+, wrapQtAppsHook
+, cmake
+, qtbase
+, qtwebengine
+, knotifications
+, kxmlgui
+, kglobalaccel
+, pipewire
+, bash
+, xdg-desktop-portal
+}:
+
+stdenv.mkDerivation rec {
+  pname = "discord-screenaudio";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "maltejur";
+    repo = "discord-screenaudio";
+    rev = "v${version}";
+    sha256 = "sha256-it7JSmiDz3k1j+qEZrrNhyAuoixiQuiEbXac7lbJmko=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    makeShellWrapper
+    wrapQtAppsHook
+    cmake
+    qtbase
+    qtwebengine
+    knotifications
+    kxmlgui
+  ];
+
+  buildInputs = [
+    kglobalaccel
+    pipewire
+    bash
+    xdg-desktop-portal
+  ];
+
+  cmakeFlags = [
+    "-DPipeWire_INCLUDE_DIRS=${pipewire.dev}/include/pipewire-0.3"
+    "-DSpa_INCLUDE_DIRS=${pipewire.dev}/include/spa-0.2"
+  ];
+
+  dontWrapQtApps = true;
+
+  # Make sure kglobalaccel is running for keybinds to work
+  postFixup = ''
+    wrapProgramShell $out/bin/discord-screenaudio \
+      ''${qtWrapperArgs[@]} \
+      --run "${kglobalaccel}/bin/kglobalaccel5 &"
+  '';
+
+  meta = with lib; {
+    description = "Discord client that supports streaming with audio on Linux";
+    longDescription = "Requires Pipewire, it currently doesn't work with PulseAudio. It can only share primary screen on X11.";
+    homepage = "https://github.com/maltejur/discord-screenaudio";
+    changelog = "https://github.com/maltejur/discord-screenaudio/releases/tag/v${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ heyimnova ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    sourceProvenance = [ sourceTypes.fromSource ];
+    mainProgram = "discord-screenaudio";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41605,6 +41605,8 @@ with pkgs;
 
   discordo = callPackage ../applications/networking/discordo/default.nix { };
 
+  discord-screenaudio = libsForQt5.callPackage ../applications/networking/instant-messengers/discord-screenaudio { };
+
   golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah { };
 
   golden-cheetah-bin = callPackage ../applications/misc/golden-cheetah-bin {};


### PR DESCRIPTION
## Description of changes

Add discord-screenaudio, a custom Discord client that supports audio streaming on Linux.

All features working on GNOME X11, not functional on GNOME Wayland however the behavior is the same in the Flatpak of discord-screenaudio in my testing (perhaps an Nvidia issue?).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
