### PR TITLE
beets: fix building

### DIFF
--- a/pkgs/tools/audio/beets/builtin-plugins.nix
+++ b/pkgs/tools/audio/beets/builtin-plugins.nix
@@ -17,20 +17,32 @@
   };
   acousticbrainz.propagatedBuildInputs = [ python3Packages.requests ];
   albumtypes = { };
-  aura.propagatedBuildInputs = with python3Packages; [ flask pillow ];
-  badfiles.wrapperBins = [ mp3val flac ];
+  aura = {
+    propagatedBuildInputs = with python3Packages; [ flask pillow ];
+    testPaths = [ ];
+  };
+  badfiles = {
+    testPaths = [ ];
+    wrapperBins = [ mp3val flac ];
+  };
   bareasc = { };
   beatport.propagatedBuildInputs = [ python3Packages.requests-oauthlib ];
-  bench = { };
-  bpd = { };
-  bpm = { };
-  bpsync = { };
+  bench.testPaths = [ ];
+  bpd.testPaths = [ ];
+  bpm.testPaths = [ ];
+  bpsync.testPaths = [ ];
   bucket = { };
-  chroma.propagatedBuildInputs = [ python3Packages.pyacoustid ];
+  chroma = {
+    propagatedBuildInputs = [ python3Packages.pyacoustid ];
+    testPaths = [ ];
+  };
   convert.wrapperBins = [ ffmpeg ];
-  deezer.propagatedBuildInputs = [ python3Packages.requests ];
+  deezer = {
+    propagatedBuildInputs = [ python3Packages.requests ];
+    testPaths = [ ];
+  };
   discogs.propagatedBuildInputs = with python3Packages; [ discogs-client requests ];
-  duplicates = { };
+  duplicates.testPaths = [ ];
   edit = { };
   embedart = {
     propagatedBuildInputs = with python3Packages; [ pillow ];
@@ -43,32 +55,44 @@
     wrapperBins = [ imagemagick ];
   };
   filefilter = { };
-  fish = { };
-  freedesktop = { };
-  fromfilename = { };
+  fish.testPaths = [ ];
+  freedesktop.testPaths = [ ];
+  fromfilename.testPaths = [ ];
   ftintitle = { };
-  fuzzy = { };
-  gmusic = { };
+  fuzzy.testPaths = [ ];
+  gmusic.testPaths = [ ];
   hook = { };
   ihate = { };
   importadded = { };
   importfeeds = { };
   info = { };
-  inline = { };
+  inline.testPaths = [ ];
   ipfs = { };
   keyfinder.wrapperBins = [ keyfinder-cli ];
-  kodiupdate.propagatedBuildInputs = [ python3Packages.requests ];
+  kodiupdate = {
+    propagatedBuildInputs = [ python3Packages.requests ];
+    testPaths = [ ];
+  };
   lastgenre.propagatedBuildInputs = [ python3Packages.pylast ];
-  lastimport.propagatedBuildInputs = [ python3Packages.pylast ];
-  loadext.propagatedBuildInputs = [ python3Packages.requests ];
+  lastimport = {
+    propagatedBuildInputs = [ python3Packages.pylast ];
+    testPaths = [ ];
+  };
+  loadext = {
+    propagatedBuildInputs = [ python3Packages.requests ];
+    testPaths = [ ];
+  };
   lyrics.propagatedBuildInputs = [ python3Packages.beautifulsoup4 ];
-  mbcollection = { };
+  mbcollection.testPaths = [ ];
   mbsubmit = { };
   mbsync = { };
   metasync = { };
-  missing = { };
+  missing.testPaths = [ ];
   mpdstats.propagatedBuildInputs = [ python3Packages.mpd2 ];
-  mpdupdate.propagatedBuildInputs = [ python3Packages.mpd2 ];
+  mpdupdate = {
+    propagatedBuildInputs = [ python3Packages.mpd2 ];
+    testPaths = [ ];
+  };
   parentwork = { };
   permissions = { };
   play = { };
@@ -76,12 +100,18 @@
   plexupdate = { };
   random = { };
   replaygain.wrapperBins = [ aacgain ffmpeg mp3gain ];
-  rewrite = { };
-  scrub = { };
+  rewrite.testPaths= [ ];
+  scrub.testPaths = [ ];
   smartplaylist = { };
-  sonosupdate.propagatedBuildInputs = [ python3Packages.soco ];
+  sonosupdate = {
+    propagatedBuildInputs = [ python3Packages.soco ];
+    testPaths = [ ];
+  };
   spotify = { };
-  subsonicplaylist.propagatedBuildInputs = [ python3Packages.requests ];
+  subsonicplaylist = {
+    propagatedBuildInputs = [ python3Packages.requests ];
+    testPaths = [ ];
+  };
   subsonicupdate.propagatedBuildInputs = [ python3Packages.requests ];
   the = { };
   thumbnails = {
@@ -89,7 +119,7 @@
     wrapperBins = [ imagemagick ];
   };
   types.testPaths = [ "test/test_types_plugin.py" ];
-  unimported = { };
+  unimported.testPaths = [ ];
   web.propagatedBuildInputs = [ python3Packages.flask ];
   zero = { };
 }

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -46,6 +46,12 @@ lib.makeExtensible (self: {
       # Pillow 10 compatibility fix, a backport of
       # https://github.com/beetbox/beets/pull/4868, which doesn't apply now
       ./patches/fix-pillow10-compat.patch
+
+      # Sphinx 6 compatibility fix.
+      (fetchpatch {
+        url = "https://github.com/beetbox/beets/commit/2106f471affd1dab35b4b26187b9c74d034528c5.patch";
+        hash = "sha256-V/886dYJW/O55VqU8sd+x/URIFcKhP6j5sUhTGMoxL8=";
+      })
     ];
     disabledTests = [
       # This issue is present on this version alone, and can be removed on the


### PR DESCRIPTION
## Description of changes

This PR contains two changes which were required to fix `beets`:

1. e13fa51765126968c65da9368f9397dd76969543 - Sphinx 6.0.0 changed extlinks to always require placeholders in link captions. This was fixed in beets in https://github.com/beetbox/beets/commit/2106f47 but no releases contain this fix.
2. 8bdeef4f813cfc236a60b9b01456482c973f9237 - #263650 switched from using `pytest` to `pytestCheckHook`, which enabled the check hook for pytest. This started throwing errors if a plugin without any tests was disabled, as it would add the plugin's test to the disabled test list even though the test didn't exist.

The second change also fixes building of anything which depended on `beets-minimal`:

* `beetsPackages.alternatives`
* `beetsPackages.copyartifacts`
* `beetsPackages.extrafiles`

Fixes #268516.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
