### PR TITLE
smlfut: init at 1.1.0

### DIFF
--- a/pkgs/by-name/sm/smlfut/package.nix
+++ b/pkgs/by-name/sm/smlfut/package.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, mlton, futhark }:
+
+stdenv.mkDerivation rec {
+  pname = "smlfut";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "diku-dk";
+    repo = "smlfut";
+    rev = "v${version}";
+    hash = "sha256-Ta0nCVD8N1k88sCdN4RhcugBgkQE7NdclCUtubgS6HM=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ mlton ];
+
+  env.MLCOMP = "mlton";
+
+  installFlags = ["PREFIX=$(out)"];
+
+  doCheck = true;
+
+  nativeCheckInputs = [ futhark ];
+
+  checkTarget = "run_test";
+
+  meta = with lib; {
+    description = "Allow SML programs to call Futhark programs";
+    homepage = "https://github.com/diku-dk/smlfut";
+    license = licenses.gpl3Plus;
+    platforms = mlton.meta.platforms;
+    maintainers = with maintainers; [ athas ];
+    mainProgram = "smlfut";
+  };
+}


### PR DESCRIPTION
## Description of changes

`smltfut` is a code generator that allows SML programs to call Futhark programs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
