### PR TITLE
home-assistant-custom-components.tapo: init at 2.11.0 python3Packages.plugp100: init at 3.13.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13295,6 +13295,12 @@
     githubId = 127548;
     name = "Judson Lester";
   };
+  nyawox = {
+    name = "nyawox";
+    email = "nyawox.git@gmail.com";
+    github = "nyawox";
+    githubId = 93813719;
+  };
   nzbr = {
     email = "nixos@nzbr.de";
     github = "nzbr";

--- a/pkgs/development/python-modules/plugp100/default.nix
+++ b/pkgs/development/python-modules/plugp100/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  certifi,
+  jsons,
+  requests,
+  aiohttp,
+  semantic-version,
+  cryptography,
+  scapy,
+  fetchFromGitHub,
+}:
+buildPythonPackage rec {
+  pname = "plugp100";
+  version = "3.13.1";
+
+  src = fetchFromGitHub {
+    owner = "petretiandrea";
+    repo = "plugp100";
+    rev = "v${version}";
+    hash = "sha256-83umSwYhhoZ5l1ShF+2HHTDGLicj2UVjCWHl9/MtUdU=";
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    jsons
+    requests
+    aiohttp
+    semantic-version
+    cryptography
+    scapy
+  ];
+
+  # Requires local device(s)
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "plugp100"
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/petretiandrea/plugp100/releases/tag/v${version}";
+    description = "Work in progress implementation of tapo protocol";
+    homepage = "https://github.com/petretiandrea/plugp100";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [nyawox];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -3,4 +3,5 @@
 
 {
   prometheus-sensor = callPackage ./prometheus-sensor {};
+  tapo = callPackage ./tapo {};
 }

--- a/pkgs/servers/home-assistant/custom-components/tapo/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/tapo/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  plugp100,
+}:
+buildHomeAssistantComponent rec {
+  pname = "tapo";
+  version = "2.11.0";
+  src = fetchFromGitHub {
+    owner = "petretiandrea";
+    repo = "home-assistant-tapo-p100";
+    rev = "v${version}";
+    hash = "sha256-44tg0A8nDE2m0EflDnXobzN2CJXNKGoe+aTnbqFxD0s=";
+  };
+
+  propagatedBuildInputs = [
+    plugp100
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/petretiandrea/home-assistant-tapo-p100/blob/v${version}/CHANGELOG.md";
+    description = "A custom integration to control Tapo devices";
+    homepage = "https://github.com/petretiandrea/home-assistant-tapo-p100";
+    maintainers = with maintainers; [nyawox];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8983,6 +8983,8 @@ self: super: with self; {
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };
 
+  plugp100 = callPackage ../development/python-modules/plugp100 { };
+
   pkgutil-resolve-name = callPackage ../development/python-modules/pkgutil-resolve-name { };
 
   pkg-about = callPackage ../development/python-modules/pkg-about { };


### PR DESCRIPTION
## Description of changes

Add custom integration for home-assistant to control tp-link tapo devices, and it's dependency.

[home-assistant-tapo-p100](https://github.com/petretiandrea/home-assistant-tapo-p100)
[plugp100](https://github.com/petretiandrea/plugp100)

Got working locally in my flake but I'm new at home-assistant. Please correct me if i'm doing something wrong.
Formatted with alejandra
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
