### PR TITLE
streamdeck-ui: 3.1.0 -> 4.0.0

### DIFF
--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -1,12 +1,14 @@
 { lib
 , python3Packages
 , fetchFromGitHub
+, substituteAll
 , copyDesktopItems
 , writeText
 , makeDesktopItem
 , wrapGAppsHook
 , xvfb-run
 , qt6
+, fontconfig
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -23,6 +25,12 @@ python3Packages.buildPythonApplication rec {
   patches = [
     # nixpkgs has a newer pillow version
     ./update-pillow.patch
+
+    # fix path to fc-list
+    (substituteAll {
+      src = ./fix-fc-list.patch;
+      fclist = "${fontconfig}/bin/fc-list";
+    })
   ];
 
   desktopItems = let

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python3Packages
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , copyDesktopItems
 , writeText
@@ -25,6 +26,13 @@ python3Packages.buildPythonApplication rec {
   patches = [
     # nixpkgs has a newer pillow version
     ./update-pillow.patch
+
+    # upstream forgot to bump the project version
+    (fetchpatch {
+      name = "bump-version.patch";
+      url = "https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/commit/bd76e7e3e0ac0da6dd070c3e81f4fcbed2db825a.patch";
+      sha256 = "sha256-GXz/a0fDmcPoHBHPYbjPkrhOMTJgoz0BRx+TkGi96QE=";
+    })
 
     # fix path to fc-list
     (substituteAll {

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -11,13 +11,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "streamdeck-ui";
-  version = "3.1.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     repo = "streamdeck-linux-gui";
     owner = "streamdeck-linux-gui";
     rev = "v${version}";
-    sha256 = "sha256-AIE9j022L4WSlHBAu3TT5uE4Ilgk/jYSmU03K8Hs8xY=";
+    sha256 = "sha256-az00iCLWMLd9YsdSZoVDB6UQIHVEln+gkf84hmUlqFY=";
   };
 
   patches = [
@@ -78,6 +78,7 @@ python3Packages.buildPythonApplication rec {
     setuptools
     filetype
     cairosvg
+    importlib-metadata
     pillow
     pynput
     pyside6
@@ -90,9 +91,12 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = [
     xvfb-run
     python3Packages.pytest
+    python3Packages.pytest-mock
+    python3Packages.pytest-qt
   ];
 
   checkPhase = ''
+    export HOME=$(pwd)
     xvfb-run pytest tests
   '';
 

--- a/pkgs/applications/misc/streamdeck-ui/fix-fc-list.patch
+++ b/pkgs/applications/misc/streamdeck-ui/fix-fc-list.patch
@@ -1,0 +1,17 @@
+diff --git a/streamdeck_ui/fonts.py b/streamdeck_ui/fonts.py
+index 89c7ae8..af720ea 100644
+--- a/streamdeck_ui/fonts.py
++++ b/streamdeck_ui/fonts.py
+@@ -34,11 +34,7 @@ def get_system_fonts():
+     fonts_dict = {}
+     try:
+         fclist_locations = [
+-            "/usr/bin/fc-list",
+-            "/usr/sbin/fc-list",
+-            "/bin/fc-list",
+-            "/usr/local/sbin/fc-list",
+-            "/usr/local/bin/fc-list",
++            "@fclist@",
+         ]
+         fclist_path = None
+         for file_path in fclist_locations:


### PR DESCRIPTION
## Description of changes

[Diff](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/compare/v3.1.0..v4.0.0)

Changelogs:

- [v3.2.0](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/releases/tag/v3.2.0)
- [v4.0.0](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/releases/tag/v4.0.0)

## TODOs

Currently getting this error:

```
The 'fc-list' command is not available on your system. Using fallback fonts.
```

Patching the paths [here](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/commit/a0ecbf83b5d144e1dd4d9cb0fa21eaebcb08a758#diff-ea2342950e58dfcee7705bc7ea8685c5b41204bf67af98dbb5e5adbec4be0c4cR37-R41) to point to a Nix store path for `fc-list` doesn't seem to fix the issue.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
