### PR TITLE
python3Packages.flask-themes2: patch tests

### DIFF
--- a/pkgs/development/python-modules/flask-themes2/default.nix
+++ b/pkgs/development/python-modules/flask-themes2/default.nix
@@ -13,6 +13,10 @@ buildPythonPackage rec {
     hash = "sha256-0U0cSdBddb9+IG3CU6zUPlxaJhQlxOV6OLgxnNDChy8=";
   };
 
+  patches = [
+    ./fix-flask-tests.patch # https://github.com/sysr-q/flask-themes2/pull/15
+  ];
+
   nativeCheckInputs = [ pytestCheckHook ];
   propagatedBuildInputs = [ flask ];
 

--- a/pkgs/development/python-modules/flask-themes2/fix-flask-tests.patch
+++ b/pkgs/development/python-modules/flask-themes2/fix-flask-tests.patch
@@ -1,0 +1,261 @@
+diff --git a/tests/test_themes.py b/tests/test_themes.py
+index 321ac85..8dbf844 100644
+--- a/tests/test_themes.py
++++ b/tests/test_themes.py
+@@ -6,32 +6,26 @@ This tests the Flask-Themes2 extension.
+ from __future__ import with_statement
+ 
+ import os
++from importlib import reload
+ from operator import attrgetter
+ 
+ from flask import Flask, render_template, url_for
+-from flask_themes2 import (
+-    Theme,
+-    ThemeManager,
+-    Themes,
+-    get_theme,
+-    get_themes_list,
+-    load_themes_from,
+-    packaged_themes_loader,
+-    render_theme_template,
+-    static_file_url,
+-    template_exists,
+-    theme_paths_loader,
+-    themes_blueprint,
+-)
+ from jinja2 import FileSystemLoader
+ 
+ TESTS = os.path.dirname(__file__)
+ 
+ 
++def import_flask_themes2():
++    import flask_themes2
++    flask_themes2 = reload(flask_themes2)
++    return flask_themes2
++
++
+ class TestThemeObject(object):
+     def test_theme(self):
++        flask_themes2 = import_flask_themes2()
+         path = os.path.join(TESTS, "themes", "cool")
+-        cool = Theme(path)
++        cool = flask_themes2.Theme(path)
+         assert cool.name == "Cool Blue v1"
+         assert cool.identifier == "cool"
+         assert cool.path == os.path.abspath(path)
+@@ -41,39 +35,44 @@ class TestThemeObject(object):
+         assert isinstance(cool.jinja_loader, FileSystemLoader)
+ 
+     def test_license_text(self):
++        flask_themes2 = import_flask_themes2()
+         path = os.path.join(TESTS, "themes", "plain")
+-        plain = Theme(path)
++        plain = flask_themes2.Theme(path)
+         assert plain.license_text.strip() == "The license."
+ 
+ 
+ class TestLoaders(object):
+     def test_load_themes_from(self):
++        flask_themes2 = import_flask_themes2()
+         path = os.path.join(TESTS, "themes")
+-        themes_iter = load_themes_from(path)
++        themes_iter = flask_themes2.load_themes_from(path)
+         themes = list(sorted(themes_iter, key=attrgetter("identifier")))
+         assert themes[0].identifier == "cool"
+         assert themes[1].identifier == "notthis"
+         assert themes[2].identifier == "plain"
+ 
+     def test_packaged_themes_loader(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+-        themes_iter = packaged_themes_loader(app)
++        themes_iter = flask_themes2.packaged_themes_loader(app)
+         themes = list(sorted(themes_iter, key=attrgetter("identifier")))
+         assert themes[0].identifier == "cool"
+         assert themes[1].identifier == "notthis"
+         assert themes[2].identifier == "plain"
+ 
+     def test_theme_paths_loader(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        themes = list(theme_paths_loader(app))
++        themes = list(flask_themes2.theme_paths_loader(app))
+         assert themes[0].identifier == "cool"
+ 
+ 
+ class TestSetup(object):
+     def test_manager(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+-        manager = ThemeManager(app, "testing")
++        manager = flask_themes2.ThemeManager(app, "testing")
+         assert app.theme_manager is manager
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+         manager.refresh()
+@@ -82,9 +81,10 @@ class TestSetup(object):
+         assert manager.themes["cool"].name == "Cool Blue v2"
+ 
+     def test_setup_themes(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         assert hasattr(app, "theme_manager")
+         assert "_themes" in app.blueprints
+@@ -92,20 +92,21 @@ class TestSetup(object):
+         assert "theme_static" in app.jinja_env.globals
+ 
+     def test_get_helpers(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+             cool = app.theme_manager.themes["cool"]
+             plain = app.theme_manager.themes["plain"]
+-            assert get_theme("cool") is cool
+-            assert get_theme("plain") is plain
+-            tl = get_themes_list()
++            assert flask_themes2.get_theme("cool") is cool
++            assert flask_themes2.get_theme("plain") is plain
++            tl = flask_themes2.get_themes_list()
+             assert tl[0] is cool
+             assert tl[1] is plain
+             try:
+-                get_theme("notthis")
++                flask_themes2.get_theme("notthis")
+             except KeyError:
+                 pass
+             else:
+@@ -116,76 +117,91 @@ class TestSetup(object):
+ 
+ class TestStatic(object):
+     def test_static_file_url(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+-            url = static_file_url("cool", "style.css")
++            url = flask_themes2.static_file_url("cool", "style.css")
+             genurl = url_for("_themes.static", themeid="cool", filename="style.css")
+             assert url == genurl
+ 
+ 
+ class TestTemplates(object):
+     def test_template_exists(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+-            assert template_exists("hello.html")
+-            assert template_exists("_themes/cool/hello.html")
+-            assert not template_exists("_themes/plain/hello.html")
++            assert flask_themes2.template_exists("hello.html")
++            assert flask_themes2.template_exists("_themes/cool/hello.html")
++            assert not flask_themes2.template_exists("_themes/plain/hello.html")
+ 
+-    def test_loader(self):
++    def test_test_loader(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+-            src = themes_blueprint.jinja_loader.get_source(
++            src = flask_themes2.themes_blueprint.jinja_loader.get_source(
+                 app.jinja_env, "_themes/cool/hello.html"
+             )
+             assert src[0].strip() == "Hello from Cool Blue v2."
+ 
+     def test_render_theme_template(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+-            coolsrc = render_theme_template("cool", "hello.html").strip()
+-            plainsrc = render_theme_template("plain", "hello.html").strip()
++            coolsrc = flask_themes2.render_theme_template("cool", "hello.html").strip()
++            plainsrc = flask_themes2.render_theme_template(
++                "plain", "hello.html"
++            ).strip()
+             assert coolsrc == "Hello from Cool Blue v2."
+             assert plainsrc == "Hello from the application"
+ 
+     def test_active_theme(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+             appdata = render_template("active.html").strip()
+-            cooldata = render_theme_template("cool", "active.html").strip()
+-            plaindata = render_theme_template("plain", "active.html").strip()
++            cooldata = flask_themes2.render_theme_template(
++                "cool", "active.html"
++            ).strip()
++            plaindata = flask_themes2.render_theme_template(
++                "plain", "active.html"
++            ).strip()
+             assert appdata == "Application, Active theme: none"
+             assert cooldata == "Cool Blue v2, Active theme: cool"
+             assert plaindata == "Application, Active theme: plain"
+ 
+     def test_theme_static(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+-            coolurl = static_file_url("cool", "style.css")
+-            cooldata = render_theme_template("cool", "static.html").strip()
++            coolurl = flask_themes2.static_file_url("cool", "style.css")
++            cooldata = flask_themes2.render_theme_template(
++                "cool", "static.html"
++            ).strip()
+             assert cooldata == "Cool Blue v2, %s" % coolurl
+ 
+     def test_theme_static_outside(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+             try:
+@@ -198,11 +214,12 @@ class TestTemplates(object):
+                 )
+ 
+     def test_theme_include_static(self):
++        flask_themes2 = import_flask_themes2()
+         app = Flask(__name__)
+         app.config["THEME_PATHS"] = [os.path.join(TESTS, "morethemes")]
+-        Themes(app, app_identifier="testing")
++        flask_themes2.Themes(app, app_identifier="testing")
+ 
+         with app.test_request_context("/"):
+             data = render_template("static_parent.html").strip()
+-            url = static_file_url("plain", "style.css")
++            url = flask_themes2.static_file_url("plain", "style.css")
+             assert data == "Application, Plain, %s" % url


### PR DESCRIPTION
Tests were broken for Flask version 2.3+ which caused the build to fail, this patch fixes that. PR to upstream the patch: https://github.com/sysr-q/flask-themes2/pull/15

## Description of changes

I'm reloading the flask_themes2 module before every test which ensures that it recreates its global objects.
Needed because Flask version 2.3+ treats setup after any requests have been made as an error and every test does some setup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
