### PR TITLE
[Backport staging-23.05] libgit2, http-parser: Fix Windows Build

### DIFF
--- a/pkgs/development/libraries/http-parser/default.nix
+++ b/pkgs/development/libraries/http-parser/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
   patches = [
     ./build-shared.patch
   ] ++ lib.optionals stdenv.isAarch32 [
@@ -21,16 +22,34 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-rZZMJeow3V1fTnjadRaRa+xTq3pdhZn/eJ4xjxEDoU4=";
     })
   ];
-  makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
+
+  makeFlags = [
+    "DESTDIR="
+    "PREFIX=$(out)"
+    "SOEXT=${lib.strings.removePrefix "." stdenv.hostPlatform.extensions.sharedLibrary}"
+    "BINEXT=${stdenv.hostPlatform.extensions.executable}"
+    "Platform=${lib.toLower stdenv.hostPlatform.uname.system}"
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [
+    "SONAME=$(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOEXT)"
+    "LIBNAME=$(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOREV).$(SOEXT)"
+    "LDFLAGS=-Wl,--out-implib=$(LIBNAME).a"
+  ];
+
   buildFlags = [ "library" ];
+
   doCheck = true;
   checkTarget = "test";
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isWindows ''
+    install -D *.dll.a $out/lib
+    ln -sf libhttp_parser.${version}.dll.a $out/lib/libhttp_parser.dll.a
+  '';
 
   meta = with lib; {
     description = "An HTTP message parser written in C";
     homepage = "https://github.com/nodejs/http-parser";
     maintainers = with maintainers; [ matthewbauer ];
     license = licenses.mit;
-    platforms = platforms.unix;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libgit2/default.nix
+++ b/pkgs/development/libraries/libgit2/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
     "-DUSE_HTTP_PARSER=system"
     "-DUSE_SSH=ON"
     "-DBUILD_SHARED_LIBS=${if staticBuild then "OFF" else "ON"}"
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [
+    "-DDLLTOOL=${stdenv.cc.bintools.targetPrefix}dlltool"
+    # For ws2_32, refered to by a `*.pc` file
+    "-DCMAKE_LIBRARY_PATH=${stdenv.cc.libc}/lib"
   ];
 
   nativeBuildInputs = [ cmake python3 pkg-config ];


### PR DESCRIPTION
## Description of changes

Manual backport of #269326 due to conflict.

Draft until that one is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
