### PR TITLE
obs-studio: 29.1.3 -> 30.0.0

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -150,7 +150,7 @@ stdenv.mkDerivation rec {
     ];
   in ''
     # Remove libcef before patchelf, otherwise it will fail
-    rm $out/lib/obs-plugins/libcef.so 
+    rm $out/lib/obs-plugins/libcef.so
 
     qtWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"

--- a/pkgs/applications/video/obs-studio/onevpl.nix
+++ b/pkgs/applications/video/obs-studio/onevpl.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, wayland
+, wayland-protocols
+, xorg
+, libva
+, libdrm
+, cmake
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onevpl";
+  version = "v2023.3.1";
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneVPL";
+    rev = version;
+    hash = "sha256-kFW5n3uGTS+7ATKAuVff5fK3LwEKdCQVgGElgypmrG4=";
+  };
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    xorg.libxcb
+    xorg.libX11
+    xorg.libpciaccess
+    libva
+    libdrm
+  ];
+  cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Release"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DENABLE_DRI3=ON"
+      "-DENABLE_DRM=ON"
+      "-DENABLE_VA=ON"
+      "-DENABLE_WAYLAND=ON"
+      "-DENABLE_X11=ON"
+  ];
+}

--- a/pkgs/applications/video/obs-studio/qrcodegencpp.nix
+++ b/pkgs/applications/video/obs-studio/qrcodegencpp.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, qrcodegen
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qrcodegencpp";
+  version = qrcodegen.version;
+
+  src = qrcodegen.src;
+
+  sourceRoot = "${finalAttrs.src.name}/cpp";
+
+  nativeBuildInputs = lib.optionals stdenv.cc.isClang [
+    stdenv.cc.cc.libllvm.out
+  ];
+
+  makeFlags = lib.optionals stdenv.cc.isClang [ "AR=llvm-ar" ];
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/lib/ libqrcodegencpp.a
+    install -Dt $out/include/qrcodegen/ qrcodegen.hpp
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -30,6 +30,10 @@
 }:
 
 let
+  gl_rpath = lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+  ];
+
   rpath = lib.makeLibraryPath [
     glib
     nss
@@ -92,7 +96,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/ $out/share/cef/
     cp libcef_dll_wrapper/libcef_dll_wrapper.a $out/lib/
     cp ../Release/libcef.so $out/lib/
+    cp ../Release/libEGL.so $out/lib/
+    cp ../Release/libGLESv2.so $out/lib/
     patchelf --set-rpath "${rpath}" $out/lib/libcef.so
+    patchelf --set-rpath "${gl_rpath}" $out/lib/libEGL.so
+    patchelf --set-rpath "${gl_rpath}" $out/lib/libGLESv2.so
     cp ../Release/*.bin $out/share/cef/
     cp -r ../Resources/* $out/share/cef/
     cp -r ../include $out/


### PR DESCRIPTION
## Description of changes

Update obs-studio to 30.0.0
Will close https://github.com/NixOS/nixpkgs/issues/267977

## Things done
Obs have new dependencies which are not in nixpkgs, I added them only for obs currently not in nixpkgs:
- Added qrcodegencpp, probably should be output to current qrcodegen but not sure about structure @AndersonTorres 
- Added onevpl, I don't have intel GPU so I can't really check if it works. Probably should be added as package in nixpkgs but as I don't own Intel card I'm not willing to maintain it for more than obs build needs. Alternative to onevpl is disabling QSV in obs

Change to libcef: added output for ANGLE libEGL and libGLESv2 to fix https://github.com/NixOS/nixpkgs/issues/226468#issuecomment-1751793235 @puffnfresh 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
