### PR TITLE
treewide: add mainProgram

### DIFF
--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -44,5 +44,6 @@ rustPlatform.buildRustPackage rec {
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     badPlatforms = platforms.darwin;
+    mainProgram = "xidlehook";
   };
 }

--- a/pkgs/tools/backup/awsbck/default.nix
+++ b/pkgs/tools/backup/awsbck/default.nix
@@ -30,5 +30,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/beeb/awsbck";
     license = with licenses; [ mit asl20 ];
     maintainers = with maintainers; [ beeb ];
+    mainProgram = "awsbck";
   };
 }

--- a/pkgs/tools/backup/bdsync/default.nix
+++ b/pkgs/tools/backup/bdsync/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jluttine ];
+    mainProgram = "bdsync";
   };
 }

--- a/pkgs/tools/backup/conserve/default.nix
+++ b/pkgs/tools/backup/conserve/default.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sourcefrog/conserve";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ happysalada ];
+    mainProgram = "conserve";
   };
 }

--- a/pkgs/tools/cd-dvd/bchunk/default.nix
+++ b/pkgs/tools/cd-dvd/bchunk/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     description = "A program that converts CD images in BIN/CUE format into a set of ISO and CDR tracks";
     platforms = platforms.unix;
     license = licenses.gpl2;
+    mainProgram = "bchunk";
   };
 }

--- a/pkgs/tools/cd-dvd/bootiso/default.nix
+++ b/pkgs/tools/cd-dvd/bootiso/default.nix
@@ -56,5 +56,6 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ muscaln ];
     platforms = platforms.all;
+    mainProgram = "bootiso";
   };
 }

--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -45,5 +45,6 @@ in stdenv.mkDerivation rec {
     maintainers = [ maintainers.bdimcheff ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+    mainProgram = "brasero";
   };
 }

--- a/pkgs/tools/cd-dvd/ccd2iso/default.nix
+++ b/pkgs/tools/cd-dvd/ccd2iso/default.nix
@@ -15,5 +15,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ yana ];
     platforms = platforms.unix;
+    mainProgram = "ccd2iso";
   };
 }

--- a/pkgs/tools/cd-dvd/cdi2iso/default.nix
+++ b/pkgs/tools/cd-dvd/cdi2iso/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ hrdinka ];
     platforms = platforms.all;
+    mainProgram = "cdi2iso";
   };
 }

--- a/pkgs/tools/cd-dvd/cue2pops/default.nix
+++ b/pkgs/tools/cd-dvd/cue2pops/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/makefu/cue2pops-linux";
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.all;
+    mainProgram = "cue2pops";
   };
 }

--- a/pkgs/tools/cd-dvd/dvd-vr/default.nix
+++ b/pkgs/tools/cd-dvd/dvd-vr/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     description = "A utility to identify and optionally copy recordings from a DVD-VR format disc";
     license = licenses.gpl2;
     maintainers = with maintainers; [ fgaz ];
+    mainProgram = "dvd-vr";
   };
 }
 

--- a/pkgs/tools/cd-dvd/dvdisaster/default.nix
+++ b/pkgs/tools/cd-dvd/dvdisaster/default.nix
@@ -93,5 +93,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];
+    mainProgram = "dvdisaster";
   };
 }

--- a/pkgs/tools/cd-dvd/iat/default.nix
+++ b/pkgs/tools/cd-dvd/iat/default.nix
@@ -18,5 +18,6 @@ stdenv.mkDerivation (finalAttr: {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ hughobrien ];
     platforms = platforms.linux;
+    mainProgram = "iat";
   };
 })

--- a/pkgs/tools/cd-dvd/isolyzer/default.nix
+++ b/pkgs/tools/cd-dvd/isolyzer/default.nix
@@ -21,5 +21,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "Verify size of ISO 9660 image against Volume Descriptor fields";
     license = licenses.asl20;
     maintainers = with maintainers; [ mkg20001 ];
+    mainProgram = "isolyzer";
   };
 }

--- a/pkgs/tools/cd-dvd/lsdvd/default.nix
+++ b/pkgs/tools/cd-dvd/lsdvd/default.nix
@@ -16,5 +16,6 @@ stdenv.mkDerivation rec {
     description = "Display information about audio, video, and subtitle tracks on a DVD";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    mainProgram = "lsdvd";
   };
 }

--- a/pkgs/tools/cd-dvd/mdf2iso/default.nix
+++ b/pkgs/tools/cd-dvd/mdf2iso/default.nix
@@ -16,5 +16,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.oxij ];
+    mainProgram = "mdf2iso";
   };
 }

--- a/pkgs/tools/cd-dvd/mkcue/default.nix
+++ b/pkgs/tools/cd-dvd/mkcue/default.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];
+    mainProgram = "mkcue";
   };
 }

--- a/pkgs/tools/cd-dvd/nrg2iso/default.nix
+++ b/pkgs/tools/cd-dvd/nrg2iso/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://gregory.kokanosky.free.fr/v4/linux/nrg2iso.en.html";
     license = licenses.gpl2;
     platforms = platforms.all;
+    mainProgram = "nrg2iso";
   };
 }

--- a/pkgs/tools/cd-dvd/sacd/default.nix
+++ b/pkgs/tools/cd-dvd/sacd/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3;
     maintainers = [ maintainers.doronbehar ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "sacd";
   };
 })

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ericdallo ];
     homepage = "https://github.com/nwoltman/srt-to-vtt-cl";
     platforms = platforms.unix;
+    mainProgram = "srt-vtt";
   };
 }

--- a/pkgs/tools/cd-dvd/uif2iso/default.nix
+++ b/pkgs/tools/cd-dvd/uif2iso/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://aluigi.org/mytoolz.htm#uif2iso";
     license = lib.licenses.gpl1Plus;
     platforms = lib.platforms.linux;
+    mainProgram = "uif2iso";
   };
 }

--- a/pkgs/tools/cd-dvd/unetbootin/default.nix
+++ b/pkgs/tools/cd-dvd/unetbootin/default.nix
@@ -80,5 +80,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ebzzry ];
     platforms = platforms.linux;
+    mainProgram = "unetbootin";
   };
 }

--- a/pkgs/tools/cd-dvd/vobcopy/default.nix
+++ b/pkgs/tools/cd-dvd/vobcopy/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
 
     maintainers = [ lib.maintainers.bluescreen303 ];
     platforms = lib.platforms.all;
+    mainProgram = "vobcopy";
   };
 }

--- a/pkgs/tools/cd-dvd/vobsub2srt/default.nix
+++ b/pkgs/tools/cd-dvd/vobsub2srt/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.ttuegel ];
+    mainProgram = "vobsub2srt";
   };
 }

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -73,5 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
       "libbrotlienc"
     ];
     platforms = platforms.all;
+    mainProgram = "brotli";
   };
 })

--- a/pkgs/tools/compression/bsc/default.nix
+++ b/pkgs/tools/compression/bsc/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     # Later commits changed the licence to Apache2 (no release yet, though)
     license = with licenses; [ lgpl3Plus ];
     platforms = platforms.unix;
+    mainProgram = "bsc";
   };
 }

--- a/pkgs/tools/compression/crabz/default.nix
+++ b/pkgs/tools/compression/crabz/default.nix
@@ -25,5 +25,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/sstadick/crabz/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ unlicense /* or */ mit ];
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "crabz";
   };
 }

--- a/pkgs/tools/compression/dejsonlz4/default.nix
+++ b/pkgs/tools/compression/dejsonlz4/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ mt-caret ];
     platforms = platforms.all;
+    mainProgram = "dejsonlz4";
   };
 }

--- a/pkgs/tools/compression/dtrx/default.nix
+++ b/pkgs/tools/compression/dtrx/default.nix
@@ -51,5 +51,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/dtrx-py/dtrx";
     license = licenses.gpl3Plus;
     maintainers = [ ];
+    mainProgram = "dtrx";
   };
 }

--- a/pkgs/tools/compression/efficient-compression-tool/default.nix
+++ b/pkgs/tools/compression/efficient-compression-tool/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = [ maintainers.lunik1 ];
     platforms = platforms.linux;
+    mainProgram = "ect";
   };
 }

--- a/pkgs/tools/compression/flips/default.nix
+++ b/pkgs/tools/compression/flips/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.xfix ];
     platforms = platforms.linux;
+    mainProgram = "flips";
   };
 }

--- a/pkgs/tools/compression/hacpack/default.nix
+++ b/pkgs/tools/compression/hacpack/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.linux;
+    mainProgram = "hacpack";
   };
 }

--- a/pkgs/tools/compression/hactool/default.nix
+++ b/pkgs/tools/compression/hactool/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = with maintainers; [ ivar ];
     platforms = platforms.unix;
+    mainProgram = "hactool";
   };
 }

--- a/pkgs/tools/compression/heatshrink/default.nix
+++ b/pkgs/tools/compression/heatshrink/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
+    mainProgram = "heatshrink";
   };
 }

--- a/pkgs/tools/compression/imagelol/default.nix
+++ b/pkgs/tools/compression/imagelol/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.unix;
+    mainProgram = "ImageLOL";
   };
 }

--- a/pkgs/tools/compression/lzbench/default.nix
+++ b/pkgs/tools/compression/lzbench/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation rec {
     description = "In-memory benchmark of open-source LZ77/LZSS/LZMA compressors";
     license = licenses.free;
     platforms = platforms.all;
+    mainProgram = "lzbench";
   };
 }

--- a/pkgs/tools/compression/lzfse/default.nix
+++ b/pkgs/tools/compression/lzfse/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.bsd3;
     maintainers = with maintainers; [ ];
+    mainProgram = "lzfse";
   };
 }

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with maintainers; [ vlaci ];
     platforms = lib.platforms.all;
+    mainProgram = "lzip";
   };
 }

--- a/pkgs/tools/compression/lziprecover/default.nix
+++ b/pkgs/tools/compression/lziprecover/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with maintainers; [ vlaci ];
     platforms = lib.platforms.all;
+    mainProgram = "lziprecover";
   };
 }

--- a/pkgs/tools/compression/lzop/default.nix
+++ b/pkgs/tools/compression/lzop/default.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
     license = licenses.gpl2;
     platforms = platforms.unix;
+    mainProgram = "lzop";
   };
 }

--- a/pkgs/tools/compression/mozlz4a/default.nix
+++ b/pkgs/tools/compression/mozlz4a/default.nix
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ kira-bruneau pshirshov raskin ];
     platforms = python3.meta.platforms;
     homepage = "https://gist.github.com/Tblue/62ff47bef7f894e92ed5";
+    mainProgram = "mozlz4a";
   };
 }

--- a/pkgs/tools/compression/nx2elf/default.nix
+++ b/pkgs/tools/compression/nx2elf/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree; # No license specified upstream
     platforms = [ "x86_64-linux" ]; # Should work on Darwin as well, but this is untested. aarch64-linux fails.
     maintainers = [ maintainers.ivar ];
+    mainProgram = "nx2elf";
   };
 }

--- a/pkgs/tools/compression/offzip/default.nix
+++ b/pkgs/tools/compression/offzip/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with maintainers; [ r-burns ];
     platforms = platforms.unix;
+    mainProgram = "offzip";
   };
 }

--- a/pkgs/tools/compression/orz/default.nix
+++ b/pkgs/tools/compression/orz/default.nix
@@ -35,5 +35,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/richox/orz";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "orz";
   };
 }

--- a/pkgs/tools/compression/ouch/default.nix
+++ b/pkgs/tools/compression/ouch/default.nix
@@ -41,5 +41,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/ouch-org/ouch/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda psibi ];
+    mainProgram = "ouch";
   };
 }

--- a/pkgs/tools/compression/pbzx/default.nix
+++ b/pkgs/tools/compression/pbzx/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.gpl3;
     maintainers = [ maintainers.matthewbauer ];
+    mainProgram = "pbzx";
   };
 }

--- a/pkgs/tools/compression/pixz/default.nix
+++ b/pkgs/tools/compression/pixz/default.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = [ maintainers.raskin ];
     platforms = platforms.unix;
+    mainProgram = "pixz";
   };
 }

--- a/pkgs/tools/compression/plzip/default.nix
+++ b/pkgs/tools/compression/plzip/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ _360ied ];
+    mainProgram = "plzip";
   };
 }

--- a/pkgs/tools/compression/rzip/default.nix
+++ b/pkgs/tools/compression/rzip/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
+    mainProgram = "rzip";
   };
 }

--- a/pkgs/tools/compression/unzrip/default.nix
+++ b/pkgs/tools/compression/unzrip/default.nix
@@ -31,5 +31,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/quininer/unzrip";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "unzrip";
   };
 }

--- a/pkgs/tools/compression/upx/default.nix
+++ b/pkgs/tools/compression/upx/default.nix
@@ -18,5 +18,6 @@ stdenv.mkDerivation rec {
     description = "The Ultimate Packer for eXecutables";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
+    mainProgram = "upx";
   };
 }

--- a/pkgs/tools/compression/xar/default.nix
+++ b/pkgs/tools/compression/xar/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ copumpkin ];
     platforms   = lib.platforms.all;
+    mainProgram = "xar";
   };
 }

--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -52,5 +52,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.spease ];
     # 64-bit only
     platforms = platforms.aarch64 ++ platforms.x86_64;
+    mainProgram = "zfp";
   };
 }

--- a/pkgs/tools/graphics/aaphoto/default.nix
+++ b/pkgs/tools/graphics/aaphoto/default.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
+    mainProgram = "aaphoto";
   };
 }

--- a/pkgs/tools/graphics/adriconf/default.nix
+++ b/pkgs/tools/graphics/adriconf/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ muscaln ];
     platforms = platforms.linux;
+    mainProgram = "adriconf";
   };
 }

--- a/pkgs/tools/graphics/blockhash/default.nix
+++ b/pkgs/tools/graphics/blockhash/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = [ maintainers.infinisil ];
     platforms = platforms.unix;
+    mainProgram = "blockhash";
   };
 }

--- a/pkgs/tools/graphics/blur-effect/default.nix
+++ b/pkgs/tools/graphics/blur-effect/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # packages 'libdrm' and 'gbm' not found
     maintainers = with maintainers; [ romildo ];
+    mainProgram = "blur_image";
   };
 }

--- a/pkgs/tools/graphics/briss/default.nix
+++ b/pkgs/tools/graphics/briss/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
+    mainProgram = "briss";
   };
 }

--- a/pkgs/tools/graphics/cfdg/default.nix
+++ b/pkgs/tools/graphics/cfdg/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     homepage = "https://contextfreeart.org/";
     license = licenses.gpl2Only;
+    mainProgram = "cfdg";
   };
 }

--- a/pkgs/tools/graphics/cuneiform/default.nix
+++ b/pkgs/tools/graphics/cuneiform/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation {
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = [ maintainers.raskin ];
+    mainProgram = "cuneiform";
   };
 }

--- a/pkgs/tools/graphics/didder/default.nix
+++ b/pkgs/tools/graphics/didder/default.nix
@@ -29,5 +29,6 @@ buildGoModule rec {
       "An extensive, fast, and accurate command-line image dithering tool";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ehmry ];
+    mainProgram = "didder";
   };
 }

--- a/pkgs/tools/graphics/ditaa/default.nix
+++ b/pkgs/tools/graphics/ditaa/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
+    mainProgram = "ditaa";
   };
 }

--- a/pkgs/tools/graphics/dnglab/default.nix
+++ b/pkgs/tools/graphics/dnglab/default.nix
@@ -24,5 +24,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dnglab/dnglab";
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ dit7ya ];
+    mainProgram = "dnglab";
   };
 }

--- a/pkgs/tools/graphics/dpic/default.nix
+++ b/pkgs/tools/graphics/dpic/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ aespinosa ];
     platforms = platforms.all;
+    mainProgram = "dpic";
   };
 }
 

--- a/pkgs/tools/graphics/editres/default.nix
+++ b/pkgs/tools/graphics/editres/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     description = "A dynamic resource editor for X Toolkit applications";
     license = licenses.mit;
     platforms = platforms.linux;
+    mainProgram = "editres";
   };
 }

--- a/pkgs/tools/graphics/epstool/default.nix
+++ b/pkgs/tools/graphics/epstool/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.asppsa ];
     platforms = platforms.all;
+    mainProgram = "epstool";
   };
 }

--- a/pkgs/tools/graphics/escrotum/default.nix
+++ b/pkgs/tools/graphics/escrotum/default.nix
@@ -47,5 +47,6 @@ with python3Packages; buildPythonApplication {
     platforms = platforms.linux;
     maintainers = with maintainers; [ rasendubi ];
     license = licenses.gpl3;
+    mainProgram = "escrotum";
   };
 }

--- a/pkgs/tools/graphics/esshader/default.nix
+++ b/pkgs/tools/graphics/esshader/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin;
+    mainProgram = "esshader";
   };
 }

--- a/pkgs/tools/graphics/exif/default.nix
+++ b/pkgs/tools/graphics/exif/default.nix
@@ -41,5 +41,6 @@ stdenv.mkDerivation rec {
     description = "A utility to read and manipulate EXIF data in digital photographs";
     platforms = platforms.unix;
     license = licenses.lgpl21Plus;
+    mainProgram = "exif";
   };
 }

--- a/pkgs/tools/graphics/facedetect/default.nix
+++ b/pkgs/tools/graphics/facedetect/default.nix
@@ -41,5 +41,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.rycee ];
+    mainProgram = "facedetect";
   };
 }

--- a/pkgs/tools/graphics/fbv/default.nix
+++ b/pkgs/tools/graphics/fbv/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "http://s-tech.elsat.net.pl/fbv/";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ peterhoeg ];
+    mainProgram = "fbv";
   };
 }

--- a/pkgs/tools/graphics/feedgnuplot/default.nix
+++ b/pkgs/tools/graphics/feedgnuplot/default.nix
@@ -62,5 +62,6 @@ perlPackages.buildPerlPackage rec {
     license = with licenses; [ artistic1 gpl1Plus ];
     platforms = platforms.unix;
     maintainers = with maintainers; [ mnacamura ];
+    mainProgram = "feedgnuplot";
   };
 }

--- a/pkgs/tools/graphics/fgallery/default.nix
+++ b/pkgs/tools/graphics/fgallery/default.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.all;
     maintainers = [ maintainers.bjornfor ];
+    mainProgram = "fgallery";
   };
 }

--- a/pkgs/tools/graphics/ggobi/default.nix
+++ b/pkgs/tools/graphics/ggobi/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     license = licenses.cpl10;
     platforms = platforms.linux;
     maintainers = [ maintainers.michelk ];
+    mainProgram = "ggobi";
   };
 }

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -88,5 +88,6 @@ in
       url = "https://sourceforge.net/p/gnuplot/gnuplot-main/ci/master/tree/Copyright";
     };
     maintainers = with maintainers; [ lovek323 ];
+    mainProgram = "gnuplot";
   };
 }

--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -113,5 +113,6 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ kira-bruneau ];
     platforms = platforms.linux;
+    mainProgram = "goverlay";
   };
 }

--- a/pkgs/tools/graphics/graph-cli/default.nix
+++ b/pkgs/tools/graphics/graph-cli/default.nix
@@ -28,5 +28,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/mcastorina/graph-cli/";
     license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ leungbk ];
+    mainProgram = "graph";
   };
 }

--- a/pkgs/tools/graphics/graph-easy/default.nix
+++ b/pkgs/tools/graphics/graph-easy/default.nix
@@ -13,5 +13,6 @@ perlPackages.buildPerlPackage {
     license = licenses.gpl1Only;
     platforms = platforms.unix;
     maintainers = [ maintainers.jensbin ];
+    mainProgram = "graph-easy";
   };
 }

--- a/pkgs/tools/graphics/gromit-mpx/default.nix
+++ b/pkgs/tools/graphics/gromit-mpx/default.nix
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ pjones ];
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
+    mainProgram = "gromit-mpx";
   };
 }

--- a/pkgs/tools/graphics/guff/default.nix
+++ b/pkgs/tools/graphics/guff/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
+    mainProgram = "guff";
   };
 }

--- a/pkgs/tools/graphics/ibniz/default.nix
+++ b/pkgs/tools/graphics/ibniz/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     license = licenses.zlib;
     platforms = platforms.linux;
     maintainers = [ maintainers.dezgeg ];
+    mainProgram = "ibniz";
   };
 }

--- a/pkgs/tools/graphics/imgur-screenshot/default.nix
+++ b/pkgs/tools/graphics/imgur-screenshot/default.nix
@@ -25,5 +25,6 @@ in stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.mit;
     maintainers = with maintainers; [ lw ];
+    mainProgram = "imgur-screenshot";
   };
 }

--- a/pkgs/tools/graphics/imgurbash2/default.nix
+++ b/pkgs/tools/graphics/imgurbash2/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
     homepage = "https://github.com/ram-on/imgurbash2";
+    mainProgram = "imgurbash2";
   };
 }

--- a/pkgs/tools/graphics/jhead/default.nix
+++ b/pkgs/tools/graphics/jhead/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     license = licenses.publicDomain;
     maintainers = with maintainers; [ rycee ];
     platforms = platforms.all;
+    mainProgram = "jhead";
   };
 }

--- a/pkgs/tools/graphics/jpegexiforient/default.nix
+++ b/pkgs/tools/graphics/jpegexiforient/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation {
     license = licenses.free;
     platforms = platforms.all;
     maintainers = with maintainers; [ infinisil ];
+    mainProgram = "jpegexiforient";
   };
 }

--- a/pkgs/tools/graphics/leela/default.nix
+++ b/pkgs/tools/graphics/leela/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.puffnfresh ];
     platforms = lib.platforms.linux;
+    mainProgram = "leela";
   };
 }

--- a/pkgs/tools/graphics/logstalgia/default.nix
+++ b/pkgs/tools/graphics/logstalgia/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
 
     platforms = platforms.gnu ++ platforms.linux;
     maintainers = with maintainers; [ pSub ];
+    mainProgram = "logstalgia";
   };
 }

--- a/pkgs/tools/graphics/lsix/default.nix
+++ b/pkgs/tools/graphics/lsix/default.nix
@@ -32,5 +32,6 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.gpl3Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ kidonng ];
+    mainProgram = "lsix";
   };
 }

--- a/pkgs/tools/graphics/mscgen/default.nix
+++ b/pkgs/tools/graphics/mscgen/default.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation rec {
     '';
 
     platforms = lib.platforms.unix;
+    mainProgram = "mscgen";
   };
 }

--- a/pkgs/tools/graphics/nifskope/default.nix
+++ b/pkgs/tools/graphics/nifskope/default.nix
@@ -63,5 +63,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ eelco ];
     platforms = platforms.linux;
     license = licenses.bsd3;
+    mainProgram = "NifSkope";
   };
 }

--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -52,5 +52,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ kovirobi ];
     platforms = platforms.unix;
+    mainProgram = "nip2";
   };
 }

--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation rec {
     description = "A PNG optimizer";
     license = licenses.zlib;
     platforms = platforms.unix;
+    mainProgram = "optipng";
   };
 }

--- a/pkgs/tools/graphics/oxipng/default.nix
+++ b/pkgs/tools/graphics/oxipng/default.nix
@@ -18,5 +18,6 @@ rustPlatform.buildRustPackage rec {
     description = "A multithreaded lossless PNG compression optimizer";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dywedir ];
+    mainProgram = "oxipng";
   };
 }

--- a/pkgs/tools/graphics/pdf2svg/default.nix
+++ b/pkgs/tools/graphics/pdf2svg/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.ianwookim ];
     platforms = platforms.unix;
+    mainProgram = "pdf2svg";
   };
 }

--- a/pkgs/tools/graphics/pdftag/default.nix
+++ b/pkgs/tools/graphics/pdftag/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ leenaars ];
     platforms = platforms.unix;
+    mainProgram = "pdftag";
   };
 }

--- a/pkgs/tools/graphics/pdftoipe/default.nix
+++ b/pkgs/tools/graphics/pdftoipe/default.nix
@@ -50,5 +50,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/otfried/ipe-tools/releases";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ yrd ];
+    mainProgram = "pdftoipe";
   };
 }

--- a/pkgs/tools/graphics/perceptualdiff/default.nix
+++ b/pkgs/tools/graphics/perceptualdiff/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ uri-canva ];
     platforms = platforms.unix;
+    mainProgram = "perceptualdiff";
   };
 }

--- a/pkgs/tools/graphics/piglit/default.nix
+++ b/pkgs/tools/graphics/piglit/default.nix
@@ -73,5 +73,6 @@ stdenv.mkDerivation rec {
     license = licenses.free; # custom license. See COPYING in the source repo.
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ Flakebi ];
+    mainProgram = "piglit";
   };
 }

--- a/pkgs/tools/graphics/pixel2svg/default.nix
+++ b/pkgs/tools/graphics/pixel2svg/default.nix
@@ -16,5 +16,6 @@ python310Packages.buildPythonPackage rec {
     description = "Converts pixel art to SVG - pixel by pixel";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ annaaurora ];
+    mainProgram = "pixel2svg.py";
   };
 }

--- a/pkgs/tools/graphics/pngcheck/default.nix
+++ b/pkgs/tools/graphics/pngcheck/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     platforms = platforms.unix;
     maintainers = with maintainers; [ starcraft66 ];
+    mainProgram = "pngcheck";
   };
 }

--- a/pkgs/tools/graphics/pngcrush/default.nix
+++ b/pkgs/tools/graphics/pngcrush/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     description = "A PNG optimizer";
     license = lib.licenses.free;
     platforms = with lib.platforms; linux ++ darwin;
+    mainProgram = "pngcrush";
   };
 }

--- a/pkgs/tools/graphics/pngloss/default.nix
+++ b/pkgs/tools/graphics/pngloss/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ _2gn ];
+    mainProgram = "pngloss";
   };
 }

--- a/pkgs/tools/graphics/pngout/default.nix
+++ b/pkgs/tools/graphics/pngout/default.nix
@@ -46,5 +46,6 @@ stdenv.mkDerivation rec {
     homepage = "http://advsys.net/ken/utils.htm";
     platforms = lib.attrNames platforms;
     maintainers = [ lib.maintainers.sander ];
+    mainProgram = "pngout";
   };
 }

--- a/pkgs/tools/graphics/pngtoico/default.nix
+++ b/pkgs/tools/graphics/pngtoico/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     description = "Small utility to convert a set of PNG images to Microsoft ICO format";
     license = lib.licenses.gpl2Plus;
     platforms = with lib.platforms; linux;
+    mainProgram = "pngtoico";
   };
 }

--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     description = "Persistence of Vision Raytracer";
     license = licenses.free;
     platforms = platforms.linux;
+    mainProgram = "povray";
   };
 }

--- a/pkgs/tools/graphics/pstoedit/default.nix
+++ b/pkgs/tools/graphics/pstoedit/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.marcweber ];
     platforms = platforms.unix;
+    mainProgram = "pstoedit";
   };
 }

--- a/pkgs/tools/graphics/qrcode/default.nix
+++ b/pkgs/tools/graphics/qrcode/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ raskin ];
     platforms = with platforms; unix;
+    mainProgram = "qrcode";
   };
 }

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
@@ -60,5 +60,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ tilcreator ];
     platforms = platforms.all;
+    mainProgram = "realesrgan-ncnn-vulkan";
   };
 }

--- a/pkgs/tools/graphics/s2png/default.nix
+++ b/pkgs/tools/graphics/s2png/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.dbohdan ];
     platforms = lib.platforms.unix;
+    mainProgram = "s2png";
   };
 }

--- a/pkgs/tools/graphics/sanjuuni/default.nix
+++ b/pkgs/tools/graphics/sanjuuni/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.tomodachi94 ];
     license = licenses.gpl2Plus;
     broken = stdenv.isDarwin;
+    mainProgram = "sanjuuni";
   };
 }

--- a/pkgs/tools/graphics/shot-scraper/default.nix
+++ b/pkgs/tools/graphics/shot-scraper/default.nix
@@ -35,5 +35,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/simonw/shot-scraper/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ techknowlogick ];
+    mainProgram = "shot-scraper";
   };
 }

--- a/pkgs/tools/graphics/shotgun/default.nix
+++ b/pkgs/tools/graphics/shotgun/default.nix
@@ -19,5 +19,6 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ figsoda lumi novenary ];
     platforms = platforms.linux;
+    mainProgram = "shotgun";
   };
 }

--- a/pkgs/tools/graphics/smartcrop/default.nix
+++ b/pkgs/tools/graphics/smartcrop/default.nix
@@ -23,5 +23,6 @@ buildGoModule {
     homepage = "https://github.com/muesli/smartcrop";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "smartcrop";
   };
 }

--- a/pkgs/tools/graphics/sng/default.nix
+++ b/pkgs/tools/graphics/sng/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     license = licenses.zlib;
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.unix;
+    mainProgram = "sng";
   };
 }

--- a/pkgs/tools/graphics/spirv-cross/default.nix
+++ b/pkgs/tools/graphics/spirv-cross/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.all;
     license = licenses.asl20;
     maintainers = with maintainers; [ Flakebi ];
+    mainProgram = "spirv-cross";
   };
 })

--- a/pkgs/tools/graphics/steghide/default.nix
+++ b/pkgs/tools/graphics/steghide/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; unix;
+    mainProgram = "steghide";
   };
 })

--- a/pkgs/tools/graphics/stegsolve/default.nix
+++ b/pkgs/tools/graphics/stegsolve/default.nix
@@ -55,5 +55,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     };
     maintainers = with maintainers; [ emilytrau ];
     platforms = platforms.all;
+    mainProgram = "stegsolve";
   };
 })

--- a/pkgs/tools/graphics/svg2pdf/default.nix
+++ b/pkgs/tools/graphics/svg2pdf/default.nix
@@ -22,5 +22,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/typst/svg2pdf/releases/tag/${src.rev}";
     license = with licenses; [ asl20 mit ];
     maintainers = with maintainers; [ doronbehar figsoda ];
+    mainProgram = "svg2pdf";
   };
 }

--- a/pkgs/tools/graphics/svgbob/default.nix
+++ b/pkgs/tools/graphics/svgbob/default.nix
@@ -22,5 +22,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/ivanceras/svgbob/raw/${version}/Changelog.md";
     license = licenses.asl20;
     maintainers = [ maintainers.marsam ];
+    mainProgram = "svgbob";
   };
 }

--- a/pkgs/tools/graphics/svgcleaner/default.nix
+++ b/pkgs/tools/graphics/svgcleaner/default.nix
@@ -22,5 +22,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/RazrFalcon/svgcleaner/releases";
     license = licenses.gpl2;
     maintainers = with maintainers; [ yuu ];
+    mainProgram = "svgcleaner";
   };
 }

--- a/pkgs/tools/graphics/textplots/default.nix
+++ b/pkgs/tools/graphics/textplots/default.nix
@@ -18,5 +18,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/loony-bean/textplots-rs";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "textplots";
   };
 }

--- a/pkgs/tools/graphics/texture-synthesis/default.nix
+++ b/pkgs/tools/graphics/texture-synthesis/default.nix
@@ -26,5 +26,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/embarkstudios/texture-synthesis";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "texture-synthesis";
   };
 }

--- a/pkgs/tools/graphics/twilight/default.nix
+++ b/pkgs/tools/graphics/twilight/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];
+    mainProgram = "twilight";
   };
 }

--- a/pkgs/tools/graphics/viu/default.nix
+++ b/pkgs/tools/graphics/viu/default.nix
@@ -29,5 +29,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/atanunq/viu";
     license = licenses.mit;
     maintainers = with maintainers; [ chuangzhu ];
+    mainProgram = "viu";
   };
 }

--- a/pkgs/tools/graphics/vkbasalt-cli/default.nix
+++ b/pkgs/tools/graphics/vkbasalt-cli/default.nix
@@ -27,5 +27,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://gitlab.com/TheEvilSkeleton/vkbasalt-cli";
     license = with licenses; [ lgpl3Only gpl3Only ];
     maintainers = with maintainers; [ martfont ];
+    mainProgram = "vkbasalt";
   };
 }

--- a/pkgs/tools/graphics/vkdisplayinfo/default.nix
+++ b/pkgs/tools/graphics/vkdisplayinfo/default.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.boost;
     maintainers = [ maintainers.LunNova ];
+    mainProgram = "vkdisplayinfo";
   };
 }

--- a/pkgs/tools/graphics/vkmark/default.nix
+++ b/pkgs/tools/graphics/vkmark/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl21Plus ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ muscaln ];
+    mainProgram = "vkmark";
   };
 }

--- a/pkgs/tools/graphics/vulkan-helper/default.nix
+++ b/pkgs/tools/graphics/vulkan-helper/default.nix
@@ -33,5 +33,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ aidalgol ];
     platforms = platforms.linux;
+    mainProgram = "vulkan-helper";
   };
 }

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.xzfc ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "waifu2x-converter-cpp";
   };
 }

--- a/pkgs/tools/graphics/xcolor/default.nix
+++ b/pkgs/tools/graphics/xcolor/default.nix
@@ -43,5 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Soft/xcolor";
     maintainers = with lib.maintainers; [ moni ];
     license = licenses.mit;
+    mainProgram = "xcolor";
   };
 }

--- a/pkgs/tools/graphics/xcur2png/default.nix
+++ b/pkgs/tools/graphics/xcur2png/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ romildo ];
+    mainProgram = "xcur2png";
   };
 }

--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ neonfuz ];
+    mainProgram = "yaxg";
   };
 }

--- a/pkgs/tools/llm/gorilla-cli/default.nix
+++ b/pkgs/tools/llm/gorilla-cli/default.nix
@@ -34,5 +34,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/gorilla-llm/gorilla-cli";
     license = licenses.asl20;
     maintainers = with maintainers; [ happysalada ];
+    mainProgram = "gorilla";
   };
 }

--- a/pkgs/tools/security/agebox/default.nix
+++ b/pkgs/tools/security/agebox/default.nix
@@ -25,5 +25,6 @@ buildGoModule rec {
     description = "Age based repository file encryption gitops tool";
     license = licenses.asl20;
     maintainers = with maintainers; [ lesuisse ];
+    mainProgram = "agebox";
   };
 }

--- a/pkgs/tools/security/apkleaks/default.nix
+++ b/pkgs/tools/security/apkleaks/default.nix
@@ -33,5 +33,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/dwisiswant0/apkleaks";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "apkleaks";
   };
 }

--- a/pkgs/tools/security/bao/default.nix
+++ b/pkgs/tools/security/bao/default.nix
@@ -20,5 +20,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/oconnor663/bao";
     maintainers = with lib.maintainers; [ amarshall ];
     license = with lib.licenses; [ cc0 asl20 ];
+    mainProgram = "bao";
   };
 }

--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -37,5 +37,6 @@ buildGoModule rec {
     homepage = "https://www.bettercap.org/";
     license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ y0no ];
+    mainProgram = "bettercap";
   };
 }

--- a/pkgs/tools/security/ctmg/default.nix
+++ b/pkgs/tools/security/ctmg/default.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = with maintainers; [ mrVanDalo ];
     platforms = platforms.linux;
+    mainProgram = "ctmg";
   };
 }

--- a/pkgs/tools/security/cyclonedx-gomod/default.nix
+++ b/pkgs/tools/security/cyclonedx-gomod/default.nix
@@ -25,5 +25,6 @@ buildGoModule rec {
     changelog = "https://github.com/CycloneDX/cyclonedx-gomod/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "cyclonedx-gomod";
   };
 }

--- a/pkgs/tools/security/dalfox/default.nix
+++ b/pkgs/tools/security/dalfox/default.nix
@@ -25,5 +25,6 @@ buildGoModule rec {
     changelog = "https://github.com/hahwul/dalfox/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "dalfox";
   };
 }

--- a/pkgs/tools/security/dismember/default.nix
+++ b/pkgs/tools/security/dismember/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/liamg/dismember";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "dismember";
   };
 }

--- a/pkgs/tools/security/erosmb/default.nix
+++ b/pkgs/tools/security/erosmb/default.nix
@@ -44,5 +44,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/viktor02/EroSmb/releases/tag/v${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "erosmb";
   };
 }

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
     platforms = platforms.unix;
+    mainProgram = "feroxbuster";
   };
 }
 

--- a/pkgs/tools/security/fscan/default.nix
+++ b/pkgs/tools/security/fscan/default.nix
@@ -19,5 +19,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [ Misaka13514 ];
     platforms = with platforms; unix ++ windows;
+    mainProgram = "fscan";
   };
 }

--- a/pkgs/tools/security/gen-oath-safe/default.nix
+++ b/pkgs/tools/security/gen-oath-safe/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     platforms =  platforms.unix;
     license = licenses.mit;
     maintainers = [ maintainers.makefu ];
+    mainProgram = "gen-oath-safe";
   };
 
 }

--- a/pkgs/tools/security/go-dork/default.nix
+++ b/pkgs/tools/security/go-dork/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     changelog = "https://github.com/dwisiswant0/go-dork/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "go-dork";
   };
 }

--- a/pkgs/tools/security/hash-identifier/default.nix
+++ b/pkgs/tools/security/hash-identifier/default.nix
@@ -23,5 +23,6 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ethancedwards8 ];
+    mainProgram = "hash-identifier";
   };
 }

--- a/pkgs/tools/security/hcxdumptool/default.nix
+++ b/pkgs/tools/security/hcxdumptool/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ danielfullmer ];
+    mainProgram = "hcxdumptool";
   };
 }

--- a/pkgs/tools/security/ic-keysmith/default.nix
+++ b/pkgs/tools/security/ic-keysmith/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     homepage = "https://github.com/dfinity/keysmith";
     license = licenses.mit;
     maintainers = with maintainers; [ imalison ];
+    mainProgram = "keysmith";
   };
 }

--- a/pkgs/tools/security/jwt-hack/default.nix
+++ b/pkgs/tools/security/jwt-hack/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/hahwul/jwt-hack";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "jwt-hack";
   };
 }

--- a/pkgs/tools/security/kepler/default.nix
+++ b/pkgs/tools/security/kepler/default.nix
@@ -43,5 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Exein-io/kepler";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "kepler";
   };
 }

--- a/pkgs/tools/security/kube-hunter/default.nix
+++ b/pkgs/tools/security/kube-hunter/default.nix
@@ -59,5 +59,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/aquasecurity/kube-hunter";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "kube-hunter";
   };
 }

--- a/pkgs/tools/security/kubestroyer/default.nix
+++ b/pkgs/tools/security/kubestroyer/default.nix
@@ -27,5 +27,6 @@ buildGoModule rec {
     changelog = "https://github.com/Rolix44/Kubestroyer/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "kubestroyer";
   };
 }

--- a/pkgs/tools/security/ldapnomnom/default.nix
+++ b/pkgs/tools/security/ldapnomnom/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     changelog = "https://github.com/lkarlslund/ldapnomnom/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "ldapnomnom";
   };
 }

--- a/pkgs/tools/security/lethe/default.nix
+++ b/pkgs/tools/security/lethe/default.nix
@@ -25,5 +25,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kostassoid/lethe";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "lethe";
   };
 }

--- a/pkgs/tools/security/libmodsecurity/default.nix
+++ b/pkgs/tools/security/libmodsecurity/default.nix
@@ -76,5 +76,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ izorkin ];
+    mainProgram = "modsec-rules-check";
   };
 }

--- a/pkgs/tools/security/lmp/default.nix
+++ b/pkgs/tools/security/lmp/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/0xInfection/LogMePwn";
     license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "lmp";
   };
 }

--- a/pkgs/tools/security/log4jcheck/default.nix
+++ b/pkgs/tools/security/log4jcheck/default.nix
@@ -30,5 +30,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/NorthwaveSecurity/log4jcheck";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "log4jcheck";
   };
 }

--- a/pkgs/tools/security/log4shell-detector/default.nix
+++ b/pkgs/tools/security/log4shell-detector/default.nix
@@ -36,5 +36,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/Neo23x0/log4shell-detector";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "log4shell-detector";
   };
 }

--- a/pkgs/tools/security/logmap/default.nix
+++ b/pkgs/tools/security/logmap/default.nix
@@ -30,5 +30,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/zhzyker/logmap";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "logmap";
   };
 }

--- a/pkgs/tools/security/mantra/default.nix
+++ b/pkgs/tools/security/mantra/default.nix
@@ -27,5 +27,6 @@ buildGoModule rec {
     changelog = "https://github.com/MrEmpy/Mantra/releases/tag/v.${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "mantra";
   };
 }

--- a/pkgs/tools/security/minisign/default.nix
+++ b/pkgs/tools/security/minisign/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = with maintainers; [ joachifm ];
     platforms = platforms.unix;
+    mainProgram = "minisign";
   };
 }

--- a/pkgs/tools/security/mongoaudit/default.nix
+++ b/pkgs/tools/security/mongoaudit/default.nix
@@ -35,5 +35,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/stampery/mongoaudit";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "mongoaudit";
   };
 }

--- a/pkgs/tools/security/nsjail/default.nix
+++ b/pkgs/tools/security/nsjail/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license     = licenses.asl20;
     maintainers = with maintainers; [ arturcygan bosu c0bw3b ];
     platforms   = platforms.linux;
+    mainProgram = "nsjail";
   };
 }

--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -26,5 +26,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.nongnu.org/oath-toolkit/";
     maintainers = with maintainers; [ schnusch ];
     platforms = with platforms; linux ++ darwin;
+    mainProgram = "oathtool";
   };
 }

--- a/pkgs/tools/security/onesixtyone/default.nix
+++ b/pkgs/tools/security/onesixtyone/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.fishi0x01 ];
+    mainProgram = "onesixtyone";
   };
 }
 

--- a/pkgs/tools/security/parsero/default.nix
+++ b/pkgs/tools/security/parsero/default.nix
@@ -24,5 +24,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/behindthefirewalls/Parsero";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ emilytrau fab ];
+    mainProgram = "parsero";
   };
 }

--- a/pkgs/tools/security/prs/default.nix
+++ b/pkgs/tools/security/prs/default.nix
@@ -59,5 +59,6 @@ rustPlatform.buildRustPackage rec {
       gpl3Only  # everything else
     ];
     maintainers = with maintainers; [ dotlambda ];
+    mainProgram = "prs";
   };
 }

--- a/pkgs/tools/security/routersploit/default.nix
+++ b/pkgs/tools/security/routersploit/default.nix
@@ -52,5 +52,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/threat9/routersploit";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "rsf";
   };
 }

--- a/pkgs/tools/security/rucredstash/default.nix
+++ b/pkgs/tools/security/rucredstash/default.nix
@@ -24,5 +24,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/psibi/rucredstash";
     license = licenses.mit;
     maintainers = with maintainers; [ psibi ];
+    mainProgram = "rucredstash";
   };
 }

--- a/pkgs/tools/security/shellz/default.nix
+++ b/pkgs/tools/security/shellz/default.nix
@@ -26,5 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/evilsocket/shellz";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "shellz";
   };
 }

--- a/pkgs/tools/security/silenthound/default.nix
+++ b/pkgs/tools/security/silenthound/default.nix
@@ -39,5 +39,6 @@ python3.pkgs.buildPythonApplication rec {
     # Unknown license, https://github.com/layer8secure/SilentHound/issues/1
     license = licenses.unfree;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "silenthound";
   };
 }

--- a/pkgs/tools/security/slowhttptest/default.nix
+++ b/pkgs/tools/security/slowhttptest/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/shekyan/slowhttptest";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "slowhttptest";
   };
 }

--- a/pkgs/tools/security/smbscan/default.nix
+++ b/pkgs/tools/security/smbscan/default.nix
@@ -37,5 +37,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/jeffhacks/smbscan";
     license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "smbscan";
   };
 }

--- a/pkgs/tools/security/stegseek/default.nix
+++ b/pkgs/tools/security/stegseek/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/RickdeJager/stegseek";
     license = with licenses; [ gpl2Only ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "stegseek";
   };
 }

--- a/pkgs/tools/security/stricat/default.nix
+++ b/pkgs/tools/security/stricat/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.bsd3;
     platforms   = lib.platforms.unix;
     maintainers = [ lib.maintainers.thoughtpolice ];
+    mainProgram = "stricat";
   };
 }

--- a/pkgs/tools/security/sx-go/default.nix
+++ b/pkgs/tools/security/sx-go/default.nix
@@ -41,5 +41,6 @@ buildGoModule rec {
     homepage = "https://github.com/v-byte-cpu/sx";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "sx-go";
   };
 }

--- a/pkgs/tools/security/tessen/default.nix
+++ b/pkgs/tools/security/tessen/default.nix
@@ -48,5 +48,6 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ monaaraj ];
+    mainProgram = "tessen";
   };
 }

--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -39,5 +39,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dani-garcia/vaultwarden";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ msteen ivan ];
+    mainProgram = "vaultwarden";
   };
 }

--- a/pkgs/tools/security/webanalyze/default.nix
+++ b/pkgs/tools/security/webanalyze/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     changelog = "https://github.com/rverton/webanalyze/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "webanalyze";
   };
 }

--- a/pkgs/tools/security/xcrawl3r/default.nix
+++ b/pkgs/tools/security/xcrawl3r/default.nix
@@ -27,5 +27,6 @@ buildGoModule rec {
     changelog = "https://github.com/hueristiq/xcrawl3r/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "xcrawl3r";
   };
 }

--- a/pkgs/tools/security/yatas/default.nix
+++ b/pkgs/tools/security/yatas/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     changelog = "https://github.com/padok-team/YATAS/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "yatas";
   };
 }

--- a/pkgs/tools/security/yubihsm-connector/default.nix
+++ b/pkgs/tools/security/yubihsm-connector/default.nix
@@ -32,5 +32,6 @@ buildGoModule rec {
     homepage = "https://developers.yubico.com/yubihsm-connector/";
     maintainers = with maintainers; [ matthewcroughan ];
     license = licenses.asl20;
+    mainProgram = "yubihsm-connector";
   };
 }

--- a/pkgs/tools/typesetting/asciidoctorj/default.nix
+++ b/pkgs/tools/typesetting/asciidoctorj/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ moaxcp ];
+    mainProgram = "asciidoctorj";
   };
 }

--- a/pkgs/tools/typesetting/biber-ms/default.nix
+++ b/pkgs/tools/typesetting/biber-ms/default.nix
@@ -50,5 +50,6 @@ perlPackages.buildPerlModule {
     license = biberSource.meta.license;
     platforms = platforms.unix;
     maintainers = [ maintainers.xworld21 ];
+    mainProgram = "biber-ms";
   };
 }

--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -31,5 +31,6 @@ perlPackages.buildPerlModule {
     license = biberSource.meta.license;
     platforms = platforms.unix;
     maintainers = [ maintainers.ttuegel ];
+    mainProgram = "biber";
   };
 }

--- a/pkgs/tools/typesetting/biblatex-check/default.nix
+++ b/pkgs/tools/typesetting/biblatex-check/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Pezmc/BibLatex-Check";
     license = licenses.mit;
     maintainers = with maintainers; [ dtzWill ];
+    mainProgram = "biblatex-check";
   };
 }

--- a/pkgs/tools/typesetting/coq2html/default.nix
+++ b/pkgs/tools/typesetting/coq2html/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation  rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jwiegley siraben ];
     platforms = platforms.unix;
+    mainProgram = "coq2html";
   };
 }

--- a/pkgs/tools/typesetting/djvu2pdf/default.nix
+++ b/pkgs/tools/typesetting/djvu2pdf/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     homepage = "https://0x2a.at/site/projects/djvu2pdf/";
     license = lib.licenses.gpl1Only;
     platforms = lib.platforms.all;
+    mainProgram = "djvu2pdf";
   };
 }

--- a/pkgs/tools/typesetting/docbook2odf/default.nix
+++ b/pkgs/tools/typesetting/docbook2odf/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
+    mainProgram = "docbook2odf";
   };
 }

--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.all;
     maintainers = with maintainers; [ bjornfor ];
+    mainProgram = "fop";
   };
 }

--- a/pkgs/tools/typesetting/git-latexdiff/default.nix
+++ b/pkgs/tools/typesetting/git-latexdiff/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     license = licenses.bsd3; # https://gitlab.com/git-latexdiff/git-latexdiff/issues/9
     platforms = platforms.unix;
+    mainProgram = "git-latexdiff";
   };
 }

--- a/pkgs/tools/typesetting/halibut/default.nix
+++ b/pkgs/tools/typesetting/halibut/default.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; unix;
+    mainProgram = "halibut";
   };
 }

--- a/pkgs/tools/typesetting/hayagriva/default.nix
+++ b/pkgs/tools/typesetting/hayagriva/default.nix
@@ -30,5 +30,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/typst/hayagriva/releases/tag/v${version}";
     license = with licenses; [ asl20 mit ];
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "hayagriva";
   };
 }

--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
       generates corresponding HTML, PostScript, or PDF files with an optional
       table of contents.
     '';
+    mainProgram = "htmldoc";
   };
 }

--- a/pkgs/tools/typesetting/kramdown-asciidoc/default.nix
+++ b/pkgs/tools/typesetting/kramdown-asciidoc/default.nix
@@ -30,6 +30,7 @@ let
       license = licenses.mit;
       maintainers = with maintainers; [ ];
       platforms = platforms.unix;
+      mainProgram = "kramdoc";
     };
   };
 in

--- a/pkgs/tools/typesetting/mmark/default.nix
+++ b/pkgs/tools/typesetting/mmark/default.nix
@@ -27,5 +27,6 @@ buildGoModule rec {
     homepage = "https://github.com/mmarkdown/mmark";
     license = with lib.licenses; bsd2;
     maintainers = with lib.maintainers; [ yrashk ];
+    mainProgram = "mmark";
   };
 }

--- a/pkgs/tools/typesetting/pdf2djvu/default.nix
+++ b/pkgs/tools/typesetting/pdf2djvu/default.nix
@@ -62,5 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://jwilk.net/software/pdf2djvu";
     license = licenses.gpl2;
     maintainers = with maintainers; [ pSub ];
+    mainProgram = "pdf2djvu";
   };
 }

--- a/pkgs/tools/typesetting/pdfchain/default.nix
+++ b/pkgs/tools/typesetting/pdfchain/default.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ hqurve ];
     platforms = platforms.unix;
+    mainProgram = "pdfchain";
   };
 }

--- a/pkgs/tools/typesetting/pdfgrep/default.nix
+++ b/pkgs/tools/typesetting/pdfgrep/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ qknight fpletz ];
     platforms = with lib.platforms; unix;
+    mainProgram = "pdfgrep";
   };
 }

--- a/pkgs/tools/typesetting/pdfsandwich/default.nix
+++ b/pkgs/tools/typesetting/pdfsandwich/default.nix
@@ -28,5 +28,6 @@ meta = with lib; {
     license = licenses.gpl2;
     maintainers = [ maintainers.rps ];
     platforms = platforms.linux;
+    mainProgram = "pdfsandwich";
   };
 }

--- a/pkgs/tools/typesetting/pdftk/default.nix
+++ b/pkgs/tools/typesetting/pdftk/default.nix
@@ -95,5 +95,6 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ raskin averelld ];
     platforms = platforms.unix;
+    mainProgram = "pdftk";
   };
 }

--- a/pkgs/tools/typesetting/pulldown-cmark/default.nix
+++ b/pkgs/tools/typesetting/pulldown-cmark/default.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/raphlinus/pulldown-cmark";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ CobaltCause ];
+    mainProgram = "pulldown-cmark";
   };
 }

--- a/pkgs/tools/typesetting/rfc-bibtex/default.nix
+++ b/pkgs/tools/typesetting/rfc-bibtex/default.nix
@@ -29,5 +29,6 @@ with python3.pkgs; buildPythonApplication rec {
     description = "Generate Bibtex entries for IETF RFCs and Internet-Drafts";
     license = licenses.mit;
     maintainers = with maintainers; [ teto ];
+    mainProgram = "rfcbibtex";
   };
 }

--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -80,5 +80,6 @@ in
       license = licenses.lgpl3Only;
       maintainers = [ maintainers.mt-caret maintainers.marsam ];
       platforms = platforms.all;
+      mainProgram = "satysfi";
     };
   }

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -137,5 +137,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.unix;
     maintainers = with maintainers; [ doronbehar alerque ];
     license = licenses.mit;
+    mainProgram = "sile";
   };
 })

--- a/pkgs/tools/typesetting/sshlatex/default.nix
+++ b/pkgs/tools/typesetting/sshlatex/default.nix
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;  # actually dual-licensed gpl3Plus | lppl13cplus
     platforms = lib.platforms.all;
     maintainers = [ maintainers.iblech ];
+    mainProgram = "sshlatex";
   };
 }

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -29,5 +29,6 @@ mkDerivation {
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.iblech maintainers.mgttlinger ];
+    mainProgram = "tikzit";
   };
 }

--- a/pkgs/tools/typesetting/typstfmt/default.nix
+++ b/pkgs/tools/typesetting/typstfmt/default.nix
@@ -24,5 +24,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/astrale-sharp/typstfmt/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda geri1701 ];
+    mainProgram = "typstfmt";
   };
 }

--- a/pkgs/tools/typesetting/xmlroff/default.nix
+++ b/pkgs/tools/typesetting/xmlroff/default.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation rec {
     homepage = "http://xmlroff.org/";
     platforms = platforms.unix;
     license = licenses.bsd3;
+    mainProgram = "xmlroff";
   };
 }

--- a/pkgs/tools/video/dvgrab/default.nix
+++ b/pkgs/tools/video/dvgrab/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation {
 
     license = licenses.gpl2Plus;
     platforms = platforms.gnu ++ platforms.linux;
+    mainProgram = "dvgrab";
   };
 }

--- a/pkgs/tools/video/go2rtc/default.nix
+++ b/pkgs/tools/video/go2rtc/default.nix
@@ -35,5 +35,6 @@ buildGoModule rec {
     changelog = "https://github.com/AlexxIT/go2rtc/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
+    mainProgram = "go2rtc";
   };
 }

--- a/pkgs/tools/video/gopro/default.nix
+++ b/pkgs/tools/video/gopro/default.nix
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.gpl3;
     maintainers = with maintainers; [ jonringer ];
+    mainProgram = "gopro";
   };
 }

--- a/pkgs/tools/video/harvid/default.nix
+++ b/pkgs/tools/video/harvid/default.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ mitchmindtree ];
+    mainProgram = "harvid";
   };
 }

--- a/pkgs/tools/video/lux/default.nix
+++ b/pkgs/tools/video/lux/default.nix
@@ -39,5 +39,6 @@ buildGoModule rec {
     changelog = "https://github.com/iawia002/lux/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ galaxy ];
+    mainProgram = "lux";
   };
 }

--- a/pkgs/tools/video/play-with-mpv/default.nix
+++ b/pkgs/tools/video/play-with-mpv/default.nix
@@ -57,5 +57,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/Thann/play-with-mpv";
     license = licenses.mit;
     maintainers = with maintainers; [ dawidsowa ];
+    mainProgram = "play-with-mpv";
   };
 }

--- a/pkgs/tools/video/rav1e/default.nix
+++ b/pkgs/tools/video/rav1e/default.nix
@@ -63,5 +63,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/xiph/rav1e/releases/tag/v${version}";
     license = licenses.bsd2;
     maintainers = [ ];
+    mainProgram = "rav1e";
   };
 }

--- a/pkgs/tools/video/replay-sorcery/default.nix
+++ b/pkgs/tools/video/replay-sorcery/default.nix
@@ -58,5 +58,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ kira-bruneau ];
     platforms = platforms.linux;
+    mainProgram = "replay-sorcery";
   };
 }

--- a/pkgs/tools/video/swfmill/default.nix
+++ b/pkgs/tools/video/swfmill/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     homepage = "http://swfmill.org";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
+    mainProgram = "swfmill";
   };
 }

--- a/pkgs/tools/video/vcsi/default.nix
+++ b/pkgs/tools/video/vcsi/default.nix
@@ -33,5 +33,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/amietn/vcsi";
     license = licenses.mit;
     maintainers = with maintainers; [ dandellion zopieux ];
+    mainProgram = "vcsi";
   };
 }

--- a/pkgs/tools/video/vncrec/default.nix
+++ b/pkgs/tools/video/vncrec/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation {
     homepage = "http://ronja.twibright.com/utils/vncrec/";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2;
+    mainProgram = "vncrec";
   };
 }

--- a/pkgs/tools/video/wtwitch/default.nix
+++ b/pkgs/tools/video/wtwitch/default.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ urandom ];
     platforms = platforms.all;
+    mainProgram = "wtwitch";
   };
 }

--- a/pkgs/tools/video/yamdi/default.nix
+++ b/pkgs/tools/video/yamdi/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = [ maintainers.ryanartecona ];
+    mainProgram = "yamdi";
   };
 }

--- a/pkgs/tools/video/yaydl/default.nix
+++ b/pkgs/tools/video/yaydl/default.nix
@@ -40,5 +40,6 @@ rustPlatform.buildRustPackage rec {
     description = "Yet another youtube down loader";
     license = licenses.cddl;
     maintainers = with maintainers; [];
+    mainProgram = "yaydl";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR sets `mainProgram` attributes for some remaining packages in the following directories:

- `pkgs/tools/backup`
- `pkgs/tools/cd-dvd`
- `pkgs/tools/compression`
- `pkgs/tools/graphics`
- `pkgs/tools/llm` (only `gorilla-cli`)
- `pkgs/tools/security`
- `pkgs/tools/typesetting`
- `pkgs/tools/video`
- `pkgs/tools/X11` (only `xidlehook`)

I wrote a verification script for the names of the binaries, so there shouldn't be any typos.

The only packages with more than one binary are `xidlehook` and `prs`. `xidlehook-client` is a management socket cli interface, and I see it as an auxiliary program. As for `prs`, `prs-gtk3-copy` is almost not mentioned on the [README](https://github.com/timvisee/prs), and the project seems to label itself as a CLI.

`nixpkgs-review rev HEAD` reports no changed packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
