### PR TITLE
libgtop: 2.41.1 -> 2.41.2

### DIFF
--- a/pkgs/development/libraries/libgtop/default.nix
+++ b/pkgs/development/libraries/libgtop/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libgtop";
-  version = "2.41.1";
+  version = "2.41.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "Q+qa0T98r5gwPmQXKxkb6blrqzQLAZ3u7HIlHuFA/js=";
+    hash = "sha256-2QJs2KSNJ83/0zL41gqSdktWQk5SLEIM0ToB9A2vksM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION

## Description of changes

https://download.gnome.org/sources/libgtop/2.41/libgtop-2.41.2.news

https://gitlab.gnome.org/GNOME/libgtop/-/compare/2.41.1...2.41.2


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages marked as broken and skipped:</summary>
  <ul>
    <li>xfce.xfce4-embed-plugin</li>
    <li>xfce.xfce4-namebar-plugin</li>
    <li>xmonad_log_applet_xfce</li>
  </ul>
</details>
<details>
  <summary>193 packages built:</summary>
  <ul>
    <li>bamf</li>
    <li>bamf.dev</li>
    <li>bamf.devdoc</li>
    <li>blueberry</li>
    <li>budgie.budgie-control-center</li>
    <li>budgie.budgie-control-center.debug</li>
    <li>cinnamon.cinnamon-common</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cinnamon.cinnamon-screensaver</li>
    <li>cinnamon.cinnamon-session</li>
    <li>cinnamon.nemo</li>
    <li>cinnamon.nemo-fileroller</li>
    <li>cinnamon.nemo-python</li>
    <li>cinnamon.nemo-with-extensions</li>
    <li>cinnamon.nemo.dev</li>
    <li>cinnamon.pix</li>
    <li>cinnamon.warpinator</li>
    <li>cinnamon.xapp</li>
    <li>cinnamon.xapp.dev</li>
    <li>cinnamon.xreader</li>
    <li>cinnamon.xviewer</li>
    <li>das_watchdog</li>
    <li>electricsheep</li>
    <li>gnome-console</li>
    <li>gnome-usage</li>
    <li>gnome.gnome-applets</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnome.gnome-nettool</li>
    <li>gnome.gnome-system-monitor</li>
    <li>gnome.metacity</li>
    <li>gnomeExtensions.system-monitor</li>
    <li>gnomeExtensions.tophat</li>
    <li>gnomeExtensions.vitals</li>
    <li>hypnotix</li>
    <li>libgtop</li>
    <li>libgtop.dev</li>
    <li>lightdm-slick-greeter</li>
    <li>mate.marco</li>
    <li>mate.mate-applets</li>
    <li>mate.mate-control-center</li>
    <li>mate.mate-indicator-applet</li>
    <li>mate.mate-media</li>
    <li>mate.mate-netbook</li>
    <li>mate.mate-notification-daemon</li>
    <li>mate.mate-panel</li>
    <li>mate.mate-power-manager</li>
    <li>mate.mate-screensaver</li>
    <li>mate.mate-sensors-applet</li>
    <li>mate.mate-settings-daemon-wrapped</li>
    <li>mate.mate-system-monitor</li>
    <li>mate.mate-tweak</li>
    <li>mate.mate-tweak.dist</li>
    <li>mate.mate-utils</li>
    <li>monitor</li>
    <li>nemiver</li>
    <li>openrgb-plugin-hardwaresync</li>
    <li>openrgb-with-all-plugins</li>
    <li>pantheon-tweaks</li>
    <li>pantheon.elementary-dock</li>
    <li>pantheon.elementary-dock.dev</li>
    <li>pantheon.elementary-files</li>
    <li>pantheon.elementary-files.dev</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-gsettings-schemas</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.gala</li>
    <li>pantheon.switchboard-plug-a11y</li>
    <li>pantheon.switchboard-plug-about</li>
    <li>pantheon.switchboard-plug-bluetooth</li>
    <li>pantheon.switchboard-plug-mouse-touchpad</li>
    <li>pantheon.switchboard-plug-pantheon-shell</li>
    <li>pantheon.switchboard-plug-power</li>
    <li>pantheon.switchboard-plug-security-privacy</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-a11y</li>
    <li>pantheon.wingpanel-indicator-bluetooth</li>
    <li>pantheon.wingpanel-indicator-datetime</li>
    <li>pantheon.wingpanel-indicator-keyboard</li>
    <li>pantheon.wingpanel-indicator-network</li>
    <li>pantheon.wingpanel-indicator-nightlight</li>
    <li>pantheon.wingpanel-indicator-notifications</li>
    <li>pantheon.wingpanel-indicator-power</li>
    <li>pantheon.wingpanel-indicator-session</li>
    <li>pantheon.wingpanel-indicator-sound</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>plank</li>
    <li>plata-theme</li>
    <li>psensor</li>
    <li>python310Packages.xapp</li>
    <li>python311Packages.xapp</li>
    <li>rofi-top</li>
    <li>sticky</li>
    <li>timeshift</li>
    <li>timeshift-minimal</li>
    <li>timeshift-unwrapped</li>
    <li>wingpanel-indicator-ayatana</li>
    <li>xed-editor</li>
    <li>xfce.exo</li>
    <li>xfce.exo.dev</li>
    <li>xfce.garcon</li>
    <li>xfce.garcon.dev</li>
    <li>xfce.libxfce4ui</li>
    <li>xfce.libxfce4ui.dev</li>
    <li>xfce.orage</li>
    <li>xfce.orage.dev</li>
    <li>xfce.parole</li>
    <li>xfce.parole.dev</li>
    <li>xfce.ristretto</li>
    <li>xfce.ristretto.dev</li>
    <li>xfce.thunar</li>
    <li>xfce.thunar-archive-plugin</li>
    <li>xfce.thunar-archive-plugin.dev</li>
    <li>xfce.thunar-dropbox-plugin</li>
    <li>xfce.thunar-media-tags-plugin</li>
    <li>xfce.thunar-media-tags-plugin.dev</li>
    <li>xfce.thunar-volman</li>
    <li>xfce.thunar-volman.dev</li>
    <li>xfce.thunar.dev</li>
    <li>xfce.xfburn</li>
    <li>xfce.xfburn.dev</li>
    <li>xfce.xfce4-appfinder</li>
    <li>xfce.xfce4-appfinder.dev</li>
    <li>xfce.xfce4-battery-plugin</li>
    <li>xfce.xfce4-battery-plugin.dev</li>
    <li>xfce.xfce4-clipman-plugin</li>
    <li>xfce.xfce4-clipman-plugin.dev</li>
    <li>xfce.xfce4-cpufreq-plugin</li>
    <li>xfce.xfce4-cpufreq-plugin.dev</li>
    <li>xfce.xfce4-cpugraph-plugin</li>
    <li>xfce.xfce4-cpugraph-plugin.dev</li>
    <li>xfce.xfce4-datetime-plugin</li>
    <li>xfce.xfce4-datetime-plugin.dev</li>
    <li>xfce.xfce4-dict</li>
    <li>xfce.xfce4-dict.dev</li>
    <li>xfce.xfce4-dockbarx-plugin</li>
    <li>xfce.xfce4-eyes-plugin</li>
    <li>xfce.xfce4-fsguard-plugin</li>
    <li>xfce.xfce4-genmon-plugin</li>
    <li>xfce.xfce4-i3-workspaces-plugin</li>
    <li>xfce.xfce4-mailwatch-plugin</li>
    <li>xfce.xfce4-mpc-plugin</li>
    <li>xfce.xfce4-netload-plugin</li>
    <li>xfce.xfce4-netload-plugin.dev</li>
    <li>xfce.xfce4-notes-plugin</li>
    <li>xfce.xfce4-notifyd</li>
    <li>xfce.xfce4-notifyd.dev</li>
    <li>xfce.xfce4-panel</li>
    <li>xfce.xfce4-panel-profiles</li>
    <li>xfce.xfce4-panel-profiles.dev</li>
    <li>xfce.xfce4-panel.dev</li>
    <li>xfce.xfce4-power-manager</li>
    <li>xfce.xfce4-power-manager.dev</li>
    <li>xfce.xfce4-pulseaudio-plugin</li>
    <li>xfce.xfce4-pulseaudio-plugin.dev</li>
    <li>xfce.xfce4-screensaver</li>
    <li>xfce.xfce4-screensaver.dev</li>
    <li>xfce.xfce4-screenshooter</li>
    <li>xfce.xfce4-screenshooter.dev</li>
    <li>xfce.xfce4-sensors-plugin</li>
    <li>xfce.xfce4-session</li>
    <li>xfce.xfce4-session.dev</li>
    <li>xfce.xfce4-settings</li>
    <li>xfce.xfce4-settings.dev</li>
    <li>xfce.xfce4-systemload-plugin</li>
    <li>xfce.xfce4-taskmanager</li>
    <li>xfce.xfce4-taskmanager.dev</li>
    <li>xfce.xfce4-terminal</li>
    <li>xfce.xfce4-terminal.dev</li>
    <li>xfce.xfce4-time-out-plugin</li>
    <li>xfce.xfce4-time-out-plugin.dev</li>
    <li>xfce.xfce4-timer-plugin</li>
    <li>xfce.xfce4-verve-plugin</li>
    <li>xfce.xfce4-verve-plugin.dev</li>
    <li>xfce.xfce4-weather-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin.dev</li>
    <li>xfce.xfce4-windowck-plugin</li>
    <li>xfce.xfce4-xkb-plugin</li>
    <li>xfce.xfce4-xkb-plugin.dev</li>
    <li>xfce.xfdashboard</li>
    <li>xfce.xfdashboard.dev</li>
    <li>xfce.xfdesktop</li>
    <li>xfce.xfdesktop.dev</li>
    <li>xfce.xfwm4</li>
    <li>xfce.xfwm4.dev</li>
    <li>xmonad_log_applet_mate</li>
    <li>xplayer</li>
    <li>zrythm</li>
  </ul>
</details>