### PR TITLE
gcc12, gcc13: fix typos in comments around __FILE__ patch

### DIFF
--- a/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
@@ -17,10 +17,10 @@ Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
   -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/eeee.eee-nlohmann-json-ver
   -fmacro-prefix-map=/nix/...
 
-In practice it quickly exhausts argument lengtth limit due to `gcc`
+In practice it quickly exhausts argument length limit due to `gcc`
 deficiency: https://gcc.gnu.org/PR111527
 
-Until it;s fixed let's hardcode header mangling if $NIX_STORE variable
+Until it's fixed let's hardcode header mangling if $NIX_STORE variable
 is present in the environment.
 
 Tested as:

--- a/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
@@ -17,10 +17,10 @@ Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
   -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/eeee.eee-nlohmann-json-ver
   -fmacro-prefix-map=/nix/...
 
-In practice it quickly exhausts argument lengtth limit due to `gcc`
+In practice it quickly exhausts argument length limit due to `gcc`
 deficiency: https://gcc.gnu.org/PR111527
 
-Until it;s fixed let's hardcode header mangling if $NIX_STORE variable
+Until it's fixed let's hardcode header mangling if $NIX_STORE variable
 is present in the environment.
 
 Tested as:


### PR DESCRIPTION
Noticed by Robert Schütz.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
