### PR TITLE
python3Packages.{shiboken,pyside}6: 6.5.2 -> 6.6.0

### DIFF
--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -1,29 +1,18 @@
 { lib
 , stdenv
-, fetchpatch2
 , cmake
 , ninja
 , python
 , moveBuildTree
 , shiboken6
-, libxcrypt
 }:
 
 stdenv.mkDerivation rec {
   pname = "pyside6";
 
-  inherit (shiboken6) version src;
+  inherit (shiboken6) version src postConfigure;
 
-  sourceRoot = "pyside-setup-everywhere-src-${version}/sources/${pname}";
-
-  patches = [
-    # Needed to build against qt 6.5.3, until pyside 6.5.3 is released
-    (fetchpatch2 {
-      url = "https://code.qt.io/cgit/pyside/pyside-setup.git/patch/sources/pyside6?id=63ef7628091c8827e3d0d688220d3ae165587eb2";
-      hash = "sha256-TN1xdBkrzZhNontShMC1SKyJK6a8fOk/Di3zX3kv5+I=";
-      stripLen = 2;
-    })
-  ];
+  sourceRoot = "pyside-setup-everywhere-src-${lib.removeSuffix ".0" version}/sources/${pname}";
 
   # FIXME: cmake/Macros/PySideModules.cmake supposes that all Qt frameworks on macOS
   # reside in the same directory as QtCore.framework, which is not true for Nix.

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -5,7 +5,6 @@
 , cmake
 , autoPatchelfHook
 , stdenv
-, libxcrypt
 }:
 
 let
@@ -13,19 +12,24 @@ let
 in
 stdenv'.mkDerivation rec {
   pname = "shiboken6";
-  version = "6.5.2";
+  version = "6.6.0";
 
   src = fetchurl {
     # https://download.qt.io/official_releases/QtForPython/shiboken6/
     url = "https://download.qt.io/official_releases/QtForPython/shiboken6/PySide6-${version}-src/pyside-setup-everywhere-src-${version}.tar.xz";
-    sha256 = "sha256-kNvx0U/NQcmKfL6kS4pJUeENC3mOFUdJdW5JRmVNG6g";
+    sha256 = "sha256-LdAC24hRqHFzNU84qoxuxC0P8frJnqQisp4t/OUtFjg=";
   };
 
-  sourceRoot = "pyside-setup-everywhere-src-${version}/sources/${pname}";
+  sourceRoot = "pyside-setup-everywhere-src-${lib.removeSuffix ".0" version}/sources/${pname}";
 
   patches = [
     ./fix-include-qt-headers.patch
+    ./dont-ignore-python-path.patch
   ];
+
+  postConfigure = ''
+    patchShebangs ../build/.qfp
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -47,14 +51,14 @@ stdenv'.mkDerivation rec {
     "-DBUILD_TESTS=OFF"
   ];
 
-  # Due to Shiboken.abi3.so being linked to libshiboken6.abi3.so.6.5 in the build tree,
+  # Due to Shiboken.abi3.so being linked to libshiboken6.abi3.so.6.6 in the build tree,
   # we need to remove the build tree reference from the RPATH and then add the correct
   # directory to the RPATH. On Linux, the second part is handled by autoPatchelfHook.
   # https://bugreports.qt.io/browse/PYSIDE-2233
   preFixup = ''
     echo "fixing RPATH of Shiboken.abi3.so"
   '' + lib.optionalString stdenv.isDarwin ''
-    install_name_tool -change {@rpath,$out/lib}/libshiboken6.abi3.6.5.dylib $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so
+    install_name_tool -change {@rpath,$out/lib}/libshiboken6.abi3.6.6.dylib $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so
   '' + lib.optionalString stdenv.isLinux ''
     patchelf $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir}
   '';

--- a/pkgs/development/python-modules/shiboken6/dont-ignore-python-path.patch
+++ b/pkgs/development/python-modules/shiboken6/dont-ignore-python-path.patch
@@ -1,0 +1,26 @@
+diff --git a/libshiboken/CMakeLists.txt b/libshiboken/CMakeLists.txt
+index 2e558a39d..30e2aeff6 100644
+--- a/libshiboken/CMakeLists.txt
++++ b/libshiboken/CMakeLists.txt
+@@ -41,7 +41,7 @@ endif()
+ add_custom_command(
+     OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/embed/signature_bootstrap_inc.h"
+     OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/embed/signature_inc.h"
+-    COMMAND ${host_python_path} -E
++    COMMAND ${host_python_path}
+             "${CMAKE_CURRENT_SOURCE_DIR}/embed/embedding_generator.py"
+             --cmake-dir "${CMAKE_CURRENT_BINARY_DIR}/embed"
+             --use-pyc ${use_pyc_in_embedding}
+diff --git a/libshiboken/embed/embedding_generator.py b/libshiboken/embed/embedding_generator.py
+index a058fd372..6f503512d 100644
+--- a/libshiboken/embed/embedding_generator.py
++++ b/libshiboken/embed/embedding_generator.py
+@@ -42,7 +42,7 @@ from build_scripts import utils
+ 
+ 
+ def runpy(cmd, **kw):
+-    subprocess.call([sys.executable, '-E'] + cmd.split(), **kw)
++    subprocess.call([sys.executable] + cmd.split(), **kw)
+ 
+ 
+ def create_zipfile(use_pyc, quiet):


### PR DESCRIPTION
## Description of changes

https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.6.0

This allows using Pyside6 with Qt 6.6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
