### PR TITLE
Revert "sharedown: mark broken"

### DIFF
--- a/pkgs/tools/misc/sharedown/default.nix
+++ b/pkgs/tools/misc/sharedown/default.nix
@@ -114,7 +114,5 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with maintainers; [
     ];
     platforms = platforms.unix;
-    # "Couldn't find any versions for \"node-gyp\" that matches \"latest\" in our cache (possible versions are \"\")
-    broken = true;
   };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#265472 it's been fixed