### PR TITLE
[staging] json_c: 0.16 -> 0.17

### DIFF
--- a/pkgs/development/libraries/json-c/default.nix
+++ b/pkgs/development/libraries/json-c/default.nix
@@ -1,23 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "json-c";
-  version = "0.16";
+  version = "0.17";
 
   src = fetchFromGitHub {
     owner = "json-c";
     repo = "json-c";
-    rev = "json-c-0.16-20220414";
-    sha256 = "sha256-KbnUWLgpg6/1wvXhUoYswyqDcgiwEcvgaWCPjNcX20o=";
+    rev = "json-c-0.17-20230812";
+    hash = "sha256-R5KIJ0xVgGqffjzJaZvvvhAneJ+ZBuanyF6KYTTxb58=";
   };
-
-  patches = [
-    # needed for emscripten, which uses LLVM 15+
-    (fetchpatch {
-      url = "https://github.com/json-c/json-c/commit/6eca65617aacd19f4928acd5766b8dd20eda0b34.patch";
-      sha256 = "sha256-fyugX+HgYlt/4AVtfNDaKS+blyUt8JYTNqkmhURb9dk=";
-    })
-  ];
 
   outputs = [ "out" "dev" ];
 
@@ -31,9 +27,10 @@ stdenv.mkDerivation rec {
       and parse JSON formatted strings back into the C representation of JSON
       objects.
     '';
-    homepage    = "https://github.com/json-c/json-c/wiki";
+    homepage = "https://github.com/json-c/json-c/wiki";
+    changelog = "https://github.com/json-c/json-c/blob/${finalAttrs.src.rev}/ChangeLog";
     maintainers = with maintainers; [ lovek323 ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
     license = licenses.mit;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

https://github.com/json-c/json-c/blob/json-c-0.17-20230812/ChangeLog

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).