### PR TITLE
rrdtool: 1.7.2 -> 1.8.0

### DIFF
--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -1,16 +1,33 @@
-{ fetchurl, lib, stdenv, gettext, perl, pkg-config, libxml2, pango, cairo, groff
-, tcl, darwin }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gettext
+, perl
+, pkg-config
+, libxml2
+, pango
+, cairo
+, groff
+, tcl
+, darwin
+}:
 
 perl.pkgs.toPerlModule (stdenv.mkDerivation rec {
   pname = "rrdtool";
-  version = "1.7.2";
+  version = "1.8.0";
 
-  src = fetchurl {
-    url = "https://oss.oetiker.ch/rrdtool/pub/rrdtool-${version}.tar.gz";
-    sha256 = "1nsqra0g2nja19akmf9x5y9hhgc35ml3w9dcdz2ayz7zgvmzm6d1";
+  src = fetchFromGitHub {
+    owner = "oetiker";
+    repo = "rrdtool-1.x";
+    rev = "v${version}";
+    hash = "sha256-a+AxU1+YpkGoFs1Iu/CHAEZ4XIkWs7Vsnr6RcfXzsBE=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
   buildInputs = [ gettext perl libxml2 pango cairo groff ]
     ++ lib.optionals stdenv.isDarwin [ tcl darwin.apple_sdk.frameworks.ApplicationServices ];


### PR DESCRIPTION
## Description of changes

https://github.com/oetiker/rrdtool-1.x/releases/tag/v1.8.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

`nixosTests.collectd`, which uses rrdtool, passed

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>collectd</li>
    <li>kcollectd</li>
    <li>librenms</li>
    <li>mrtg</li>
    <li>munin</li>
    <li>ntopng</li>
    <li>php81Extensions.rrd</li>
    <li>php82Extensions.rrd</li>
    <li>php83Extensions.rrd</li>
    <li>rrdtool</li>
    <li>smokeping</li>
  </ul>
</details>