### PR TITLE
python311Packages.jupyter-core: 5.3.1 -> 5.5.0 

### DIFF
--- a/pkgs/development/python-modules/jupyter-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-core/default.nix
@@ -64,7 +64,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Base package on which Jupyter projects rely";
     homepage = "https://jupyter.org/";
+    changelog = "https://github.com/jupyter/jupyter_core/blob/${src.rev}/CHANGELOG.md";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
+    maintainers = teams.jupyter.members;
   };
 }

--- a/pkgs/development/python-modules/jupyter-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-core/default.nix
@@ -5,21 +5,22 @@
 , hatchling
 , platformdirs
 , traitlets
+, pip
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "jupyter-core";
-  version = "5.3.1";
+  version = "5.5.0";
   disabled = pythonOlder "3.7";
 
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyter";
     repo = "jupyter_core";
     rev = "refs/tags/v${version}";
-    hash = "sha256-kQ7oNEC5L19PTPaX6C2bP5FYuzlsFsS0TABsw6VvoL8=";
+    hash = "sha256-GufCQUkR4283xMsyrbv5tDfJ8SeL35WBW5Aw2z6Ardc=";
   };
 
   patches = [
@@ -36,12 +37,18 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    pip
     pytestCheckHook
   ];
 
   preCheck = ''
     export HOME=$TMPDIR
   '';
+
+  pytestFlagsArray = [
+    # suppress pytest.PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=-1, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
+    "-W ignore::pytest.PytestUnraisableExceptionWarning"
+  ];
 
   disabledTests = [
     # creates a temporary script, which isn't aware of PYTHONPATH

--- a/pkgs/development/python-modules/jupyter-core/tests_respect_pythonpath.patch
+++ b/pkgs/development/python-modules/jupyter-core/tests_respect_pythonpath.patch
@@ -1,8 +1,8 @@
-diff --git a/jupyter_core/tests/test_command.py b/jupyter_core/tests/test_command.py
-index 4ef38cd..08fba22 100644
---- a/jupyter_core/tests/test_command.py
-+++ b/jupyter_core/tests/test_command.py
-@@ -174,7 +174,7 @@ def test_not_on_path(tmpdir):
+diff --git a/tests/test_command.py b/tests/test_command.py
+index a0833c1..67c2110 100644
+--- a/tests/test_command.py
++++ b/tests/test_command.py
+@@ -191,7 +191,7 @@ def test_not_on_path(tmpdir):
      witness_src = "#!{}\n{}\n".format(sys.executable, 'print("WITNESS ME")')
      write_executable(witness, witness_src)
  
@@ -11,7 +11,7 @@ index 4ef38cd..08fba22 100644
      if "SYSTEMROOT" in os.environ:  # Windows http://bugs.python.org/issue20614
          env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
      if sys.platform == "win32":
-@@ -198,7 +198,7 @@ def test_path_priority(tmpdir):
+@@ -216,7 +216,7 @@ def test_path_priority(tmpdir):
      witness_b_src = "#!{}\n{}\n".format(sys.executable, 'print("WITNESS B")')
      write_executable(witness_b, witness_b_src)
  


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/jupyter/jupyter_core/compare/refs/tags/v5.3.1...v5.5.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
