### PR TITLE
gnome.gdm, upower: Simplify DESTDIR hack

### DIFF
--- a/pkgs/desktops/gnome/core/gdm/default.nix
+++ b/pkgs/desktops/gnome/core/gdm/default.nix
@@ -5,7 +5,6 @@
 , substituteAll
 , meson
 , ninja
-, rsync
 , pkg-config
 , glib
 , itstool
@@ -70,7 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    rsync
     gobject-introspection
   ];
 
@@ -131,33 +129,36 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preInstall = ''
-    install -D ${override} $DESTDIR/$out/share/glib-2.0/schemas/org.gnome.login-screen.gschema.override
+    install -D ${override} "$DESTDIR/$out/share/glib-2.0/schemas/org.gnome.login-screen.gschema.override"
   '';
 
   postInstall = ''
     # Move stuff from DESTDIR to proper location.
-    # We use rsync to merge the directories.
-    rsync --archive "$DESTDIR/etc" "$out"
-    rm --recursive "$DESTDIR/etc"
     for o in $(getAllOutputNames); do
+        # debug is created later by _separateDebugInfo hook.
         if [[ "$o" = "debug" ]]; then continue; fi
-        rsync --archive "$DESTDIR/''${!o}" "$(dirname "''${!o}")"
-        rm --recursive "$DESTDIR/''${!o}"
+        mv "$DESTDIR''${!o}" "$(dirname "''${!o}")"
     done
-    # Ensure the DESTDIR is removed.
-    rmdir "$DESTDIR/nix/store" "$DESTDIR/nix" "$DESTDIR"
+
+    mv "$DESTDIR/etc" "$out"
+
+    # Ensure we did not forget to install anything.
+    rmdir --parents --ignore-fail-on-non-empty "$DESTDIR${builtins.storeDir}"
+    ! test -e "$DESTDIR"
 
     # We are setting DESTDIR so the post-install script does not compile the schemas.
     glib-compile-schemas "$out/share/glib-2.0/schemas"
   '';
 
-  # HACK: We want to install configuration files to $out/etc
-  # but GDM should read them from /etc on a NixOS system.
-  # With autotools, it was possible to override Make variables
-  # at install time but Meson does not support this
-  # so we need to convince it to install all files to a temporary
-  # location using DESTDIR and then move it to proper one in postInstall.
-  DESTDIR = "${placeholder "out"}/dest";
+  env = {
+    # HACK: We want to install configuration files to $out/etc
+    # but GDM should read them from /etc on a NixOS system.
+    # With autotools, it was possible to override Make variables
+    # at install time but Meson does not support this
+    # so we need to convince it to install all files to a temporary
+    # location using DESTDIR and then move it to proper one in postInstall.
+    DESTDIR = "dest";
+  };
 
   separateDebugInfo = true;
 

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitLab
 , makeWrapper
 , pkg-config
-, rsync
 , libxslt
 , meson
 , ninja
@@ -69,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxslt
     makeWrapper
     pkg-config
-    rsync
     glib
   ] ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -138,7 +136,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Our gobject-introspection patches make the shared library paths absolute
     # in the GIR files. When running tests, the library is not yet installed,
     # though, so we need to replace the absolute path with a local one during build.
-    # We are using a symlink that will be overwitten during installation.
     mkdir -p "$out/lib"
     ln -s "$PWD/libupower-glib/libupower-glib.so" "$out/lib/libupower-glib.so.3"
   '';
@@ -159,21 +156,28 @@ stdenv.mkDerivation (finalAttrs: {
     # meson rebuild during install and it is not used at runtime anyway.
     sed -Ei 's~#!.+/bin/python3~#!/usr/bin/python3~' \
       ../src/linux/integration-test.py
+
+    # Undo preCheck installation since DESTDIR hack expects outputs to not exist.
+    rm "$out/lib/libupower-glib.so.3"
+    rmdir "$out/lib" "$out"
   '';
 
   postInstall = ''
     # Move stuff from DESTDIR to proper location.
-    # We use rsync to merge the directories.
-    for dir in etc var; do
-        rsync --archive "$DESTDIR/$dir" "$out"
-        rm --recursive "$DESTDIR/$dir"
+    for o in $(getAllOutputNames); do
+        # devdoc is created later by _multioutDocs hook.
+        if [[ "$o" = "devdoc" ]]; then continue; fi
+        mv "$DESTDIR''${!o}" "$(dirname "''${!o}")"
     done
-    for o in out dev installedTests; do
-        rsync --archive "$DESTDIR/''${!o}" "$(dirname "''${!o}")"
-        rm --recursive "$DESTDIR/''${!o}"
-    done
-    # Ensure the DESTDIR is removed.
-    rmdir "$DESTDIR/nix/store" "$DESTDIR/nix" "$DESTDIR"
+
+    mv "$DESTDIR/var" "$out"
+    # The /etc already exist so we need to merge it.
+    cp --recursive "$DESTDIR/etc" "$out"
+    rm --recursive "$DESTDIR/etc"
+
+    # Ensure we did not forget to install anything.
+    rmdir --parents --ignore-fail-on-non-empty "$DESTDIR${builtins.storeDir}"
+    ! test -e "$DESTDIR"
   '';
 
   postFixup = ''
@@ -194,7 +198,7 @@ stdenv.mkDerivation (finalAttrs: {
     # at install time but Meson does not support this
     # so we need to convince it to install all files to a temporary
     # location using DESTDIR and then move it to proper one in postInstall.
-    DESTDIR = "${placeholder "out"}/dest";
+    DESTDIR = "dest";
   };
 
   passthru = {


### PR DESCRIPTION
## Description of changes

Let’s point `DESTDIR` to a path under the build directory rather than under "$out". This will prevent `installPhase` from creating `$out` or any other output directory, allowing us to install the outputs just by moving them out of `$DESTDIR` directly into the store with `mv`. Of course, that will also require moving the installing of `etc` after the outputs are installed.

Since `$out` does not currently contain `etc` subdirectory, we can also just move `$DESTDIR/etc` directly to `$out` rather than copying it. And even if `$out/etc` existed, we could just merge it with `cp --recursive` instead of `rsync` so `rsync` is not actually necessary.

The code remains written defensively against files accidentally being lost or misplaced while shuffling them around:
- Parent directories of targets are used as `mv` destinations so that the move fails loudly if the directory already exists, rather than being moved inside as e.g. `$out/etc/etc`.
- `$DESTDIR` is removed with `rmdir`, which checks the directories were fully emptied out.

While at it let’s also improve practices a bit:
- Quote command arguments.
- Move `DESTDIR` definition into `env` block.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [x] Compared the directory trees of outputs and there were no changes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
