### PR TITLE
skarnet.org November 2023 release (2)

### DIFF
--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-dns";
-  version = "2.3.6.0";
-  sha256 = "AefHUyzF56a4kVRhsBwvcGt/IhF4KSPiXqpU7gxtx8c=";
+  version = "2.3.7.0";
+  sha256 = "rusndssjTpA5enjGqjclkkqgcQwQNcpw3VYouExnAdE=";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -19,8 +19,8 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 buildPackage {
   pname = "s6-networking";
-  version = "2.6.0.0";
-  sha256 = "MdHWj7BdY5zr6VFLui9npU5YAfJsDRYvh1XNSxYuGLA=";
+  version = "2.7.0.0";
+  sha256 = "mf1uP5PW1qlb9+l4lVt9BTYpWReUsGjtogBKuLSQVVI=";
 
   description = "A suite of small networking utilities for Unix systems";
 

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6";
-  version = "2.12.0.0";
-  sha256 = "sha256-mBjDqeIYGSQGJw9B00K+23oZ8Z3gBbqzxitACTAz72w=";
+  version = "2.12.0.2";
+  sha256 = "qpF+/+Eq6XN5CQ91/aSfDV8PZ81lVDaEz/BtyIFyj4w=";
 
   description = "skarnet.org's small & secure supervision software suite";
 

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -8,8 +8,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "skalibs";
-  version = "2.14.0.0";
-  sha256 = "p0X9NM+EvsdDmO/6G29MOcVXNnM5ObEmA45SstXcwdI=";
+  version = "2.14.0.1";
+  sha256 = "tD69s2+KjfQPGgjBOwg5O85J+vM05ioNuRmzrkr9FIg=";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "tipidee";
-  version = "0.0.1.0";
-  sha256 = "sha256-rKi9IX9CcRhY4n44i2vDom9MIeuGxRAHF7u0C3nNvFU=";
+  version = "0.0.2.0";
+  sha256 = "5I+/gfvN8s4bf6Oi+5kzRndWeLV7movyRfznz0kNMoY=";
 
   description = "A HTTP 1.1 webserver, serving static files and CGI/NPH";
 


### PR DESCRIPTION
## Description of changes

http://skarnet.org/lists/skaware/1908.html

I'm inclined to consider the s6-networking changes non-breaking for release purposes, since it sounds like the circumstances in which they are breaking are very minor.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
