### PR TITLE
sway-assign-cgroups: init at 0.4.0

### DIFF
--- a/pkgs/applications/window-managers/sway/assign-cgroups.nix
+++ b/pkgs/applications/window-managers/sway/assign-cgroups.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "assign-cgroups";
+  version = "0.4.0";
+  src = fetchFromGitHub {
+    owner = "alebastr";
+    repo = "sway-systemd";
+    rev = "v${version}";
+    sha256 = "sha256-wznYE1/lVJtvf5Nq96gbPYisxc2gWLahVydwcH1vwoQ=";
+  };
+  format = "other";
+
+  propagatedBuildInputs = with python3Packages; [ dbus-next i3ipc psutil tenacity xlib ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp src/assign-cgroups.py $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Place GUI applications into systemd scopes for systemd-oomd compatibility.";
+    longDescription = ''
+      Automatically assign a dedicated systemd scope to the GUI applications
+      launched in the same cgroup as the compositor. This could be helpful for
+      implementing cgroup-based resource management and would be necessary when
+      `systemd-oomd` is in use.
+
+      Limitations: The script is using i3ipc window:new event to detect application
+      launches and would fail to detect background apps or special surfaces.
+      Therefore it's recommended to supplement the script with use of systemd user
+      services for such background apps.
+    '';
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nickhu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32630,6 +32630,7 @@ with pkgs;
   swayosd = callPackage ../applications/window-managers/sway/osd.nix { };
   swayws = callPackage ../applications/window-managers/sway/ws.nix { };
   swaywsr = callPackage ../applications/window-managers/sway/wsr.nix { };
+  sway-assign-cgroups = callPackage ../applications/window-managers/sway/assign-cgroups.nix { };
   sway-contrib = recurseIntoAttrs (callPackages ../applications/window-managers/sway/contrib.nix { });
 
   swaycons = callPackage ../applications/window-managers/sway/swaycons.nix { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the [assign-cgroups.py](https://github.com/alebastr/sway-systemd/blob/main/src/assign-cgroups.py) script from https://github.com/alebastr/sway-systemd.

`systemd-oomd`, the userspace out-of-memory daemon, will try to reclaim memory from userspace before it's exhausted and the system hangs. It does this by sending kill signals to a cgroup. Common desktop environments like GNOME and KDE launch applications into a new cgroup, but sway does not, so when `systemd-oomd` chooses a cgroup to kill it will terminate the whole sway session.

This script watches for window creation and puts GUI apps in their own cgroup, effectively adding compatibility for sway and `systemd-oomd`.

### Usage

I can't preempt how people are launching sway, and in an ideal world this could be wrapped up in a NixOS/home-manager module (future work), but here are the steps to get this working.

0. Disable `earlyoom`, `nohang`, any other userspace oom killer that might conflict with `systemd-oomd`. Also enable swap, as `systemd-oomd` basically requires it to function.
1. Enable `systemd-oomd` for user services (typically, sway is launched as a user systemd unit, at least this is how it's done in home-manager currently - so all child processes also get spawned into this slice):
	```nix
	systemd.oomd = {
		enable = true; # default
        enableRootSlice = true;
		enableUserServices = true;
	};
	```
3. Add `${pkgs.sway-assign-cgroups}/bin/assign-cgroups.py` to your sway autostart configuration; here is an example systemd user unit in home-manager format:
	```nix
    systemd = {
      user = {
        services = {
          assign-cgroups = {
            Unit = { Description = pkgs.sway-assign-cgroups.meta.description; };
            Service = {
              ExecStart = "${pkgs.sway-assign-cgroups}/bin/assign-cgroups.py";
            };
            Install = { WantedBy = [ "sway-session.target" ]; };
          };
        };
      };
    };
	```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
