### PR TITLE
{lib,python3Packages.}ndtypes: add `dev` output

### DIFF
--- a/pkgs/development/libraries/libndtypes/default.nix
+++ b/pkgs/development/libraries/libndtypes/default.nix
@@ -1,10 +1,13 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 }:
 
 stdenv.mkDerivation {
   pname = "libndtypes";
   version = "unstable-2019-08-01";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "xnd-project";

--- a/pkgs/development/python-modules/gumath/default.nix
+++ b/pkgs/development/python-modules/gumath/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage {
   postPatch = ''
     substituteInPlace setup.py \
       --replace 'add_include_dirs = [".", "libgumath", "ndtypes/python/ndtypes", "xnd/python/xnd"] + INCLUDES' \
-                'add_include_dirs = [".", "${libndtypes}/include", "${libxnd}/include", "${libgumath}/include"]' \
+                'add_include_dirs = [".", "${libndtypes.dev}/include", "${libxnd}/include", "${libgumath}/include"]' \
       --replace 'add_library_dirs = ["libgumath", "ndtypes/libndtypes", "xnd/libxnd"] + LIBS' \
                 'add_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib", "${libgumath}/lib"]' \
       --replace 'add_runtime_library_dirs = ["$ORIGIN"]' \

--- a/pkgs/development/python-modules/ndtypes/default.nix
+++ b/pkgs/development/python-modules/ndtypes/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
   postPatch = ''
     substituteInPlace setup.py \
       --replace 'include_dirs = ["libndtypes"]' \
-                'include_dirs = ["${libndtypes}/include"]' \
+                'include_dirs = ["${libndtypes.dev}/include"]' \
       --replace 'library_dirs = ["libndtypes"]' \
                 'library_dirs = ["${libndtypes}/lib"]' \
       --replace 'runtime_library_dirs = ["$ORIGIN"]' \

--- a/pkgs/development/python-modules/ndtypes/default.nix
+++ b/pkgs/development/python-modules/ndtypes/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage {
   disabled = isPy27;
   inherit (libndtypes) version src meta;
 
+  outputs = [ "out" "dev" ];
+
   propagatedBuildInputs = [ numpy ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Prior to this change, making a python environment with the `xnd` module yields the following error:

```shell
nix-shell -I nixpkgs=./. -p 'python311.withPackages (ps: [ ps.xnd ])'
error: collision between `/nix/store/zqwgj0cwr7ssi3jqh3jhbbsjv1kadmvf-python3.11-ndtypes-unstable-2019-08-01/include/docstrings.h' and `/nix/store/cvcwci3iplx07ln9k288ddaw7px29r23-python3.11-xnd-unstable-2019-08-01/include/docstrings.h'
```

The fix is to move the headers to a `dev` output. This has the effect of pulling the propagated build inputs with it which can be problematic for downstream users. Instead of splitting `xnd` into `out` and `dev`, we split `ndtypes`, which only relies on `numpy`, and nearly only `xnd` depends on anyway. 

This PR also splits `libndtypes` while at it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
