### PR TITLE
python3Packages.types-appdirs: Fix typo in `meta.homepage`

### DIFF
--- a/pkgs/development/python-modules/types-appdirs/default.nix
+++ b/pkgs/development/python-modules/types-appdirs/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "This is a PEP 561 type stub package for the appdirs package. It can be used by type-checking tools like mypy, pyright, pytype, PyCharm, etc. to check code that uses appdirs. ";
-    homepage = "https://pypi.org/project/types-appdirss";
+    homepage = "https://pypi.org/project/types-appdirs";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ];
   };


### PR DESCRIPTION
## Description of changes

Fix typo in `python3Packages.types-appdirs.meta.homepage`

## Things done

- [x] Checked no rebuild was needed on:
  - x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
