### PR TITLE
jankyborders: init at 1.6.0

### DIFF
--- a/pkgs/by-name/ja/jankyborders/package.nix
+++ b/pkgs/by-name/ja/jankyborders/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, pkg-config
+, pkgs
+, overrideSDK
+, darwin
+, testers
+}:
+let
+  stdenv = overrideSDK pkgs.stdenv "11.0";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "JankyBorders";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "FelixKratz";
+    repo = "JankyBorders";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-DX1d228UCOI+JU+RxenhiGyn3AiqpsGe0aCtr091szs=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = with darwin.apple_sdk.frameworks; [
+    AppKit
+    ApplicationServices
+    CoreFoundation
+    CoreGraphics
+    SkyLight
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ./bin/borders $out/bin/borders
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    version = "borders-v${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "JankyBorders is a lightweight tool designed to add colored borders to user windows on macOS 14.0+";
+    longDescription = "It enhances the user experience by visually highlighting the currently focused window without relying on the accessibility API, thereby being faster than comparable tools.";
+    homepage = "https://github.com/FelixKratz/JankyBorders";
+    license = lib.licenses.gpl3;
+    mainProgram = "borders";
+    maintainers = with lib.maintainers; [ khaneliman ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description of changes
https://github.com/FelixKratz/JankyBorders

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
