### PR TITLE
bazel_6: fix CLang 16 Werror-s on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -199,6 +199,10 @@ stdenv.mkDerivation rec {
   inherit src;
   inherit sourceRoot;
   patches = [
+    # upb definition inside bazel sets its own copts that take precedence
+    # over flags we set externally, so need to patch them at the source
+    ./upb-clang16.patch
+
     # Force usage of the _non_ prebuilt java toolchain.
     # the prebuilt one does not work in nix world.
     ./java_toolchain.patch
@@ -403,6 +407,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in external/{absl,upb} dependencies
+      export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/upb-clang16.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/upb-clang16.patch
@@ -1,0 +1,30 @@
+diff --git a/distdir_deps.bzl b/distdir_deps.bzl
+index c7fc4588e4..01e6966fca 100644
+--- a/distdir_deps.bzl
++++ b/distdir_deps.bzl
+@@ -192,6 +192,8@@ DIST_DEPS = {
+         "archive": "a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+         "sha256": "cf7f71eaff90b24c1a28b49645a9ff03a9a6c1e7134291ce70901cb63e7364b5",
+         "strip_prefix": "upb-a5477045acaa34586420942098f5fecd3570f577",
++        "patches": ["//:upb-clang16.patch"],
++        "patch_args": ["-p1"],
+         "urls": [
+             "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+             "https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz",
+diff --git a/upb-clang16.patch b/upb-clang16.patch
+new file mode 100644
+index 0000000000..f81855181f
+--- /dev/null
++++ upb-clang16.patch
+@@ -0,0 +1,10 @@
++--- a/bazel/build_defs.bzl
+++++ b/bazel/build_defs.bzl
++@@ -43,6 +43,7 @@
++     "-Werror=pedantic",
++     "-Wall",
++     "-Wstrict-prototypes",
+++    "-Wno-gnu-offsetof-extensions",
++     # GCC (at least) emits spurious warnings for this that cannot be fixed
++     # without introducing redundant initialization (with runtime cost):
++     #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+


### PR DESCRIPTION
## Description of changes

Fixing `bazel_6` after #234710

bazel_6 https://hydra.nixos.org/build/241090720/nixlog/1
```
external/upb/upb/upb.c:228:25: error: defining a type within '__builtin_offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]
  n = UPB_ALIGN_DOWN(n, UPB_ALIGN_OF(upb_Arena));
                        ^~~~~~~~~~~~~~~~~~~~~~~
```
bazel_6 https://hydra.nixos.org/build/241127779/nixlog/1
```
In file included from external/com_google_absl/absl/algorithm/container.h:55:
external/com_google_absl/absl/meta/type_traits.h:560:8: error: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Werror,-Wdeprecated-builtins]
      (__has_trivial_assign(ExtentsRemoved) || !kIsCopyOrMoveAssignable) &&
       ^
```

Note: `bazel_5` and `bazel_4` require more work, for some reason extra `-Wall` in combination with `-Werror` sneaks in and overrides `-Wno-` settings, haven't managed yet to debug where exactly are the last flags (last one wins) come from there.

ZHF: #265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
