### PR TITLE
add writable option to services.ttyd

### DIFF
--- a/nixos/modules/services/web-servers/ttyd.nix
+++ b/nixos/modules/services/web-servers/ttyd.nix
@@ -14,6 +14,7 @@ let
          ++ (concatLists (mapAttrsToList (_k: _v: [ "--client-option" "${_k}=${_v}" ]) cfg.clientOptions))
          ++ [ "--terminal-type" cfg.terminalType ]
          ++ optionals cfg.checkOrigin [ "--check-origin" ]
+         ++ optionals cfg.writable [ "--writable" ]
          ++ [ "--max-clients" (toString cfg.maxClients) ]
          ++ optionals (cfg.indexFile != null) [ "--index" cfg.indexFile ]
          ++ optionals cfg.enableIPv6 [ "--ipv6" ]
@@ -73,6 +74,12 @@ in
         type = types.ints.u8;
         default = 1;
         description = lib.mdDoc "Signal to send to the command on session close.";
+      };
+
+      writable = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Allow clients to write to the TTY.";
       };
 
       clientOptions = mkOption {


### PR DESCRIPTION
addresses breaking change in ttyd 1.7.4, where the web terminal is now readonly by default, by providing a new option "writable"

see issue https://github.com/NixOS/nixpkgs/issues/268501