### PR TITLE
zotero_7: init at 7.0.0-beta

### DIFF
--- a/pkgs/applications/office/zotero/zotero_7.nix
+++ b/pkgs/applications/office/zotero/zotero_7.nix
@@ -145,6 +145,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.agpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ i077 ];
+    maintainers = with maintainers; [ atila ];
   };
 }

--- a/pkgs/applications/office/zotero/zotero_7.nix
+++ b/pkgs/applications/office/zotero/zotero_7.nix
@@ -1,0 +1,150 @@
+{ lib
+, stdenv
+, fetchurl
+, wrapGAppsHook
+, autoPatchelfHook
+, makeDesktopItem
+, atk
+, cairo
+, coreutils
+, curl
+, cups
+, dbus-glib
+, dbus
+, dconf
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, glibc
+, gtk3
+, libX11
+, libXScrnSaver
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrender
+, libXt
+, libnotify
+, gnome
+, libGLU
+, libGL
+, nspr
+, nss
+, pango
+, gsettings-desktop-schemas
+, alsa-lib
+, libXtst
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zotero";
+  version = "7.0.0-beta";
+
+  src = fetchurl {
+    url = "https://download.zotero.org/client/beta/${version}.51%2B7c5600913/Zotero-${version}.51%2B7c5600913_linux-x86_64.tar.bz2";
+    hash = "sha256-zJ+jG7zlvWq+WEYOPyMIhqHPfsUe9tn0cbRyibQ7bFw=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    gsettings-desktop-schemas
+    glib
+    gtk3
+    gnome.adwaita-icon-theme
+    dconf
+    libXtst
+    alsa-lib
+    stdenv.cc.cc
+    atk
+    cairo
+    curl
+    cups
+    dbus-glib
+    dbus
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    glibc
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libxcb
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXinerama
+    libXrender
+    libXt
+    libnotify
+    libGLU
+    libGL
+    nspr
+    nss
+    pango
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+
+  desktopItem = makeDesktopItem {
+    name = "zotero";
+    exec = "zotero -url %U";
+    icon = "zotero";
+    comment = meta.description;
+    desktopName = "Zotero";
+    genericName = "Reference Management";
+    categories = [ "Office" "Database" ];
+    startupNotify = true;
+    mimeTypes = [ "x-scheme-handler/zotero" "text/plain" ];
+  };
+
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$prefix/usr/lib/zotero-bin-${version}"
+    cp -r * "$prefix/usr/lib/zotero-bin-${version}"
+    mkdir -p "$out/bin"
+    ln -s "$prefix/usr/lib/zotero-bin-${version}/zotero" "$out/bin/"
+
+    # install desktop file and icons.
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications/
+    for size in 16 32 48 256; do
+      install -Dm444 chrome/icons/default/default$size.png \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/zotero.png
+    done
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ coreutils ]}
+    )
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.zotero.org";
+    description = "Collect, organize, cite, and share your research sources";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.agpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ i077 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36955,6 +36955,8 @@ with pkgs;
 
   zotero = callPackage ../applications/office/zotero { };
 
+  zotero_7 = callPackage ../applications/office/zotero/zotero_7.nix { };
+
   zscroll = callPackage ../applications/misc/zscroll { };
 
   zsteg = callPackage ../tools/security/zsteg { };


### PR DESCRIPTION
## Description of changes

I added the beta version of Zotero. I'm not sure how to put the two derivations in a single file, so I could use some help there. Also, there is a warning on the terminal that is shown when I run the binary:

```
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=0.720421) [GFX1-]: glxtest: libpci missing
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=0.720421) |[1][GFX1-]: glxtest: libEGL missing (t=0.720463) [GFX1-]: glxtest: libEGL missing
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=0.720421) |[1][GFX1-]: glxtest: libEGL missing (t=0.720463) |[2][GFX1-]: glxtest: EGL test failed (t=0.720474) [GFX1-]: glxtest: EGL test failed
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=0.720421) |[1][GFX1-]: glxtest: libEGL missing (t=0.720463) |[2][GFX1-]: glxtest: EGL test failed (t=0.720474) |[3][GFX1-]: No GPUs detected via PCI (t=0.720492) [GFX1-]: No GPUs detected via PCI
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>zotero_7</li>
  </ul>
</details>