### PR TITLE
singularity-tools: refactor and add `runImageInLinuxVM`; apptainer.passthru.tests.exec-image-in-linux-vm: init

### DIFF
--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -53,7 +53,7 @@ rec {
       runAsRootFile = shellScript "run-as-root.sh" runAsRoot;
       runScriptFile = shellScript "run-script.sh" runScript;
       result = vmTools.runInLinuxVM (
-        runCommand "${projectName}-image-${name}.img"
+        runCommand "${projectName}-image-${name}.sif"
           {
             buildInputs = [
               singularity

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -104,12 +104,12 @@ rec {
             if [ ! -e bin/sh ]; then
               ln -s ${runtimeShell} bin/sh
             fi
-            mkdir -p .${projectName}.d
-            ln -s ${runScriptFile} .${projectName}.d/runscript
+            mkdir -p .singularity.d
+            ln -s ${runScriptFile} .singularity.d/runscript
 
-            # Fill out .${projectName}.d
-            mkdir -p .${projectName}.d/env
-            touch .${projectName}.d/env/94-appsbase.sh
+            # Fill out .singularity.d
+            mkdir -p .singularity.d/env
+            touch .singularity.d/env/94-appsbase.sh
 
             cd ..
             mkdir -p /var/lib/${projectName}/mnt/session

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -1,16 +1,16 @@
-{ runCommand
-, lib
+{ lib
 , stdenv
-, storeDir ? builtins.storeDir
-, writeScript
-, singularity
-, writeClosure
-, bash
+, runCommand
 , vmTools
+, writeClosure
+, writeScript
+, e2fsprogs
 , gawk
 , util-linux
+, bash
 , runtimeShell
-, e2fsprogs
+, singularity
+, storeDir ? builtins.storeDir
 }:
 rec {
   shellScript = name: text:

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -5,6 +5,7 @@
   vmTools,
   writeClosure,
   writeScript,
+  writeShellScriptBin,
   e2fsprogs,
   util-linux,
   bash,
@@ -15,28 +16,237 @@
 let
   defaultSingularity = singularity;
 in
-rec {
-  shellScript =
-    name: text:
-    writeScript name ''
-      #!${runtimeShell}
-      set -e
-      ${text}
-    '';
-
-  mkLayer =
+lib.makeExtensible (self: {
+  buildSandboxFromContents =
+    let
+      shellScript =
+        name: text:
+        writeScript name ''
+          #!${runtimeShell}
+          set -e
+          ${text}
+        '';
+    in
     {
       name,
       contents ? [ ],
-      # May be "apptainer" instead of "singularity"
-      projectName ? (singularity.projectName or "singularity"),
+      runScript ? "#!${stdenv.shell}\nexec /bin/sh",
+      runAsRoot ? "",
+      projectName ? defaultSingularity.projectName or "singularity",
     }:
-    runCommand "${projectName}-layer-${name}" { inherit contents; } ''
-      mkdir $out
-      for f in $contents ; do
-        cp -ra $f $out/
-      done
-    '';
+    let
+      layerClosure = writeClosure (
+        contents
+        ++ [
+          bash
+          runScriptFile
+        ]
+      );
+      runAsRootFile = shellScript "run-as-root.sh" runAsRoot;
+      runScriptFile = shellScript "run-script.sh" runScript;
+      buildScriptBin = writeShellScriptBin "build-sandbox" ''
+        if [ "$#" -lt 1 ]; then
+          echo "Expect SANDBOX_PATH" >&2
+          exit 1
+        fi
+        pathSandbox="$1"
+        cd "$pathSandbox"
+        mkdir proc sys dev
+
+        ${lib.optionalString (runAsRoot != "") ''
+          # Run root script
+          mkdir -p ./${builtins.storeDir}
+          mount --rbind ${builtins.storeDir} ./${builtins.storeDir}
+          unshare -imnpuf --mount-proc chroot ./ ${runAsRootFile}
+          umount -R ./${builtins.storeDir}
+        ''}
+
+        # Build /bin and copy across closure
+        mkdir -p bin ./${builtins.storeDir}
+        for f in $(cat ${layerClosure}) ; do
+          cp -r $f ./$f
+        done
+
+        for c in ${lib.escapeShellArgs (map (s: "${s}") contents)} ; do
+          for f in $c/bin/* ; do
+            if [ ! -e bin/$(basename $f) ] ; then
+              ln -s $f bin/
+            fi
+          done
+        done
+
+        # Create runScript and link shell
+        if [ ! -e bin/sh ]; then
+          ln -s ${runtimeShell} bin/sh
+        fi
+        mkdir -p .singularity.d
+        ln -s ${runScriptFile} .singularity.d/runscript
+
+        # Fill out .singularity.d
+        mkdir -p .singularity.d/env
+        touch .singularity.d/env/94-appsbase.sh
+      '';
+    in
+    runCommand "${projectName}-sandbox-${name}"
+      {
+        passthru = {
+          inherit
+            buildScriptBin
+            layerClosure
+            projectName
+            runAsRoot
+            runScript
+            ;
+        };
+      }
+      ''
+        runHook preImageBuild
+        mkdir -p "$out"
+        "${lib.getExe buildScriptBin}" "$out"
+        runHook postImageBuild
+      '';
+
+  buildImageFromSandbox =
+    {
+      name,
+      sandbox ? self.buildSandboxFromContents (
+        builtins.intersectAttrs (lib.functionArgs self.buildSandboxFromContents) args
+        // {
+          name = "${name}-from-contents";
+          projectName = singularity.projectName or "singularity";
+        }
+      ),
+      # Whether to build the sandbox into a temporary path
+      # with sandboxBuildScriptBin
+      # and then build the image frem the temporary sandbox,
+      # or to build the image directly from `"${sandbox}"`
+      fromBuildScriptBin ? (sandbox ? buildScriptBin),
+      singularity ? sandbox.singularity or defaultSingularity,
+      # Placeholders for buildSandboxFromContents arguments
+      contents ? null,
+      runScript ? null,
+      runAsRoot ? null,
+      executableFlags ? null,
+      buildImageFlags ? null,
+    }@args:
+    let
+      projectName = singularity.projectName or sandbox.projectName or "singularity";
+      inherit fromBuildScriptBin;
+      buildScriptBin = writeShellScriptBin "build-image" ''
+        if [ "$#" -lt 1 ]; then
+          echo "Expect IMAGE_PATH" >&2
+          exit 1
+        fi
+        pathSIF="$1"
+        shift
+          ${
+            if fromBuildScriptBin then
+              ''
+                pathSandbox="$(mktemp -t -d sandbox_XXXXXX)"
+                trap "rm -rf \"$pathSandbox\"" EXIT INT
+                ${lib.escapeShellArg (lib.getExe sandbox.buildScriptBin)} "$pathSandbox"
+              ''
+            else
+              ''
+                pathSandbox=${lib.escapeShellArg "${sandbox}"}
+              ''
+          }
+          ${projectName} build "$pathSIF" "$pathSandbox"
+      '';
+    in
+    runCommand "${projectName}-image-${name}.sif"
+      {
+        buildInputs = [
+          singularity
+          util-linux
+        ];
+        passthru = sandbox.passthru or { } // {
+          inherit
+            buildScriptBin
+            fromBuildScriptBin
+            sandbox
+            singularity
+            projectName
+            ;
+        };
+      }
+      ''
+        runHook preImageBuild
+        ${lib.escapeShellArg "${lib.getExe buildScriptBin}"} "$out"
+        runHook postImageBuild
+      '';
+
+  buildImageInLinuxVM =
+    {
+      diskSize ? 1024,
+      memSize ? 512,
+      preHookName ? "preImageBuild",
+      postHookName ? "postImageBuild",
+      # Note: Sylabs SingularityCE requires loop device to run images,
+      # which is not available in the Nix build sandbox.
+      supportImageRunning ? false,
+      # For image running support
+      localtime ? "UTC",
+    }:
+    drv:
+    vmTools.runInLinuxVM (
+      drv.overrideAttrs (
+        finalAttrs: previousAttrs:
+        {
+          inherit supportImageRunning;
+          nativeBuildInputs = previousAttrs.nativeBuildInputs or [ ] ++ [
+            e2fsprogs
+            util-linux
+          ];
+          preVM = vmTools.createEmptyImage {
+            size = diskSize;
+            fullName = "${finalAttrs.projectName}-run-disk";
+          };
+          projectName =
+            previousAttrs.projectName or drv.projectName or drv.singularity.projectName
+              or (throw "projectName not specified");
+          externalLocalStateDir =
+            previousAttrs.externalLocalStateDir or drv.singularity.externalLocalStateDir or "/var/lib";
+          ${preHookName} = ''
+            rm -rf $out
+            mkdir disk
+            mkfs -t ext4 -b 4096 /dev/${vmTools.hd}
+            mount /dev/${vmTools.hd} disk
+            if [[ -n "''${externalLocalStateDir-}" ]]; then
+              mkdir -p "$externalLocalStateDir/$projectName/mnt/session"
+            fi
+            echo "root:x:0:0:System administrator:/root:/bin/sh" > /etc/passwd
+            echo > /etc/resolv.conf
+            TMPDIR="$(realpath disk)"; export TMPDIR
+            if (( supportImageRunning )); then
+              echo "root:x:0:"  > /etc/group
+              echo "$localtime" > /etc/localtime
+              mkdir -p /var/tmp
+            fi
+            cd disk
+          '';
+          passthru = {
+            unprivileged-package = drv;
+          };
+        }
+        // lib.optionalAttrs supportImageRunning { inherit localtime; }
+      )
+    );
+
+  runImageInLinuxVM = lib.setFunctionArgs (
+    {
+      preHookName ? "preImageRun",
+      postHookName ? "postImageRun",
+      ...
+    }@args:
+    self.buildImageInLinuxVM (
+      args
+      // {
+        inherit preHookName postHookName;
+        supportImageRunning = true;
+      }
+    )
+  ) (removeAttrs (lib.functionArgs self.buildImageInLinuxVM) [ "supportImageRunning" ]);
 
   buildImage =
     {
@@ -44,80 +254,19 @@ rec {
       contents ? [ ],
       diskSize ? 1024,
       runScript ? "#!${stdenv.shell}\nexec /bin/sh",
-      runAsRoot ? null,
+      runAsRoot ? "",
       memSize ? 1024,
       singularity ? defaultSingularity,
     }:
-    let
-      projectName = singularity.projectName or "singularity";
-      runAsRootFile = shellScript "run-as-root.sh" runAsRoot;
-      runScriptFile = shellScript "run-script.sh" runScript;
-      result = vmTools.runInLinuxVM (
-        runCommand "${projectName}-image-${name}.sif"
-          {
-            buildInputs = [
-              singularity
-              e2fsprogs
-              util-linux
-            ];
-            layerClosure = writeClosure contents;
-            preVM = vmTools.createEmptyImage {
-              size = diskSize;
-              fullName = "${projectName}-run-disk";
-            };
-            inherit memSize;
-          }
-          ''
-            rm -rf $out
-            mkdir disk
-            mkfs -t ext3 -b 4096 /dev/${vmTools.hd}
-            mount /dev/${vmTools.hd} disk
-            mkdir -p disk/img
-            cd disk/img
-            mkdir proc sys dev
-
-            # Run root script
-            ${lib.optionalString (runAsRoot != null) ''
-              mkdir -p ./${builtins.storeDir}
-              mount --rbind "${builtins.storeDir}" ./${builtins.storeDir}
-              unshare -imnpuf --mount-proc chroot ./ ${runAsRootFile}
-              umount -R ./${builtins.storeDir}
-            ''}
-
-            if grep "^substitut"
-
-            # Build /bin and copy across closure
-            mkdir -p bin ./${builtins.storeDir}
-            for f in $(cat $layerClosure) ; do
-              cp -ar $f ./$f
-            done
-
-            for c in ${toString contents} ; do
-              for f in $c/bin/* ; do
-                if [ ! -e bin/$(basename $f) ] ; then
-                  ln -s $f bin/
-                fi
-              done
-            done
-
-            # Create runScript and link shell
-            if [ ! -e bin/sh ]; then
-              ln -s ${runtimeShell} bin/sh
-            fi
-            mkdir -p .singularity.d
-            ln -s ${runScriptFile} .singularity.d/runscript
-
-            # Fill out .singularity.d
-            mkdir -p .singularity.d/env
-            touch .singularity.d/env/94-appsbase.sh
-
-            cd ..
-            mkdir -p /var/lib/${projectName}/mnt/session
-            echo "root:x:0:0:System administrator:/root:/bin/sh" > /etc/passwd
-            echo > /etc/resolv.conf
-            TMPDIR=$(pwd -P) ${projectName} build $out ./img
-          ''
-      );
-    in
-    result;
-}
+    self.buildImageInLinuxVM { inherit diskSize memSize; } (
+      self.buildImageFromSandbox {
+        inherit
+          name
+          contents
+          runScript
+          runAsRoot
+          singularity
+          ;
+      }
+    );
+})

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -11,7 +11,6 @@
   bash,
   runtimeShell,
   singularity,
-  storeDir ? builtins.storeDir,
 }:
 rec {
   shellScript =
@@ -80,11 +79,13 @@ rec {
 
             # Run root script
             ${lib.optionalString (runAsRoot != null) ''
-              mkdir -p ./${storeDir}
-              mount --rbind ${storeDir} ./${storeDir}
+              mkdir -p ./${builtins.storeDir}
+              mount --rbind "${builtins.storeDir}" ./${builtins.storeDir}
               unshare -imnpuf --mount-proc chroot ./ ${runAsRootFile}
-              umount -R ./${storeDir}
+              umount -R ./${builtins.storeDir}
             ''}
+
+            if grep "^substitut"
 
             # Build /bin and copy across closure
             mkdir -p bin ./${builtins.storeDir}

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -6,7 +6,6 @@
   writeClosure,
   writeScript,
   e2fsprogs,
-  gawk,
   util-linux,
   bash,
   runtimeShell,
@@ -59,7 +58,6 @@ rec {
               singularity
               e2fsprogs
               util-linux
-              gawk
             ];
             layerClosure = writeClosure contents;
             preVM = vmTools.createEmptyImage {

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -11,6 +11,10 @@
   runtimeShell,
   singularity,
 }:
+
+let
+  defaultSingularity = singularity;
+in
 rec {
   shellScript =
     name: text:
@@ -35,9 +39,6 @@ rec {
     '';
 
   buildImage =
-    let
-      defaultSingularity = singularity;
-    in
     {
       name,
       contents ? [ ],

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -1,19 +1,21 @@
-{ lib
-, stdenv
-, runCommand
-, vmTools
-, writeClosure
-, writeScript
-, e2fsprogs
-, gawk
-, util-linux
-, bash
-, runtimeShell
-, singularity
-, storeDir ? builtins.storeDir
+{
+  lib,
+  stdenv,
+  runCommand,
+  vmTools,
+  writeClosure,
+  writeScript,
+  e2fsprogs,
+  gawk,
+  util-linux,
+  bash,
+  runtimeShell,
+  singularity,
+  storeDir ? builtins.storeDir,
 }:
 rec {
-  shellScript = name: text:
+  shellScript =
+    name: text:
     writeScript name ''
       #!${runtimeShell}
       set -e
@@ -21,15 +23,13 @@ rec {
     '';
 
   mkLayer =
-    { name
-    , contents ? [ ]
+    {
+      name,
+      contents ? [ ],
       # May be "apptainer" instead of "singularity"
-    , projectName ? (singularity.projectName or "singularity")
+      projectName ? (singularity.projectName or "singularity"),
     }:
-    runCommand "${projectName}-layer-${name}"
-      {
-        inherit contents;
-      } ''
+    runCommand "${projectName}-layer-${name}" { inherit contents; } ''
       mkdir $out
       for f in $contents ; do
         cp -ra $f $out/
@@ -40,13 +40,14 @@ rec {
     let
       defaultSingularity = singularity;
     in
-    { name
-    , contents ? [ ]
-    , diskSize ? 1024
-    , runScript ? "#!${stdenv.shell}\nexec /bin/sh"
-    , runAsRoot ? null
-    , memSize ? 1024
-    , singularity ? defaultSingularity
+    {
+      name,
+      contents ? [ ],
+      diskSize ? 1024,
+      runScript ? "#!${stdenv.shell}\nexec /bin/sh",
+      runAsRoot ? null,
+      memSize ? 1024,
+      singularity ? defaultSingularity,
     }:
     let
       projectName = singularity.projectName or "singularity";
@@ -55,7 +56,12 @@ rec {
       result = vmTools.runInLinuxVM (
         runCommand "${projectName}-image-${name}.img"
           {
-            buildInputs = [ singularity e2fsprogs util-linux gawk ];
+            buildInputs = [
+              singularity
+              e2fsprogs
+              util-linux
+              gawk
+            ];
             layerClosure = writeClosure contents;
             preVM = vmTools.createEmptyImage {
               size = diskSize;
@@ -110,8 +116,8 @@ rec {
             echo "root:x:0:0:System administrator:/root:/bin/sh" > /etc/passwd
             echo > /etc/resolv.conf
             TMPDIR=$(pwd -P) ${projectName} build $out ./img
-          '');
-
+          ''
+      );
     in
     result;
 }


### PR DESCRIPTION
## Description of changes

* Refactor singularity-tools:
    * ~Replace `mkLayer` with `pkgs.writeClosure`. This prevents unnecessary copy of the closures just to get the reference list.~ (done in #178717)
    * Drop `storeDir` from the override interface.
    * Use directory name `.singularity.d` in sandbox for both `apptainer` and `singularity`
    * Split the `buildImage` into multiple reusable build helpers.
        * Add `passthru.buildscriptPackage` to each of the image derivation, which can be executed to build the image outside of Nix Store. This saves the space and CPU time needed to spawn a VM, allocate a virtual disk file, and copy the result image out from the store.
        * Make each image build helper run `preImageBuild` and `postImageBuild` hooks to provide a uniform overriding interface.
        * Split the privileged, VM-spawning build process into `buildImageInLinuxVM`. Add argument `supportImageRuning` to opt in image running support during build.
* Add `runImageInLinuxVM` which wraps around `buildImageInLinuxVM`.
* Add `apptainer.passthru.tests.exec-image-in-linux-vm` to automate the binary functionality tests. If applied, we can test the image building and running functionality of Apptainer simply by running the Nix CI, and version bumping PRs made by r-ryantm can be merged directly when all the tests is passed.
  It's currently impossible for `singularity` (Sylabs SingularityCE) to run images in Nix sandbox, since it (still) requires a loop device to mount the image, which is not available in the Nix sandbox.

Depends on #178717.

Initial effort for #224636.

Cc: @jbedo @SomeoneSerge @GaetanLepage

```
 _______________
< Hello, world! >
 ---------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
