### PR TITLE
quickgui: add quickemu to PATH

### DIFF
--- a/pkgs/applications/virtualization/quickgui/default.nix
+++ b/pkgs/applications/virtualization/quickgui/default.nix
@@ -1,12 +1,14 @@
-{ stdenv
+{ stdenvNoCC
 , lib
 , fetchurl
 , autoPatchelfHook
 , dpkg
 , wrapGAppsHook
+, quickemu
+, gnome
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "quickgui";
   version = "1.2.8";
 
@@ -18,11 +20,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoPatchelfHook
     dpkg
+    wrapGAppsHook
   ];
 
   buildInputs = [
-    wrapGAppsHook
+    quickemu
+    gnome.zenity
   ];
+
+  strictDeps = true;
 
   unpackCmd = "dpkg-deb -x $curSrc source";
 
@@ -30,19 +36,32 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mv usr $out
-    substituteInPlace $out/share/applications/quickgui.desktop \
-      --replace "/usr" $out
 
     runHook postInstall
   '';
 
-  meta = {
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ quickemu gnome.zenity ]}
+    )
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/applications/quickgui.desktop \
+      --replace "/usr" $out
+
+    # quickgui PR 88
+    echo "Categories=System;" >> $out/share/applications/quickgui.desktop
+  '';
+
+  meta = with lib; {
     description = "A Flutter frontend for quickemu";
     homepage = "https://github.com/quickemu-project/quickgui";
     changelog = "https://github.com/quickemu-project/quickgui/releases/tag/v${version}";
-    maintainers = [ lib.maintainers.heyimnova ];
-    platforms = lib.platforms.linux;
-    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ heyimnova ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
     mainProgram = "quickgui";
   };
 }


### PR DESCRIPTION
## Description of changes

Add quickemu to PATH for quickgui so the user does not need to install it separately to use quickgui. Also add license for quickgui, correct meta.platforms, add zenity so the file picker works, and make some other general improvements to the package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
