### PR TITLE
qt-video-wlr: 2020-08-03 -> 2023-07-22

### DIFF
--- a/pkgs/applications/misc/qt-video-wlr/default.nix
+++ b/pkgs/applications/misc/qt-video-wlr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, meson, ninja, wayland, pixman, cairo, librsvg, wayland-protocols, wlroots, libxkbcommon, gst_all_1, wrapQtAppsHook, qtbase, qtmultimedia }:
+{ stdenv, lib, fetchFromGitHub, pkg-config, meson, cmake, ninja, gst_all_1, wrapQtAppsHook, qtbase, qtmultimedia, layer-shell-qt }:
 let
  gstreamerPath = with gst_all_1; lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
      gstreamer
@@ -9,38 +9,39 @@ let
  ];
 in stdenv.mkDerivation rec {
   pname = "qt-video-wlr";
-  version = "2020-08-03";
+  version = "2023-07-22";
 
   src = fetchFromGitHub {
     owner = "xdavidwu";
     repo = "qt-video-wlr";
-    rev = "f88a7aa43f28b879b18752069f4a1ec33d73f2fe";
-    sha256 = "135kfyg1b61xvfpk8vpk4qyw6s9q1mn3a6lfkrqrhl0dz9kka9lx";
+    rev = "1373c8eeb0a5d867927ba30a9a9bb2d5b0057a87";
+    hash = "sha256-mg0ROD9kV88I5uCm+niAI5tJuhkmYC7Z8dixxrNow4c=";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja wrapQtAppsHook ];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    cmake # only used for find layer-shell-qt
+    ninja
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
-      wayland
-      pixman
-      cairo
-      librsvg
-      wayland-protocols
-      wlroots
-      libxkbcommon
-      qtbase
-      qtmultimedia
+    qtbase
+    qtmultimedia
+    layer-shell-qt
   ];
 
   qtWrapperArgs = [
-      "--prefix PATH : $out/bin/qt-video-wlr"
-      "--prefix GST_PLUGIN_PATH : ${gstreamerPath}"
+    "--prefix PATH : $out/bin/qt-video-wlr"
+    "--prefix GST_PLUGIN_PATH : ${gstreamerPath}"
   ];
 
   meta = with lib; {
     description = "Qt pip-mode-like video player for wlroots-based wayland compositors";
     homepage = "https://github.com/xdavidwu/qt-video-wlr";
     license = licenses.mit;
-    maintainers = with maintainers; [ fionera ];
+    maintainers = with maintainers; [ fionera rewine ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5478,9 +5478,7 @@ with pkgs;
 
   flashfocus = callPackage ../misc/flashfocus { };
 
-  qt-video-wlr = libsForQt5.callPackage ../applications/misc/qt-video-wlr {
-    wlroots = wlroots_0_15;
-  };
+  qt-video-wlr = libsForQt5.callPackage ../applications/misc/qt-video-wlr { };
 
   fwup = callPackage ../tools/misc/fwup {
     inherit (darwin.apple_sdk.frameworks) DiskArbitration;


### PR DESCRIPTION
## Description of changes

https://github.com/xdavidwu/qt-video-wlr



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
