### PR TITLE
cinnamon.cinnamon-screensaver: Fix broken theming with pygobject 3.46

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -38,6 +38,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-d7h9OJ39HVQNCHNr13M1ybDFoU3Xnd1PEczGLHZU/lU=";
   };
 
+  patches = [
+    # See https://github.com/linuxmint/cinnamon-screensaver/issues/446#issuecomment-1819580053
+    ./fix-broken-theming-with-pygobject-3-46.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/fix-broken-theming-with-pygobject-3-46.patch
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/fix-broken-theming-with-pygobject-3-46.patch
@@ -1,0 +1,17 @@
+diff --git a/src/cinnamon-screensaver-main.py b/src/cinnamon-screensaver-main.py
+index 05b727c..a185159 100755
+--- a/src/cinnamon-screensaver-main.py
++++ b/src/cinnamon-screensaver-main.py
+@@ -139,9 +139,9 @@ class Main(Gtk.Application):
+ 
+             fallback_prov = Gtk.CssProvider()
+ 
+-            if fallback_prov.load_from_data(fallback_css.encode()):
+-                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default(), fallback_prov, 600)
+-                Gtk.StyleContext.reset_widgets(Gdk.Screen.get_default())
++            fallback_prov.load_from_data(fallback_css.encode())
++            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default(), fallback_prov, 600)
++            Gtk.StyleContext.reset_widgets(Gdk.Screen.get_default())
+ 
+ if __name__ == "__main__":
+     setproctitle.setproctitle('cinnamon-screensaver')


### PR DESCRIPTION
pygobject!231 ("Fix incompatibility for CssProvider.load_from_data() (GTK 4.10)") breaks theming here since they eliminated any return value from GtkCssProvider.load_from_data.

/cc https://github.com/NixOS/nixpkgs/pull/247766

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

