### PR TITLE
gscan2pdf: fix build failure, add patches

### DIFF
--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -2,7 +2,7 @@
   # libs
   librsvg, sane-backends, sane-frontends,
   # runtime dependencies
-  imagemagick, libtiff, djvulibre, poppler_utils, ghostscript, unpaper, pdftk,
+  imagemagick, libtiff_4_5, djvulibre, poppler_utils, ghostscript, unpaper, pdftk,
   # test dependencies
   xvfb-run, liberation_ttf, file, tesseract }:
 
@@ -71,7 +71,7 @@ perlPackages.buildPerlPackage rec {
     wrapProgram "$out/bin/gscan2pdf" \
       --prefix PATH : "${sane-backends}/bin" \
       --prefix PATH : "${imagemagick}/bin" \
-      --prefix PATH : "${libtiff}/bin" \
+      --prefix PATH : "${libtiff_4_5}/bin" \
       --prefix PATH : "${djvulibre}/bin" \
       --prefix PATH : "${poppler_utils}/bin" \
       --prefix PATH : "${ghostscript}/bin" \
@@ -87,7 +87,10 @@ perlPackages.buildPerlPackage rec {
 
   nativeCheckInputs = [
     imagemagick
-    libtiff
+    # Needs older libtiff version, because it stopped packageing tools like
+    # tiff2pdf and others in version 4.6. These tools are necessary for gscan2pdf.
+    # See commit f57a4b0ac1b954eec0c8def2a99e2a464ac6ff7a for in-depth explanation.
+    libtiff_4_5
     djvulibre
     poppler_utils
     ghostscript

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, perlPackages, wrapGAppsHook,
+{ lib, fetchurl, perlPackages, wrapGAppsHook, fetchpatch,
   # libs
   librsvg, sane-backends, sane-frontends,
   # runtime dependencies
@@ -16,6 +16,15 @@ perlPackages.buildPerlPackage rec {
     url = "mirror://sourceforge/gscan2pdf/gscan2pdf-${version}.tar.xz";
     hash = "sha256-NGz6DUa7TdChpgwmD9pcGdvYr3R+Ft3jPPSJpybCW4Q=";
   };
+
+  patches = [
+    # fixes warnings during tests. See https://sourceforge.net/p/gscan2pdf/bugs/421
+    (fetchpatch {
+      name = "0001-Remove-given-and-when-keywords-and-operator.patch";
+      url = "https://sourceforge.net/p/gscan2pdf/bugs/_discuss/thread/602a7cedfd/1ea4/attachment/0001-Remove-given-and-when-keywords-and-operator.patch";
+      hash = "sha256-JtrHUkfEKnDhWfEVdIdYVlr5b/xChTzsrrPmruLaJ5M=";
+    })
+  ];
 
   nativeBuildInputs = [ wrapGAppsHook ];
 

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -133,12 +133,6 @@ perlPackages.buildPerlPackage rec {
     #   Non-zero wait status: 139
     rm t/0601_Dialog_Scan.t
 
-    # Disable a test which failed due to convert returning an exit value of 1
-    # convert: negative or zero image size `/build/KL5kTVnNCi/YfgegFM53e.pnm' @ error/resize.c/ResizeImage/3743.
-    # *** unhandled exception in callback:
-    # ***   "convert" unexpectedly returned exit value 1 at t/357_unpaper_rtl.t line 63.
-    rm t/357_unpaper_rtl.t
-
     xvfb-run -s '-screen 0 800x600x24' \
       make test
   '';

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -24,6 +24,8 @@ perlPackages.buildPerlPackage rec {
       url = "https://sourceforge.net/p/gscan2pdf/bugs/_discuss/thread/602a7cedfd/1ea4/attachment/0001-Remove-given-and-when-keywords-and-operator.patch";
       hash = "sha256-JtrHUkfEKnDhWfEVdIdYVlr5b/xChTzsrrPmruLaJ5M=";
     })
+    # fixes an error with utf8 file names. See https://sourceforge.net/p/gscan2pdf/bugs/400
+    ./image-utf8-fix.patch
   ];
 
   nativeBuildInputs = [ wrapGAppsHook ];

--- a/pkgs/applications/graphics/gscan2pdf/image-utf8-fix.patch
+++ b/pkgs/applications/graphics/gscan2pdf/image-utf8-fix.patch
@@ -1,0 +1,32 @@
+diff --git a/bin/gscan2pdf b/bin/gscan2pdf
+index e075b0f2..ff124522 100755
+--- a/bin/gscan2pdf
++++ b/bin/gscan2pdf
+@@ -3434,9 +3434,11 @@ sub save_image {
+         if ( @{$list_of_pages} > 1 ) {
+             my $w = length scalar @{$list_of_pages};
+             for ( 1 .. @{$list_of_pages} ) {
++                _utf8_on($filename);
+                 my $current_filename =
+                   sprintf "${filename}_%0${w}d.$SETTING{'image type'}",
+                   $_;
++                _utf8_off($filename);
+                 if ( -f $current_filename ) {
+                     my $text = sprintf __('This operation would overwrite %s'),
+                       $current_filename;
+@@ -3450,11 +3452,15 @@ sub save_image {
+                     return;
+                 }
+             }
++            _utf8_on($filename);
+             $filename = "${filename}_%0${w}d.$SETTING{'image type'}";
++            _utf8_off($filename);
+         }
+         else {
+             if ( $filename !~ /[.]$SETTING{'image type'}$/ixsm ) {
++                _utf8_on($filename);
+                 $filename = "$filename.$SETTING{'image type'}";
++                _utf8_off($filename);
+                 return if ( file_exists( $file_chooser, $filename ) );
+             }
+             return if ( file_writable( $file_chooser, $filename ) );


### PR DESCRIPTION
## Description of changes

Due to the removal of tools like `tiff2pdf` from `libtiff` many tests fail or cause a timeout.
This commit fixes the dependency to `libtiff_4_5`. Also it includes two upstream patches, which haven't been merged and re-adds a previously removed test.

fixes #268406

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
