### PR TITLE
multipass: fix submodule fetching

### DIFF
--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -46,8 +46,14 @@ stdenv.mkDerivation
     owner = "canonical";
     repo = "multipass";
     rev = "refs/tags/v${version}";
-    hash = "sha256-OWZiVw3ztx1g1slq/5a7/JcLdDNB5RqYT5U3w1UXUpg=";
+    hash = "sha256-1k0jbYMwfYuHmM/Cm76sbo3+mN6WypALMQBwlZ+9d+c=";
     fetchSubmodules = true;
+    leaveDotGit = true;
+    postFetch = ''
+      # Workaround for https://github.com/NixOS/nixpkgs/issues/8567
+      cd $out
+      rm -rf .git
+    '';
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

`mulitpass` currently fails to build from source: https://hydra.nixos.org/build/241500327

Relevant portion of log:
```
error: Server does not allow request for unadvertised object 090e6a054d6283b144d20f5783852b95eade90ee
fatal: Fetched in submodule path '3rd-party/xz-decoder/xz-embedded', but it did not contain 090e6a054d6283b144d20f5783852b95eade90ee. Direct fetching of that commit failed.
error: Server does not allow request for unadvertised object 090e6a054d6283b144d20f5783852b95eade90ee
fatal: Fetched in submodule path '3rd-party/xz-decoder/xz-embedded', but it did not contain 090e6a054d6283b144d20f5783852b95eade90ee. Direct fetching of that commit failed.
```

Setting `leaveDotGit` fixes this and what it basically does is removing `--depth 1` flag passed to `git`, so instead of `git submodule update --init --recursive --progress --depth 1` (producing above error), we do `git submodule update --init --recursive --progress` (success).

I'm not so skilled with Nix yet, so maybe there is some other trick that we can do to fix this problem. This isn't really an upstreamable issue, because not using `--depth 1` works.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
