### PR TITLE
nixos/github-runner: GitHub App auth

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -145,7 +145,7 @@ in
               # If the token file contains a PAT (i.e., it starts with "ghp_" or "github_pat_"), we have to use the --pat option,
               # if it is not a PAT, we assume it contains a registration token and use the --token option
               token=$(<"${newConfigTokenPath}")
-              if [[ "$token" =~ ^ghp_* ]] || [[ "$token" =~ ^github_pat_* ]]; then
+              if [[ "$token" =~ ^ghp_* ]] || [[ "$token" =~ ^ghs_* ]] || [[ "$token" =~ ^github_pat_* ]]; then
                 args+=(--pat "$token")
               else
                 args+=(--token "$token")

--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -37,7 +37,7 @@ in
   } // cfg.extraEnvironment;
 
   path = (with pkgs; [
-    bash
+    bashInteractive
     coreutils
     git
     gnutar


### PR DESCRIPTION
## Description of changes

This adds the ability to pass details of a Github App installation as an alternative to the `tokenFile`, which can be useful for the `ephemeral` runner use case - rather than having to pass a PAT for an org-level github admin, an app can be set up with the more fine grained `organization_self_hosted_runners` permission only. The app then has the ability to add a runner and fetch a registration token which is passed to the startup process as normal:

- the private key generates a JWT
- the JWT is used to generate an app installation token (1hr expiry)
- the app installation token is passed to the runner (it's prefixed with `ghs_`) which can then self-register.

(ref: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app)

This is tested and working on a NixOS machine - I saw the `github-runner` test but I'm not unsure how to mock out the token auth process.

Potential areas of conern as a result of the change:
- the security of the way the app's private key is handled in particular would be appreciated - I believe the current set up prevents actions from being able to view the private key via the `unconfigure` script which runs as root, but I may have missed something here.
- I don't believe this approach is compatible with configs where `ephemeral` is set to false - any thoughts on how this could be better handled (or at least documented) would be appreciated. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
