### PR TITLE
bogofilter: 1.2.4 -> 1.2.5

### DIFF
--- a/pkgs/tools/misc/bogofilter/default.nix
+++ b/pkgs/tools/misc/bogofilter/default.nix
@@ -1,20 +1,30 @@
-{fetchurl, lib, stdenv, flex, db}:
+{ lib
+, stdenv
+, fetchurl
+, flex
+, db
+, makeWrapper
+, pax
+}:
 
 stdenv.mkDerivation rec {
   pname = "bogofilter";
-  version = "1.2.4";
+  version = "1.2.5";
 
   src = fetchurl {
-    url = "mirror://sourceforge/bogofilter/bogofilter-${version}.tar.bz2";
-    sha256 = "1d56n2m9inm8gnzm88aa27xl2a7sp7aff3484vmflpqkinjqf0p1";
+    url = "mirror://sourceforge/bogofilter/bogofilter-${version}.tar.xz";
+    hash = "sha256-MkihNzv/VSxQCDStvqS2yu4EIkUWrlgfslpMam3uieo=";
   };
 
-  # FIXME: We would need `pax' as a "propagated build input" (for use
-  # by the `bf_tar' script) but we don't have it currently.
+  nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ flex db ];
 
   doCheck = false; # needs "y" tool
+
+  postInstall = ''
+    wrapProgram "$out/bin/bf_tar" --prefix PATH : "${lib.makeBinPath [ pax ]}"
+  '';
 
   meta = {
     homepage = "http://bogofilter.sourceforge.net/";


### PR DESCRIPTION
## Description of changes

bogofilter-1.2.4 was [released](https://www.bogofilter.org/pipermail/bogofilter-announce/2013/000182.html) in 2013(!)

Bump to 1.2.5, which was [released](https://www.bogofilter.org/pipermail/bogofilter-announce/2019/000187.html) in 2019.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
