### PR TITLE
alp: init at 1.1.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6515,6 +6515,12 @@
     githubId = 67984144;
     name = "Gerhard Schwanzer";
   };
+  gernotfeichter = {
+    email = "gernotfeichter@gmail.com";
+    github = "gernotfeichter";
+    githubId = 23199375;
+    name = "Gernot Feichter";
+  };
   gerschtli = {
     email = "tobias.happ@gmx.de";
     github = "Gerschtli";

--- a/pkgs/by-name/al/alp/package.nix
+++ b/pkgs/by-name/al/alp/package.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, buildGoModule
+, fetchFromGitHub
+, runCommand
+, alp
+}:
+
+buildGoModule rec {
+  pname = "alp";
+  version = "1.1.17";
+
+  src = fetchFromGitHub {
+    owner = "gernotfeichter";
+    repo = "alp";
+    rev = version;
+    hash = "sha256-7lyWu1bVn7UwLb/Em6VBbg3FrMyxGjebxt5gJhm/xpI=";
+  };
+  vendorHash = "sha256-a2CQZKN/rPWh/Pn9gXfSArTCcGST472tsz1Kqm7M4vM=";
+
+  sourceRoot = "${src.name}/linux";
+
+  # Executing Go commands directly in checkPhase and buildPhase below,
+  # because the default testsuite runs all go tests, some of which require docker.
+  # Docker is too expensive for https://github.com/NixOS/ofborg.
+  checkPhase = ''
+    runHook preCheck
+
+    go test -run Test_main_init
+
+    runHook postCheck
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    go build -o $GOPATH/bin/${pname} main.go
+
+    runHook postBuild
+  '';
+
+  passthru.tests = {
+    test-version = runCommand "${pname}-test" {} ''
+      ${alp}/bin/alp version > $out
+      cat $out | grep '${version}'
+    '';
+  };
+
+  meta = with lib; {
+    description = "A convenient authentication method that lets you use your android device as a key for your Linux machine";
+    homepage = "https://github.com/gernotfeichter/alp";
+    license = licenses.gpl2Only;
+    mainProgram = "alp";
+    maintainers = with maintainers; [ gernotfeichter ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds https://github.com/gernotfeichter/alp (go program to use your android phone as key to your linux machine).

Since the package alone will not do that much, I added nixos specific installation instructions to the main README.md (in repo above) to make proper use of it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
