### PR TITLE
bork: 7.0.1 → 7.0.2

### DIFF
--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -15,15 +15,15 @@
 
 buildPythonPackage rec {
   pname = "bork";
-  version = "7.0.1";
+  version = "7.0.2";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "duckinator";
     repo = pname;
-    rev = "refs/tags/v${version}";
-    hash = "sha256-y/p2uuU+QKgJSdJmMt3oebm/zcuatYWTW8Jl79YxA3g=";
+    rev = "v${version}";
+    hash = "sha256-sHCPT6nTenE6mbTifNPtg0OMNIJCs7LRcF8Xuk+MwLs=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

Update `bork`, v7.0.2 fixes a bug I reported.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
