### PR TITLE
hivex: 1.3.21 → 1.3.23

### DIFF
--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "hivex";
-  version = "1.3.21";
+  version = "1.3.23";
 
   src = fetchurl {
     url = "https://libguestfs.org/download/hivex/${pname}-${version}.tar.gz";
-    sha256 = "sha256-ms4+9KL/LKUKmb4Gi2D7H9vJ6rivU+NF6XznW6S2O1Y=";
+    hash = "sha256-QM9UhPFclGciWfs7makL7285DmPzelKhwGgIogFqa70=";
   };
 
   patches = [ ./hivex-syms.patch ];

--- a/pkgs/development/libraries/hivex/hivex-syms.patch
+++ b/pkgs/development/libraries/hivex/hivex-syms.patch
@@ -1,13 +1,11 @@
 diff -rupN hivex-1.3.14/lib/Makefile.am hivex-1.3.14-new/lib/Makefile.am
 --- hivex-1.3.14/lib/Makefile.am	2013-09-10 13:04:12.000000000 +0200
 +++ hivex-1.3.14-new/lib/Makefile.am	2014-11-06 01:31:05.956106861 +0100
-@@ -40,8 +40,7 @@ libhivex_la_SOURCES = \
- 
- libhivex_la_LIBADD =  ../gnulib/lib/libgnu.la $(LTLIBOBJS)
- libhivex_la_LDFLAGS = \
--	-version-info 0:0:0 \
+@@ -51,7 +51,6 @@
+ 	-pthread \
+ 	-version-info 0:0:0 \
+ 	-no-undefined \
 -	$(VERSION_SCRIPT_FLAGS)$(srcdir)/hivex.syms \
-+	-version-info 0:0:0
  	$(LTLIBICONV) \
  	$(LTLIBINTL) \
  	$(LTLIBTHREAD)


### PR DESCRIPTION
## Description of changes

Compatibility with latest versions of OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
