### PR TITLE
[staging] boehmgc: 8.2.2 -> 8.2.4

### DIFF
--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -1,7 +1,8 @@
 { lib
 , stdenv
-, fetchurl
-# doc: https://github.com/ivmai/bdwgc/blob/v8.2.2/doc/README.macros (LARGE_CONFIG)
+, fetchFromGitHub
+, autoreconfHook
+# doc: https://github.com/ivmai/bdwgc/blob/v8.2.4/doc/README.macros (LARGE_CONFIG)
 , enableLargeConfig ? false
 , enableMmap ? true
 , enableStatic ? false
@@ -10,18 +11,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "boehm-gc";
-  version = "8.2.2";
+  version = "8.2.4";
 
-  src = fetchurl {
-    urls = [
-      # "https://www.hboehm.info/gc/gc_source/gc-${finalAttrs.version}.tar.gz"
-      "https://github.com/ivmai/bdwgc/releases/download/v${finalAttrs.version}/gc-${finalAttrs.version}.tar.gz"
-    ];
-    sha256 = "sha256-8wEHvLBi4JIKeQ//+lbZUSNIVGhZNkwjoUviZLOINqA=";
+  src = fetchFromGitHub {
+    owner = "ivmai";
+    repo = "bdwgc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-KHijT4BBKfDvTpHpwognN+3ZXoC6JabBTFSYFyOUT9o=";
   };
 
   outputs = [ "out" "dev" "doc" ];
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   configureFlags = [
     "--enable-cplusplus"
@@ -38,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   # not fix the problem the test failure will be a reminder to
   # extend the set of versions requiring the workaround).
   makeFlags = lib.optionals (stdenv.hostPlatform.isPower64 &&
-                  finalAttrs.version == "8.2.2")
+                  finalAttrs.version == "8.2.4")
     [
       # do not use /proc primitives to track dirty bits; see:
       # https://github.com/ivmai/bdwgc/issues/479#issuecomment-1279687537

--- a/pkgs/tools/package-management/nix/patches/boehmgc-coroutine-sp-fallback.patch
+++ b/pkgs/tools/package-management/nix/patches/boehmgc-coroutine-sp-fallback.patch
@@ -1,8 +1,8 @@
 diff --git a/pthread_stop_world.c b/pthread_stop_world.c
-index b5d71e62..aed7b0bf 100644
+index 2b45489..0e6d8ef 100644
 --- a/pthread_stop_world.c
 +++ b/pthread_stop_world.c
-@@ -768,6 +768,8 @@ STATIC void GC_restart_handler(int sig)
+@@ -776,6 +776,8 @@ STATIC void GC_restart_handler(int sig)
  /* world is stopped.  Should not fail if it isn't.                      */
  GC_INNER void GC_push_all_stacks(void)
  {
@@ -11,10 +11,10 @@ index b5d71e62..aed7b0bf 100644
      GC_bool found_me = FALSE;
      size_t nthreads = 0;
      int i;
-@@ -851,6 +853,31 @@ GC_INNER void GC_push_all_stacks(void)
-           hi = p->altstack + p->altstack_size;
+@@ -868,6 +870,31 @@ GC_INNER void GC_push_all_stacks(void)
+             hi = p->altstack + p->altstack_size;
+ #         endif
            /* FIXME: Need to scan the normal stack too, but how ? */
-           /* FIXME: Assume stack grows down */
 +        } else {
 +          if (pthread_getattr_np(p->id, &pattr)) {
 +            ABORT("GC_push_all_stacks: pthread_getattr_np failed!");
@@ -41,5 +41,5 @@ index b5d71e62..aed7b0bf 100644
 +          #error "STACK_GROWS_UP not supported in boost_coroutine2 (as of june 2021), so we don't support it in Nix."
 +          #endif
          }
-         GC_push_all_stack_sections(lo, hi, traced_stack_sect);
- #       ifdef STACK_GROWS_UP
+ #       ifdef STACKPTR_CORRECTOR_AVAILABLE
+           if (GC_sp_corrector != 0)


### PR DESCRIPTION
## Description of changes

Update boehmgc and rebase/fix the Nix patch.

https://github.com/ivmai/bdwgc/blob/v8.2.4/ChangeLog
[Compare changes on GitHub](https://github.com/ivmai/bdwgc/compare/v8.2.2...v8.2.4)

Closes #234967, which couldn't be merged yet because the nix patch was not ported.
Ping @vcunat.

`nixVersions` in `boehmgc.tests` complained about removed nix versions, so I tested with:

```
$ echo '{ allowAliases = false; }' > config.nix
$ NIXPKGS_CONFIG=$PWD/config.nix nix build -f . boehmgc.tests --no-link
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
