### PR TITLE
tiledb: 2.8.3 -> 2.18.0

### DIFF
--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -11,30 +11,37 @@
 , openssl
 , boost
 , libpqxx
+, git
 , clang-tools
 , catch2
 , python3
 , gtest
 , doxygen
+, ninja
+, curl
+, zip
+, unzip
 , fixDarwinDylibNames
 , useAVX2 ? stdenv.hostPlatform.avx2Support
 }:
 
 stdenv.mkDerivation rec {
   pname = "tiledb";
-  version = "2.8.3";
+  version = "2.18.0";
 
   src = fetchFromGitHub {
     owner = "TileDB-Inc";
     repo = "TileDB";
     rev = version;
-    hash = "sha256-HKMVwrPnk9/mukH3mJ2LEAvA9LBF4PcgBZjbbLhO9qU=";
+    hash = "sha256-2tSk1VFY+iIgzThZ7Ruy6xDpRZDn0sG3OJgaqqgDpGw=";
+    fetchSubmodules = true;
   };
 
   # (bundled) blosc headers have a warning on some archs that it will be using
   # unaccelerated routines.
   cmakeFlags = [
     "-DTILEDB_WERROR=0"
+    "-DCMAKE_MAKE_PROGRAM=ninja"
   ] ++ lib.optional (!useAVX2) "-DCOMPILER_SUPPORTS_AVX2=FALSE";
 
   nativeBuildInputs = [
@@ -42,6 +49,10 @@ stdenv.mkDerivation rec {
     cmake
     python3
     doxygen
+    ninja
+    curl
+    zip
+    unzip
   ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   nativeCheckInputs = [
@@ -59,6 +70,7 @@ stdenv.mkDerivation rec {
     openssl
     boost
     libpqxx
+    git
   ];
 
   # emulate the process of pulling catch down


### PR DESCRIPTION
## Description of changes

[Change log](https://github.com/TileDB-Inc/TileDB/blob/71ca8b4ddc615e2ad124fb76427df65667850e5e/HISTORY.md)

@imincik @drupol @umeat 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
