### PR TITLE
satty: init at 0.7.0

### DIFF
--- a/pkgs/by-name/sa/satty/package.nix
+++ b/pkgs/by-name/sa/satty/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wrapGAppsHook4
+, cairo
+, gdk-pixbuf
+, glib
+, gtk4
+, libadwaita
+, pango
+, fetchpatch
+, copyDesktopItems
+}:
+
+rustPlatform.buildRustPackage rec {
+
+  pname = "satty";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "gabm";
+    repo = "Satty";
+    rev = "v${version}";
+    hash = "sha256-x2ljheG7ZqaeiPersC/e8Er2jvk5TJs65Y3N1GjTiNU=";
+  };
+
+  cargoPatches = [
+    (fetchpatch {
+      name = "fix-Cargo.lock";
+      url = "https://github.com/gabm/Satty/commit/39be6ddce264552df971e949a6a3175b102530b2.patch";
+      hash = "sha256-GUHupZE1A7AmXvZ8WvRzBkQyH7qlMTetBjHuakfIZ7w=";
+    })
+  ];
+
+  cargoHash = "sha256-0GsbWd/gpKZm7nNXkuJhB02YKUj3XCrSfpRA9KBXydU=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    glib
+    gtk4
+    libadwaita
+    pango
+  ];
+
+  postInstall = ''
+    install -Dt $out/share/icons/hicolor/scalable/apps/ assets/satty.svg
+  '';
+
+  desktopItems = [ "satty.desktop" ];
+
+  meta = with lib; {
+    description = "A screenshot annotation tool inspired by Swappy and Flameshot";
+    homepage = "https://github.com/gabm/Satty";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ pinpox ];
+    mainProgram = "satty";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Added package for satty, a screenshot annotation tool inspired by Swappy and Flameshot. 
Init from latest main commit, as it contains a fix (thanks @a-kenji !) for the build that is not in the release and breaks the build.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
