### PR TITLE
DisnixWebService: fix build for Axis2 1.8.1 

### DIFF
--- a/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
+++ b/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
@@ -1,12 +1,25 @@
-{lib, stdenv, fetchurl, apacheAnt, jdk, axis2, dbus_java }:
+{lib, stdenv, fetchFromGitHub, fetchpatch, apacheAnt, jdk, axis2, dbus_java }:
 
 stdenv.mkDerivation rec {
   pname = "DisnixWebService";
   version = "0.10.1";
-  src = fetchurl {
-    url = "https://github.com/svanderburg/DisnixWebService/releases/download/DisnixWebService-${version}/DisnixWebService-${version}.tar.gz";
-    sha256 = "02jxbgn9a0c9cr6knzp78bp9wiywzczy89wav7yxhg79vff8a1gr";
+
+  src = fetchFromGitHub {
+    owner = "svanderburg";
+    repo = "DisnixWebService";
+    rev = "refs/tags/DisnixWebService-${version}";
+    hash = "sha256-zcYr2Ytx4pevSthTQLpnQ330wDxN9dWsZA20jbO6PxQ=";
   };
+
+  patches = [
+    # Correct the DisnixWebService build for compatibility with Axis2 1.8.1
+    # See https://github.com/svanderburg/DisnixWebService/pull/2
+    (fetchpatch {
+      url = "https://github.com/svanderburg/DisnixWebService/commit/cee99c6af744b5dda16728a70ebd2800f61871a0.patch";
+      hash = "sha256-4rSEN8AwivUXUCIUYFBRIoE19jVDv+Vpgakmy8fR06A=";
+    })
+  ];
+
   buildInputs = [ apacheAnt jdk ];
   PREFIX = "\${env.out}";
   AXIS2_LIB = "${axis2}/lib";

--- a/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
+++ b/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A SOAP interface and client for Disnix";
+    homepage = "https://github.com/svanderburg/DisnixWebService";
+    changelog = "https://github.com/svanderburg/DisnixWebService/blob/DisnixWebService-${version}/NEWS.txt";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
## Description of changes

DisnixWebService build is broken with Axis2 1.8.1 upgrade: https://github.com/NixOS/nixpkgs/pull/263550

This is because, Axis2 1.8.1 introduces some breaking changes that breaks the build of DixnixWebService.

See the [release notes](https://axis.apache.org/axis2/java/core/release-notes/1.8.1.html):

> Any code references for the HTTPConstants class needs
> to be updated to org.apache.axis2.kernel.http.HTTPConstants.
>

See upstream fix: https://github.com/svanderburg/DisnixWebService/pull/2

ZHF: https://github.com/NixOS/nixpkgs/issues/265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
