### PR TITLE
Fix failing build of `xkcdpass` due to non-deterministic test

### DIFF
--- a/pkgs/development/python-modules/xkcdpass/default.nix
+++ b/pkgs/development/python-modules/xkcdpass/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , installShellFiles
 , pytestCheckHook
 , pythonAtLeast
@@ -18,6 +19,13 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-zEgC3tTQ6kwDovHPHRTvYndWVF79DpnAX454VDZiedE=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/redacted/XKCD-password-generator/commit/72d174a82822af1934c94de1b66fd956230142f5.patch";
+      hash = "sha256-GES40GHM0+Zx8bRceCy9/fOHJVlWZ7TCLfzhZczjfTE=";
+    })
+  ];
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/development/python-modules/xkcdpass/default.nix
+++ b/pkgs/development/python-modules/xkcdpass/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
 
   patches = [
     (fetchpatch {
+      name = "fix-non-deterministic-test.patch";
       url = "https://github.com/redacted/XKCD-password-generator/commit/72d174a82822af1934c94de1b66fd956230142f5.patch";
       hash = "sha256-GES40GHM0+Zx8bRceCy9/fOHJVlWZ7TCLfzhZczjfTE=";
     })


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Trying to fix this build: https://hydra.nixos.org/build/240490554

ZHF: #265948

@balsoft