### PR TITLE
homebank: 5.7.1 -> 5.7.2

### DIFF
--- a/pkgs/applications/office/homebank/default.nix
+++ b/pkgs/applications/office/homebank/default.nix
@@ -3,10 +3,10 @@
 
 stdenv.mkDerivation rec {
   pname = "homebank";
-  version = "5.7.1";
+  version = "5.7.2";
   src = fetchurl {
-    url = "http://homebank.free.fr/public/sources/homebank-${version}.tar.gz";
-    hash = "sha256-fwqSnXde7yalqfKfo8AT8+762/aYLMCGp8dd3bm09Ck=";
+    url = "https://www.gethomebank.org/public/sources/homebank-${version}.tar.gz";
+    hash = "sha256-Mx1++I2Q8/NMpmEPfxjonpNUQ7GLCRqH2blL11Vjme8=";
   };
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook intltool ];
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Free, easy, personal accounting for everyone";
-    homepage = "http://homebank.free.fr/";
+    homepage = "https://www.gethomebank.org";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
## Description of changes

This MR upgrades Homebank to latest upstream release: 5.7.2

This also updates the project homepage, as there was an update. 

ChangeLog:

 * bugfix: crash was possible when no file loaded and change to main chart
 * bugfix: lock icon for transaction sometime disapear due to column resize
 * bugfix: currency don't update due to wrong api url since 5.7
 * bugfix: HomeBank closes after leaving "preferences" menu with no file open.
 * bugfix: remove/sanitize GTK listview quicksearch
 * bugfix: category popoverlist shows subcat income standalone its expense parent
 * bugfix: manage categories add subcategory fail after a search
 * bugfix: assign edit cancel faultly persist the rule search
 * bugfix: App crashes when exporting a report after I delete a category that contained data
 * bugfix: ISO 8601 date format not respected when exporting to clipboard or CSV
 * bugfix: budget by time do not filter txn type exp/inc
 * bugfix: statistics report crash when opened with a too wide date range 
 * wish  : count and show number of selected transactions when suppressing them

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
