### PR TITLE
logseq: add aarch64-darwin target

### DIFF
--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -7,62 +7,87 @@
 , electron_25
 , git
 , nix-update-script
+, undmg
+, unzip
 }:
 
 stdenv.mkDerivation (finalAttrs: let
   inherit (finalAttrs) pname version src appimageContents;
 
-in {
+  appname = "Logseq";
+
+  linux = {
+    src = fetchurl {
+      url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-linux-x64-${version}.AppImage";
+      hash = "sha256-iT0Gc/ePx1tUNTPoE2Ol+dHUmbS4CkneZbyraRBx5Ak=";
+      name = "${pname}-${version}.AppImage";
+    };
+
+    appimageContents = appimageTools.extract {
+      inherit pname src version;
+    };
+
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/share/${pname} $out/share/applications
+      cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
+      cp -a ${appimageContents}/${appname}.desktop $out/share/applications/${pname}.desktop
+
+      # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
+      chmod +w -R $out/share/${pname}/resources/app/node_modules/dugite/git
+      chmod +w $out/share/${pname}/resources/app/node_modules/dugite
+      rm -rf $out/share/${pname}/resources/app/node_modules/dugite/git
+      chmod -w $out/share/${pname}/resources/app/node_modules/dugite
+
+      mkdir -p $out/share/pixmaps
+      ln -s $out/share/${pname}/resources/app/icons/logseq.png $out/share/pixmaps/${pname}.png
+
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace Exec=${appname} Exec=${pname} \
+        --replace Icon=${appname} Icon=${pname}
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
+      makeWrapper ${electron_25}/bin/electron $out/bin/${pname} \
+        --set "LOCAL_GIT_DIRECTORY" ${git} \
+        --add-flags $out/share/${pname}/resources/app \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+    '';
+  };
+
+  darwin = {
+    src = fetchurl {
+      url =  "https://github.com/logseq/logseq/releases/download/${version}/logseq-darwin-arm64-${version}.dmg";
+      hash = "sha256-h5I1ZSIdo7yGfhryJSyvQFSo0OIPfcFxfDoSIaI48IM=";
+      name = "${pname}-${version}.dmg";
+    };
+
+    nativeBuildInputs = [ makeWrapper undmg unzip ];
+
+    installPhase = ''
+      runHook preinstall
+
+      mkdir -p $out/{bin,Applications/${appname}.app}
+      cp -R . $out/Applications/${appname}.app
+      makeWrapper $out/Applications/${appname}.app/Contents/MacOS/${appname} $out/bin/${pname}
+
+      runHook postInstall
+    '';
+  };
+in (if stdenv.isLinux then linux else darwin) // {
   pname = "logseq";
   version = "0.9.20";
-
-  src = fetchurl {
-    url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-linux-x64-${version}.AppImage";
-    hash = "sha256-iT0Gc/ePx1tUNTPoE2Ol+dHUmbS4CkneZbyraRBx5Ak=";
-    name = "${pname}-${version}.AppImage";
-  };
-
-  appimageContents = appimageTools.extract {
-    inherit pname src version;
-  };
-
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin $out/share/${pname} $out/share/applications
-    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
-    cp -a ${appimageContents}/Logseq.desktop $out/share/applications/${pname}.desktop
-
-    # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
-    chmod +w -R $out/share/${pname}/resources/app/node_modules/dugite/git
-    chmod +w $out/share/${pname}/resources/app/node_modules/dugite
-    rm -rf $out/share/${pname}/resources/app/node_modules/dugite/git
-    chmod -w $out/share/${pname}/resources/app/node_modules/dugite
-
-    mkdir -p $out/share/pixmaps
-    ln -s $out/share/${pname}/resources/app/icons/logseq.png $out/share/pixmaps/${pname}.png
-
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace Exec=Logseq Exec=${pname} \
-      --replace Icon=Logseq Icon=${pname}
-
-    runHook postInstall
-  '';
-
-  postFixup = ''
-    # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
-    makeWrapper ${electron_25}/bin/electron $out/bin/${pname} \
-      --set "LOCAL_GIT_DIRECTORY" ${git} \
-      --add-flags $out/share/${pname}/resources/app \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
-  '';
 
   passthru.updateScript = nix-update-script { };
 
@@ -71,7 +96,12 @@ in {
     homepage = "https://github.com/logseq/logseq";
     changelog = "https://github.com/logseq/logseq/releases/tag/${version}";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [
+      cdmistman
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
   };
 })


### PR DESCRIPTION
## Description of changes

`logseq` is packaged, but not for `aarch64-darwin`! I went ahead and did so

Note, though, that the developers don't sign the `.app` using xcode. As such, MacOS (at least Ventura) will quarantine this app when downloaded via Nix (when downloaded/installed via `.dmg` directly, MacOS will just warn the user that the publisher can't be verified). I couldn't find a way to work around this, so 🤷 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
