### PR TITLE
gh-actions-cache: run tests

### DIFF
--- a/pkgs/tools/misc/gh-actions-cache/default.nix
+++ b/pkgs/tools/misc/gh-actions-cache/default.nix
@@ -21,8 +21,9 @@ buildGoModule rec {
     "-w"
   ];
 
-  # Tests need network
-  doCheck = false;
+  # Needed for tests.
+  # https://github.com/actions/gh-actions-cache/issues/53#issuecomment-1464954495
+  env.GH_TOKEN = "dummy-token-to-facilitate-rest-client";
 
   meta = {
     description = "gh extension to manage GitHub Actions caches";


### PR DESCRIPTION
## Description of changes

The tests don't need network, but a dummy GH_TOKEN.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A gh-actions-cache
/nix/store/hk8wvmz9cn8km47vfqv4bpqqdp4z61yn-gh-actions-cache-1.0.4

$ find /nix/store/hk8wvmz9cn8km47vfqv4bpqqdp4z61yn-gh-actions-cache-1.0.4 -type f
/nix/store/hk8wvmz9cn8km47vfqv4bpqqdp4z61yn-gh-actions-cache-1.0.4/bin/gh-actions-cache

$ /nix/store/hk8wvmz9cn8km47vfqv4bpqqdp4z61yn-gh-actions-cache-1.0.4/bin/gh-actions-cache --help

gh-actions-cache: Works with GitHub Actions Cache.

USAGE:
        gh actions-cache <command> [flags]

CORE COMMANDS:
        list:           list caches with result length cap of 100
        delete:         delete caches with a key

INHERITED FLAGS
        --help          Show help for command

EXAMPLES:
        $ gh actions-cache list
        $ gh actions-cache list --limit 100
        $ gh actions-cache list --order desc
        $ gh actions-cache delete Linux-node-f5dbf39c9d11eba80242ac13

```