### PR TITLE
zfs: 2.2.0 -> 2.2.1; zfsUnstable: 2.2.1-unstable-2023-10-21 -> 2.2.1 

### DIFF
--- a/pkgs/os-specific/linux/zfs/stable.nix
+++ b/pkgs/os-specific/linux/zfs/stable.nix
@@ -18,20 +18,20 @@ callPackage ./generic.nix args {
   # check the release notes for compatible kernels
   kernelCompatible =
     if stdenv'.isx86_64 || removeLinuxDRM
-    then kernel.kernelOlder "6.6"
+    then kernel.kernelOlder "6.7"
     else kernel.kernelOlder "6.2";
 
   latestCompatibleLinuxPackages = if stdenv'.isx86_64 || removeLinuxDRM
-    then linuxKernel.packages.linux_6_5
+    then linuxKernel.packages.linux_6_6
     else linuxKernel.packages.linux_6_1;
 
   # this package should point to the latest release.
-  version = "2.2.0";
+  version = "2.2.1";
 
   tests = [
     nixosTests.zfs.installer
     nixosTests.zfs.stable
   ];
 
-  hash = "sha256-s1sdXSrLu6uSOmjprbUa4cFsE2Vj7JX5i75e4vRnlvg=";
+  hash = "sha256-2Q/Nhp3YKgMCLPNRNBq5r9U4GeuYlWMWAsjsQy3vFW4=";
 }

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -16,21 +16,20 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfsUnstable";
   # check the release notes for compatible kernels
   kernelCompatible = if stdenv'.isx86_64 || removeLinuxDRM
-    then kernel.kernelOlder "6.6"
+    then kernel.kernelOlder "6.7"
     else kernel.kernelOlder "6.2";
 
   latestCompatibleLinuxPackages = if stdenv'.isx86_64 || removeLinuxDRM
-    then linuxKernel.packages.linux_6_5
+    then linuxKernel.packages.linux_6_6
     else linuxKernel.packages.linux_6_1;
 
   # this package should point to a version / git revision compatible with the latest kernel release
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.2.1-unstable-2023-10-21";
-  rev = "95785196f26e92d82cf4445654ba84e4a9671c57";
+  version = "2.2.1";
 
-  hash = "sha256-s1sdXSrLu6uSOmjprbUa4cFsE2Vj7JX5i75e4vRnlvg=";
+  hash = "sha256-2Q/Nhp3YKgMCLPNRNBq5r9U4GeuYlWMWAsjsQy3vFW4=";
 
   isUnstable = true;
   tests = [


### PR DESCRIPTION
## Description of changes

https://github.com/openzfs/zfs/releases/tag/zfs-2.2.1

Notably:

> We recommend that anyone running zfs-2.2.0 to please update to this release. Gentoo users have identified a block cloning bug (https://github.com/openzfs/zfs/issues/15526) that can result in data corruption in zfs-2.2.0. To workaround this, zfs-2.2.1 disables block cloning by default (see https://github.com/openzfs/zfs/pull/15529 and https://github.com/openzfs/zfs/commit/479dca51c66a731e637bd2d4f9bba01a05f9ac9f). Users running the 2.1.x branch or older are unaffected, as block cloning is a 2.2.x-only feature.

## Things done

`nix-build -A zfs.passthru.tests`, and am also running with this patch on x86_64-linux.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
