### PR TITLE
added rofi-blocks package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5029,6 +5029,12 @@
     githubId = 2746374;
     name = "edeneast";
   };
+  edenkras = {
+    email = "edenkras@gmail.com";
+    github = "edenkras";
+    githubId = 35879078;
+    name = "Eden Kras";
+  };
   ederoyd46 = {
     email = "matt@ederoyd.co.uk";
     github = "ederoyd46";

--- a/pkgs/applications/misc/rofi-blocks/0001-Patch-plugindir-to-output.patch
+++ b/pkgs/applications/misc/rofi-blocks/0001-Patch-plugindir-to-output.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 1ca2cc6..078001b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -57,7 +57,7 @@ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 json-gl
+ PKG_CHECK_MODULES([cairo],    [cairo])
+ PKG_CHECK_MODULES([rofi],     [rofi])
+
+-[rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"
++[rofi_PLUGIN_INSTALL_DIR]="`echo $out/lib/rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])
+
+ LT_INIT([disable-static])

--- a/pkgs/applications/misc/rofi-blocks/default.nix
+++ b/pkgs/applications/misc/rofi-blocks/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "OmarCastro";
     repo = "rofi-blocks";
     rev = "0a2ba561aa9a31586c0bc8203f8836a18a1f664e";
-    sha256 = "sha256-U955hzd55xiV5XdQ18iUIwNLn2JrvuHsItgUSf6ww58=";
+    hash = "sha256-U955hzd55xiV5XdQ18iUIwNLn2JrvuHsItgUSf6ww58=";
   };
 
   patches = [

--- a/pkgs/applications/misc/rofi-blocks/default.nix
+++ b/pkgs/applications/misc/rofi-blocks/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Rofi modi that allows controlling rofi content through communication with an external program";
     homepage = "https://github.com/OmarCastro/rofi-blocks";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ edenkras ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/rofi-blocks/default.nix
+++ b/pkgs/applications/misc/rofi-blocks/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cairo
+, json-glib
+, pkg-config
+, rofi-unwrapped
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-blocks";
+  version = "unstable-2023-10-27";
+
+  src = fetchFromGitHub {
+    owner = "OmarCastro";
+    repo = "rofi-blocks";
+    rev = "0a2ba561aa9a31586c0bc8203f8836a18a1f664e";
+    sha256 = "sha256-U955hzd55xiV5XdQ18iUIwNLn2JrvuHsItgUSf6ww58=";
+  };
+
+  patches = [
+    ./0001-Patch-plugindir-to-output.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    cairo
+    rofi-unwrapped
+    json-glib
+  ];
+
+  meta = with lib; {
+    description = "Rofi modi that allows controlling rofi content through communication with an external program";
+    homepage = "https://github.com/OmarCastro/rofi-blocks";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ edenkras ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33915,6 +33915,8 @@ with pkgs;
 
   rofi-top = callPackage ../applications/misc/rofi-top { };
 
+  rofi-blocks = callPackage ../applications/misc/rofi-blocks { };
+
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
 
   seamly2d = libsForQt5.callPackage ../applications/graphics/seamly2d { };


### PR DESCRIPTION
## Description of changes

https://github.com/OmarCastro/rofi-blocks
Rofi modi that allows controlling rofi content through communication with an external program

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
