### PR TITLE
blackshades: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/by-name/bl/blackshades/package.nix
+++ b/pkgs/by-name/bl/blackshades/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blackshades";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromSourcehut {
     owner = "~cnx";
     repo = "blackshades";
     rev = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-qdpXpuXHr9w2XMfgOVveWv3JoqdJHVB8TCqZdyaw/DM=";
+    hash = "sha256-K/OFL49hXAzeEU1pfpxrIF7NgFfRk11Ah1OHKN8Ulb0=";
   };
 
   nativeBuildInputs = [ zig_0_11.hook ];
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Psychic bodyguard FPS";
     changelog = "https://git.sr.ht/~cnx/blackshades/refs/${finalAttrs.version}";
     mainProgram = "blackshades";
-    license = lib.licenses.gpl3Plus;
+    license = with lib.licenses; [ gpl3Plus cc-by-30 cc-by-sa-30 cc-by-40 ];
     maintainers = with lib.maintainers; [ McSinyx ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

[Upstream change log](https://git.sr.ht/~cnx/blackshades/refs/2.5.2)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).