### PR TITLE
bazel_6: fix: make patched bash a native binary

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -141,7 +141,7 @@ let
     '';
   };
 
-  # Sript-based interpreters in shebangs aren't guaranteed to work,
+  # Script-based interpreters in shebangs aren't guaranteed to work,
   # especially on MacOS. So let's produce a binary
   bashWithDefaultShellUtils = stdenv.mkDerivation {
     name = "bash";

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -23,6 +23,7 @@
 , substituteAll
 , writeTextFile
 , writeShellApplication
+, makeBinaryWrapper
 }:
 
 let
@@ -129,7 +130,7 @@ let
 
   defaultShellPath = lib.makeBinPath defaultShellUtils;
 
-  bashWithDefaultShellUtils = writeShellApplication {
+  bashWithDefaultShellUtilsSh = writeShellApplication {
     name = "bash";
     runtimeInputs = defaultShellUtils;
     text = ''
@@ -137,6 +138,17 @@ let
         export PATH=${defaultShellPath}
       fi
       exec ${bash}/bin/bash "$@"
+    '';
+  };
+
+  # Sript-based interpreters in shebangs aren't guaranteed to work,
+  # especially on MacOS. So let's produce a binary
+  bashWithDefaultShellUtils = stdenv.mkDerivation {
+    name = "bash";
+    src = bashWithDefaultShellUtilsSh;
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    buildPhase = ''
+      makeWrapper ${bashWithDefaultShellUtilsSh}/bin/bash $out/bin/bash
     '';
   };
 


### PR DESCRIPTION
## Description of changes

https://hydra.nixos.org/build/240805256/nixlog/1
https://hydra.nixos.org/build/240805170/nixlog/2
Failure is a bit obscured but long story short, a script within bazel gets custom nixpkgs shebang which in turn makes shell run in POSIX-compatible mode. Bazel expects bash in non-POSIX mode and osx-specific script starts to fail due to `set -e` and subshell interaction differences in those modes (sub-shells and functions suddently start inheriting `set -e` and fail to produce desired output). More debug info is available in #267670

Shell scripts aren't guaranteed to work as interpreters in shebang. In particular thin shell wrappers aren't shebang-ready on MacOS. It may work sometimes depending on what exactly would try to execute a script with such shebang, but generally it's not guaranteed to work. See #124556

Bash wrapper was introduced in #266847 and so far seems like the issue only affects darwin builds: hydra failure is in osx-specific script, also shebang issue is usually darwin-specific.

Let's wrap it as a native binary to make it shebang-compatible.

The wrapper is only currently added to `bazel_6` so no need for changes in other versions.

Note: there seems to be some other breakage on the most recent main branch, probably makes sense to address separately

ZHF: #265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
