### PR TITLE
emacs: Use lib.withFeature

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -329,15 +329,16 @@ mkDerivation (finalAttrs: {
     "--with-xml2=yes"
   ]
   ++ (lib.optional stdenv.isDarwin (lib.withFeature withNS "ns"))
-  ++ lib.optional (!withToolkitScrollBars) "--without-toolkit-scroll-bars"
-  ++ lib.optional withNativeCompilation "--with-native-compilation"
-  ++ lib.optional withImageMagick "--with-imagemagick"
-  ++ lib.optional withTreeSitter "--with-tree-sitter"
-  ++ lib.optional withXinput2 "--with-xinput2"
-  ++ lib.optional withXwidgets "--with-xwidgets"
-  ++ lib.optional withSmallJaDic "--with-small-ja-dic"
-  ++ lib.optional (!withCompressInstall) "--without-compress-install"
-  ;
+  ++ [
+    (lib.withFeature withCompressInstall "compress-install")
+    (lib.withFeature withToolkitScrollBars "toolkit-scroll-bars")
+    (lib.withFeature withNativeCompilation "native-compilation")
+    (lib.withFeature withImageMagick "imagemagick")
+    (lib.withFeature withSmallJaDic "small-ja-dic")
+    (lib.withFeature withTreeSitter "tree-sitter")
+    (lib.withFeature withXinput2 "xinput2")
+    (lib.withFeature withXwidgets "xwidgets")
+  ];
 
   env = lib.optionalAttrs withNativeCompilation {
     NATIVE_FULL_AOT = "1";


### PR DESCRIPTION
## Description of changes

As discussed in [1], this improves readability.

Not all `--with` options have a corresponding `--without` (and vice-versa), but Emacs's `configure` script can endure this. Additionally, this "encodes" the default options in system-configuration-options.

[1]: https://github.com/NixOS/nixpkgs/pull/267946#issuecomment-1815394037

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).