### PR TITLE
nixdoc: 2.5.1 -> 2.6.0, add infinisil as maintainer

### DIFF
--- a/pkgs/tools/nix/nixdoc/default.nix
+++ b/pkgs/tools/nix/nixdoc/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nixdoc";
-  version = "2.5.1";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nixdoc";
     rev = "v${version}";
-    sha256 = "sha256-QgKzpFdzisWD6DZxs1LsKINBr/bSYQILpEu5RdcNgbc=";
+    sha256 = "sha256-g1PBPpvK3kg0bJEDXsifVgcl3+v54q08Ae3nZ4cJ+Xs=";
   };
 
-  cargoHash = "sha256-MztvOV1yAOgpwPYOUUZb7XHKhhhd/fvKPIFbsnMdhAQ=";
+  cargoHash = "sha256-E5SJfwGfy1DcLC0cF/5FTbVEJs/WYb2KO+OdOo2fgQk=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.Security ];
 
@@ -19,7 +19,10 @@ rustPlatform.buildRustPackage rec {
     description = "Generate documentation for Nix functions";
     homepage    = "https://github.com/nix-community/nixdoc";
     license     = [ licenses.gpl3 ];
-    maintainers = [ maintainers.asymmetric ];
+    maintainers = with maintainers; [
+      infinisil
+      asymmetric
+    ];
     platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/nix-community/nixdoc/releases/tag/v2.6.0

Ping @phaer

## Things done
- [x] Built the Nixpkgs manual (which depends on nixdoc) on `x86_64-linux`