### PR TITLE
mesonlsp: init at 4.2.2

### DIFF
--- a/pkgs/by-name/me/mesonlsp/disable-tests-that-require-network-access.patch
+++ b/pkgs/by-name/me/mesonlsp/disable-tests-that-require-network-access.patch
@@ -1,0 +1,57 @@
+From 5a886abd956607503e9dc7cd22923eaf8b01e46f Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <contact@paveloom.dev>
+Date: Mon, 3 Jun 2024 20:31:27 +0300
+Subject: [PATCH] Disable tests that require network access.
+
+---
+ tests/integration/meson.build |  2 --
+ tests/libutils/test.cpp       | 20 --------------------
+ 2 files changed, 22 deletions(-)
+
+diff --git a/tests/integration/meson.build b/tests/integration/meson.build
+index da1b3b76..8908e690 100644
+--- a/tests/integration/meson.build
++++ b/tests/integration/meson.build
+@@ -51,8 +51,6 @@ wrap_files = files(
+     'wrap-test/vorbis.wrap',
+ )
+
+-test('wrap-test', wrap_tester, args: [wrap_files], timeout: 200000)
+-
+ partial_interpreter_tests = [
+     [
+         'foreach',
+diff --git a/tests/libutils/test.cpp b/tests/libutils/test.cpp
+index 2b20191c..c313312b 100644
+--- a/tests/libutils/test.cpp
++++ b/tests/libutils/test.cpp
+@@ -131,26 +131,6 @@ TEST(UtilsTest, testMergingDirectories) {
+   ASSERT_EQ('a', std::ifstream(outputDir / "i1/a.txt").get());
+ }
+
+-TEST(UtilsTest, testDownloadAndExtraction) {
+-  auto zipFileName = std::filesystem::path{randomFile() + "-1"};
+-  auto result = downloadFile(
+-      "https://github.com/JCWasmx86/mesonlsp/archive/refs/heads/main.zip",
+-      zipFileName);
+-  ASSERT_TRUE(result);
+-  auto directoryName = std::filesystem::path{randomFile() + "-2"};
+-  std::filesystem::create_directory(directoryName);
+-  result = extractFile(zipFileName, directoryName);
+-  ASSERT_TRUE(result);
+-  auto mustExist =
+-      directoryName / "mesonlsp-main/Benchmarks/extract_git_data.sh";
+-  ASSERT_TRUE(std::filesystem::exists(mustExist));
+-  auto mustFailFilename = std::filesystem::path{randomFile() + "-3"};
+-  result =
+-      downloadFile("lnfvwoefvnwefvwvipwnefv2efvpov2nvov", mustFailFilename);
+-  ASSERT_FALSE(result);
+-  ASSERT_FALSE(std::filesystem::exists(mustFailFilename));
+-}
+-
+ int main(int argc, char **argv) {
+   testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+--
+2.45.1
+

--- a/pkgs/by-name/me/mesonlsp/package.nix
+++ b/pkgs/by-name/me/mesonlsp/package.nix
@@ -1,0 +1,170 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  gtest,
+  makeWrapper,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+
+  curl,
+  libarchive,
+  libossp_uuid,
+  libpkgconf,
+  libuuid,
+  nlohmann_json,
+  pkgsStatic,
+
+  mesonlsp,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mesonlsp";
+  version = "4.2.2";
+
+  src = fetchFromGitHub {
+    owner = "JCWasmx86";
+    repo = "mesonlsp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-pN8MCqrRfVpmM8KWa7HPTghoegplM4bP/HRVJVs05iE=";
+  };
+
+  patches = [
+    ./disable-tests-that-require-network-access.patch
+    ./simplify-the-format-header-polyfill.patch
+  ];
+
+  nativeBuildInputs = [
+    gtest
+    makeWrapper
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs =
+    [
+      curl
+      libarchive
+      libpkgconf
+      nlohmann_json
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      libossp_uuid
+      pkgsStatic.fmt
+    ]
+    ++ lib.optionals stdenv.isLinux [ libuuid ];
+
+  mesonFlags = [ "-Dbenchmarks=false" ];
+
+  mesonCheckFlags = [ "--print-errorlogs" ];
+
+  doCheck = true;
+
+  postUnpack =
+    let
+      ada = fetchFromGitHub {
+        owner = "ada-url";
+        repo = "ada";
+        rev = "v2.7.4";
+        hash = "sha256-V5LwL03x7/a9Lvg1gPvgGipo7IICU7xyO2D3GqP6Lbw=";
+      };
+
+      muon = fetchFromGitHub {
+        owner = "JCWasmx86";
+        repo = "muon";
+        rev = "62af239567ec3b086bae7f02d4aed3a545949155";
+        hash = "sha256-k883mKwuP35f0WtwX8ybl9uYbvA3y6Vxtv2EJMpZDEs=";
+      };
+
+      sha256 = fetchFromGitHub {
+        owner = "amosnier";
+        repo = "sha-2";
+        rev = "49265c656f9b370da660531db8cc6bf0a2e110a6";
+        hash = "sha256-X9M/ZATYXUiE4oGorPBnsdaKnKaObarnMRh6QEfkBls=";
+      };
+
+      tomlplusplus = fetchFromGitHub {
+        owner = "marzer";
+        repo = "tomlplusplus";
+        rev = "v3.4.0";
+        hash = "sha256-h5tbO0Rv2tZezY58yUbyRVpsfRjY3i+5TPkkxr6La8M=";
+      };
+
+      tree-sitter = fetchFromGitHub {
+        owner = "tree-sitter";
+        repo = "tree-sitter";
+        rev = "v0.20.8";
+        hash = "sha256-278zU5CLNOwphGBUa4cGwjBqRJ87dhHMzFirZB09gYM=";
+      };
+
+      tree-sitter-ini = fetchFromGitHub {
+        owner = "JCWasmx86";
+        repo = "tree-sitter-ini";
+        rev = "20aa563306e9406ac55babb4474521060df90a30";
+        hash = "sha256-1hHjtghBIf7lOPpupT1pUCZQCnzUi4Qt/yHSCdjMhCU=";
+      };
+
+      tree-sitter-meson = fetchFromGitHub {
+        owner = "JCWasmx86";
+        repo = "tree-sitter-meson";
+        rev = "09665faff74548820c10d77dd8738cd76d488572";
+        hash = "sha256-ice2NdK1/U3NylIQDnNCN41rK/G6uqFOX+OeNf3zm18=";
+      };
+    in
+    ''
+      (
+        cd "$sourceRoot/subprojects"
+
+        cp -R --no-preserve=mode,ownership ${ada} ada
+        cp "packagefiles/ada/meson.build" ada
+
+        cp -R --no-preserve=mode,ownership ${muon} muon
+
+        cp -R --no-preserve=mode,ownership ${sha256} sha256
+        cp "packagefiles/sha256/meson.build" sha256
+
+        cp -R --no-preserve=mode,ownership ${tomlplusplus} tomlplusplus-3.4.0
+
+        cp -R --no-preserve=mode,ownership ${tree-sitter} tree-sitter-0.20.8
+        cp "packagefiles/tree-sitter-0.20.8/meson.build" tree-sitter-0.20.8
+
+        cp -R --no-preserve=mode,ownership ${tree-sitter-ini} tree-sitter-ini
+        cp "packagefiles/tree-sitter-ini/meson.build" tree-sitter-ini
+
+        cp -R --no-preserve=mode,ownership ${tree-sitter-meson} tree-sitter-meson
+        cp "packagefiles/tree-sitter-meson/meson.build" tree-sitter-meson
+      )
+    '';
+
+  postPatch = ''
+    substituteInPlace subprojects/muon/include/compilers.h \
+      --replace-fail 'compiler_language new' 'compiler_language new_'
+
+    patchShebangs src/libtypenamespace
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = mesonlsp;
+      version = "v${finalAttrs.version}";
+    };
+  };
+
+  meta = with lib; {
+    description = "An unofficial, unendorsed language server for Meson written in C++";
+    homepage = "https://github.com/JCWasmx86/mesonlsp";
+    changelog = "https://github.com/JCWasmx86/mesonlsp/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl3Plus;
+    mainProgram = "mesonlsp";
+    maintainers = with maintainers; [ paveloom ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/by-name/me/mesonlsp/simplify-the-format-header-polyfill.patch
+++ b/pkgs/by-name/me/mesonlsp/simplify-the-format-header-polyfill.patch
@@ -1,0 +1,47 @@
+From ae3fb8943dd5b2d282a2c6d4525a8ce0dd0244e8 Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <contact@paveloom.dev>
+Date: Tue, 25 Jun 2024 23:03:50 +0300
+Subject: [PATCH] Simplify the `<format>` header polyfill.
+
+---
+ src/polyfill/polyfill.hpp | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/polyfill/polyfill.hpp b/src/polyfill/polyfill.hpp
+index 5c5ba39a..b5d145ed 100644
+--- a/src/polyfill/polyfill.hpp
++++ b/src/polyfill/polyfill.hpp
+@@ -1,9 +1,6 @@
+ #pragma once
+
+ #if defined(__APPLE__)
+-#if __has_include(<format>) and !defined(__x86_64__)
+-#include <format>
+-#else
+ #include <chrono>
+ #include <fmt/core.h>
+
+@@ -23,10 +20,8 @@ struct fmt::formatter<std::chrono::time_point<Clock, Duration>> {
+     return fmt::format_to(ctx.out(), "{}", tp.time_since_epoch().count());
+   }
+ };
+-#endif
+-#else
++#elif defined(_WIN32)
+ #include <format>
+-#ifdef _WIN32
+ template <> struct std::formatter<wchar_t *> {
+   constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
+
+@@ -35,6 +30,6 @@ template <> struct std::formatter<wchar_t *> {
+     return std::format_to(ctx.out(), L"{}", str);
+   }
+ };
+-
+-#endif
++#else
++#include <format>
+ #endif
+--
+2.45.1
+


### PR DESCRIPTION
## Description of changes

https://github.com/JCWasmx86/Swift-MesonLSP

Depends on https://github.com/NixOS/nixpkgs/pull/269015.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
