### PR TITLE
snapraid: fix split parity files

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -1313,6 +1313,9 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   qemu-vm module from overriding `fileSystems` by setting
   `virtualisation.fileSystems = lib.mkForce { };`.
 
+- When using [split parity files](https://www.snapraid.it/manual#7.1) in `snapraid`,
+  the snapraid-sync systemd service will no longer fail to run.
+
 ## Nixpkgs Library {#sec-release-23.11-nixpkgs-lib}
 
 ### Breaking Changes {#sec-release-23.11-lib-breaking}

--- a/nixos/modules/tasks/snapraid.nix
+++ b/nixos/modules/tasks/snapraid.nix
@@ -217,9 +217,13 @@ in
               # to remove them if they are stale
               let
                 contentDirs = map dirOf contentFiles;
+                # Multiple "split" parity files can be specified in a single
+                # "parityFile", separated by a comma.
+                # https://www.snapraid.it/manual#7.1
+                splitParityFiles = map (s: splitString "," s) parityFiles;
               in
               unique (
-                attrValues dataDisks ++ parityFiles ++ contentDirs
+                attrValues dataDisks ++ splitParityFiles ++ contentDirs
               );
           } // optionalAttrs touchBeforeSync {
             ExecStartPre = "${pkgs.snapraid}/bin/snapraid touch";


### PR DESCRIPTION
## Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/269248

SnapRAID has a feature where you can specify "split" parity files. This is useful when you're using 16tb or bigger ext4-formatted disks for parity. ext4 doesn't support files bigger than 16tb so this "split parity file" can be used to specify two parity files on a single parity disk and SnapRAID will automatically use the subsequent file when the current cannot grow anymore (hits 16TB). You specify these split parity files by separating them with commas in the "parity" config option. This mostly already works except when it comes to the scheduled systemd sync job where it specifies ReadWritePaths. If you specify a parity with multiple files you'll get an error when the systemd job runs: `Failed to set up mount namespacing:
/run/systemd/unit-root/mnt/parity1/snapraid1.parity,/mnt/parity1/snapraid2.parity: No such file or directory` Essentially, when the parity file paths are passed into ReadWritePaths, they're always treated as a single path.  This change makes sure to split the paths if they contain a comma.

The big concern for this change is if it would break users who have commas in their actual parity file paths.  This won't be an issue because SnapRAID itself blindly splits on commas for parity files, so legitimate commas in a parity file path wouldn't work in SnapRAID anyway. See here: https://github.com/amadvance/snapraid/blob/978d812153736c06763192f0f1d4b34e54ad633f/cmdline/state.c#L692

SnapRAID doc for split parity files: https://www.snapraid.it/manual#7.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Used this package locally with my broken configuration and verified working by running `sudo systemctl show snapraid-sync.service` and verifying `ReadWritePaths` had the paths split properly.  Also ran the systemd service and verified it ran successfully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
