### PR TITLE
zbar: add patches for CVE-2023-40889 & CVE-2023-40890

### DIFF
--- a/pkgs/tools/graphics/zbar/0.23.92-CVE-2023-40889.patch
+++ b/pkgs/tools/graphics/zbar/0.23.92-CVE-2023-40889.patch
@@ -1,0 +1,17 @@
+Simple bounds checks for CVE-2023-40889, based on third-party
+fix by Remi Meier @
+https://github.com/Raemi/zbar/commit/5e8acc6974f17e56c3ddaa5509870beb8d7a599c
+
+--- a/zbar/qrcode/qrdec.c
++++ b/zbar/qrcode/qrdec.c
+@@ -3900,8 +3900,8 @@ void qr_reader_match_centers(qr_reader *_reader,qr_code_data_list *_qrlist,
+     /*TODO: We might be able to accelerate this step significantly by
+        considering the remaining finder centers in a more intelligent order,
+        based on the first finder center we just chose.*/
+-    for(j=i+1;!mark[i]&&j<_ncenters;j++){
+-      for(k=j+1;!mark[j]&&k<_ncenters;k++)if(!mark[k]){
++    for(j=i+1; i < _ncenters && !mark[i]&&j<_ncenters;j++){
++      for(k=j+1; j < _ncenters && !mark[j]&&k<_ncenters;k++)if(!mark[k]){
+         qr_finder_center *c[3];
+         qr_code_data      qrdata;
+         int               version;

--- a/pkgs/tools/graphics/zbar/0.23.92-CVE-2023-40890.patch
+++ b/pkgs/tools/graphics/zbar/0.23.92-CVE-2023-40890.patch
@@ -1,0 +1,26 @@
+Simple bounds checks for CVE-2023-40890
+
+--- a/zbar/decoder/databar.c
++++ b/zbar/decoder/databar.c
+@@ -23,6 +23,8 @@
+ 
+ #include <config.h>
+ #include <zbar.h>
++#include <stdlib.h>
++#include <stdio.h>
+ 
+ #ifdef DEBUG_DATABAR
+ # define DEBUG_LEVEL (DEBUG_DATABAR)
+@@ -691,6 +693,12 @@ lookup_sequence (databar_segment_t *seg,
+             fixed = -1;
+         s <<= 1;
+         dbprintf(2, "%x", s);
++
++        if (i > 20) {
++            fprintf(stderr, "Bug: Out-of-bounds condition detected\n");
++            exit(99);
++        }
++
+         seq[i++] = s++;
+         seq[i++] = s;
+     }

--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , imagemagickBig
 , pkg-config
 , withXorg ? true
@@ -41,6 +42,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-VhVrngAX7pXZp+szqv95R6RGAJojp3svdbaRKigGb0w=";
   };
+
+  patches = [
+    ./0.23.92-CVE-2023-40889.patch
+    ./0.23.92-CVE-2023-40890.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2023-40889
https://nvd.nist.gov/vuln/detail/CVE-2023-40890

Unfixed upstream, these are both (based on) third party patches. Can't test against the PoC input because the reporter didn't include that, but each patch addresses a lack of bounds checking at approximately the location of the reporter's stack trace.

On macos 10.15 & nixos aarch64-linux have built just `.*zbar.*` packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
