### PR TITLE
inter: 3.19 -> 4.0

### DIFF
--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -2,19 +2,19 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "inter";
-  version = "3.19";
+  version = "4.0";
 
   src = fetchzip {
     url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
     stripRoot = false;
-    hash = "sha256-6kUQUTFtxiJEU6sYC6HzMwm1H4wvaKIoxoY3F6GJJa8=";
+    hash = "sha256-hFK7xFJt69n+98+juWgMvt+zeB9nDkc8nsR8vohrFIc=";
   };
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/fonts/opentype
-    cp */*.otf $out/share/fonts/opentype
+    mkdir -p $out/share/fonts/truetype
+    cp Inter.ttc InterVariable*.ttf $out/share/fonts/truetype
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

Inter released its 4.0 version (https://github.com/rsms/inter/releases/tag/v4.0), with

> - Six additional "Display" designs, assigned to an opsz variable-font axis, exposed as a second family "Inter Display" as static fonts.
> - Several new OpenType features
> - Humanist-style italics
> - Many technical changes (UPM changed to 2048, refined metrics, many improved features, etc)

The structure of the release zip also made a change, as shown below:

```
 ├──extras
 │  ├──otf
 │  │  └──Inter-*.ttf
 │  ├──ttf
 │  │  └──Inter-*.ttf
 │  └──woff-hinted
 ├──help.txt
 ├──Inter.ttc
 ├──InterVariable-Italic.ttf
 ├──InterVariable.ttf
 ├──LICENSE.txt
 └──web
    ├──Inter-*.woff2
    └──inter.css
```

Our packaging for 3.* versions installed all otf files. Now that Inter put ttc in their release, I chose to install `Inter.ttc` instead of 36 otf files. Also I added `InterVariable-Italic.ttf` and `InterVariable.ttf` to our packaging (in fact they already have appeared in 3.* releases). Note that Inter Variable uses “Inter Variable” family name instead of sharing “Inter” family name, including them would not cause conflicts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
