### PR TITLE
hyprshot: init at 1.2.3

### DIFF
--- a/pkgs/by-name/hy/hyprshot/package.nix
+++ b/pkgs/by-name/hy/hyprshot/package.nix
@@ -1,0 +1,46 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, hyprland
+, jq
+, grim
+, slurp
+, wl-clipboard
+, libnotify
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hyprshot";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "Gustash";
+    repo = "hyprshot";
+    rev = finalAttrs.version;
+    hash = "sha256-sew47VR5ZZaLf1kh0d8Xc5GVYbJ1yWhlug+Wvf+k7iY=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 hyprshot -t "$out/bin"
+    wrapProgram "$out/bin/hyprshot" \
+      --prefix PATH ":" ${lib.makeBinPath [
+          hyprland jq grim slurp wl-clipboard libnotify
+        ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Gustash/hyprshot";
+    description = "Hyprshot is an utility to easily take screenshots in Hyprland using your mouse.";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ Cryolitia ];
+    mainProgram = "hyprshot";
+    platforms = hyprland.meta.platforms;
+  };
+})


### PR DESCRIPTION
## Description of changes

Hyprshot is an utility to easily take screenshots in Hyprland using your mouse.

Homepage: https://github.com/Gustash/Hyprshot

link https://github.com/NixOS/nixpkgs/issues/250853

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
