### PR TITLE
i3-auto-layout: 0.2 -> unstable 2022-05-29

### DIFF
--- a/pkgs/applications/window-managers/i3/auto-layout.nix
+++ b/pkgs/applications/window-managers/i3/auto-layout.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "i3-auto-layout";
-  version = "0.2";
+  version = "unstable-2022-05-29";
 
   src = fetchFromGitHub {
     owner = "chmln";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0ps08lga6qkgc8cgf5cx2lgwlqcnd2yazphh9xd2fznnzrllfxxz";
+    rev = "9e41eb3891991c35b7d35c9558e788899519a983";
+    sha256 = "sha256-gpVYVyh+2y4Tttvw1SuCf7mx/nxR330Ob2R4UmHZSJs=";
   };
 
-  cargoSha256 = "1i01kqvsykanzs7pi94gab9k2dqg1ki40mmjrwa22n0ypkbnvsmx";
+  cargoSha256 = "sha256-OxQ7S+Sqc3aRH53Bs53Y+EKOYFgboGOBsQ7KJgICcGo=";
 
   # Currently no tests are implemented, so we avoid building the package twice
   doCheck = false;
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
     description = "Automatic, optimal tiling for i3wm";
     homepage = "https://github.com/chmln/i3-auto-layout";
     license = licenses.mit;
-    maintainers = with maintainers; [ mephistophiles ];
+    maintainers = with maintainers; [ mephistophiles perstark ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

The package is not currently working. It needs an update to the i3ipc package to run. It was merged into the src via https://github.com/chmln/i3-auto-layout/pull/7. This update points to that commit. There have been multiple requests for updates and PRs for updates but the project seems stale. This PR will at least ensure that there is a working package in nixpkgs. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
