### PR TITLE
floorp: 11.5.1 -> 11.6.0

### DIFF
--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -7,17 +7,19 @@
 
 ((buildMozillaMach rec {
   pname = "floorp";
-  packageVersion = "11.5.1";
+  packageVersion = "11.6.0";
   applicationName = "Floorp";
   binaryName = "floorp";
-  version = "155.4.0";
+
+  # Must match the contents of `browser/config/version.txt` in the source tree
+  version = "155.5.0";
 
   src = fetchFromGitHub {
     owner = "Floorp-Projects";
     repo = "Floorp";
     fetchSubmodules = true;
     rev = "v${packageVersion}";
-    hash = "sha256-988jKyfIGZ2UPHTNO1cK2lxR/5j3U/QYR3ZI9WsvHUI=";
+    hash = "sha256-5OQZckST6l9OZ7jnj52nuALCWiH1hVdDoDHSpqwUUfA=";
   };
 
   extraConfigureFlags = [

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -45,6 +45,7 @@
   tests = [ nixosTests.floorp ];
 }).override {
   privacySupport = true;
+  webrtcSupport = true;
   enableOfficialBranding = false;
 }).overrideAttrs (prev: {
   MOZ_REQUIRE_SIGNING = "";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: https://blog.ablaze.one/3633/2023-11-18/
Git changelog: https://github.com/Floorp-Projects/Floorp/compare/v11.5.1...v11.6.0

Also fixes #266620, as briefly discussed on Matrix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
