### PR TITLE
functional-linear-algebra: 0.4->0.4.1

### DIFF
--- a/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
+++ b/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, lib, mkDerivation, standard-library }:
 
 mkDerivation rec {
-  version = "0.4";
+  version = "0.4.1";
   pname = "functional-linear-algebra";
 
   buildInputs = [ standard-library ];
@@ -10,7 +10,7 @@ mkDerivation rec {
     repo = "functional-linear-algebra";
     owner = "ryanorendorff";
     rev = "v${version}";
-    sha256 = "05jk3792k9xf8iiwzm2hwlvd25f2pqqr3gppmqjf8xb9199i8fk0";
+    sha256 = "GrTeMEHEXb0t2RgHWiGfvvofNYl8YYaaoCE18JrG6Q4=";
   };
 
   preConfigure = ''
@@ -26,6 +26,5 @@ mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ryanorendorff ];
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

Updates the agda package `functional-linear-algebra` from 0.4 to 0.4.1, which works with the newer 2.6.4 version of Agda. 

@turion, I am unsure if you want this merged into the haskell-updates or the master branch. I chose master since it builds against both. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Build with the following command:

```
nix-build -E "with import <nixpkgs> {}; agdaPackages.callPackage ./pkgs/development/libraries/agda/functional-linear-algebra/default.nix {}"
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
