### PR TITLE
hareThirdParty.hare-json: init at unstable-2023-09-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17260,6 +17260,12 @@
     githubId = 327943;
     name = "Scott Zhu Reeves";
   };
+  starzation = {
+    email = "nixpkgs@starzation.net";
+    github = "starzation";
+    githubId = 145975416;
+    name = "Starzation";
+  };
   stasjok = {
     name = "Stanislav Asunkin";
     email = "nixpkgs@stasjok.ru";

--- a/pkgs/development/hare-packages/hare-json/default.nix
+++ b/pkgs/development/hare-packages/hare-json/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, hare, harec, fetchFromSourcehut }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-json";
+  version = "unstable-2023-09-21";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-json";
+    rev = "e24e5dceb8628ff569338e6c4fdba35a5017c5e2";
+    hash = "sha256-7QRieokqXarKwLfZynS8Rum9JV9hcxod00BWAUwwliM=";
+  };
+
+  nativeBuildInputs = [ hare ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HARECACHE="$NIX_BUILD_TOP/.harecache"
+    export BINOUT="$NIX_BUILD_TOP/.bin"
+
+    makeFlagsArray+=(
+      PREFIX="${builtins.placeholder "out"}"
+    )
+
+    runHook postConfigure
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~sircmpwn/hare-json/";
+    description = "This package provides JSON support for Hare";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ starzation ];
+
+    inherit (harec.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -4,4 +4,6 @@ lib.makeScope newScope (self:
 let
   inherit (self) callPackage;
 in
-{ })
+{
+  hare-json = callPackage ../development/hare-packages/hare-json { };
+})


### PR DESCRIPTION
## Description of changes

hare-json packages provides JSON support for Hare ([Homepage](https://git.sr.ht/~sircmpwn/hare-json))

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
