### PR TITLE
babashka: Add -H:PageSize=64K build option on aarch64

### DIFF
--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -5,6 +5,7 @@
 , fetchurl
 , writeScript
 , installShellFiles
+, stdenv
 }:
 
 let
@@ -28,6 +29,8 @@ let
       "--no-fallback"
       "--native-image-info"
       "--enable-preview"
+    ] ++ lib.optionals stdenv.isAarch64 [
+      "-H:PageSize=64K"
     ];
 
     doInstallCheck = true;


### PR DESCRIPTION
## Description of changes

Babashka builds upstream with `-H:PageSize=64K` for `aarch64`. This PR updates things accordingly.

The change enables the package to be used with [all aarch64 kernel page sizes (4K, 16K and 64K) with the downside of a bit of wasted memory](https://github.com/oracle/graal/pull/5605#issuecomment-1364006130).

Here is the PR from babashka that I based the changes on: https://github.com/babashka/babashka/pull/1606

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (4K and 16K kernel page size)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
