### PR TITLE
opendrop: cleanup, add openssl to PATH

### DIFF
--- a/pkgs/tools/networking/opendrop/default.nix
+++ b/pkgs/tools/networking/opendrop/default.nix
@@ -1,24 +1,37 @@
 { lib
 , buildPythonApplication
-, fetchPypi
+, fetchFromGitHub
 , fleep
+, ifaddr
 , libarchive-c
 , pillow
 , requests-toolbelt
 , setuptools
-, zeroconf }:
+, zeroconf
+, pytestCheckHook
+, openssl
+}:
 
 buildPythonApplication rec {
   pname = "opendrop";
   version = "0.13.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit version pname;
-    sha256 = "sha256-FE1oGpL6C9iBhI8Zj71Pm9qkObJvSeU2gaBZwK1bTQc=";
+  src = fetchFromGitHub {
+    owner = "seemoo-lab";
+    repo = "opendrop";
+    rev = "v${version}";
+    hash = "sha256-4FeVQO7Z6t9mjIgesdjKx4Mi+Ro5EVGJpEFjCvB2SlA=";
   };
+
+  nativeBuildInputs = [
+    # Tests fail if I put it on buildInputs
+    openssl
+  ];
 
   propagatedBuildInputs = [
     fleep
+    ifaddr
     libarchive-c
     pillow
     requests-toolbelt
@@ -26,16 +39,26 @@ buildPythonApplication rec {
     zeroconf
   ];
 
-  # There are tests, but getting the following error:
-  # nix_run_setup: error: argument action: invalid choice: 'test' (choose from 'receive', 'find', 'send')
-  # Opendrop works as intended though
-  doCheck = false;
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath nativeBuildInputs}"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # Solves PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with lib; {
     description = "An open Apple AirDrop implementation written in Python";
     homepage = "https://owlink.org/";
+    changelog = "https://github.com/seemoo-lab/opendrop/releases/tag/${src.rev}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ wolfangaukang ];
+    mainProgram = "opendrop";
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

Solves #237748. Also:
- adding a `changelog` and  `mainProgram` to the meta
- using `fetchFromGitHub` instead of `fetchPypi` to use tests
- add `format` section
- add missing library

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
