### PR TITLE
netbsd.sys: fix build

### DIFF
--- a/pkgs/applications/version-management/cvs/default.nix
+++ b/pkgs/applications/version-management/cvs/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     "AR=${stdenv.cc.targetPrefix}ar"
   ];
 
-  env = lib.optionalAttrs stdenv.cc.isClang {
+  env = lib.optionalAttrs (stdenv.isDarwin && stdenv.cc.isClang) {
     NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
   };
 

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -603,6 +603,12 @@ in makeScopeWithSplicing' {
     version = "9.2";
     sha256 = "03s18q8d9giipf05bx199fajc2qwikji0djz7hw63d2lya6bfnpj";
 
+    # Make the build ignore linker warnings
+    prePatch = ''
+      substituteInPlace sys/conf/Makefile.kern.inc \
+        --replace "-Wa,--fatal-warnings" ""
+    '';
+
     patches = [
       # Fix this error when building bootia32.efi and bootx64.efi:
       # error: PHDR segment not covered by LOAD segment
@@ -634,7 +640,11 @@ in makeScopeWithSplicing' {
     makeFlags = defaultMakeFlags ++ [ "FIRMWAREDIR=$(out)/libdata/firmware" ];
     hardeningDisable = [ "pic" ];
     MKKMOD = "no";
-    env.NIX_CFLAGS_COMPILE = toString [ "-Wa,--no-warn" ];
+    env.NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=array-parameter"
+      "-Wno-error=array-bounds"
+      "-Wa,--no-warn"
+    ];
 
     postBuild = ''
       make -C arch/$MACHINE/compile/$CONFIG $makeFlags

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -618,8 +618,13 @@ in makeScopeWithSplicing' {
       ./sys-headers-incsdir.patch
     ];
 
-    # multiple header dirs, see above
-    inherit (self.include) postPatch;
+    postPatch =
+      ''
+        substituteInPlace sys/arch/i386/stand/efiboot/Makefile.efiboot \
+          --replace "-nocombreloc" "-z nocombreloc"
+      '' +
+      # multiple header dirs, see above
+      self.include.postPatch;
 
     CONFIG = "GENERIC";
 


### PR DESCRIPTION
## Description of changes

Coming from NixOS on `x86_64-linux`, this fixes the build of `pkgsCross.x86_64-netbsd.netbsd.sys` for me.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
