### PR TITLE
kmod-debian-aliases: 22-1.1 -> 30+20230601-2,  kmod-blacklist-ubuntu: 28-1ubuntu4 -> 30+20230519-1ubuntu3 

### DIFF
--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl }:
 
 let
-  version = "28-1ubuntu4"; # impish 2021-06-24
+  version = "30+20230519-1ubuntu3"; # mantic 2023-08-26
 
 in stdenv.mkDerivation {
   pname = "kmod-blacklist";
@@ -9,7 +9,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://launchpad.net/ubuntu/+archive/primary/+files/kmod_${version}.debian.tar.xz";
-    sha256 = "sha256-K8tWpaLmCm3Jcxw3OZ+D7Koiug7epooRn1YMfqjGAiw=";
+    hash = "sha256-VGw1/rUjl9/j6026ut0dvC0/8maAAz8umb0D3YGf8p4=";
   };
 
   installPhase = ''
@@ -22,7 +22,6 @@ in stdenv.mkDerivation {
     done
 
     substituteInPlace "$out"/modprobe.conf \
-      --replace "blacklist bochs-drm" "" \
       --replace /sbin/lsmod /run/booted-system/sw/bin/lsmod \
       --replace /sbin/rmmod /run/booted-system/sw/bin/rmmod \
       --replace /sbin/modprobe /run/booted-system/sw/bin/modprobe \

--- a/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
+++ b/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
@@ -2,16 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "kmod-debian-aliases.conf";
-  version = "22-1.1";
+  version = "30+20230601-2";
 
   src = fetchurl {
-    url = "https://snapshot.debian.org/archive/debian/20160404T220610Z/pool/main/k/kmod/kmod_${version}.debian.tar.xz";
-    sha256 = "0daap2n4bvjqcnksaayy6csmdb1px4r02w3xp36bcp6w3lbnqamh";
+    url = "https://snapshot.debian.org/archive/debian/20231117T085632Z/pool/main/k/kmod/kmod_${version}.debian.tar.xz";
+    hash = "sha256-xJMGKht8hu0aQjN9TER87Rv5EYkVMeDfX/jJ8+UjAqM=";
   };
 
   installPhase = ''
-    patch -i patches/aliases_conf
-    cp aliases.conf $out
+    cp extra/aliases.conf $out
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Effective change is a new priority in debian aliases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
