### PR TITLE
tokei: add libz

### DIFF
--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, libiconv, Security }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, libz, libiconv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "tokei";
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-U7Bode8qwDsNf4FVppfEHA9uiOFz74CtKgXG6xyYlT8=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = [libz] ++ lib.optionals stdenv.isDarwin [
     libiconv Security
   ];
 


### PR DESCRIPTION
This fixes the `tokei` build.


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin