### PR TITLE
bloaty: 1.1 -> unstable-2023-11-06

### DIFF
--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,14 +1,15 @@
 { lib, stdenv, cmake, zlib, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "1.1";
   pname = "bloaty";
+  version = "1.1-unstable-2023-11-06";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "bloaty";
-    rev = "v${version}";
-    sha256 = "1556gb8gb8jwf5mwxppcqz3mp269b5jhd51kj341iqkbn27zzngk";
+    # no version since 1.1 in 2020
+    rev = "16f9fe54d9cd0e9abe1d25fc1a9b44c214cfaa9f";
+    hash = "sha256-w855aSLzzvuUWjAU9zOKuZTNGLZiEKMJYjVGejH48xQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cmake, zlib, fetchFromGitHub }:
+{ lib, stdenv, cmake, zlib, fetchFromGitHub, re2, abseil-cpp, protobuf, capstone, gtest, pkg-config, lit, llvmPackages_16 }:
 
 stdenv.mkDerivation rec {
   pname = "bloaty";
@@ -7,18 +7,49 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "bloaty";
-    # no version since 1.1 in 2020
     rev = "16f9fe54d9cd0e9abe1d25fc1a9b44c214cfaa9f";
-    hash = "sha256-w855aSLzzvuUWjAU9zOKuZTNGLZiEKMJYjVGejH48xQ=";
-    fetchSubmodules = true;
+    hash = "sha256-mIVlNMKtJMfH2QdYZ6+oV7619oYzvKkq3fHY6uofqlM=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  # Old vendored package which has no other use than here, so not packaged in nixpkgs.
+  demumble = fetchFromGitHub {
+    owner = "nico";
+    repo = "demumble";
+    rev = "01098eab821b33bd31b9778aea38565cd796aa85";
+    hash = "sha256-605SsXd7TSdm3BH854ChHIZbOXcHI/n8RN+pFMz4Ex4=";
+  };
 
-  buildInputs = [ zlib ];
+  cmakeFlags = [
+    "-DLIT_EXECUTABLE=${lit}/bin/lit"
+    "-DFILECHECK_EXECUTABLE=${llvmPackages_16.libllvm}/bin/FileCheck"
+    "-DYAML2OBJ_EXECUTABLE=${llvmPackages_16.libllvm}/bin/yaml2obj"
+  ];
+
+  postPatch = ''
+    # Build system relies on some of those source files
+    rm -rf third_party/googletest third_party/abseil-cpp third_party/demumble
+    ln -s ${gtest.src} third_party/googletest
+    ln -s ${abseil-cpp.src} third_party/abseil-cpp
+    ln -s ${demumble} third_party/demumble
+    substituteInPlace CMakeLists.txt \
+      --replace "find_package(Python COMPONENTS Interpreter)" "" \
+      --replace "if(Python_FOUND AND LIT_EXECUTABLE" "if(LIT_EXECUTABLE" \
+      --replace "COMMAND \''\${Python_EXECUTABLE} \''\${LIT_EXECUTABLE}" "COMMAND \''\${LIT_EXECUTABLE}"
+    # wasm test fail. Possibly due to LLVM version < 17. See https://github.com/google/bloaty/pull/354
+    rm -rf tests/wasm
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ zlib re2 abseil-cpp protobuf capstone gtest lit llvmPackages_16.libllvm ];
 
   doCheck = true;
 
+  postCheck = ''
+    # These lit tests need to be build seperatly.
+    # See https://github.com/google/bloaty/blob/main/tests/README.md
+    cmake --build . --target check-bloaty
+  '';
   installPhase = ''
     install -Dm755 {.,$out/bin}/bloaty
   '';


### PR DESCRIPTION
## Description of changes

Update of `bloaty` to a recent commit. No updated tag since 2020 (see https://github.com/google/bloaty/issues/334). On `aarch64-darwin` the build failed today with the following error:

```
[...]
[ 27%] Building C object third_party/capstone/CMakeFiles/capstone-static.dir/arch/X86/X86Module.c.o
In file included from /tmp/nix-build-bloaty-1.1.drv-0/source/third_party/googletest/googlemock/src/gmock-all.cc:39:
In file included from /tmp/nix-build-bloaty-1.1.drv-0/source/third_party/googletest/googlemock/include/gmock/gmock.h:59:
/tmp/nix-build-bloaty-1.1.drv-0/source/third_party/googletest/googlemock/include/gmock/gmock-actions.h:454:3: error: definition of implicit copy constructor for 'PolymorphicAction<testing::internal::ReturnNullAction>' is deprecated because it has a user-declared copy >
  GTEST_DISALLOW_ASSIGN_(PolymorphicAction);
  ^
/tmp/nix-build-bloaty-1.1.drv-0/source/third_party/googletest/googletest/include/gtest/internal/gtest-port.h:679:8: note: expanded from macro 'GTEST_DISALLOW_ASSIGN_'
  void operator=(type const &) = delete
       ^
/tmp/nix-build-bloaty-1.1.drv-0/source/third_party/googletest/googlemock/include/gmock/gmock-actions.h:1010:10: note: in implicit copy constructor for 'testing::PolymorphicAction<testing::internal::ReturnNullAction>' first required here
  return MakePolymorphicAction(internal::ReturnNullAction());
         ^
/tmp/nix-build-bloaty-1.1.drv-0/source/third_party/googletest/googlemock/include/gmock/gmock-actions.h:454:3: error: definition of implicit copy constructor for 'PolymorphicAction<testing::internal::ReturnVoidAction>' is deprecated because it has a user-declared copy >
  GTEST_DISALLOW_ASSIGN_(PolymorphicAction);
 [...]
```

[Full build log](https://pastebin.com/2ezVEunM)

An update to a recent commit fixed the build issue 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
