### PR TITLE
home-assistant: Add adaptive_lighting custom component

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12002,6 +12002,12 @@
     githubId = 9799623;
     name = "Rick van Schijndel";
   };
+  mindstorms6 = {
+    email = "breland@bdawg.org";
+    github = "mindstorms6";
+    githubId = 92937;
+    name = "Breland Miley";
+  };
   minijackson = {
     email = "minijackson@riseup.net";
     github = "minijackson";

--- a/pkgs/servers/home-assistant/custom-components/adaptive_lighting/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/adaptive_lighting/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, buildHomeAssistantComponent
+, ulid-transform
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "basnijholt";
+  domain = "adaptive_lighting";
+  version = "1.19.1";
+
+  src = fetchFromGitHub {
+    owner = "basnijholt";
+    repo = "adaptive-lighting";
+    rev = "refs/tags/${version}";
+    hash = "sha256-AZsloE1vNQ9o2pg878J6I5qYXyI4fqYEvr18SrTocWo=";
+  };
+
+  propagatedBuildInputs = [
+    ulid-transform
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/basnijholt/adaptive-lighting/releases/tag/${version}";
+    description = "Home Assistant Adaptive Lighting Plugin - Sun Synchronized Lighting";
+    homepage = "https://github.com/basnijholt/adaptive-lighting";
+    maintainers = with maintainers; [ mindstorms6 ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -2,6 +2,7 @@
 }:
 
 {
+  adaptive_lighting = callPackage ./adaptive_lighting {};
   miele = callPackage ./miele {};
   prometheus_sensor = callPackage ./prometheus_sensor {};
 }


### PR DESCRIPTION
## Description of changes

Adds `adaptive-lighting` to home-assistant custom components. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


`nix-build -A home-assistant` is passing.
The command `nix-build -A home-assistant.tests` is failing:

```
subtest: Check custom components and custom lovelace modules get removed
hass: must succeed: /nix/store/81nqwa85vq6v53ra11sy3w5x2kzzd0vn-nixos-system-hass-23.11pre-git/specialisation/removeCustomThings/bin/switch-to-configuration test
hass # [   80.766619] nixos[1793]: switching to system configuration /nix/store/dpxzxll5gmavhga2bcp3wiyx55dgngwv-nixos-system-hass-23.11pre-git
hass # stopping the following units: home-assistant.service
hass # [   80.807596] systemd[1]: Stopping Home Assistant...
hass # [   80.816952] systemd[1]: Stopped target Local File Systems.
hass # [   80.821905] hass[1657]: 2023-11-20 15:50:54.609 INFO (MainThread) [homeassistant.components.emulated_hue.upnp] UPNP responder shutting down
hass # [   80.833946] systemd[1]: Stopped target All Network Interfaces (deprecated).
hass # [   80.844849] systemd[1]: Stopped target Remote File Systems.
hass # [   81.980715] systemd[1]: home-assistant.service: Deactivated successfully.
hass # [   81.986469] systemd[1]: Stopped Home Assistant.
hass # [   81.989458] systemd[1]: home-assistant.service: Consumed 9.259s CPU time, no IO, received 84B IP traffic, sent 84B IP traffic.
hass # activating the configuration...
hass # [   82.949597] systemd[1]: Reloading requested from client PID 1850 ('systemctl') (unit backdoor.service)...
hass # [   82.952920] systemd[1]: Reloading...
hass # [   84.013920] systemd[1]: Reloading finished in 1057 ms.
hass # setting up tmpfiles
hass # starting the following units: home-assistant.service
hass # [   84.323096] systemd[1]: Starting Home Assistant...
hass # [   84.394440] systemd[1]: Reached target All Network Interfaces (deprecated).
hass # [   84.398664] systemd[1]: Reached target Remote File Systems.
hass # [   84.415379] systemd[1]: Starting Load Kernel Module efi_pstore...
hass # [   84.435549] systemd[1]: Starting Create SUID/SGID Wrappers...
hass # [   84.440866] systemd[1]: File System Check on Root Device was skipped because of an unmet condition check (ConditionPathIsReadWrite=!/).
hass # [   84.451761] systemd[1]: Reached target Local File Systems.
hass # [   84.468949] systemd[1]: modprobe@efi_pstore.service: Deactivated successfully.
hass # [   84.477431] systemd[1]: Finished Load Kernel Module efi_pstore.
hass # [   84.492132] systemd[1]: Platform Persistent Storage Archival was skipped because of an unmet condition check (ConditionDirectoryNotEmpty=/sys/fs/pstore).
hass # [   84.695895] systemd[1]: Started Home Assistant.
hass # [   85.131208] systemd[1]: suid-sgid-wrappers.service: Deactivated successfully.
hass # [   85.136188] systemd[1]: Finished Create SUID/SGID Wrappers.
hass # [   85.311617] nixos[1793]: finished switching to system configuration /nix/store/dpxzxll5gmavhga2bcp3wiyx55dgngwv-nixos-system-hass-23.11pre-git
(finished: must succeed: /nix/store/81nqwa85vq6v53ra11sy3w5x2kzzd0vn-nixos-system-hass-23.11pre-git/specialisation/removeCustomThings/bin/switch-to-configuration test, in 6.06 seconds)
hass: must fail: grep -q 'mini-graph-card-bundle.js' '/var/lib/foobar/ui-lovelace.yaml'
(finished: must fail: grep -q 'mini-graph-card-bundle.js' '/var/lib/foobar/ui-lovelace.yaml', in 0.05 seconds)
hass: must fail: test -f /var/lib/foobar/custom_components/prometheus_sensor/manifest.json
Test "Check custom components and custom lovelace modules get removed" failed with error: "command `test -f /var/lib/foobar/custom_components/prometheus_sensor/manifest.json` unexpectedly succeeded"
cleanup
kill machine (pid 9)
```

However, it does not seem to be the case that these changes would cause that failure so any guidance is appreciated. 