### PR TITLE
onedriver: 0.13.0-2 -> 0.14.1

### DIFF
--- a/pkgs/by-name/on/onedriver/package.nix
+++ b/pkgs/by-name/on/onedriver/package.nix
@@ -2,20 +2,20 @@
 , fetchFromGitHub
 , lib
 , pkg-config
-, webkitgtk
+, webkitgtk_4_1
 , glib
 , fuse
 , installShellFiles
 }:
 let
   pname = "onedriver";
-  version = "0.13.0-2";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "jstaf";
     repo = "onedriver";
     rev = "v${version}";
-    hash = "sha256-Bcjgmx9a4pTRhkzR3tbOB6InjvuH71qomv4t+nRNc+w=";
+    hash = "sha256-mA5otgqXQAw2UYUOJaC1zyJuzEu2OS/pxmjJnWsVdxs=";
   };
 in
 buildGoModule {
@@ -23,7 +23,7 @@ buildGoModule {
   vendorHash = "sha256-OOiiKtKb+BiFkoSBUQQfqm4dMfDW3Is+30Kwcdg8LNA=";
 
   nativeBuildInputs = [ pkg-config installShellFiles ];
-  buildInputs = [ webkitgtk glib fuse ];
+  buildInputs = [ webkitgtk_4_1 glib fuse ];
 
   ldflags = [ "-X github.com/jstaf/onedriver/cmd/common.commit=v${version}" ];
 
@@ -34,14 +34,14 @@ buildGoModule {
 
   postInstall = ''
     echo "Running postInstall"
-    install -Dm644 ./resources/onedriver.svg $out/share/icons/onedriver/onedriver.svg
-    install -Dm644 ./resources/onedriver.png $out/share/icons/onedriver/onedriver.png
-    install -Dm644 ./resources/onedriver-128.png $out/share/icons/onedriver/onedriver-128.png
+    install -Dm644 ./pkg/resources/onedriver.svg $out/share/icons/onedriver/onedriver.svg
+    install -Dm644 ./pkg/resources/onedriver.png $out/share/icons/onedriver/onedriver.png
+    install -Dm644 ./pkg/resources/onedriver-128.png $out/share/icons/onedriver/onedriver-128.png
 
-    install -Dm644 ./resources/onedriver.desktop $out/share/applications/onedriver.desktop
+    install -Dm644 ./pkg/resources/onedriver.desktop $out/share/applications/onedriver.desktop
 
     mkdir -p $out/share/man/man1
-    installManPage ./resources/onedriver.1
+    installManPage ./pkg/resources/onedriver.1
 
     substituteInPlace $out/share/applications/onedriver.desktop \
       --replace "/usr/bin/onedriver-launcher" "$out/bin/onedriver-launcher" \


### PR DESCRIPTION
## Description of changes

Taken from project's repository: 

> - Fixes a bug with file corruption in some scenarios from version 0.14.0.
> - We now use quickxorhash checksums for both personal and business accounts.
> - The cache for file contents has been moved out of boltdb and onto the local filesystem.
>   This makes accessing, reading, and writing files faster than before.
> - onedriver no longer allows you to create filenames that are not allowed by OneDrive.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
