### PR TITLE
python311Packages.llm-clip: init at 0.1

### DIFF
--- a/pkgs/development/python-modules/llm-clip/default.nix
+++ b/pkgs/development/python-modules/llm-clip/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  llm,
+  pytestCheckHook,
+  pythonOlder,
+  sentence-transformers,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "llm-clip";
+  version = "0.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-QeX8YBees4W8RdBuYrRX2iv93otXIsUEmfMd914wVfo=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  buildInputs = [
+    llm
+  ];
+
+  propagatedBuildInputs = [
+    sentence-transformers
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Tests will try to download files from huggingface
+  doCheck = false;
+
+  # Avoid warnings with not having a writable folder when testing imports
+  preBuild = ''
+    export TRANSFORMERS_CACHE=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [
+    "llm_clip"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/simonw/llm-clip";
+    description = "Generate embeddings for images and text using CLIP with LLM";
+    changelog = "https://github.com/simonw/llm-clip/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [aldoborrero];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6405,6 +6405,7 @@ self: super: with self; {
   };
 
   llm = callPackage ../development/python-modules/llm { };
+  llm-clip = callPackage ../development/python-modules/llm-clip { };
 
   llvmlite = callPackage ../development/python-modules/llvmlite {
     # llvmlite always requires a specific version of llvm.


### PR DESCRIPTION
## Description of changes

It introduces [llm-clip](https://github.com/simonw/llm-clip) a plugin for `llm` that allows using [CLIP](https://openai.com/research/clip) for embeddings.

This continues the work discussed on #255320 of adding all of the supported plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
