### PR TITLE
emulationstation-de: init at 2.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7896,6 +7896,12 @@
     githubId = 41924494;
     name = "Ivar";
   };
+  ivarmedi = {
+    email = "ivar@larsson.me";
+    github = "ivarmedi";
+    githubId = 1318743;
+    name = "Ivar";
+  };
   iwanb = {
     email = "tracnar@gmail.com";
     github = "iwanb";

--- a/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores.patch
+++ b/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores.patch
@@ -1,0 +1,18 @@
+--- a/resources/systems/unix/es_find_rules.xml	2023-11-22 15:18:15.912747163 -0500
++++ b/resources/systems/unix/es_find_rules.xml	2023-11-22 15:20:38.628250448 -0500
+@@ -45,6 +45,8 @@
+             <entry>/usr/local/lib/libretro</entry>
+             <!-- NetBSD repository -->
+             <entry>/usr/pkg/lib/libretro</entry>
++            <!-- NixOS / Nixpkgs -->
++            <entry>/run/current-system/sw/lib/retroarch/cores</entry>
+         </rule>
+     </core>
+     <emulator name="3DSEN-WINDOWS">
+@@ -1079,4 +1081,4 @@
+             <entry>~/bin/ZEsarUX/zesarux</entry>
+         </rule>
+     </emulator>
+-</ruleList>
+\ No newline at end of file
++</ruleList>

--- a/pkgs/by-name/em/emulationstation-de/package.nix
+++ b/pkgs/by-name/em/emulationstation-de/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchzip,
+  pkg-config,
+  alsa-lib,
+  curl,
+  ffmpeg,
+  freeimage,
+  freetype,
+  libgit2,
+  poppler,
+  pugixml,
+  SDL2
+}:
+
+stdenv.mkDerivation {
+  pname = "emulationstation-de";
+  version = "2.2.1";
+
+  src = fetchzip {
+    url = "https://gitlab.com/es-de/emulationstation-de/-/archive/v2.2.1/emulationstation-de-v2.2.1.tar.gz";
+    hash = "sha256:1kp9p3fndnx4mapgfvy742zwisyf0y5k57xkqkis0kxyibx0z8i6";
+  };
+
+  patches = [ ./001-add-nixpkgs-retroarch-cores.patch ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    curl
+    ffmpeg
+    freeimage
+    freetype
+    libgit2
+    poppler
+    pugixml
+    SDL2
+  ];
+
+  installPhase = ''
+    install -D ../emulationstation $out/bin/emulationstation
+    cp -r ../resources/ $out/bin/resources/
+  '';
+
+  meta = {
+    description = "EmulationStation Desktop Edition is a frontend for browsing and launching games from your multi-platform game collection.";
+    homepage = "https://es-de.org";
+    maintainers = with lib.maintainers; [ ivarmedi ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "emulationstation";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add the ES-DE fork of Emulationstation Desktop Edition. The `emulationstation` package available is very old (and not really the same piece of software)
Desktop Edition is the variant used by e.g. [EmuDeck](https://www.emudeck.com/).

<https://www.es-de.org/>

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
