### PR TITLE
vector: Added upstream patch for Rust 1.73 fix

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -46,6 +46,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-vK+k+VbUVgJ8idlvuod5ExAkkeTYDk/135dyLRct0zs=";
   };
 
+  patches = [ ./vector-pr19075.patch ];
+
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/tools/misc/vector/vector-pr19075.patch
+++ b/pkgs/tools/misc/vector/vector-pr19075.patch
@@ -1,0 +1,23 @@
+From 14cd9c12416b5c9ada55ced51e8f92fdce56a4b1 Mon Sep 17 00:00:00 2001
+From: Aaron Andersen <aaron@fosslib.net>
+Date: Tue, 7 Nov 2023 09:05:26 -0500
+Subject: [PATCH] fix(config): rustc warnings
+
+---
+ src/convert_config.rs | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/convert_config.rs b/src/convert_config.rs
+index f0a900cf421a0..d81b998c5ee1f 100644
+--- a/src/convert_config.rs
++++ b/src/convert_config.rs
+@@ -157,8 +157,7 @@ fn walk_dir_and_convert(
+             let new_output_dir = if entry_path.is_dir() {
+                 let last_component = entry_path
+                     .file_name()
+-                    .unwrap_or_else(|| panic!("Failed to get file_name for {entry_path:?}"))
+-                    .clone();
++                    .unwrap_or_else(|| panic!("Failed to get file_name for {entry_path:?}"));
+                 let new_dir = output_dir.join(last_component);
+ 
+                 if !new_dir.exists() {


### PR DESCRIPTION
## Description of changes

Fixes compilation on `.1` with Rust 1.73.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).