### PR TITLE
bazel_6, bazel_5, bazel_4: fix CLang 16 Werror-s on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -204,6 +204,8 @@ stdenv.mkDerivation rec {
   inherit src;
   inherit sourceRoot;
   patches = [
+    ./upb-clang16.patch
+
     # On Darwin, the last argument to gcc is coming up as an empty string. i.e: ''
     # This is breaking the build of any C target. This patch removes the last
     # argument if it's found to be an empty string.

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -399,6 +399,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in third_party/{zlib}, external/{upb} dependencies
+      export NIX_CFLAGS_COMPILE+=" -Wno-implicit-function-declaration -Wno-gnu-offsetof-extensions"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/upb-clang16.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/upb-clang16.patch
@@ -1,0 +1,57 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 2d995f095e..55fddef663 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -1232,7 +1232,7 @@ register_toolchains("//src/main/res:empty_rc_toolchain")
+ http_archive(
+     name = "com_github_grpc_grpc",
+     patch_args = ["-p1"],
+-    patches = ["//third_party/grpc:grpc_1.33.1.patch"],
++    patches = ["//third_party/grpc:grpc_1.33.1.patch", "//:grpc-upb-clang16.patch"],
+     sha256 = "58eaee5c0f1bd0b92ebe1fa0606ec8f14798500620e7444726afcaf65041cb63",
+     strip_prefix = "grpc-1.33.1",
+     urls = [
+diff --git a/grpc-upb-clang16.patch b/grpc-upb-clang16.patch
+new file mode 100644
+index 0000000000..ae6a7ad0e0
+--- /dev/null
++++ b/grpc-upb-clang16.patch
+@@ -0,0 +1,13 @@
++diff -r -u a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
++--- a/bazel/grpc_deps.bzl
+++++ b/bazel/grpc_deps.bzl
++@@ -285,6 +285,8 @@
++             name = "upb",
++             sha256 = "7992217989f3156f8109931c1fc6db3434b7414957cb82371552377beaeb9d6c",
++             strip_prefix = "upb-382d5afc60e05470c23e8de19b19fc5ad231e732",
+++            patches = ["//:upb-clang16.patch"],
+++            patch_args = ["-p1"],
++             urls = [
++                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
++                 "https://github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
++
+diff --git a/upb-clang16.patch b/upb-clang16.patch
+new file mode 100644
+index 0000000000..b799737fac
+--- /dev/null
++++ b/upb-clang16.patch
+@@ -0,0 +1,10 @@
++--- a/BUILD
+++++ b/BUILD
++@@ -34,6 +34,7 @@
++     "-Wextra",
++     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++     "-Werror",
+++    "-Wno-gnu-offsetof-extensions",
++     "-Wno-long-long",
++     # copybara:strip_end
++ ]
++@@ -42,6 +43,7 @@
++     # copybara:strip_for_google3_begin
++     "-pedantic",
++     "-Werror=pedantic",
+++    "-Wno-gnu-offsetof-extensions",
++     "-Wstrict-prototypes",
++     # copybara:strip_end
++ ]
+

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -166,6 +166,8 @@ stdenv.mkDerivation rec {
   inherit src;
   inherit sourceRoot;
   patches = [
+    ./upb-clang16.patch
+
     # On Darwin, the last argument to gcc is coming up as an empty string. i.e: ''
     # This is breaking the build of any C target. This patch removes the last
     # argument if it's found to be an empty string.

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -364,6 +364,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in external/{absl,upb} dependencies
+      export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/upb-clang16.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/upb-clang16.patch
@@ -1,0 +1,37 @@
+diff --git a/distdir_deps.bzl b/distdir_deps.bzl
+index 9068f50537..f11c5b4e1c 100644
+--- a/distdir_deps.bzl
++++ b/distdir_deps.bzl
+@@ -110,6 +110,8 @@ DIST_DEPS = {
+     "protocolbuffers": {
+         "archive": "2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
+         "sha256": "6a5f67874af66b239b709c572ac1a5a00fdb1b29beaf13c3e6f79b1ba10dc7c4",
++        "patches": ["//:upb-clang16.patch"],
++        "patch_args": ["-p1"],
+         "urls": [
+             "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
+             "https://github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
+diff --git a/upb-clang16.patch b/upb-clang16.patch
+new file mode 100644
+index 0000000000..f81855181f
+--- /dev/null
++++ upb-clang16.patch
+@@ -0,0 +1,10 @@
++--- a/bazel/build_defs.bzl
+++++ b/bazel/build_defs.bzl
++@@ -34,6 +34,7 @@
++         "-Wextra",
++         # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++         "-Werror",
+++        "-Wno-gnu-offsetof-extensions",
++         "-Wno-long-long",
++         # copybara:strip_end
++     ],
++@@ -48,6 +49,7 @@
++         "-pedantic",
++         "-Werror=pedantic",
++         "-Wall",
+++        "-Wno-gnu-offsetof-extensions",
++         "-Wstrict-prototypes",
++         # GCC (at least) emits spurious warnings for this that cannot be fixed
++         # without introducing redundant initialization (with runtime cost):

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -199,6 +199,8 @@ stdenv.mkDerivation rec {
   inherit src;
   inherit sourceRoot;
   patches = [
+    ./upb-clang16.patch
+
     # Force usage of the _non_ prebuilt java toolchain.
     # the prebuilt one does not work in nix world.
     ./java_toolchain.patch

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -403,6 +403,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in external/{absl,upb} dependencies
+      export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/upb-clang16.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/upb-clang16.patch
@@ -1,0 +1,30 @@
+diff --git a/distdir_deps.bzl b/distdir_deps.bzl
+index c7fc4588e4..01e6966fca 100644
+--- a/distdir_deps.bzl
++++ b/distdir_deps.bzl
+@@ -192,6 +192,8@@ DIST_DEPS = {
+         "archive": "a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+         "sha256": "cf7f71eaff90b24c1a28b49645a9ff03a9a6c1e7134291ce70901cb63e7364b5",
+         "strip_prefix": "upb-a5477045acaa34586420942098f5fecd3570f577",
++        "patches": ["//:upb-clang16.patch"],
++        "patch_args": ["-p1"],
+         "urls": [
+             "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+             "https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+diff --git a/upb-clang16.patch b/upb-clang16.patch
+new file mode 100644
+index 0000000000..f81855181f
+--- /dev/null
++++ upb-clang16.patch
+@@ -0,0 +1,10 @@
++--- a/bazel/build_defs.bzl
+++++ b/bazel/build_defs.bzl
++@@ -43,6 +43,7 @@
++     "-Werror=pedantic",
++     "-Wall",
++     "-Wstrict-prototypes",
+++    "-Wno-gnu-offsetof-extensions",
++     # GCC (at least) emits spurious warnings for this that cannot be fixed
++     # without introducing redundant initialization (with runtime cost):
++     #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+


### PR DESCRIPTION
## Description of changes

WIP Trying to fix bazel_* after #234710 

TODO: upb adds copts last and `-Werror` wins https://github.com/protocolbuffers/upb/blob/a5477045acaa34586420942098f5fecd3570f577/bazel/build_defs.bzl#L43
```
ERROR: /private/tmp/nix-build-bazel-6.4.0.drv-6/bazel_GviWM2J0/out/external/upb/BUILD:102:11: Compiling upb/upb.c [for tool] failed: (Exit 1): cc_wrapper.sh failed: error executing command (from target @upb//:upb) 
  (cd /private/tmp/nix-build-bazel-6.4.0.drv-6/bazel_GviWM2J0/out/execroot/io_bazel && \
  exec env - \
... -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions '-std=c99' -pedantic '-Werror=pedantic' -Wall -Wstrict-prototypes -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c external/upb/upb/upb.c -o bazel-out/darwin-opt-exec-EDC14992/bin/external/upb/_objs/upb/upb.o)
# Configuration: 5b91c041255b8a865f889a23e1897de0f7a874d5fc7840158993ff22fe12f070
# Execution platform: //:default_host_platform
external/upb/upb/upb.c:228:25: error: defining a type within '__builtin_offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]
```

Trying to fix following

bazel_6 https://hydra.nixos.org/build/241090720/nixlog/1
```
external/upb/upb/upb.c:228:25: error: defining a type within '__builtin_offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]
  n = UPB_ALIGN_DOWN(n, UPB_ALIGN_OF(upb_Arena));
                        ^~~~~~~~~~~~~~~~~~~~~~~
```
bazel_6 https://hydra.nixos.org/build/241127779/nixlog/1
```
In file included from external/com_google_absl/absl/algorithm/container.h:55:
external/com_google_absl/absl/meta/type_traits.h:560:8: error: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Werror,-Wdeprecated-builtins]
      (__has_trivial_assign(ExtentsRemoved) || !kIsCopyOrMoveAssignable) &&
       ^
```
bazel_5
```
external/com_google_absl/absl/meta/type_traits.h:560:8: error: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Werror,-Wdeprecated-builtins]
      (__has_trivial_assign(ExtentsRemoved) || !kIsCopyOrMoveAssignable) &&
```
bazel_4
```
third_party/zlib/gzlib.c:496:14: error: call to undeclared function 'lseek'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    offset = LSEEK(state->fd, 0, SEEK_CUR);
```

ZHF: #265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
