### PR TITLE
gumbo: 0.10.1 -> 0.12.1

### DIFF
--- a/pkgs/development/libraries/gumbo/default.nix
+++ b/pkgs/development/libraries/gumbo/default.nix
@@ -1,20 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool }:
+{ lib
+, stdenv
+, fetchFromGitea
+, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "gumbo";
-  version = "0.10.1";
+  version = "0.12.1";
 
-  src = fetchFromGitHub {
-    owner = "google";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "grisha";
     repo = "gumbo-parser";
-    rev = "v${version}";
-    sha256 = "0xslckwdh2i0g2qjsb6rnm8mjmbagvziz0hjlf7d1lbljfms1iw1";
+    rev = version;
+    hash = "sha256-d4V4bI08Prmg3U0KGu4yIwpHcvTJT3NAd4lbzdBU/AE=";
   };
 
-  strictDeps = true;
-  nativeBuildInputs = [ autoconf automake libtool ];
-
-  preConfigure = "./autogen.sh";
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
     description = "C99 HTML parsing algorithm";


### PR DESCRIPTION
## Description of changes
switch to fork
old upstream is archived: https://github.com/google/gumbo-parser/commit/a0f9059087c690e700cf42df4cfa58a63c1dae95

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).