### PR TITLE
nix-your-shell: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/shells/nix-your-shell/default.nix
+++ b/pkgs/shells/nix-your-shell/default.nix
@@ -5,16 +5,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "nix-your-shell";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "MercuryTechnologies";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-5zHjz0NOKcZCuR6QaLrwOXih3Xoqf2uBrJnxTX/TQok=";
+    hash = "sha256-2fS91/qeZt4JwQQeA+26RTN6zdm8/HUxG8sJDobX0+0=";
   };
 
-  cargoSha256 = "sha256-4Z/z4VgnJQd8Uc0tMDnx7sChzXtG5ZDL88jTlhPSonM=";
+  cargoHash = "sha256-e7gxNaKP0n+Zx0KaQEfNA3QsS5HZ2KIB6HJ22Ve8+EA=";
 
   meta = with lib; {
     mainProgram = "nix-your-shell";


### PR DESCRIPTION
## Description of changes

[Release notes for 1.4.0 upstream.](https://github.com/MercuryTechnologies/nix-your-shell/releases/tag/v1.4.0) Highlights:
- Add Xonsh support
- Fix Nushell support
- Add `nix-output-monitor` support

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin