### PR TITLE
nautilus-open-in-blackbox: init at 0.1.1

### DIFF
--- a/pkgs/by-name/na/nautilus-open-in-blackbox/package.nix
+++ b/pkgs/by-name/na/nautilus-open-in-blackbox/package.nix
@@ -1,0 +1,35 @@
+{ python3, fetchFromGitHub, gnome, stdenv, lib }:
+stdenv.mkDerivation rec {
+  pname = "nautilus-open-in-blackbox";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+      owner = "ppvan";
+      repo = "nautilus-open-in-blackbox";
+      rev = "refs/tags/${version}";
+      hash = "sha256-5rvh3qNalpjamcBVQrnAW6GxhwPPlRxP5h045YDqvrM=";
+  };
+
+  # The Orignal Source code tries to execute `/usr/bin/blackbox` which is not valid in NixOS
+  # This patch replaces the call with `blackbox`
+  patches = [ ./paths.patch ];
+
+  buildInputs = [
+    gnome.nautilus-python
+    python3.pkgs.pygobject3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 ./nautilus-open-in-blackbox.py -t $out/share/nautilus-python/extensions
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Extension for nautilus, which adds an context-entry for opening in blackbox";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ blankparticle ];
+    homepage = "https://github.com/ppvan/nautilus-open-in-blackbox";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/na/nautilus-open-in-blackbox/paths.patch
+++ b/pkgs/by-name/na/nautilus-open-in-blackbox/paths.patch
@@ -1,0 +1,23 @@
+diff --git a/nautilus-open-in-blackbox.py b/nautilus-open-in-blackbox.py
+index 9a43f90..0a5b632 100755
+--- a/nautilus-open-in-blackbox.py
++++ b/nautilus-open-in-blackbox.py
+@@ -78,17 +78,10 @@ class BlackBoxNautilus(GObject.GObject, Nautilus.MenuProvider):
+ 
+         return item
+ 
+-    def is_native(self):
+-        return shutil.which("blackbox") == "/usr/bin/blackbox"
+-
+     def _nautilus_run(self, menu, path):
+         """'Open with BlackBox 's menu item callback."""
+         print("Openning:", path)
+-        args = None
+-        if self.is_native():
+-            args = args = ["blackbox", "-w", path]
+-        else:
+-            args = ["/usr/bin/flatpak", "run", TERMINAL_NAME, "-w", path]
++        args = ["blackbox", "-w", path]
+ 
+         subprocess.Popen(args, cwd=path)
+ 


### PR DESCRIPTION
## Description of changes
A Nautilus Plugin to add Open in Blackbox in Context Menu
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
