### PR TITLE
nomnatong: init at 5.07

### DIFF
--- a/pkgs/by-name/no/nomnatong/package.nix
+++ b/pkgs/by-name/no/nomnatong/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, python3Packages
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "nomnatong";
+  version = "5.07";
+
+  src = fetchFromGitHub {
+    owner = "nomfoundation";
+    repo = "font";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-31sqjOIrJByfTx4Ez6KvQDApCeVYMQnGeiM9INMR3zI=";
+  };
+
+  nativeBuildInputs = [
+    python3Packages.afdko
+    python3Packages.fonttools
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  buildPhase = ''
+    runHook preBuild
+
+    makeotf -r -f font.pfa -omitMacNames -ff features.txt -mf FontMenuNameDB -ga -ci UnicodeVariationSequences.txt
+    otf2ttf NomNaTong-Regular.otf
+    sfntedit -d DSIG NomNaTong-Regular.otf
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 NomNaTong-Regular.otf -t $out/share/fonts/opentype/
+    install -Dm444 NomNaTong-Regular.ttf -t $out/share/fonts/truetype/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "http://nomfoundation.org/nom-tools/Nom-Font";
+    description = "The Hán-Nôm Coded Character Set and Nom Na Tong Regular Reference Font";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds Nom Na Tong, a Hán Nôm font.

Homepage: http://nomfoundation.org/nom-tools/Nom-Font

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
