### PR TITLE
`lib.fileset`: Minor changes

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -263,7 +263,7 @@ in {
           lib.fileset.fromSource: The source origin of the argument is of type ${typeOf path}, but it should be a path instead.''
     else if ! pathExists path then
       throw ''
-        lib.fileset.fromSource: The source origin (${toString path}) of the argument does not exist.''
+        lib.fileset.fromSource: The source origin (${toString path}) of the argument is a path that does not exist.''
     else if isFiltered then
       _fromSourceFilter path source.filter
     else

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -381,7 +381,7 @@ rec {
 
   # Turn a fileset into a source filter function suitable for `builtins.path`
   # Only directories recursively containing at least one files are recursed into
-  # Type: Path -> fileset -> (String -> String -> Bool)
+  # Type: fileset -> (String -> String -> Bool)
   _toSourceFilter = fileset:
     let
       # Simplify the tree, necessary to make sure all empty directories are null
@@ -753,9 +753,9 @@ rec {
 
       resultingTree =
         _differenceTree
-        positive._internalBase
-        positive._internalTree
-        negativeTreeWithPositiveBase;
+          positive._internalBase
+          positive._internalTree
+          negativeTreeWithPositiveBase;
     in
     # If the first file set is empty, we can never have any files in the result
     if positive._internalIsEmptyWithoutBase then

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -1064,12 +1064,17 @@ rm -rf -- *
 ## lib.fileset.fromSource
 
 # Check error messages
-expectFailure 'fromSource null' 'lib.fileset.fromSource: The source origin of the argument is of type null, but it should be a path instead.'
 
+# String-like values are not supported
 expectFailure 'fromSource (lib.cleanSource "")' 'lib.fileset.fromSource: The source origin of the argument is a string-like value \(""\), but it should be a path instead.
 \s*Sources created from paths in strings cannot be turned into file sets, use `lib.sources` or derivations instead.'
 
+# Wrong type
+expectFailure 'fromSource null' 'lib.fileset.fromSource: The source origin of the argument is of type null, but it should be a path instead.'
 expectFailure 'fromSource (lib.cleanSource null)' 'lib.fileset.fromSource: The source origin of the argument is of type null, but it should be a path instead.'
+
+# fromSource on non-existent paths gives an error
+expectFailure 'fromSource ./a' 'lib.fileset.fromSource: The source origin \('"$work"'/a\) of the argument is a path that does not exist.'
 
 # fromSource on a path works and is the same as coercing that path
 mkdir a


### PR DESCRIPTION
## Description of changes

Originally part of https://github.com/NixOS/nixpkgs/pull/267091, but should be done on its own:

- Make fromSource's missing file error message more consistent with others, and add a test for it
- Indent some function arguments
- Fix an internal type

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done
- [x] Ran the tests