### PR TITLE
displaycal: 3.9.10 -> 3.9.11

### DIFF
--- a/pkgs/applications/graphics/displaycal/default.nix
+++ b/pkgs/applications/graphics/displaycal/default.nix
@@ -10,13 +10,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "displaycal";
-  version = "3.9.10";
+  version = "3.9.11";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "DisplayCAL";
     inherit version;
-    hash = "sha256-oDHDVb0zuAC49yPfmNe7xuFKaA1BRZGr75XwsLqugHs=";
+    hash = "sha256-zAZW2eMjwRYevlz8KEzTxzGO8vx5AydfY3vGTapNo1c=";
   };
 
   nativeBuildInputs = [
@@ -30,8 +30,11 @@ python3.pkgs.buildPythonApplication rec {
     wxPython_4_2
     dbus-python
     distro
+    numpy
+    pillow
     pychromecast
     send2trash
+    zeroconf
   ];
 
   buildInputs = [
@@ -44,6 +47,9 @@ python3.pkgs.buildPythonApplication rec {
     libXinerama
     libXrandr
   ]);
+
+  # Workaround for eoyilmaz/displaycal-py3#261
+  setupPyGlobalFlags = [ "appdata" ];
 
   doCheck = false; # Tests try to access an X11 session and dbus in weird locations.
 


### PR DESCRIPTION
## Description of changes

The build of 3.9.10 is currently failing and the update to 3.9.11 stalled at eoyilmaz/displaycal-py3#261.

From skimming it appears that passing an [additional setup argument](https://github.com/eoyilmaz/displaycal-py3/blob/3.9.11/setup.py#L362C1-L362C34) puts the missing files [in place](https://github.com/eoyilmaz/displaycal-py3/blob/3.9.11/setup.py#L691-L700). I’m unfamiliar with Python packaging though so not confident this is the right move.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
