### PR TITLE
fetchgitlab: add sparseCheckout and forceFetchGit args

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -4,7 +4,7 @@ lib.makeOverridable (
 # gitlab example
 { owner, repo, rev, protocol ? "https", domain ? "gitlab.com", name ? "source", group ? null
 , fetchSubmodules ? false, leaveDotGit ? false
-, deepClone ? false
+, deepClone ? false, forceFetchGit ? false
 , sparseCheckout ? []
 , ... # For hash agility
 } @ args:
@@ -13,9 +13,9 @@ let
   slug = lib.concatStringsSep "/" ((lib.optional (group != null) group) ++ [ owner repo ]);
   escapedSlug = lib.replaceStrings [ "." "/" ] [ "%2E" "%2F" ] slug;
   escapedRev = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] rev;
-  passthruAttrs = removeAttrs args [ "protocol" "domain" "owner" "group" "repo" "rev" "fetchSubmodules" "leaveDotGit" "deepClone" ];
+  passthruAttrs = removeAttrs args [ "protocol" "domain" "owner" "group" "repo" "rev" "fetchSubmodules" "forceFetchGit" "leaveDotGit" "deepClone" ];
 
-  useFetchGit = fetchSubmodules || leaveDotGit || deepClone || (sparseCheckout != []);
+  useFetchGit = fetchSubmodules || leaveDotGit || deepClone || forceFetchGit || (sparseCheckout != []);
   fetcher = if useFetchGit then fetchgit else fetchzip;
 
   gitRepoUrl = "${protocol}://${domain}/${slug}.git";

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,9 +1,10 @@
-{ fetchgit, fetchzip, lib }:
+{ lib, fetchgit, fetchzip }:
 
 lib.makeOverridable (
 # gitlab example
 { owner, repo, rev, protocol ? "https", domain ? "gitlab.com", name ? "source", group ? null
-, fetchSubmodules ? false, leaveDotGit ? false, deepClone ? false
+, fetchSubmodules ? false, leaveDotGit ? false
+, deepClone ? false
 , ... # For hash agility
 } @ args:
 
@@ -13,7 +14,7 @@ let
   escapedRev = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] rev;
   passthruAttrs = removeAttrs args [ "protocol" "domain" "owner" "group" "repo" "rev" "fetchSubmodules" "leaveDotGit" "deepClone" ];
 
-  useFetchGit = deepClone || fetchSubmodules || leaveDotGit;
+  useFetchGit = fetchSubmodules || leaveDotGit || deepClone;
   fetcher = if useFetchGit then fetchgit else fetchzip;
 
   gitRepoUrl = "${protocol}://${domain}/${slug}.git";

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -5,6 +5,7 @@ lib.makeOverridable (
 { owner, repo, rev, protocol ? "https", domain ? "gitlab.com", name ? "source", group ? null
 , fetchSubmodules ? false, leaveDotGit ? false
 , deepClone ? false
+, sparseCheckout ? []
 , ... # For hash agility
 } @ args:
 
@@ -14,13 +15,13 @@ let
   escapedRev = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] rev;
   passthruAttrs = removeAttrs args [ "protocol" "domain" "owner" "group" "repo" "rev" "fetchSubmodules" "leaveDotGit" "deepClone" ];
 
-  useFetchGit = fetchSubmodules || leaveDotGit || deepClone;
+  useFetchGit = fetchSubmodules || leaveDotGit || deepClone || (sparseCheckout != []);
   fetcher = if useFetchGit then fetchgit else fetchzip;
 
   gitRepoUrl = "${protocol}://${domain}/${slug}.git";
 
   fetcherArgs = (if useFetchGit then {
-    inherit rev deepClone fetchSubmodules leaveDotGit;
+    inherit rev deepClone fetchSubmodules sparseCheckout leaveDotGit;
     url = gitRepoUrl;
   } else {
     url = "${protocol}://${domain}/api/v4/projects/${escapedSlug}/repository/archive.tar.gz?sha=${escapedRev}";

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -24,7 +24,7 @@
 # the rest are given to fetchurl as is
 , ... } @ args:
 
-assert (extraPostFetch != "") -> lib.warn "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub'." true;
+assert (extraPostFetch != "") -> lib.warn "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub' or 'fetchFromGitLab'." true;
 
 let
   tmpFilename =


### PR DESCRIPTION
## Description of changes

Add support for sparse checkout and add an option to force use of fetchgit. This makes fetchFromGitLab more similar to fetchFromGitHub.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
