### PR TITLE
obuild: 0.1.10 → 0.1.11

### DIFF
--- a/pkgs/development/tools/ocaml/obuild/default.nix
+++ b/pkgs/development/tools/ocaml/obuild/default.nix
@@ -1,19 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, ocaml }:
+{ lib, stdenv, fetchFromGitHub, ocamlPackages }:
 
 stdenv.mkDerivation rec {
   pname = "obuild";
-  version = "0.1.10";
+  version = "0.1.11";
 
   src = fetchFromGitHub {
     owner = "ocaml-obuild";
     repo = "obuild";
     rev = "obuild-v${version}";
-    sha256 = "sha256-dqWP9rwWmr7i3O29v/kipJL01B3qQozaToOFCdfTWZU=";
+    hash = "sha256-me9/FVD7S0uPIpFZzcxDfYKVWn9ifq6JryBAGCo681I=";
   };
 
   strictDeps = true;
 
-  nativeBuildInputs = [ ocaml ];
+  nativeBuildInputs = with ocamlPackages; [ ocaml findlib ];
 
   buildPhase = ''
     patchShebangs ./bootstrap
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/ocaml-obuild/obuild";
-    platforms = ocaml.meta.platforms or [ ];
+    inherit (ocamlPackages.ocaml.meta) platforms;
     description = "Simple package build system for OCaml";
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ ];


### PR DESCRIPTION
## Description of changes

Support for OCaml 5.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
