### PR TITLE
distrobox: 1.5.0.2 -> 1.6.0.1

### DIFF
--- a/pkgs/applications/virtualization/distrobox/always-mount-nix.patch
+++ b/pkgs/applications/virtualization/distrobox/always-mount-nix.patch
@@ -1,0 +1,137 @@
+diff --git a/distrobox-create b/distrobox-create
+index 64e9911..136659d 100755
+--- a/distrobox-create
++++ b/distrobox-create
+@@ -74,6 +74,10 @@ unshare_ipc=0
+ unshare_netns=0
+ unshare_process=0
+ unshare_devsys=0
++
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Use cd + dirname + pwd so that we do not have relative paths in mount points
+ # We're not using "realpath" here so that symlinks are not resolved this way
+ # "realpath" would break situations like Nix or similar symlink based package
+@@ -98,6 +102,7 @@ version="1.6.0.1"
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf
+diff --git a/distrobox-enter b/distrobox-enter
+index 6d8998a..bb05437 100755
+--- a/distrobox-enter
++++ b/distrobox-enter
+@@ -75,10 +75,14 @@ skip_workdir=0
+ verbose=0
+ version="1.6.0.1"
+ 
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Source configuration files, this is done in an hierarchy so local files have
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf
+diff --git a/distrobox-generate-entry b/distrobox-generate-entry
+index 3243691..6a7910a 100755
+--- a/distrobox-generate-entry
++++ b/distrobox-generate-entry
+@@ -45,10 +45,14 @@ icon_default="${HOME}/.local/share/icons/terminal-distrobox-icon.svg"
+ verbose=0
+ version="1.6.0.1"
+ 
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Source configuration files, this is done in an hierarchy so local files have
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf
+diff --git a/distrobox-list b/distrobox-list
+index aaec85e..235e529 100755
+--- a/distrobox-list
++++ b/distrobox-list
+@@ -44,10 +44,14 @@ verbose=0
+ version="1.6.0.1"
+ container_manager="autodetect"
+ 
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Source configuration files, this is done in an hierarchy so local files have
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf
+diff --git a/distrobox-rm b/distrobox-rm
+index 702c1dd..2e37538 100755
+--- a/distrobox-rm
++++ b/distrobox-rm
+@@ -54,10 +54,14 @@ rm_home=0
+ response_rm_home="N"
+ version="1.6.0.1"
+ 
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Source configuration files, this is done in an hierarchy so local files have
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf
+diff --git a/distrobox-stop b/distrobox-stop
+index fd17cc1..e0dbc8f 100755
+--- a/distrobox-stop
++++ b/distrobox-stop
+@@ -52,10 +52,14 @@ non_interactive=0
+ verbose=0
+ version="1.6.0.1"
+ 
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Source configuration files, this is done in an hierarchy so local files have
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf
+diff --git a/distrobox-upgrade b/distrobox-upgrade
+index ab5e96f..dc8d295 100755
+--- a/distrobox-upgrade
++++ b/distrobox-upgrade
+@@ -39,10 +39,14 @@ rootful=0
+ verbose=0
+ version="1.6.0.1"
+ 
++self_dir="$(dirname "$(realpath "$0")")"
++nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
++
+ # Source configuration files, this is done in an hierarchy so local files have
+ # priority over system defaults
+ # leave priority to environment variables.
+ config_files="
++	$nix_config_file
+ 	/usr/share/distrobox/distrobox.conf
+ 	/usr/share/defaults/distrobox/distrobox.conf
+ 	/usr/etc/distrobox/distrobox.conf

--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -46,7 +46,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       forward compatibility with software and freedom to use whatever distribution
       you’re more comfortable with
     '';
-    homepage = "https://distrobox.privatedns.org/";
+    homepage = "https://distrobox.it/";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ atila ];

--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -2,19 +2,23 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "distrobox";
-  version = "1.5.0.2";
+  version = "1.6.0.1";
 
   src = fetchFromGitHub {
     owner = "89luca89";
     repo = finalAttrs.pname;
     rev = finalAttrs.version;
-    hash = "sha256-ss8049D6n1V/gDzEMjywDnoke5s2we9j3mO8yta72UA=";
+    hash = "sha256-UWrXpb20IHcwadPpwbhSjvOP1MBXic5ay+nP+OEVQE4=";
   };
 
   dontConfigure = true;
   dontBuild = true;
 
   nativeBuildInputs = [ makeWrapper ];
+
+  # https://github.com/89luca89/distrobox/pull/1080
+  patches = [ ./always-mount-nix.patch ];
+
   installPhase = ''
     runHook preInstall
 
@@ -30,6 +34,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapProgram "$out/bin/distrobox-generate-entry" \
       --prefix PATH ":" ${lib.makeBinPath [ wget ]}
+
+    mkdir -p $out/share/distrobox
+    echo 'container_additional_volumes="/nix:/nix"' > $out/share/distrobox/distrobox.conf
   '';
 
   meta = with lib; {

--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "89luca89";
-    repo = finalAttrs.pname;
+    repo = "distrobox";
     rev = finalAttrs.version;
     hash = "sha256-UWrXpb20IHcwadPpwbhSjvOP1MBXic5ay+nP+OEVQE4=";
   };


### PR DESCRIPTION
## Description of changes

https://github.com/89luca89/distrobox/releases/tag/1.6.0.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
