### PR TITLE
ia-writer-quattro: init at unstable-2023-06-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19506,6 +19506,12 @@
     githubId = 3992240;
     name = "Elijah Rum";
   };
+  x0ba = {
+    name = "x0ba";
+    email = "dax@omg.lol";
+    github = "x0ba";
+    githubId = 64868985;
+  };
   x3ro = {
     name = "^x3ro";
     email = "nix@x3ro.dev";

--- a/pkgs/by-name/ia/ia-writer-quattro/package.nix
+++ b/pkgs/by-name/ia/ia-writer-quattro/package.nix
@@ -1,0 +1,31 @@
+{ lib, stdenvNoCC, fetchFromGitHub, }:
+
+stdenvNoCC.mkDerivation {
+  pname = "ia-writer-quattro";
+  version = "unstable-2023-06-16";
+
+  src = fetchFromGitHub {
+    owner = "iaolo";
+    rev = "f32c04c3058a75d7ce28919ce70fe8800817491b";
+    repo = "iA-fonts";
+    hash = "sha256-2T165nFfCzO65/PIHauJA//S+zug5nUwPcg8NUEydfc=";
+  };
+
+  dontConfigure = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp -R $src/iA\ Writer\ Quattro/Static/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "iA Writer Quattro Typeface";
+    homepage = "https://github.com/iaolo/iA-Fonts";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.x0ba ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This commit adds the [iA Writer Quattro](https://github.com/iaolo/iA-Fonts) typeface and adds myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
