### PR TITLE
python311Packages.distrax: 0.1.4 -> 0.1.5

### DIFF
--- a/pkgs/development/python-modules/distrax/default.nix
+++ b/pkgs/development/python-modules/distrax/default.nix
@@ -1,21 +1,27 @@
 { lib
-, fetchPypi
 , buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, chex
+, jaxlib
 , numpy
 , tensorflow-probability
-, chex
 , dm-haiku
 , pytestCheckHook
-, jaxlib
 }:
 
 buildPythonPackage rec {
   pname = "distrax";
-  version = "0.1.4";
+  version = "0.1.5";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-klXT5wfnWUGMrf5sQhYqz7Foc/Ou5y4GIFgtTff1ZFQ=";
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "google-deepmind";
+    repo = "distrax";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-A1aCL/I89Blg9sNmIWQru4QJteUTN6+bhgrEJPmCrM0=";
   };
 
   buildInputs = [
@@ -32,6 +38,26 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "distrax"
+  ];
+
+  disabledTests = [
+    # AssertionError on numerical values
+    # Reported upstream in https://github.com/google-deepmind/distrax/issues/267
+    "test_method_with_input_unnormalized_probs__with_device"
+    "test_method_with_input_unnormalized_probs__with_jit"
+    "test_method_with_input_unnormalized_probs__without_device"
+    "test_method_with_input_unnormalized_probs__without_jit"
+    "test_method_with_value_1d"
+    "test_nested_distributions__with_device"
+    "test_nested_distributions__without_device"
+    "test_nested_distributions__with_jit"
+    "test_nested_distributions__without_jit"
+    "test_stability__with_device"
+    "test_stability__with_jit"
+    "test_stability__without_device"
+    "test_stability__without_jit"
+    "test_von_mises_sample_gradient"
+    "test_von_mises_sample_moments"
   ];
 
   disabledTestPaths = [
@@ -54,7 +80,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepmind/distrax";
     license = licenses.asl20;
     maintainers = with maintainers; [ onny ];
-    # Broken on all platforms (starting 2022-07-27)
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

`distrax` is currently broken on `master`.
This PR updates it to the latest version and disables the broken tests.
(Those failures have also been reported upstream).

Changelog: https://github.com/google-deepmind/distrax/releases/tag/v0.1.5

cc @onny

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
