### PR TITLE
pw3270: init at 5.4

### DIFF
--- a/pkgs/by-name/li/lib3270/package.nix
+++ b/pkgs/by-name/li/lib3270/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, pkg-config
+, autoconf
+, automake
+, libtool
+, gettext
+, openssl
+, curl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lib3270";
+  version = "5.4";
+
+  src = fetchFromGitHub {
+    owner = "PerryWerneck";
+    repo = pname;
+    rev = version;
+    hash = "sha256-w6Bg+TvSDAuZwtu/nyAIuq6pgheM5nXtfuryECfnKng=";
+  };
+
+  nativeBuildInputs = [
+    which
+    pkg-config
+    autoconf
+    automake
+    libtool
+  ];
+
+  buildInputs = [
+    gettext
+    openssl
+    curl
+  ];
+
+  postPatch = ''
+    # Patch the required version.
+    sed -i -e "s/20211118/19800101/" src/core/session.c
+  '';
+
+  preConfigure = ''
+    NOCONFIGURE=1 sh autogen.sh
+  '';
+
+  enableParallelBuilds = true;
+
+  meta = with lib; {
+    description = "TN3270 client Library";
+    homepage = "https://github.com/PerryWerneck/lib3270";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.vifino ];
+  };
+}

--- a/pkgs/by-name/li/libv3270/package.nix
+++ b/pkgs/by-name/li/libv3270/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, which
+, pkg-config
+, gtk3
+, lib3270
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libv3270";
+  version = "5.4";
+
+  src = fetchFromGitHub {
+    owner = "PerryWerneck";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Z3FvxPa1pfeECxfB5ZL6gwhkbTKFpfO3D/zLVLF+uiI=";
+  };
+
+  nativeBuildInputs = [
+    which
+    pkg-config
+    autoconf
+    automake
+    libtool
+  ];
+
+  buildInputs = [
+    gtk3
+    lib3270
+  ];
+
+  postPatch = ''
+    # lib3270_build_data_filename is relative to lib3270's share - not ours.
+    for f in $(find . -type f -iname "*.c"); do
+      sed -i -e "s@lib3270_build_data_filename(@g_build_filename(\"$out/share/pw3270\", @" "$f"
+    done
+  '';
+
+  preConfigure = ''
+    mkdir -p scripts
+    touch scripts/config.rpath
+    NOCONFIGURE=1 sh ./autogen.sh
+  '';
+
+  enableParallelBuilds = true;
+
+  meta = with lib; {
+    description = "3270 Virtual Terminal for GTK";
+    homepage = "https://github.com/PerryWerneck/libv3270";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.vifino ];
+  };
+}

--- a/pkgs/by-name/pw/pw3270/package.nix
+++ b/pkgs/by-name/pw/pw3270/package.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, pkg-config
+, automake
+, autoconf
+, m4
+, libtool
+, gtk3
+, libv3270
+, lib3270
+, openssl
+, gettext
+, desktop-file-utils
+, glib
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pw3270";
+  version = "5.4";
+
+  src = fetchFromGitHub {
+    owner = "PerryWerneck";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Nk/OUqrWngKgb1D1Wi8q5ygKtvuRKUPhPQaLvWi1Z4g=";
+  };
+
+  nativeBuildInputs = [
+    which
+    pkg-config
+    autoconf
+    automake
+    libtool
+    desktop-file-utils
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    gettext
+    libv3270
+    lib3270
+    openssl
+  ];
+
+  postPatch = ''
+    # lib3270_build_data_filename is relative to lib3270's share - not ours.
+    for f in $(find . -type f -iname "*.c"); do
+      sed -i -e "s@lib3270_build_data_filename(@g_build_filename(\"$out/share/pw3270\", @" "$f"
+    done
+  '';
+
+  preConfigure = ''
+    NOCONFIGURE=1 sh autogen.sh
+  '';
+
+  postFixup = ''
+    # Schemas get installed to wrong directory.
+    mkdir -p $out/share/glib-2.0
+    mv $out/share/gsettings-schemas/${pname}-${version}/glib-2.0/schemas $out/share/glib-2.0/
+    rm -rf $out/share/gsettings-schemas
+  '';
+
+  enableParallelBuilds = true;
+
+  meta = with lib; {
+    description = "3270 Emulator for gtk";
+    homepage = "https://softwarepublico.gov.br/social/pw3270/";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.vifino ];
+    mainProgram = "pw3270";
+  };
+}


### PR DESCRIPTION
## Description of changes

pw3270 is an IBM 3270/tn3270 emulator.

It took *a lot* of effort to get this patched enough to build it.
It makes a lot of pretty bad assumptions about the system that just explode spectacularly with Nix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
