### PR TITLE
[Backport release-23.05 ] {,ungoogled-}chromium: 119.0.6045.123 -> 119.0.6045.159

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -41,9 +41,9 @@
         version = "2023-09-12";
       };
     };
-    sha256 = "042apqqiaflfhnan4l5j1d50gv9kpz80pyhgm6yawrqq0fih87si";
-    sha256bin64 = "08a1rsbd6npwqh4zp4y6n0lcjc14m5lzs4bcwdvb7zql5j85d01w";
-    version = "119.0.6045.123";
+    sha256 = "08x1bsshn4jn5d66isk249z8rcfgw8z4zc5p5zgpil25yggfc4zk";
+    sha256bin64 = "1zllank3wl6d6csdqczbilgag5xziirb8lv3a7xr1717zdnbn2f4";
+    version = "119.0.6045.159";
   };
   ungoogled-chromium = {
     deps = {

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -54,12 +54,12 @@
         version = "2023-09-12";
       };
       ungoogled-patches = {
-        rev = "119.0.6045.123-1";
-        sha256 = "0ca2kdr8cni2lyiq051vlzslcpnxgjfw45mn3qknzf4amlrxyip0";
+        rev = "119.0.6045.159-1";
+        sha256 = "1ixhch6zasw5hfn675xgxgb1dwv07a14j90pgpqgfsmngihjn1cj";
       };
     };
-    sha256 = "042apqqiaflfhnan4l5j1d50gv9kpz80pyhgm6yawrqq0fih87si";
-    sha256bin64 = "08a1rsbd6npwqh4zp4y6n0lcjc14m5lzs4bcwdvb7zql5j85d01w";
-    version = "119.0.6045.123";
+    sha256 = "08x1bsshn4jn5d66isk249z8rcfgw8z4zc5p5zgpil25yggfc4zk";
+    sha256bin64 = "1zllank3wl6d6csdqczbilgag5xziirb8lv3a7xr1717zdnbn2f4";
+    version = "119.0.6045.159";
   };
 }


### PR DESCRIPTION
## Description of changes

Manual backport of
- #268005

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
