### PR TITLE
nixos/nix-serve: fix module compatibility with unflaked Nix

### DIFF
--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -67,7 +67,9 @@ in
   };
 
   config = mkIf cfg.enable {
-    nix.settings.extra-allowed-users = [ "nix-serve" ];
+    nix.settings = lib.optionalAttrs (lib.versionAtLeast config.nix.package.version "2.4") {
+      extra-allowed-users = [ "nix-serve" ];
+    };
 
     systemd.services.nix-serve = {
       description = "nix-serve binary cache server";


### PR DESCRIPTION
The option `extra-allowed-users` was introduced in Nix 2.4, and fails config validation on Nix 2.3.

Relates to https://github.com/NixOS/nix/issues/9412

Breakage discovered in https://cl.tvl.fyi/c/depot/+/10083, commit that introduced the bug was 44cf4801c0937b76cc6f416a0b160b5d1b3286af