### PR TITLE
stdenv Rust fixes

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -45,7 +45,7 @@ rec {
            else args';
 
     # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
-    rust = assert !(args ? rust && args ? rustc); args.rust or args.rustc or {};
+    rust = args.rust or args.rustc or {};
 
     final = {
       # Prefer to parse `config` as it is strictly more informative.
@@ -169,96 +169,6 @@ rec {
       # TODO: remove after 23.05 is EOL, with an error pointing to the rust.* attrs.
       rustc = args.rustc or {};
 
-      rust = rust // {
-        # Once args.rustc.platform.target-family is deprecated and
-        # removed, there will no longer be any need to modify any
-        # values from args.rust.platform, so we can drop all the
-        # "args ? rust" etc. checks, and merge args.rust.platform in
-        # /after/.
-        platform = rust.platform or {} // {
-          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
-          arch =
-            /**/ if rust ? platform then rust.platform.arch
-            else if final.isAarch32 then "arm"
-            else if final.isMips64  then "mips64"     # never add "el" suffix
-            else if final.isPower64 then "powerpc64"  # never add "le" suffix
-            else final.parsed.cpu.name;
-
-          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_os
-          os =
-            /**/ if rust ? platform then rust.platform.os or "none"
-            else if final.isDarwin then "macos"
-            else final.parsed.kernel.name;
-
-          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
-          target-family =
-            /**/ if args ? rust.platform.target-family then args.rust.platform.target-family
-            else if args ? rustc.platform.target-family
-            then
-              (
-                # Since https://github.com/rust-lang/rust/pull/84072
-                # `target-family` is a list instead of single value.
-                let
-                  f = args.rustc.platform.target-family;
-                in
-                  if builtins.isList f then f else [ f ]
-              )
-            else lib.optional final.isUnix "unix"
-                 ++ lib.optional final.isWindows "windows";
-
-          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
-          vendor = let
-            inherit (final.parsed) vendor;
-          in rust.platform.vendor or {
-            "w64" = "pc";
-          }.${vendor.name} or vendor.name;
-        };
-
-        # The name of the rust target, even if it is custom. Adjustments are
-        # because rust has slightly different naming conventions than we do.
-        rustcTarget = let
-          inherit (final.parsed) cpu kernel abi;
-          cpu_ = rust.platform.arch or {
-            "armv7a" = "armv7";
-            "armv7l" = "armv7";
-            "armv6l" = "arm";
-            "armv5tel" = "armv5te";
-            "riscv64" = "riscv64gc";
-          }.${cpu.name} or cpu.name;
-          vendor_ = final.rust.platform.vendor;
-        in rust.config
-          or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
-
-        # The name of the rust target if it is standard, or the json file
-        # containing the custom target spec.
-        rustcTargetSpec =
-          /**/ if rust ? platform
-          then builtins.toFile (final.rust.rustcTarget + ".json") (builtins.toJSON rust.platform)
-          else final.rust.rustcTarget;
-
-        # The name of the rust target if it is standard, or the
-        # basename of the file containing the custom target spec,
-        # without the .json extension.
-        #
-        # This is the name used by Cargo for target subdirectories.
-        cargoShortTarget =
-          lib.removeSuffix ".json" (baseNameOf "${final.rust.rustcTargetSpec}");
-
-        # When used as part of an environment variable name, triples are
-        # uppercased and have all hyphens replaced by underscores:
-        #
-        # https://github.com/rust-lang/cargo/pull/9169
-        # https://github.com/rust-lang/cargo/issues/8285#issuecomment-634202431
-        cargoEnvVarTarget =
-          lib.strings.replaceStrings ["-"] ["_"]
-            (lib.strings.toUpper final.rust.cargoShortTarget);
-
-        # True if the target is no_std
-        # https://github.com/rust-lang/rust/blob/2e44c17c12cec45b6a682b1e53a04ac5b5fcc9d2/src/bootstrap/config.rs#L415-L421
-        isNoStdTarget =
-          builtins.any (t: lib.hasInfix t final.rust.rustcTarget) ["-none" "nvptx" "switch" "-uefi"];
-      };
-
       linuxArch =
         if final.isAarch32 then "arm"
         else if final.isAarch64 then "arm64"
@@ -356,7 +266,97 @@ rec {
 
     }) // mapAttrs (n: v: v final.parsed) inspect.predicates
       // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates
-      // args;
+      // args // {
+        rust = rust // {
+          # Once args.rustc.platform.target-family is deprecated and
+          # removed, there will no longer be any need to modify any
+          # values from args.rust.platform, so we can drop all the
+          # "args ? rust" etc. checks, and merge args.rust.platform in
+          # /after/.
+          platform = rust.platform or {} // {
+            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
+            arch =
+              /**/ if rust ? platform then rust.platform.arch
+              else if final.isAarch32 then "arm"
+              else if final.isMips64  then "mips64"     # never add "el" suffix
+              else if final.isPower64 then "powerpc64"  # never add "le" suffix
+              else final.parsed.cpu.name;
+
+            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_os
+            os =
+              /**/ if rust ? platform then rust.platform.os or "none"
+              else if final.isDarwin then "macos"
+              else final.parsed.kernel.name;
+
+            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
+            target-family =
+              /**/ if args ? rust.platform.target-family then args.rust.platform.target-family
+              else if args ? rustc.platform.target-family
+              then
+                (
+                  # Since https://github.com/rust-lang/rust/pull/84072
+                  # `target-family` is a list instead of single value.
+                  let
+                    f = args.rustc.platform.target-family;
+                  in
+                    if builtins.isList f then f else [ f ]
+                )
+              else lib.optional final.isUnix "unix"
+                   ++ lib.optional final.isWindows "windows";
+
+            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
+            vendor = let
+              inherit (final.parsed) vendor;
+            in rust.platform.vendor or {
+              "w64" = "pc";
+            }.${vendor.name} or vendor.name;
+          };
+
+          # The name of the rust target, even if it is custom. Adjustments are
+          # because rust has slightly different naming conventions than we do.
+          rustcTarget = let
+            inherit (final.parsed) cpu kernel abi;
+            cpu_ = rust.platform.arch or {
+              "armv7a" = "armv7";
+              "armv7l" = "armv7";
+              "armv6l" = "arm";
+              "armv5tel" = "armv5te";
+              "riscv64" = "riscv64gc";
+            }.${cpu.name} or cpu.name;
+            vendor_ = final.rust.platform.vendor;
+          in rust.config
+            or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
+
+          # The name of the rust target if it is standard, or the json file
+          # containing the custom target spec.
+          rustcTargetSpec = rust.rustcTargetSpec or (
+            /**/ if rust ? platform
+            then builtins.toFile (final.rust.rustcTarget + ".json") (builtins.toJSON rust.platform)
+            else final.rust.rustcTarget);
+
+          # The name of the rust target if it is standard, or the
+          # basename of the file containing the custom target spec,
+          # without the .json extension.
+          #
+          # This is the name used by Cargo for target subdirectories.
+          cargoShortTarget =
+            lib.removeSuffix ".json" (baseNameOf "${final.rust.rustcTargetSpec}");
+
+          # When used as part of an environment variable name, triples are
+          # uppercased and have all hyphens replaced by underscores:
+          #
+          # https://github.com/rust-lang/cargo/pull/9169
+          # https://github.com/rust-lang/cargo/issues/8285#issuecomment-634202431
+          cargoEnvVarTarget =
+            lib.strings.replaceStrings ["-"] ["_"]
+              (lib.strings.toUpper final.rust.cargoShortTarget);
+
+          # True if the target is no_std
+          # https://github.com/rust-lang/rust/blob/2e44c17c12cec45b6a682b1e53a04ac5b5fcc9d2/src/bootstrap/config.rs#L415-L421
+          isNoStdTarget =
+            builtins.any (t: lib.hasInfix t final.rust.rustcTarget) ["-none" "nvptx" "switch" "-uefi"];
+        };
+      };
   in assert final.useAndroidPrebuilt -> final.isAndroid;
      assert lib.foldl
        (pass: { assertion, message }:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16938,13 +16938,10 @@ with pkgs;
   # https://github.com/NixOS/nixpkgs/issues/89426
   rustc-wasm32 = (rustc.override {
     stdenv = stdenv.override {
-      targetPlatform = stdenv.targetPlatform // {
-        parsed = {
-          cpu.name = "wasm32";
-          vendor.name = "unknown";
-          kernel.name = "unknown";
-          abi.name = "unknown";
-        };
+      targetPlatform = lib.systems.elaborate {
+        # lib.systems.elaborate won't recognize "unknown" as the last component.
+        config = "wasm32-unknown-wasi";
+        rust.config = "wasm32-unknown-unknown";
       };
     };
   }).overrideAttrs (old: {


### PR DESCRIPTION
## Description of changes

See commit messages.  Fixes a couple of regressions from #233628.

wasm32-rustc is still not ideal.  As followup, I'd like to investigate whether we could just always include the wasm32-unknown-unknown target in rustc builds, since it doesn't require any libc dependency or anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
