### PR TITLE
subtitleedit: 4.0.1 -> 4.0.2

### DIFF
--- a/pkgs/applications/video/subtitleedit/default.nix
+++ b/pkgs/applications/video/subtitleedit/default.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "subtitleedit";
-  version = "4.0.1";
+  version = "4.0.2";
 
   src = fetchzip {
     url = "https://github.com/SubtitleEdit/subtitleedit/releases/download/${version}/SE${lib.replaceStrings [ "." ] [ "" ] version}.zip";
-    hash = "sha256-Z7NVn4F19Hx55YWPNmbpWZ8yQulXd50bcy2A/8pCqJ4=";
+    hash = "sha256-kcs2h6HeWniJhGDNsy+EBauXbiDIlLCOJkVOCIzLBzM=";
     stripRoot = false;
   };
 

--- a/pkgs/applications/video/subtitleedit/default.nix
+++ b/pkgs/applications/video/subtitleedit/default.nix
@@ -1,17 +1,19 @@
 { lib
 , stdenv
-, copyDesktopItems
-, makeDesktopItem
-, makeWrapper
 , fetchzip
+, makeDesktopItem
+, nix-update-script
+
+, copyDesktopItems
+, icoutils
+, makeWrapper
+
 , ffmpeg
 , gtk2
 , hunspell
-, icoutils
 , mono
 , mpv
 , tesseract4
-, nix-update-script
 }:
 
 stdenv.mkDerivation rec {
@@ -80,16 +82,16 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A subtitle editor";
-    homepage = "https://nikse.dk/subtitleedit";
-    license = licenses.gpl3Plus;
     longDescription = ''
       With Subtitle Edit you can easily adjust a subtitle if it is out of sync with
       the video in several different ways. You can also use it for making
       new subtitles from scratch (using the time-line /waveform/spectrogram)
       or for translating subtitles.
     '';
-    maintainers = with maintainers; [ paveloom ];
+    homepage = "https://nikse.dk/subtitleedit";
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ paveloom ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/SubtitleEdit/subtitleedit/releases/tag/4.0.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
