### PR TITLE
recode: 3.7.12 -> 3.7.14

### DIFF
--- a/pkgs/tools/text/recode/default.nix
+++ b/pkgs/tools/text/recode/default.nix
@@ -1,21 +1,35 @@
-{ lib, stdenv, fetchurl, python3, perl, intltool, flex, texinfo, libiconv, libintl }:
+{ lib
+, stdenv
+, fetchurl
+, python3Packages
+, flex
+, texinfo
+, libiconv
+, libintl
+}:
 
 stdenv.mkDerivation rec {
   pname = "recode";
-  version = "3.7.12";
+  version = "3.7.14";
 
   # Use official tarball, avoid need to bootstrap/generate build system
   src = fetchurl {
     url = "https://github.com/rrthomas/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-TbHJB28E26oVlyb1AAhH5eWoOuyOXGT4ygQ4P2zaEtU=";
+    hash = "sha256-eGqv1USFGisTsKN36sFQD4IM5iYVzMLmMLUB53Q7nzM=";
   };
 
-  nativeBuildInputs = [ python3 python3.pkgs.cython perl intltool flex texinfo libiconv ];
+  nativeBuildInputs = [ python3Packages.python flex texinfo libiconv ];
+
   buildInputs = [ libintl ];
 
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  nativeCheckInputs = with python3Packages; [
+    cython
+    setuptools
+  ];
 
   meta = {
     homepage = "https://github.com/rrthomas/recode";


### PR DESCRIPTION
## Description of changes

https://github.com/rrthomas/recode/blob/v3.7.14/NEWS
https://github.com/rrthomas/recode/compare/v3.7.12...v3.7.14

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>9 packages built:</summary>
  <ul>
    <li>bombono</li>
    <li>ding</li>
    <li>enca</li>
    <li>fancy-motd</li>
    <li>fortune</li>
    <li>gtypist</li>
    <li>plowshare</li>
    <li>recode</li>
    <li>xcowsay</li>
  </ul>
</details>