### PR TITLE
nixos/hardware/ipu6: update all related packages

### DIFF
--- a/nixos/modules/hardware/video/webcam/ipu6.nix
+++ b/nixos/modules/hardware/video/webcam/ipu6.nix
@@ -13,11 +13,12 @@ in
     enable = mkEnableOption (lib.mdDoc "support for Intel IPU6/MIPI cameras");
 
     platform = mkOption {
-      type = types.enum [ "ipu6" "ipu6ep" ];
+      type = types.enum [ "ipu6" "ipu6ep" "ipu6epmtl" ];
       description = lib.mdDoc ''
         Choose the version for your hardware platform.
 
-        Use `ipu6` for Tiger Lake and `ipu6ep` for Alder Lake respectively.
+        Use `ipu6` for Tiger Lake, `ipu6ep` for Alder Lake or Raptor Lake,
+        and `ipu6epmtl` for Meteor Lake.
       '';
     };
 
@@ -42,14 +43,13 @@ in
 
       extraPackages = with pkgs.gst_all_1; [ ]
         ++ optional (cfg.platform == "ipu6") icamerasrc-ipu6
-        ++ optional (cfg.platform == "ipu6ep") icamerasrc-ipu6ep;
+        ++ optional (cfg.platform == "ipu6ep") icamerasrc-ipu6ep
+        ++ optional (cfg.platform == "ipu6epmtl") icamerasrc-ipu6epmtl;
 
       input = {
         pipeline = "icamerasrc";
-        format = mkIf (cfg.platform == "ipu6ep") (mkDefault "NV12");
+        format = mkIf (cfg.platform != "ipu6") (mkDefault "NV12");
       };
     };
-
   };
-
 }

--- a/nixos/modules/hardware/video/webcam/ipu6.nix
+++ b/nixos/modules/hardware/video/webcam/ipu6.nix
@@ -29,9 +29,7 @@ in
       ipu6-drivers
     ];
 
-    hardware.firmware = with pkgs; [ ]
-      ++ optional (cfg.platform == "ipu6") ipu6-camera-bin
-      ++ optional (cfg.platform == "ipu6ep") ipu6ep-camera-bin;
+    hardware.firmware = [ pkgs.ipu6-camera-bins ];
 
     services.udev.extraRules = ''
       SUBSYSTEM=="intel-ipu6-psys", MODE="0660", GROUP="video"

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -14,6 +14,7 @@
 , Security
 , VideoToolbox
 , ipu6ep-camera-hal
+, ipu6epmtl-camera-hal
 }:
 
 {
@@ -46,6 +47,9 @@
   icamerasrc-ipu6 = callPackage ./icamerasrc { };
   icamerasrc-ipu6ep = callPackage ./icamerasrc {
     ipu6-camera-hal = ipu6ep-camera-hal;
+  };
+  icamerasrc-ipu6epmtl = callPackage ./icamerasrc {
+    ipu6-camera-hal = ipu6epmtl-camera-hal;
   };
 
   # note: gst-python is in ../../python-modules/gst-python - called under python3Packages

--- a/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
+++ b/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "icamerasrc-${ipu6-camera-hal.ipuVersion}";
-  version = "unstable-2023-03-09";
+  version = "unstable-2023-10-23";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "icamerasrc";
-    rev = "17841ab6249aaa69bd9b3959262bf182dee74111";
-    hash = "sha256-j8ZYe4nyy5yfo10CGeXDwbAaAPvdr0ptMWB8hQDyESQ=";
+    rev = "528a6f177732def4d5ebc17927220d8823bc8fdc";
+    hash = "sha256-Ezcm5OpF/NKvJf5sFeJyvNc2Uq0166GukC9MuNUV2Fs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
+++ b/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
@@ -8,7 +8,7 @@
 , libdrm
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "icamerasrc-${ipu6-camera-hal.ipuVersion}";
   version = "unstable-2023-10-23";
 

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  PKG_CONFIG_PATH = "${lib.getDev ipu6-camera-bins}/lib/${ipuTarget}/pkgconfig";
+  PKG_CONFIG_PATH = "${lib.makeLibraryPath [ ipu6-camera-bins ]}/${ipuTarget}/pkgconfig";
 
   cmakeFlags = [
     "-DIPU_VER=${ipuVersion}"
@@ -66,6 +66,12 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace src/platformdata/PlatformData.h \
       --replace '/usr/share/' "${placeholder "out"}/share/"
+  '';
+
+  postFixup = ''
+    for lib in $out/lib/*.so; do
+      patchelf --add-rpath "${lib.makeLibraryPath [ ipu6-camera-bins ]}/${ipuTarget}" $lib
+    done
   '';
 
   passthru = {

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -11,17 +11,29 @@
 , ipu6-camera-bin
 , libtool
 , gst_all_1
-}:
 
+# Pick one of
+# - ipu6 (Tiger Lake)
+# - ipu6ep (Alder Lake)
+# - ipu6epmtl (Meteor Lake)
+, ipuVersion ? "ipu6"
+}:
+let
+  ipuTarget = {
+    "ipu6" = "ipu_tgl";
+    "ipu6ep" = "ipu_adl";
+    "ipu6epmtl" = "ipu_mtl";
+  }.${ipuVersion};
+in
 stdenv.mkDerivation {
-  pname = "${ipu6-camera-bin.ipuVersion}-camera-hal";
-  version = "unstable-2023-02-08";
+  pname = "${ipuVersion}-camera-hal";
+  version = "unstable-2023-09-25";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-camera-hal";
-    rev = "884b81aae0ea19a974eb8ccdaeef93038136bdd4";
-    hash = "sha256-AePL7IqoOhlxhfPRLpCman5DNh3wYS4MUcLgmgBUcCM=";
+    rev = "9fa05a90886d399ad3dda4c2ddc990642b3d20c9";
+    hash = "sha256-yS1D7o6dsQ4FQkjfwcisOxcP7Majb+4uQ/iW5anMb5c=";
   };
 
   nativeBuildInputs = [
@@ -29,8 +41,10 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
+  PKG_CONFIG_PATH = "${lib.getDev ipu6-camera-bin}/lib/${ipuTarget}/pkgconfig";
+
   cmakeFlags = [
-    "-DIPU_VER=${ipu6-camera-bin.ipuVersion}"
+    "-DIPU_VER=${ipuVersion}"
     # missing libiacss
     "-DUSE_PG_LITE_PIPE=ON"
     # missing libipu4
@@ -39,8 +53,6 @@ stdenv.mkDerivation {
 
   NIX_CFLAGS_COMPILE = [
     "-Wno-error"
-    "-I${lib.getDev ipu6-camera-bin}/include/ia_imaging"
-    "-I${lib.getDev ipu6-camera-bin}/include/ia_camera"
   ];
 
   enableParallelBuilding = true;
@@ -64,7 +76,7 @@ stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit (ipu6-camera-bin) ipuVersion;
+    inherit ipuVersion;
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -47,8 +47,6 @@ stdenv.mkDerivation {
     "-DIPU_VER=${ipuVersion}"
     # missing libiacss
     "-DUSE_PG_LITE_PIPE=ON"
-    # missing libipu4
-    "-DENABLE_VIRTUAL_IPU_PIPE=OFF"
   ];
 
   NIX_CFLAGS_COMPILE = [
@@ -68,11 +66,6 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace src/platformdata/PlatformData.h \
       --replace '/usr/share/' "${placeholder "out"}/share/"
-  '';
-
-  postFixup = ''
-    substituteInPlace $out/lib/pkgconfig/libcamhal.pc \
-      --replace 'prefix=/usr' "prefix=$out"
   '';
 
   passthru = {

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -8,7 +8,7 @@
 
 # runtime
 , expat
-, ipu6-camera-bin
+, ipu6-camera-bins
 , libtool
 , gst_all_1
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  PKG_CONFIG_PATH = "${lib.getDev ipu6-camera-bin}/lib/${ipuTarget}/pkgconfig";
+  PKG_CONFIG_PATH = "${lib.getDev ipu6-camera-bins}/lib/${ipuTarget}/pkgconfig";
 
   cmakeFlags = [
     "-DIPU_VER=${ipuVersion}"
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     expat
-    ipu6-camera-bin
+    ipu6-camera-bins
     libtool
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -4,25 +4,18 @@
 , autoPatchelfHook
 , expat
 , zlib
-
-# Pick one of
-# - ipu6 (Tiger Lake)
-# - ipu6ep (Alder Lake)
-, ipuVersion ? "ipu6"
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "${ipuVersion}-camera-bin";
-  version = "unstable-2023-02-08";
+  pname = "ipu6-camera-bin";
+  version = "unstable-2023-10-26";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-camera-bins";
-    rev = "276859fc6de83918a32727d676985ec40f31af2b";
-    hash = "sha256-QnedM2UBbGyd2wIF762Mi+VkDZYtC6MifK4XGGxlUzw=";
+    rev = "af5ba0cb4a763569ac7514635013e9d870040bcf";
+    hash = "sha256-y0pT5M7AKACbquQWLZPYpTPXRC5hipLNL61nhs+cst4=";
   };
-
-  sourceRoot = "${finalAttrs.src.name}/${ipuVersion}";
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -40,13 +33,13 @@ stdenv.mkDerivation (finalAttrs: {
       include \
       $out/
 
-    install -m 0644 -D ../LICENSE $out/share/doc/LICENSE
+    install -m 0644 -D LICENSE $out/share/doc/LICENSE
 
     runHook postInstall
   '';
 
   postFixup = ''
-    for pcfile in $out/lib/pkgconfig/*.pc; do
+    for pcfile in $out/lib/*/pkgconfig/*.pc; do
       substituteInPlace $pcfile \
         --replace 'exec_prefix=/usr' 'exec_prefix=''${prefix}' \
         --replace 'prefix=/usr' "prefix=$out" \
@@ -55,17 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  passthru = {
-    inherit ipuVersion;
-  };
-
-  meta = let
-    generation = {
-      ipu6 = "Tiger Lake";
-      ipu6ep = "Alder Lake";
-    }.${ipuVersion};
-  in with lib; {
-    description = "${generation} IPU firmware and proprietary image processing libraries";
+  meta = with lib; {
+    description = "IPU firmware and proprietary image processing libraries";
     homepage = "https://github.com/intel/ipu6-camera-bins";
     license = licenses.issl;
     sourceProvenance = with sourceTypes; [

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -41,10 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     for pcfile in $out/lib/*/pkgconfig/*.pc; do
       substituteInPlace $pcfile \
-        --replace 'exec_prefix=/usr' 'exec_prefix=''${prefix}' \
-        --replace 'prefix=/usr' "prefix=$out" \
-        --replace 'libdir=/usr/lib' 'libdir=''${prefix}/lib' \
-        --replace 'includedir=/usr/include' 'includedir=''${prefix}/include'
+        --replace 'prefix=/usr' "prefix=$out"
     done
   '';
 

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -7,7 +7,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "ipu6-camera-bin";
+  pname = "ipu6-camera-bins";
   version = "unstable-2023-10-26";
 
   src = fetchFromGitHub {

--- a/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation {
   pname = "ivsc-firmware";
-  version = "unstable-2022-11-02";
+  version = "unstable-2023-08-11";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ivsc-firmware";
-    rev = "29c5eff4cdaf83e90ef2dcd2035a9cdff6343430";
-    hash = "sha256-GuD1oTnDEs0HslJjXx26DkVQIe0eS+js4UoaTDa77ME=";
+    rev = "10c214fea5560060d387fbd2fb8a1af329cb6232";
+    hash = "sha256-kEoA0yeGXuuB+jlMIhNm+SBljH+Ru7zt3PzGb+EPBPw=";
   };
 
   dontBuild = true;

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "ipu6-drivers";
-  version = "unstable-2023-11-15";
+  version = "unstable-2023-11-24";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-drivers";
-    rev = "067270ff020aaec9456085c217f1c2747c8c5ef5";
-    hash = "sha256-fK5WTO1wfu3nVBsUfKiAgrxwH9DSaludNLBtMxMhG+A=";
+    rev = "07f0612eabfdc31df36f5e316a9eae115807804f";
+    hash = "sha256-8JRZG6IKJT0qtoqJHm8641kSQMLc4Z+DRzK6FpL9Euk=";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "ipu6-drivers";
-  version = "unstable-2023-08-28";
+  version = "unstable-2023-11-15";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-drivers";
-    rev = "7c3d6ab1e9e234563a0af51286b0a8d60445f2a3";
-    hash = "sha256-D782v6hIqAl2EO1+zKeakURD3UGVP3c7p3ba/61yfW4=";
+    rev = "067270ff020aaec9456085c217f1c2747c8c5ef5";
+    hash = "sha256-fK5WTO1wfu3nVBsUfKiAgrxwH9DSaludNLBtMxMhG+A=";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/ivsc-driver/default.nix
+++ b/pkgs/os-specific/linux/ivsc-driver/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation {
   pname = "ivsc-driver";
-  version = "unstable-2023-03-10";
+  version = "unstable-2023-11-09";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ivsc-driver";
-    rev = "c8db12b907e2e455d4d5586e5812d1ae0eebd571";
-    hash = "sha256-OM9PljvaMKrk72BFeSCqaABFeAws+tOdd3oC2jyNreE=";
+    rev = "73a044d9633212fac54ea96cdd882ff5ab40573e";
+    hash = "sha256-vE5pOtVqjiWovlUMSEoBKTk/qvs8K8T5oY2r7njh0wQ=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -1,20 +1,15 @@
 { lib, stdenv, fetchFromGitHub, kernel, kmod }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "v4l2loopback";
-  version = "unstable-2023-02-19-${kernel.version}";
+  version = "unstable-2023-11-23-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "umlaeute";
     repo = "v4l2loopback";
-    rev = "fb410fc7af40e972058809a191fae9517b9313af";
-    hash = "sha256-gLFtR7s+3LUQ0BZxHbmaArHbufuphbtAX99nxJU3c84=";
+    rev = "850a2e36849f6ad3c9bf74f2ae3f603452bd8a71";
+    hash = "sha256-LqP5R3oKbjUQUfDZUWpkrmyopWhOt4wlgSgGywTPJXM=";
   };
-
-  patches = [
-    # fix bug https://github.com/umlaeute/v4l2loopback/issues/535
-    ./revert-pr518.patch
-  ];
 
   hardeningDisable = [ "format" "pic" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27982,7 +27982,7 @@ with pkgs;
 
   iproute2 = callPackage ../os-specific/linux/iproute { };
 
-  ipu6-camera-bin = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {};
+  ipu6-camera-bins = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {};
 
   ipu6-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27986,12 +27986,12 @@ with pkgs;
 
   ipu6-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {};
 
-  ipu6ep-camera-bin = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {
+  ipu6ep-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {
     ipuVersion = "ipu6ep";
   };
 
-  ipu6ep-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {
-    ipu6-camera-bin = ipu6ep-camera-bin;
+  ipu6epmtl-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {
+    ipuVersion = "ipu6epmtl";
   };
 
   ivsc-firmware = callPackage ../os-specific/linux/firmware/ivsc-firmware { };


### PR DESCRIPTION
ipu6-drivers: update to fix compilation with kernels >= 6.6.0.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).