### PR TITLE
optipng: 0.7.7 -> 0.7.8

### DIFF
--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -6,21 +6,25 @@
 
 stdenv.mkDerivation rec {
   pname = "optipng";
-  version = "0.7.7";
+  version = "0.7.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/optipng/optipng-${version}.tar.gz";
-    sha256 = "0lj4clb851fzpaq446wgj0sfy922zs5l5misbpwv6w7qrqrz4cjg";
+    hash = "sha256-JaO9aEgfIVAsyqD0wT+E3PayAzjkxOjFHyzvvYUTOYw=";
   };
 
   buildInputs = [ libpng ];
 
-  LDFLAGS = lib.optional static "-static";
   # Workaround for crash in cexcept.h. See
   # https://github.com/NixOS/nixpkgs/issues/28106
   preConfigure = ''
     export LD=$CC
   '';
+
+  # OptiPNG does not like --static, --build or --host
+  dontDisableStatic = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [ ];
 
   configureFlags = [
     "--with-system-zlib"


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-43907.

Changelog:
```
 * Upgraded libpng to version 1.6.40.
 * Upgraded zlib to version 1.3-optipng.
 * Upgraded cexcept to version 2.0.2-optipng.
!! Fixed a global-buffer-overflow vulnerability in the GIF reader.
   [Reported by Zeng Yunxiang; fixed by Thomas Hurst]
 ! Fixed a stack-print-after-scope defect in the error handler.
 ! Fixed an assertion failure in the image reduction module.
 ! Fixed the command-line wildargs expansion in the Windows port.
 * Raised the minimum required libpng version from 1.2.9 to 1.6.35.
 * Raised the minimum required zlib version from 1.2.1 to 1.2.8.
 * Refactored the structured exception handling.
```

https://optipng.sourceforge.net/history.txt
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>18 packages built:</summary>
  <ul>
    <li>arx-libertatis</li>
    <li>ayu-theme-gtk</li>
    <li>curtail</li>
    <li>deliantra-arch</li>
    <li>deliantra-data</li>
    <li>deliantra-maps</li>
    <li>deliantra-server</li>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>elementary-xfce-icon-theme</li>
    <li>image_optim</li>
    <li>mojave-gtk-theme</li>
    <li>optipng</li>
    <li>paperless-ngx</li>
    <li>pop-gtk-theme</li>
    <li>sacad</li>
    <li>sacad.dist</li>
    <li>trimage</li>
  </ul>
</details>