### PR TITLE
quartus-prime-lite: fix loading of libudev.so.0

### DIFF
--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -28,6 +28,7 @@ in buildFHSEnv rec {
     xorg.libICE
     xorg.libSM
     zlib
+    libudev0-shim
     # qsys requirements
     xorg.libXtst
     xorg.libXi
@@ -53,7 +54,6 @@ in buildFHSEnv rec {
     xorg.libX11
     xorg.libXext
     xorg.libXrender
-    libudev0-shim
     libxcrypt-legacy
   ];
 
@@ -95,7 +95,6 @@ in buildFHSEnv rec {
     # LD_PRELOAD fixes issues in the licensing system that cause memory corruption and crashes when
     # starting most operations in many containerized environments, including WSL2, Docker, and LXC
     # (a similiar fix involving LD_PRELOADing tcmalloc did not solve the issue in my situation)
-    # we use the name so that quartus can load the 64 bit verson and modelsim can load the 32 bit version
     # https://community.intel.com/t5/Intel-FPGA-Software-Installation/Running-Quartus-Prime-Standard-on-WSL-crashes-in-libudev-so/m-p/1189032
     #
     # But, as can be seen in the above resource, LD_PRELOADing libudev breaks
@@ -103,7 +102,7 @@ in buildFHSEnv rec {
     # `(vlog-2163) Macro `<protected> is undefined.`), so only use LD_PRELOAD
     # for non-ModelSim wrappers.
     if [ "$NIXPKGS_IS_MODELSIM_WRAPPER" != 1 ]; then
-        export LD_PRELOAD=''${LD_PRELOAD:+$LD_PRELOAD:}libudev.so.0
+        export LD_PRELOAD=''${LD_PRELOAD:+$LD_PRELOAD:}/usr/lib/libudev.so.0
     fi
   '';
 


### PR DESCRIPTION
Loading without a path was broken by nixpkgs commit e2d06c56951459ab3aebfb40c366ab635a021366. Fortunately we don't want libudev.so.0 in modelsim now anyway which was the reason for loading by name only, so we move it back to being 64-bit only and load it by absolute path.

cc: @bjornfor 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
