### PR TITLE
Cinnamon 6.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -27,6 +27,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Cinnamon has been updated to 6.0. Please beware that the [Wayland session](https://blog.linuxmint.com/?p=4591) is still experimental in this release.
+
 - Programs written in [Nim](https://nim-lang.org/) are built with libraries selected by lockfiles.
   The `nimPackages` and `nim2Packages` sets have been removed.
   See https://nixos.org/manual/nixpkgs/unstable#nim for more information.

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -200,8 +200,7 @@ in
         })
       ];
 
-      # https://salsa.debian.org/cinnamon-team/cinnamon/-/commit/f87c64f8d35ba406eb11ad442989a0716f6620cf#
-      xdg.portal.config.x-cinnamon.default = mkDefault [ "xapp" "gtk" ];
+      xdg.portal.configPackages = mkDefault [ pkgs.cinnamon.cinnamon-common ];
 
       # Override GSettings schemas
       environment.sessionVariables.NIX_GSETTINGS_OVERRIDES_DIR = "${nixos-gsettings-overrides}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -186,6 +186,7 @@ in {
   chrony = handleTestOn ["aarch64-linux" "x86_64-linux"] ./chrony.nix {};
   chrony-ptp = handleTestOn ["aarch64-linux" "x86_64-linux"] ./chrony-ptp.nix {};
   cinnamon = handleTest ./cinnamon.nix {};
+  cinnamon-wayland = handleTest ./cinnamon-wayland.nix {};
   cjdns = handleTest ./cjdns.nix {};
   clickhouse = handleTest ./clickhouse.nix {};
   cloud-init = handleTest ./cloud-init.nix {};

--- a/nixos/tests/cinnamon-wayland.nix
+++ b/nixos/tests/cinnamon-wayland.nix
@@ -1,0 +1,71 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "cinnamon-wayland";
+
+  meta.maintainers = lib.teams.cinnamon.members;
+
+  nodes.machine = { nodes, ... }: {
+    imports = [ ./common/user-account.nix ];
+    services.xserver.enable = true;
+    services.xserver.desktopManager.cinnamon.enable = true;
+    services.xserver.displayManager = {
+      autoLogin.enable = true;
+      autoLogin.user = nodes.machine.users.users.alice.name;
+      defaultSession = "cinnamon-wayland";
+    };
+  };
+
+  enableOCR = true;
+
+  testScript = { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+      env = "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${toString user.uid}/bus";
+      su = command: "su - ${user.name} -c '${env} ${command}'";
+
+      # Call javascript in cinnamon (the shell), returns a tuple (success, output),
+      # where `success` is true if the dbus call was successful and `output` is what
+      # the javascript evaluates to.
+      eval = name: su "gdbus call --session -d org.Cinnamon -o /org/Cinnamon -m org.Cinnamon.Eval ${name}";
+    in
+    ''
+      machine.wait_for_unit("display-manager.service")
+
+      with subtest("Wait for wayland server"):
+          machine.wait_for_file("/run/user/${toString user.uid}/wayland-0")
+
+      with subtest("Check that logging in has given the user ownership of devices"):
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
+
+      with subtest("Wait for the Cinnamon shell"):
+          # Correct output should be (true, '2')
+          # https://github.com/linuxmint/cinnamon/blob/5.4.0/js/ui/main.js#L183-L187
+          machine.wait_until_succeeds("${eval "Main.runState"} | grep -q 'true,..2'")
+
+      with subtest("Check if Cinnamon components actually start"):
+          for i in ["csd-media-keys", "xapp-sn-watcher", "nemo-desktop"]:
+            machine.wait_until_succeeds(f"pgrep -f {i}")
+          machine.wait_until_succeeds("journalctl -b --grep 'Loaded applet menu@cinnamon.org'")
+          machine.wait_until_succeeds("journalctl -b --grep 'calendar@cinnamon.org: Calendar events supported'")
+
+      with subtest("Open Cinnamon Settings"):
+          machine.succeed("${su "cinnamon-settings themes >&2 &"}")
+          machine.wait_until_succeeds("${eval "global.display.focus_window.wm_class"} | grep -i 'cinnamon-settings'")
+          machine.wait_for_text('(Style|Appearance|Color)')
+          machine.sleep(2)
+          machine.screenshot("cinnamon_settings")
+
+      with subtest("Check if screensaver works"):
+          # This is not supported at the moment.
+          # https://trello.com/b/HHs01Pab/cinnamon-wayland
+          machine.execute("${su "cinnamon-screensaver-command -l >&2 &"}")
+          machine.wait_until_succeeds("journalctl -b --grep 'Cinnamon Screensaver is unavailable on Wayland'")
+
+      with subtest("Open GNOME Terminal"):
+          machine.succeed("${su "dbus-launch gnome-terminal"}")
+          machine.wait_until_succeeds("${eval "global.display.focus_window.wm_class"} | grep -i 'gnome-terminal'")
+          machine.sleep(2)
+
+      with subtest("Check if Cinnamon has ever coredumped"):
+          machine.fail("coredumpctl --json=short | grep -E 'cinnamon|nemo'")
+    '';
+})

--- a/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "1.8.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    sha256 = "sha256-OSL4Ls3bCua5ut8zWodeIH1SfevCbsS7BgBJYdcJaVE=";
+    sha256 = "sha256-2iwH8npCfo4z1K4WQNP2Pd32PJTkCX/rT0+1RTrBO8E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/bulky/default.nix
+++ b/pkgs/desktops/cinnamon/bulky/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bulky";
-  version = "2.10";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "bulky";
     rev = version;
-    hash = "sha256-3hpg9a5HU7mSSlMOWvmB/p0Mlyla5PDiS0J9iYJLr6Q=";
+    hash = "sha256-8/Q8ess+qF7kdjiS2y2alUSnjKlJ74yuSe4UTPVChNQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -9,7 +9,6 @@
 , cjs
 , evolution-data-server
 , fetchFromGitHub
-, fetchpatch
 , gdk-pixbuf
 , gettext
 , libgnomekbd
@@ -20,7 +19,6 @@
 , intltool
 , json-glib
 , callPackage
-, libsoup
 , libstartup_notification
 , libXtst
 , libXdamage
@@ -73,25 +71,18 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "5.8.4";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-34kOSDIU56cSZ4j0FadVfr9HLQytnK4ys88DFF7LTiM=";
+    hash = "sha256-kQvPdamS0t7YcWyCekdsLNXZfidaV3tdSptzHPGMSZ0=";
   };
 
   patches = [
     ./use-sane-install-dir.patch
     ./libdir.patch
-
-    # Backport pillow 10.0.0 support.
-    # https://github.com/linuxmint/cinnamon/issues/11746
-    (fetchpatch {
-      url = "https://github.com/linuxmint/cinnamon/commit/fce9aad1ebb290802dc550e8dae6344dddf9dec1.patch";
-      hash = "sha256-flt7CblfXlLieAVNeC8TBnv1TX0Zca1obPWusBMnIxE=";
-    })
   ];
 
   buildInputs = [
@@ -108,7 +99,6 @@ stdenv.mkDerivation rec {
     gsound
     gtk3
     json-glib
-    libsoup # referenced in js/ui/environment.js
     libstartup_notification
     libXtst
     libXdamage
@@ -170,9 +160,10 @@ stdenv.mkDerivation rec {
 
     pushd ./files/usr/share/cinnamon/cinnamon-settings
       substituteInPlace ./bin/capi.py                     --replace '"/usr/lib"' '"${cinnamon-control-center}/lib"'
-      substituteInPlace ./bin/CinnamonGtkSettings.py      --replace "'python3'" "'${pythonEnv.interpreter}'"
       substituteInPlace ./bin/SettingsWidgets.py          --replace "/usr/share/sounds" "/run/current-system/sw/share/sounds"
-      substituteInPlace ./bin/Spices.py                   --replace "msgfmt" "${gettext}/bin/msgfmt"
+      substituteInPlace ./bin/Spices.py                   --replace "subprocess.run(['/usr/bin/" "subprocess.run(['" \
+                                                          --replace 'subprocess.run(["/usr/bin/' 'subprocess.run(["' \
+                                                          --replace "msgfmt" "${gettext}/bin/msgfmt"
       substituteInPlace ./modules/cs_info.py              --replace "lspci" "${pciutils}/bin/lspci"
       substituteInPlace ./modules/cs_themes.py            --replace "$out/share/cinnamon/styles.d" "/run/current-system/sw/share/cinnamon/styles.d"
     popd
@@ -201,7 +192,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    providedSessions = [ "cinnamon" "cinnamon2d" ];
+    providedSessions = [ "cinnamon" "cinnamon2d" "cinnamon-wayland" ];
   };
 
   meta = with lib; {

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -35,13 +35,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "5.8.2";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-7AXm4ZTpI/4Xa2lwDmEvomNdwmgVoXSKqojpFZMuoVQ=";
+    hash = "sha256-zkJkZagZBt6JMiC/HLsyP9+qVLtTszumOk3PKt18X4Y=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-desktop/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-desktop/default.nix
@@ -10,6 +10,7 @@
 , python3
 , lib
 , stdenv
+, systemd
 , xkeyboard_config
 , xorg
 , wrapGAppsHook
@@ -18,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-desktop";
-  version = "5.8.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-rYTWtdYfMow3cIPhJdcmhyaIIU7fgVecWigbsCW0Piw=";
+    hash = "sha256-Ay9JyPBsE345dBwQHChkaGuoXiB2nPyvCNhWWphL8kY=";
   };
 
   outputs = [ "out" "dev" ];
@@ -37,6 +38,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gdk-pixbuf
+    systemd
     xkeyboard_config
     xorg.libxkbfile
     xorg.libXext

--- a/pkgs/desktops/cinnamon/cinnamon-menus/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-menus/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-menus";
-  version = "5.8.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-AgA/DA7I9/0AJhlmgk0yAOJaZzpiQV1vM949Y6EOWVg=";
+    hash = "sha256-zP1jA5Fwxh6QrM5YwJo7SFPWaxkJsv1D84dhIDP5xuI=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -19,7 +19,6 @@
 , gobject-introspection
 , python3
 , pam
-, accountsservice
 , cairo
 , xapp
 , xdotool
@@ -29,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "5.8.1";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-d7h9OJ39HVQNCHNr13M1ybDFoU3Xnd1PEczGLHZU/lU=";
+    hash = "sha256-5hXhCPXC7b2SsmvNSLDe/WYQcufN7FfhnaAgTNtqg0I=";
   };
 
   patches = [
@@ -75,7 +74,6 @@ stdenv.mkDerivation rec {
     xapp
     xdotool
     pam
-    accountsservice
     cairo
     cinnamon-desktop
     cinnamon-common

--- a/pkgs/desktops/cinnamon/cinnamon-session/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-session/default.nix
@@ -23,15 +23,22 @@
 , pango
 }:
 
+let
+  pythonEnv = python3.withPackages (pp: with pp; [
+    pp.xapp # don't omit `pp.`, see #213561
+    pygobject3
+    setproctitle
+  ]);
+in
 stdenv.mkDerivation rec {
   pname = "cinnamon-session";
-  version = "5.8.1";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-NVoP1KYh/z96NKMi9LjL4RgkjJg32oSy5WHJ91+70DI=";
+    hash = "sha256-9wdakMCW0RnsYdf9OmK/Q9o8m0g+5EfHVbjqvFY3d/w=";
   };
 
   patches = [
@@ -40,6 +47,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     # meson.build
+    cinnamon-desktop
     gtk3
     glib
     libcanberra
@@ -57,12 +65,11 @@ stdenv.mkDerivation rec {
     xorg.xtrans
 
     # other (not meson.build)
-
-    cinnamon-desktop
     cinnamon-settings-daemon
     dbus-glib
     glib
     gsettings-desktop-schemas
+    pythonEnv # for cinnamon-session-quit
   ];
 
   nativeBuildInputs = [
@@ -81,8 +88,10 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    chmod +x data/meson_install_schemas.py # patchShebangs requires executable file
-    patchShebangs data/meson_install_schemas.py
+    # patchShebangs requires executable file
+    chmod +x data/meson_install_schemas.py cinnamon-session-quit/cinnamon-session-quit.py
+    patchShebangs --build data/meson_install_schemas.py
+    patchShebangs --host cinnamon-session-quit/cinnamon-session-quit.py
   '';
 
   preFixup = ''

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-settings-daemon";
-  version = "5.8.1";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-2ObfUdrCuvyhtpoxNzoH8tsFQLxNkMLQPFfJajXEsXU=";
+    hash = "sha256-bT6NetCBo3J9IiiJ9Hs4iC1N3n/AP9Q+6wZciuKA4i4=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-translations";
-  version = "5.8.2";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-hFqCKzJogGka6vsIj8SCL9GMDsTQO50jwpYKr74V5Fo=";
+    hash = "sha256-lbJ4Hhd+7Hd70ZrEw0Q7Yts9yciXzqSuNTerW6oY93A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cjs/default.nix
+++ b/pkgs/desktops/cinnamon/cjs/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cjs";
-  version = "5.8.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cjs";
     rev = version;
-    hash = "sha256-DKCe8dKdYfdeWQ9Iqr0AmDU7YDN9QrQGdTkrBV/ywV0=";
+    hash = "sha256-oSqEAZWEVb8NxFTScl8s5Mb04tCGDyVVslYW00s4YYk=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/muffin/default.nix
+++ b/pkgs/desktops/cinnamon/muffin/default.nix
@@ -6,6 +6,7 @@
 , cinnamon-desktop
 , dbus
 , desktop-file-utils
+, egl-wayland
 , glib
 , gnome
 , gobject-introspection
@@ -19,6 +20,7 @@
 , libinput
 , libstartup_notification
 , libwacom
+, libxcvt
 , libXdamage
 , libxkbcommon
 , libXtst
@@ -29,13 +31,16 @@
 , pkg-config
 , python3
 , udev
+, wayland
+, wayland-protocols
 , wrapGAppsHook
 , xorgserver
+, xwayland
 }:
 
 stdenv.mkDerivation rec {
   pname = "muffin";
-  version = "5.8.1";
+  version = "6.0.0";
 
   outputs = [ "out" "dev" "man" ];
 
@@ -43,7 +48,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-9YE+pHXJb21CcAflL9swNyhQY3ZCkLlZbnmUwTNdyfA=";
+    hash = "sha256-17B2C3SW9smTgLBBGJc9LwFpXoP9WidZEGgI2hbJTH8=";
   };
 
   patches = [
@@ -69,6 +74,7 @@ stdenv.mkDerivation rec {
     cairo
     cinnamon-desktop
     dbus
+    egl-wayland
     glib
     gtk3
     libcanberra
@@ -78,10 +84,14 @@ stdenv.mkDerivation rec {
     libinput
     libstartup_notification
     libwacom
+    libxcvt
     libXdamage
     libxkbcommon
     pipewire
     udev
+    wayland
+    wayland-protocols
+    xwayland
   ];
 
   propagatedBuildInputs = [
@@ -89,6 +99,13 @@ stdenv.mkDerivation rec {
     json-glib
     libXtst
     graphene
+  ];
+
+  mesonFlags = [
+    # Based on Mint's debian/rules.
+    "-Degl_device=true"
+    "-Dwayland_eglstream=true"
+    "-Dxwayland_path=${lib.getExe xwayland}"
   ];
 
   postPatch = ''

--- a/pkgs/desktops/cinnamon/nemo-extensions/srcs.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/srcs.nix
@@ -4,12 +4,12 @@ rec {
   # When you bump this, you should make sure all nemo-extensions
   # are actually using this file since we try to deal with tags
   # like nemo-fileroller-5.6.1 according to upstream's wishes.
-  version = "5.8.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
     rev = version;
-    sha256 = "sha256-tyRYPWJa93w05a0PcYvz1GA8/xX2kHLdIzz4tCcppiY=";
+    sha256 = "sha256-M8ImntyfFfSL591UpqZosE7F8ydbpfrBhcLOBtW/sGQ=";
   };
 }

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "5.8.5";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Nl/T+8mmQdCTHo3qAUd+ATflSDXiGCQfGb1gXzvLuAc=";
+    sha256 = "sha256-JeiBhgfGyGyNT9eNhtUl6Pp1jgG02NRlm5lam592lS0=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/pix/default.nix
+++ b/pkgs/desktops/cinnamon/pix/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -34,23 +33,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "3.0.2";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-iNUhcHG4nCZ4WNELodyLdztzfNg9g+F0eQrZHXS6Zj0=";
+    sha256 = "sha256-hhtW2QyexGIyovhWOReeJ0bxgye8LJl1RrEs0/5+q24=";
   };
-
-  patches = [
-    # Fix build with exiv2 0.28, can be removed on next update
-    # https://github.com/linuxmint/pix/pull/178
-    (fetchpatch {
-      url = "https://github.com/linuxmint/pix/commit/46e19703a973d51fa97e6a22121560f5ba200eea.patch";
-      sha256 = "sha256-Z+pUxoy0m/agXW++YxEUhRuax0qvuGVXNhU8d9mvGh4=";
-    })
-  ];
 
   nativeBuildInputs = [
     bison

--- a/pkgs/desktops/cinnamon/xapp/default.nix
+++ b/pkgs/desktops/cinnamon/xapp/default.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "2.6.1";
+  version = "2.8.0";
 
   outputs = [ "out" "dev" ];
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-ZxIPiDLcMHEmlnrImctI2ZfH3AIOjB4m/RPGipJ7koM=";
+    hash = "sha256-kpVNzBvUo2Ktzln51xLbySeKutVeJaI57kL8cBZscTM=";
   };
 
   # Recommended by upstream, which enables the build of xapp-debug.

--- a/pkgs/desktops/cinnamon/xviewer/default.nix
+++ b/pkgs/desktops/cinnamon/xviewer/default.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.4.1";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HVxCBqaKtsEGhGAB+dBCOnjAjLZHv0XqTifPrvoYdj8=";
+    sha256 = "sha256-bI0TFJYulj1XlgKU5YLrlYKnkHORVYz4TK9mhl9mGag=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This updates Cinnamon to 6.0, which is part of Mint 21.3.

Various useful links:

- Cinnamon wayland status **(still experimental, you should stay on x11 session when possible)**: [Trello board](https://trello.com/b/HHs01Pab/cinnamon-wayland).
- Things we need to do: [GitHub board](https://github.com/NixOS/nixpkgs/projects/46).
- List of upstream changes: [this page](https://github.com/bobby285271/what-changed/blob/master/003-cinnamon.md).
- Semi-automatic commit generater: [this gist](https://gist.github.com/bobby285271/d23fb0b2b1fdf5317a17dbf88af792a3).

<!--

lightdm-slick-greeter: 1.8.2 -> 2.0.0
cinnamon.pix: 3.0.2 -> 3.2.0
cinnamon.xviewer: 3.4.1 -> 3.4.2
cinnamon.bulky: 2.10 -> 3.0
cinnamon.nemo-extensions: 5.8.0 -> 6.0.0
cinnamon.xapp: 2.6.1 -> 2.8.0
cinnamon.nemo: 5.8.5 -> 6.0.0
cinnamon.muffin: 5.8.1 -> 6.0.0
cinnamon.cjs: 5.8.0 -> 6.0.0
cinnamon.cinnamon-translations: 5.8.2 -> 6.0.0
cinnamon.cinnamon-settings-daemon: 5.8.1 -> 6.0.0
cinnamon.cinnamon-session: 5.8.1 -> 6.0.1
cinnamon.cinnamon-screensaver: 5.8.1 -> 6.0.0
cinnamon.cinnamon-menus: 5.8.0 -> 6.0.0
cinnamon.cinnamon-desktop: 5.8.0 -> 6.0.0
cinnamon.cinnamon-control-center: 5.8.2 -> 6.0.0
cinnamon.cinnamon-common: 5.8.4 -> unstable-2023-11-19
cinnamon.mint-l-theme: 1.9.5 -> 1.9.6
cinnamon.mint-l-icons: 1.6.5 -> 1.6.6
cinnamon.mint-y-icons: 1.6.7 -> 1.6.9
cinnamon.mint-themes: 2.1.5 -> 2.1.6
cinnamon.xreader: 3.8.2 -> 3.8.3
cinnamon.mint-artwork: 1.7.6 -> 1.7.7


-->