### PR TITLE
Enable `wxWebView` in `wxGTK32`.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -561,6 +561,8 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - TeX Live environments can now be built with the new `texlive.withPackages`. The procedure for creating custom TeX packages has been changed, see the [Nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#sec-language-texlive-custom-packages) for more details.
 
+- In `wxGTK32`, the webkit module `wxWebView` has been enabled on all builds; prior releases only enabled this on Darwin.
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - Node.js v14, v16 has been removed as they were end of life. Any dependent packages that contributors were not able to reasonably upgrade were dropped after a month of notice to their maintainers, were **removed**.

--- a/pkgs/development/libraries/wxwidgets/wxGTK32.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK32.nix
@@ -21,7 +21,7 @@
 , compat30 ? true
 , unicode ? true
 , withMesa ? !stdenv.isDarwin
-, withWebKit ? stdenv.isDarwin
+, withWebKit ? true
 , webkitgtk
 , setfile
 , AGL


### PR DESCRIPTION
Closes #267712

Needed as a dependency for a number of language-specific packages, including https://hexdocs.pm/desktop in Elixir.

## Description of changes

Enables `wxWebView`, based on Webkit, in GTK's `wxWidgets` package.
Prior to this, the web view had only been enabled in OS X.

Checked using the flake in #267712; ran `./result/bin/iex -e ':wx.demo'`

![Screenshot from 2023-11-15 12-40-40](https://github.com/NixOS/nixpkgs/assets/30454698/5d901010-ba85-4bc4-944c-f5e5c800a290)
![Screenshot from 2023-11-16 01-15-33](https://github.com/NixOS/nixpkgs/assets/30454698/0a822513-c22c-4edd-bad5-c083b55f7be7)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] (nonfeasible on local) Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [ ] Tested basic functionality of all some binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).