### PR TITLE
xflr5: 6.47 -> 6.61

### DIFF
--- a/pkgs/applications/science/physics/xflr5/default.nix
+++ b/pkgs/applications/science/physics/xflr5/default.nix
@@ -1,12 +1,11 @@
-{ mkDerivation, lib, fetchurl, qmake }:
+{ mkDerivation, lib, fetchzip, qmake }:
 
 mkDerivation rec {
   pname = "xflr5";
-  version = "6.47";
-
-  src = fetchurl {
-    url = "mirror://sourceforge/xflr5/${pname}_v${version}_src.tar.gz";
-    sha256 = "02x3r9iv3ndwxa65mxn9m5dlhcrnjiq7cffi6rmb456gs3v3dnav";
+  version = "6.61";
+  src = fetchzip {
+    url = "https://sourceforge.net/code-snapshots/svn/x/xf/xflr5/code/xflr5-code-r1481-tags-v6.61-xflr5.zip";
+    sha256 = "sha256-voWnXiBo7+kBPiZLVpSiXyBsYJv/Phd3noA81SQ5Vtw=";
   };
 
   nativeBuildInputs = [ qmake ];


### PR DESCRIPTION

## Description of changes


This updates to the latest version. Unfortunately the project stopped publishing source tarballs in the way we used to consume them. We've to retrieve a source snapshot from sourceforge's SVN service instead. The alternative would be a subversion checkout which I don't think is any better or worse.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
