### PR TITLE
vala: search for vapi files in targetOffset, not hostOffset

### DIFF
--- a/pkgs/desktops/gnome/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome/apps/seahorse/default.nix
@@ -57,10 +57,6 @@ stdenv.mkDerivation rec {
     gnupg
     desktop-file-utils
     gcr
-    # error: Package `...' not found in specified Vala API directories or GObject-Introspection GIR directories
-    # TODO: the vala setuphook should look for vala filess in targetOffset instead of hostOffset
-    libhandy
-    libsecret
   ];
 
   buildInputs = [

--- a/pkgs/development/compilers/vala/setup-hook.sh
+++ b/pkgs/development/compilers/vala/setup-hook.sh
@@ -5,7 +5,7 @@ make_vala_find_vapi_files() {
     fi
 }
 
-addEnvHooks "$hostOffset" make_vala_find_vapi_files
+addEnvHooks "$targetOffset" make_vala_find_vapi_files
 
 disable_incompabile_pointer_conversion_warning() {
     # Work around incompatible function pointer conversion errors with clang 16

--- a/pkgs/development/libraries/libgnome-games-support/default.nix
+++ b/pkgs/development/libraries/libgnome-games-support/default.nix
@@ -2,7 +2,6 @@
 , fetchurl
 , pkg-config
 , glib
-, gobject-introspection
 , gtk3
 , libgee
 , gettext
@@ -24,7 +23,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     gettext
-    gobject-introspection
     meson
     ninja
     pkg-config


### PR DESCRIPTION
## Description of changes

this is in response to an old TODO: <https://github.com/NixOS/nixpkgs/pull/189397#discussion_r961923690>; CC @Artturin 

this PR should only change things (practically) for cross-compiled builds. previously, vala projects would struggle to find the vapi (vala API) files of their build dependencies. workarounds were to copy these dependencies into `nativeBuildInputs`, or provide the project some other way to find the API info (e.g. `gobject-introspection`). vala now looks in the right place for vapi files, as demonstrated by the commits in this patch which remove both class of workaround.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
