### PR TITLE
buuf-nestort-icon-theme: init at 2023-11-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16570,6 +16570,11 @@
     githubId = 158321;
     name = "Stewart Mackenzie";
   };
+  sk4rd = {
+    github = "sk4rd";
+    githubId = 42469640;
+    name = "Mikolaj Bajtkiewicz";
+  };
   skovati = {
     github = "skovati";
     githubId = 49844593;

--- a/pkgs/data/icons/buuf-nestort-icon-theme/default.nix
+++ b/pkgs/data/icons/buuf-nestort-icon-theme/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenvNoCC, fetchgit }:
+
+stdenvNoCC.mkDerivation {
+  pname = "buuf-netsort-icon-theme";
+  version = "2023-11-17";
+
+  src = fetchgit {
+    url = "https://git.disroot.org/eudaimon/buuf-nestort.git";
+    rev = "e946fc5aafdc3f9ccc056bc8b70ab2489c676812";
+    hash = "sha256-phBREuCOMPLMSEUyYkgG37SDyTP95tNb/jtk93QQTvQ=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons/
+    cp -r . $out/share/icons/buuf-netsort-icon-theme
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A whimsical and unique icon theme adapted for many desktops";
+    homepage = "https://git.disroot.org/eudaimon/buuf-nestort";
+    platforms = platforms.all;
+    license = licenses.cc-by-nc-sa-25;
+    maintainers = with maintainers; [ sk4rd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4381,6 +4381,8 @@ with pkgs;
 
   buttercup-desktop = callPackage ../tools/security/buttercup-desktop { };
 
+  buuf-nestort-icon-theme = callPackage ../data/icons/buuf-nestort-icon-theme { };
+
   charles = charles4;
   inherit (callPackage ../applications/networking/charles {})
     charles3


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
