### PR TITLE
clamtk: wrap with wrapGAppsHook

### DIFF
--- a/pkgs/by-name/cl/clamtk/package.nix
+++ b/pkgs/by-name/cl/clamtk/package.nix
@@ -69,7 +69,7 @@ perlPackages.buildPerlPackage rec {
     license = licenses.gpl1Plus;
     homepage = "https://github.com/dave-theunsub/clamtk";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ jgarcia ];
+    maintainers = with maintainers; [ jgarcia ShamrockLee ];
   };
 
 }

--- a/pkgs/by-name/cl/clamtk/package.nix
+++ b/pkgs/by-name/cl/clamtk/package.nix
@@ -1,7 +1,7 @@
 { lib
 , perlPackages
 , fetchFromGitHub
-, makeWrapper
+, wrapGAppsHook
 , gobject-introspection
 , perl
 , clamav
@@ -18,7 +18,7 @@ perlPackages.buildPerlPackage rec {
     hash = "sha256-o6OaXOXLykTUuF/taKnEhZRV04/3nlU5aNY05ANr1Ko=";
   };
 
-  nativeBuildInputs = [ makeWrapper gobject-introspection ];
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
   buildInputs = [ perl clamav ];
   propagatedBuildInputs = with perlPackages; [ Glib LWP LWPProtocolHttps TextCSV JSON LocaleGettext Gtk3 ];
 
@@ -51,9 +51,15 @@ perlPackages.buildPerlPackage rec {
     install -D images/* -t $out/share/pixmaps
     install -D clamtk.1.gz -t $out/share/man/man1
     install -D -m755 clamtk -t $out/bin
-    wrapProgram $out/bin/clamtk --prefix PERL5LIB : $PERL5LIB --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"
 
     runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PERL5LIB : $PERL5LIB
+      --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This patch fixes crashing due to missing icon files with `wrapGAppsHook` and pass extra `makeWrapper` arguments through gappsWrapperArgs.

ClamTk is known to crash when the icon files are not presented. As an application that uses the Gtk widget, it expects a bunch of environment variables to get various resources, including icons. This is exactly what [`wrapGAppsHook`](https://nixos.org/manual/nixpkgs/stable/#sec-language-gnome) is made for.

Fixes #268203

Cc: @chewblacka

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
