### PR TITLE
overwitch, nixos/overwitch: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3879,6 +3879,12 @@
       fingerprint = "D68C 8469 5C08 7E0F 733A  28D0 EEB8 D1CE 62C4 DFEA";
     }];
   };
+  dag-h = {
+    email = "dagharju@proton.me";
+    github = "dag-h";
+    githubId = 16627772;
+    name = "Dag Harju";
+  };
   dalance = {
     email = "dalance@gmail.com";
     github = "dalance";

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -148,6 +148,8 @@
 
 - [c2FmZQ](https://github.com/c2FmZQ/c2FmZQ/), an application that can securely encrypt, store, and share files, including but not limited to pictures and videos. Available as [services.c2fmzq-server](#opt-services.c2fmzq-server.enable).
 
+- [overwitch](https://github.com/dagargo/overwitch), an Overbridge 2 device client for JACK. Available as [programs.overwitch](#opt-programs.overwitch.enable).
+
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
 - `services.postgresql.ensurePermissions` has been deprecated in favor of `services.postgresql.ensureUsers.*.ensureDBOwnership` which simplifies the setup of database owned by a certain system user

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -230,6 +230,7 @@
   ./programs/oblogout.nix
   ./programs/oddjobd.nix
   ./programs/openvpn3.nix
+  ./programs/overwitch.nix
   ./programs/pantheon-tweaks.nix
   ./programs/partition-manager.nix
   ./programs/plotinus.nix

--- a/nixos/modules/programs/overwitch.nix
+++ b/nixos/modules/programs/overwitch.nix
@@ -1,0 +1,35 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.overwitch;
+
+  overwitch = cfg.package.override {
+    withGui = cfg.gui.enable;
+  };
+in {
+  options.programs.overwitch = {
+    enable = mkEnableOption (lib.mdDoc "Install overwitch and add the necessary udev and hwdb rules.");
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.overwitch;
+      defaultText = "pkgs.overwitch";
+      description = "Set version of overwitch package to use.";
+    };
+
+    gui.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc "Whether to enable the overwitch GUI application.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ overwitch  ];
+    services.udev.packages = [ overwitch ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ dag-h ];
+}

--- a/pkgs/applications/audio/overwitch/default.nix
+++ b/pkgs/applications/audio/overwitch/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libtool
+, libusb
+, libjack2
+, libsamplerate
+, libsndfile
+, gettext
+, json-glib
+, gtk3
+, wrapGAppsHook
+, pkg-config
+, autoreconfHook
+, withGui ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "overwitch";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "dagargo";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-RjzPGAXkw/TFv3kevOY6vZTGRdR9N1qO7plnzZ9X3jU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    libtool
+    libusb
+    libjack2
+    libsamplerate
+    libsndfile
+    gettext
+    json-glib
+    gtk3
+  ];
+
+  configureFlags = [
+    (lib.optionalString (!withGui) "CLI_ONLY=yes")
+  ];
+
+  postInstall = ''
+    # install udev/hwdb rules
+    mkdir -p $out/etc/udev/rules.d/
+    mkdir -p $out/etc/udev/hwdb.d/
+    cp ./udev/*.hwdb $out/etc/udev/hwdb.d/
+    cp ./udev/*.rules $out/etc/udev/rules.d/
+  '';
+
+  meta = with lib; {
+    description = "JACK client for Overbridge devices";
+    homepage = "https://github.com/dagargo/overwitch";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dag-h ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24454,6 +24454,8 @@ with pkgs;
 
   osmid = callPackage ../applications/audio/osmid { };
 
+  overwitch = callPackage ../applications/audio/overwitch { withGui = false; };
+
   osinfo-db = callPackage ../data/misc/osinfo-db { };
   osinfo-db-tools = callPackage ../tools/misc/osinfo-db-tools { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24456,6 +24456,8 @@ with pkgs;
 
   overwitch = callPackage ../applications/audio/overwitch { withGui = false; };
 
+  overwitch-gtk = res.overwitch.override { withGui = true; };
+
   osinfo-db = callPackage ../data/misc/osinfo-db { };
   osinfo-db-tools = callPackage ../tools/misc/osinfo-db-tools { };
 


### PR DESCRIPTION
## Description of changes

Closes #165104.

Overwitch is an Overbridge 2 device client for JACK (JACK Audio Connection Kit).

The package requires udev/hwdb rules to be set to function properly, so these have been added in the new `nixos/overwitch` module. The package can conditionally be built without the GTK GUI. The package has therefore been added as both `overwitch` (CLI only) and `overwitch-gtk` (CLI and GUI). 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).