### PR TITLE
pgbadger: fix build on darwin

### DIFF
--- a/pkgs/tools/misc/pgbadger/default.nix
+++ b/pkgs/tools/misc/pgbadger/default.nix
@@ -1,4 +1,4 @@
-{ buildPerlPackage, stdenv, lib, fetchFromGitHub, which, bzip2, PodMarkdown, JSONXS
+{ buildPerlPackage, shortenPerlShebang, stdenv, lib, fetchFromGitHub, which, bzip2, PodMarkdown, JSONXS
 , TextCSV_XS }:
 buildPerlPackage rec {
   pname = "pgbadger";
@@ -14,11 +14,19 @@ buildPerlPackage rec {
     patchShebangs ./pgbadger
   '';
 
+  # pgbadger has too many `-Idir` flags on its shebang line on Darwin,
+  # causing the build to fail when trying to generate the documentation.
+  # Rewrite the -I flags in `use lib` form.
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    shortenPerlShebang ./pgbadger
+  '';
+
   outputs = [ "out" ];
 
   PERL_MM_OPT = "INSTALL_BASE=${placeholder "out"}";
 
   buildInputs = [ PodMarkdown JSONXS TextCSV_XS ];
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ shortenPerlShebang ];
 
   nativeCheckInputs = [ which bzip2 ];
 
@@ -28,6 +36,5 @@ buildPerlPackage rec {
     changelog = "https://github.com/darold/pgbadger/raw/v${version}/ChangeLog";
     license = lib.licenses.postgresql;
     maintainers = lib.teams.determinatesystems.members;
-    broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/pgbadger.x86_64-darwin
   };
 }


### PR DESCRIPTION
## Description of changes

The pgbadger build was failing on darwin due to an error while trying to generate the package's documentation.

The pgbadger script is executed during the build to dump the help text. The script's shebang line is too long on darwin and needs to be shortened using `shortenPerlShebang` for it to execute.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).