### PR TITLE
tests.nixpkgs-check-by-name: More reliable .envrc reloading

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/.envrc
+++ b/pkgs/test/nixpkgs-check-by-name/.envrc
@@ -1,1 +1,7 @@
+if has nix_direnv_watch_file; then
+  nix_direnv_watch_file default.nix shell.nix
+else
+  watch_file default.nix shell.nix
+fi
+
 use nix


### PR DESCRIPTION
See also https://github.com/nix-community/nix-direnv/issues/408 and https://github.com/nix-community/nix-direnv/pull/407

Discovered while reviewing https://github.com/NixOS/nixpkgs/pull/267048, which will benefit from this.