### PR TITLE
squeak: fix build with LLVM 16

### DIFF
--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -1,15 +1,40 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, fetchzip
-, autoconf, automake, autoreconfHook, clang, dos2unix, file, perl
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, fetchzip
+, autoconf
+, automake
+, autoreconfHook
+, dos2unix
+, file
+, perl
 , pkg-config
-, alsa-lib, coreutils, freetype, glib, glibc, gnugrep, libGL, libpulseaudio
-, libtool, libuuid, openssl, pango, xorg
-, squeakImageHash ? null, squeakSourcesHash ? null, squeakSourcesVersion ? null
-, squeakVersion ? null, squeakVmCommitHash ? null, squeakVmCommitHashHash ? null
+, alsa-lib
+, coreutils
+, freetype
+, glib
+, glibc
+, gnugrep
+, libGL
+, libpulseaudio
+, libtool
+, libuuid
+, openssl
+, pango
+, xorg
+, squeakImageHash ? null
+, squeakSourcesHash ? null
+, squeakSourcesVersion ? null
+, squeakVersion ? null
+, squeakVmCommitHash ? null
+, squeakVmCommitHashHash ? null
 , squeakVmVersion ? null
 } @ args:
 
 let
-  inherit (builtins) elemAt;
+  inherit (builtins) elemAt toString;
+
   nullableOr = o: default: if o == null then default else o;
 
   bits = stdenv.hostPlatform.parsed.cpu.bits;
@@ -75,7 +100,6 @@ in stdenv.mkDerivation {
     autoconf
     automake
     autoreconfHook
-    clang
     dos2unix
     file
     perl
@@ -140,7 +164,16 @@ in stdenv.mkDerivation {
   # Workaround build failure on -fno-common toolchains:
   #   ld: vm/vm.a(cogit.o):spur64src/vm/cogitX64SysV.c:2552: multiple definition of
   #       `traceStores'; vm/vm.a(gcc3x-cointerp.o):spur64src/vm/cogit.h:140: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  env.NIX_CFLAGS_COMPILE = toString (
+    [ "-fcommon" ]
+    ++ (lib.optionals stdenv.cc.isClang [
+      # LLVM 16 turned these into errors (rightly, perhaps.)
+      # Allow this package to continue to build despite this change.
+      "-Wno-error=int-conversion"
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=incompatible-function-pointer-types"
+    ])
+  );
 
   preAutoreconf = ''
     pushd ./platforms/unix/config > /dev/null

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17287,7 +17287,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation Security;
   };
 
-  squeak = callPackage ../development/compilers/squeak { };
+  squeak = callPackage ../development/compilers/squeak {
+    stdenv = clangStdenv;
+  };
 
   squirrel-sql = callPackage ../development/tools/database/squirrel-sql {
     drivers = [ jtds_jdbc mssql_jdbc mysql_jdbc postgresql_jdbc ];


### PR DESCRIPTION
## Description of changes

Part of ZHF (#265948) for 23.11: https://hydra.nixos.org/build/241300457

I bisected this failure to this first bad commit: [9ed7bfe46bf193e55a6fd8ae89dfe54b4dca2c18] llvmPackages: 11 -> 16 on Linux, then looked around for other repairs made to assuage LLVM's errors. This appears to be the pattern.

To fit the `lib.optionals stdenv.cc.isClang` check, I passed `clangStdenv` in `all-packages.nix` instead of the previous pattern of putting `clang` in `nativeBuildInputs`.

I also took this moment to make the long list of dependencies be formatted one-per-line, as per `nixpkgs-fmt` style. And as I added another use of `toString`, I added it to the list of things brought in from `builtins`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).