### PR TITLE
ghc: Fix `otool` and `install_name_tool` paths not set in settings

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -477,6 +477,11 @@ stdenv.mkDerivation ({
   preInstall = ''
     pushd _build/bindist/*
 
+    # the bindist configure script uses different env variables than the GHC configure script
+    # see https://github.com/NixOS/nixpkgs/issues/267250 and https://gitlab.haskell.org/ghc/ghc/-/issues/24211
+    export InstallNameToolCmd=$INSTALL_NAME_TOOL
+    export OtoolCmd=$OTOOL
+
     $configureScript $configureFlags "''${configureFlagsArray[@]}"
   '';
 


### PR DESCRIPTION
## Description of changes

Fixes #267250

Diff between the original and the new `settings` file:
```diff
--- /nix/store/yj3jx0yappw3fnwkvasg09niqvdxzcw9-ghc-9.6.3/lib/ghc-9.6.3/lib/settings	1970-01-01 01:00:01.000000000 +0100
+++ /nix/store/rr1qknbr8qxih1nw8hil15a970mp1ira-ghc-9.6.3/lib/ghc-9.6.3/lib/settings	1970-01-01 01:00:01.000000000 +0100
@@ -19,8 +19,8 @@
 ,("ar supports at file", "YES")
 ,("ar supports -L", "NO")
 ,("ranlib command", "/nix/store/vpnp0c420cjmx82g05jq3nm5skdrblvk-cctools-binutils-darwin-16.0.6-973.0.1/bin/ranlib")
-,("otool command", "otool")
-,("install_name_tool command", "install_name_tool")
+,("otool command", "/nix/store/vpnp0c420cjmx82g05jq3nm5skdrblvk-cctools-binutils-darwin-16.0.6-973.0.1/bin/otool")
+,("install_name_tool command", "/nix/store/ydcx9rj4gf3dxm1kc0lx7l5d5vrjdwp2-cctools-binutils-darwin-wrapper-16.0.6-973.0.1/bin/install_name_tool")
 ,("touch command", "touch")
 ,("dllwrap command", "/bin/false")
 ,("windres command", "/bin/false")
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
