### PR TITLE
darwin.CoreSymbolication: fix C99 compilation

### DIFF
--- a/pkgs/os-specific/darwin/CoreSymbolication/default.nix
+++ b/pkgs/os-specific/darwin/CoreSymbolication/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, stdenv }:
+{ lib, fetchFromGitHub, fetchpatch, stdenv }:
 
 stdenv.mkDerivation {
   pname = "core-symbolication";
@@ -10,6 +10,15 @@ stdenv.mkDerivation {
     rev = "24c87c23664b3ee05dc7a5a87d647ae476a680e4";
     hash = "sha256-PzvLq94eNhP0+rLwGMKcMzxuD6MlrNI7iT/eV0obtSE=";
   };
+
+  patches = [
+    # C99 compilation fix
+    # https://github.com/matthewbauer/CoreSymbolication/pull/1
+    (fetchpatch {
+      url = "https://github.com/boltzmannrain/CoreSymbolication/commit/1c26cc93f260bda9230a93e91585284e80aa231f.patch";
+      hash = "sha256-d/ieDEnvZ9kVOjBVUdJzGmdvC1AF3Jk4fbwp04Q6l/I=";
+    })
+  ];
 
   makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" ];
 


### PR DESCRIPTION
## Description of changes

https://hydra.nixos.org/build/241116326/nixlog/1
```
build flags: SHELL=/nix/store/x1xxsh1gp6y389hyl40a0i74dkxiprl7-bash-5.2-p15/bin/bash PREFIX=\$\(out\) CC=cc
cc -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -fblocks   -c -o CoreSymbolication.o CoreSymbolication.c
In file included from CoreSymbolication.c:1:
./CoreSymbolication.h:393:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
CSSymbolOwnerSetTransientUserData(CSSymbolOwnerRef owner, uint32_t gen);
^
int
1 error generated.
```

Also submitted patch upstream at
https://github.com/matthewbauer/CoreSymbolication/pull/1

ZHF: #265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
