### PR TITLE
zix: enable tests

### DIFF
--- a/pkgs/development/libraries/audio/zix/default.nix
+++ b/pkgs/development/libraries/audio/zix/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -17,6 +18,16 @@ stdenv.mkDerivation rec {
     hash = "sha256-nMm3Mdqc4ncCae8SoyGxZYURzmXLNcp1GjsSExfB6x4=";
   };
 
+  patches = [
+    # clang-16 support on Darwin:
+    #   https://gitlab.com/drobilla/zix/-/issues/3
+    (fetchpatch {
+      name = "darwin-sync.patch";
+      url = "https://gitlab.com/drobilla/zix/-/commit/a6f804073de1f1e626464a9dd0a169fd3f69fdff.patch";
+      hash = "sha256-ZkDPjtUzIyqnYarQR+7aCj7S/gSngbd6d75aRT+h7Ww=";
+    })
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -27,13 +38,6 @@ stdenv.mkDerivation rec {
     "-Dbenchmarks=disabled"
     "-Ddocs=disabled"
   ];
-
-  env = lib.optionalAttrs stdenv.isDarwin {
-    # Do not fail the build on clang-16/darwin.
-    # TODO: drop the workaround when upstream fixes it in:
-    #   https://gitlab.com/drobilla/zix/-/issues/3
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-  };
 
   meta = with lib; {
     description = "A lightweight C99 portability and data structure library";

--- a/pkgs/development/libraries/audio/zix/default.nix
+++ b/pkgs/development/libraries/audio/zix/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     "-Ddocs=disabled"
   ];
 
+  doCheck = true;
+
   meta = with lib; {
     description = "A lightweight C99 portability and data structure library";
     homepage = "https://gitlab.com/drobilla/zix";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
