### PR TITLE
nixos/kubernetes: certmgr-selfsigned is now an alias

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -212,7 +212,7 @@ in
 
     services.certmgr = {
       enable = true;
-      package = pkgs.certmgr-selfsigned;
+      package = pkgs.certmgr;
       svcManager = "command";
       specs =
         let


### PR DESCRIPTION
## Description of changes

- `certmgr`: v1.6.4 (2019-02-05) → 3.0.3 (2020-07-10)
  Incidentally fixes build failure during `fetchpatch`
- `certmgr-selfsigned` is now an alias for `certmgr`
  The relevant patch was merged upstream, in v2.0.0-rc0 and later.
- `nixos/kubernetes` now uses `certmgr` rather than the alias.

CC to
- @johanot, @srhb (maintainers)
- @NixOS/kubernetes (reverse dependency)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - :x: `nixosTests.kubernetes` currently failing.
- [x] Tested compilation of all packages that depend on this change
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
