### PR TITLE
libpostal: fix on darwin

### DIFF
--- a/pkgs/development/libraries/libpostal/0001-test-adding-header-to-fix-warning.patch
+++ b/pkgs/development/libraries/libpostal/0001-test-adding-header-to-fix-warning.patch
@@ -1,0 +1,24 @@
+From bfdb6b8f87cc1cae9ba47870ff23deae0bb8ba51 Mon Sep 17 00:00:00 2001
+From: Al <albarrentine@gmail.com>
+Date: Sun, 17 Dec 2017 20:17:01 -0500
+Subject: [PATCH] [test] adding header to fix warning
+
+---
+ test/test_expand.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/test_expand.c b/test/test_expand.c
+index 59ed9af7..2b211728 100644
+--- a/test/test_expand.c
++++ b/test/test_expand.c
+@@ -4,6 +4,7 @@
+ #include <stdarg.h>
+ 
+ #include "greatest.h"
++#include "../src/string_utils.h"
+ #include "../src/libpostal.h"
+ 
+ SUITE(libpostal_expansion_tests);
+-- 
+2.42.0
+

--- a/pkgs/development/libraries/libpostal/default.nix
+++ b/pkgs/development/libraries/libpostal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libpostal";
@@ -10,6 +10,18 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-gQTD2LQibaB2TK0SbzoILAljAGExURvDcF3C/TfDXqk=";
   };
+
+  patches = [
+    # Fix darwin compilation with XCode 12 https://github.com/openvenues/libpostal/issues/511
+    (fetchpatch {
+      name = "Fix-C-compilation-macOS.patch";
+      url = "https://github.com/openvenues/libpostal/commit/9fcf066e38121b5c1439fc6bdc9a7e02234c8622.patch";
+      hash = "sha256-VpboGK+5sc1XrxMB051KWc8vP7Eu2g7zmTirzSaerns=";
+    })
+    # https://github.com/openvenues/libpostal/commit/bfdb6b8f87cc1cae9ba47870ff23deae0bb8ba51.patch
+    # with extra hunk removed so it applies
+    ./0001-test-adding-header-to-fix-warning.patch
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 


### PR DESCRIPTION
## Description of changes

Speculative (don't have a mac to test it on, hoping ofborg will do the honours) fix for libpostal on darwin by pulling in a merged-but-as-yet-unreleased patch described as fixing the same error seen on hydra.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

ZHF: #265948