### PR TITLE
python311Packages.mitsuba3: init at unstable-2023-11-23

### DIFF
--- a/pkgs/by-name/dr/drjit-core/0001-CMakeLists.txt-find_package-by-default-fallback-to-t.patch
+++ b/pkgs/by-name/dr/drjit-core/0001-CMakeLists.txt-find_package-by-default-fallback-to-t.patch
@@ -1,0 +1,82 @@
+From 31b97895b5b974bd08e2cb42ed333a804dbb4103 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Tue, 21 Nov 2023 19:33:27 +0000
+Subject: [PATCH 1/3] CMakeLists.txt: find_package by default, fallback to the
+ vendored deps
+
+---
+ CMakeLists.txt | 43 +++++++++++++++++++++++++++++++------------
+ 1 file changed, 31 insertions(+), 12 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 02250db..6b5a60c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,11 +70,38 @@ if (NOT APPLE)
+ endif()
+ 
+ # ----------------------------------------------------------
+-#  Build the nanothread library
++#  Find or build the dependencies
+ # ----------------------------------------------------------
+ 
+-add_subdirectory(ext/nanothread)
+-mark_as_advanced(NANOTHREAD_ENABLE_TESTS)
++find_package(nanothread)
++if (NOT nanothread_FOUND)
++  add_subdirectory(ext/nanothread)
++  mark_as_advanced(NANOTHREAD_ENABLE_TESTS)
++endif()
++
++find_package(PkgConfig)
++if (PkgConfig_FOUND)
++  pkg_check_modules(lz4 liblz4 IMPORTED_TARGET)
++  add_library(lz4 ALIAS PkgConfig::lz4)
++endif()
++if(NOT lz4_FOUND)
++  add_library(lz4 ext/lz4/lz4.c ext/lz4/xxhash.c)
++  target_include_directories(lz4 PUBLIC ext/lz4)
++endif()
++
++find_package(xxHash)
++if (NOT xxHash_FOUND)
++  add_library(xxhash ext/lz4/xxhash.c)
++  target_include_directories(xxhash PUBLIC ext/lz4)
++
++  add_library(xxHash::xxhash ALIAS xxhash)
++endif()
++
++
++find_package(tsl-robin-map)
++if (NOT tsl-robin-map_FOUND)
++  add_subdirectory(ext/robin_map)
++endif()
+ 
+ # ----------------------------------------------------------
+ #  Build Dr.Jit-Core
+@@ -135,21 +162,13 @@ add_library(
+   src/init.cpp
+   src/api.cpp
+ 
+-  # LZ4 compression library & XXHash hash function
+-  ext/lz4/lz4.h ext/lz4/lz4.c
+-  ext/lz4/xxhash.h ext/lz4/xxh3.h ext/lz4/xxhash.c
+-
+   # Precompiled kernels in compressed PTX format
+   resources/kernels.h resources/kernels.c
+ )
+ 
+ target_compile_features(drjit-core PRIVATE cxx_std_17)
+ 
+-target_include_directories(drjit-core PRIVATE
+-  ext/nanothread/include
+-  ext/robin_map/include
+-  ext/lz4
+-)
++target_link_libraries(drjit-core PRIVATE nanothread tsl::robin_map lz4 xxHash::xxhash)
+ 
+ if (MSVC)
+   # Conditional expression is constant (a few in robin_hash.h)
+-- 
+2.42.0
+

--- a/pkgs/by-name/dr/drjit-core/0002-cmake-add-the-install-targets.patch
+++ b/pkgs/by-name/dr/drjit-core/0002-cmake-add-the-install-targets.patch
@@ -1,0 +1,60 @@
+From cbb72da0c1a9aaa753a585084f976eebd409e472 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Tue, 21 Nov 2023 19:45:22 +0000
+Subject: [PATCH 2/3] cmake: add the install targets
+
+---
+ .gitignore              |  1 +
+ CMakeLists.txt          | 11 ++++++++++-
+ drjit-core-config.cmake |  1 +
+ 3 files changed, 12 insertions(+), 1 deletion(-)
+ create mode 100644 drjit-core-config.cmake
+
+diff --git a/.gitignore b/.gitignore
+index aabfccc..f3a36f6 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,6 +1,7 @@
+ /.clangd
+ /compile_commands.json
+ *.cmake
++!drjit-core-config.cmake
+ CMakeCache.txt
+ CMakeFiles
+ Makefile
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b5a60c..bb1f694 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -189,7 +189,7 @@ target_compile_definitions(drjit-core PRIVATE -DLZ4LIB_VISIBILITY=)
+ target_include_directories(drjit-core
+   PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++  $<INSTALL_INTERFACE:include>)
+ 
+ target_compile_definitions(drjit-core PRIVATE -DDRJIT_BUILD=1)
+ target_link_libraries(drjit-core PRIVATE nanothread)
+@@ -248,3 +248,12 @@ set_target_properties(drjit-core PROPERTIES INTERPROCEDURAL_OPTIMIZATION_DEBUG
+ if (DRJIT_ENABLE_TESTS)
+   add_subdirectory(tests)
+ endif()
++
++configure_file(drjit-core-config.cmake "${CMAKE_CURRENT_BINARY_DIR}/drjit-core/drjit-core-config.cmake")
++install(TARGETS drjit-core EXPORT drjit-core-targets)
++install(DIRECTORY include/drjit-core DESTINATION include)
++install(FILES drjit-core-config.cmake DESTINATION lib/cmake/drjit-core)
++install(
++  EXPORT drjit-core-targets
++  FILE drjit-core-targets.cmake
++  DESTINATION lib/cmake/drjit-core)
+diff --git a/drjit-core-config.cmake b/drjit-core-config.cmake
+new file mode 100644
+index 0000000..0b800fd
+--- /dev/null
++++ b/drjit-core-config.cmake
+@@ -0,0 +1 @@
++include("${CMAKE_CURRENT_LIST_DIR}/drjit-core-targets.cmake")
+-- 
+2.42.0
+

--- a/pkgs/by-name/dr/drjit-core/0003-libdrjit-core-try-linking-libLLVM.so-directly.patch
+++ b/pkgs/by-name/dr/drjit-core/0003-libdrjit-core-try-linking-libLLVM.so-directly.patch
@@ -1,0 +1,28 @@
+From a7eb76dcaae709161a521b6e193ea1b243a22b96 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Fri, 24 Nov 2023 02:11:55 +0000
+Subject: [PATCH 3/3] libdrjit-core: try linking libLLVM.so directly
+
+---
+ CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bb1f694..0594b04 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -166,6 +166,11 @@ add_library(
+   resources/kernels.h resources/kernels.c
+ )
+ 
++find_package(LLVM)
++if (LLVM_FOUND)
++  target_link_libraries(drjit-core PRIVATE LLVM)
++endif()
++
+ target_compile_features(drjit-core PRIVATE cxx_std_17)
+ 
+ target_link_libraries(drjit-core PRIVATE nanothread tsl::robin_map lz4 xxHash::xxhash)
+-- 
+2.42.0
+

--- a/pkgs/by-name/dr/drjit-core/package.nix
+++ b/pkgs/by-name/dr/drjit-core/package.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, pkg-config
+, robin-map
+, nanothread
+, xxHash
+, lz4
+, llvmPackages
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "drjit-core";
+  version = "unstable-2023-10-21";
+
+  src = fetchFromGitHub {
+    owner = "mitsuba-renderer";
+    repo = "drjit-core";
+    rev = "d70987768138df1a09cbab86cbbe381a28d3d50a";
+    hash = "sha256-GOqqMpKydFuizQ+GhDt1YXxK5aCM9O2yESRQN1BCKYg=";
+    fetchSubmodules = true;
+  };
+  patches = [
+    ./0001-CMakeLists.txt-find_package-by-default-fallback-to-t.patch
+    ./0002-cmake-add-the-install-targets.patch
+    ./0003-libdrjit-core-try-linking-libLLVM.so-directly.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    nanothread
+
+    lz4
+    robin-map
+    xxHash
+
+    llvmPackages.libllvm.dev
+
+    stdenv.cc.cc.lib # libatomic...
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "DRJIT_ENABLE_TESTS" (finalAttrs.doCheck))
+  ];
+
+  doCheck = true;
+
+  # I don't know how but the `make test`/`make check` targets are broken
+  checkPhase = ''
+    runHook preCheck
+    for test in ./tests/test_* ; do
+      HOME=$TMPDIR "$test"
+    done
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Dr.Jit — A Just-In-Time-Compiler for Differentiable Rendering (core library";
+    homepage = "https://github.com/mitsuba-renderer/drjit-core";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+    mainProgram = "drjit-core";
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/by-name/fa/fast-float/package.nix
+++ b/pkgs/by-name/fa/fast-float/package.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fast-float";
+  version = "5.3.0";
+
+  src = fetchFromGitHub {
+    owner = "fastfloat";
+    repo = "fast_float";
+    rev = "v${version}";
+    hash = "sha256-zHSLoGhlKkF0PP7TQNUzgv2Qn3yeBR5hqQ8X5lxoUeg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "Fast and exact implementation of the C++ from_chars functions for float and double types: 4x to 10x faster than strtod, part of GCC 12 and WebKit/Safari";
+    homepage = "https://github.com/fastfloat/fast_float";
+    license = with licenses; [ asl20 boost mit ];
+    maintainers = with maintainers; [ SomeoneSerge ];
+    mainProgram = "fast-float";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/na/nanothread/0001-CMakeLists.txt-add-install-targets.patch
+++ b/pkgs/by-name/na/nanothread/0001-CMakeLists.txt-add-install-targets.patch
@@ -1,0 +1,149 @@
+From 12f00300b2a3d25e15a7ed0b0233e4cfdd2d50f1 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Tue, 21 Nov 2023 18:03:15 +0000
+Subject: [PATCH 1/2] CMakeLists.txt: add install targets
+
+---
+ .gitignore             |  1 +
+ CMakeLists.txt         | 68 +++++++++++++++++++++++-------------------
+ nanothreadConfig.cmake |  1 +
+ 3 files changed, 39 insertions(+), 31 deletions(-)
+ create mode 100644 nanothreadConfig.cmake
+
+diff --git a/.gitignore b/.gitignore
+index 8783593..3948241 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,6 +1,7 @@
+ /.clangd
+ /compile_commands.json
+ *.cmake
++!nanothreadConfig.cmake
+ CMakeCache.txt
+ CMakeFiles
+ Makefile
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 29fa840..4d6dd11 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,73 +3,79 @@
+ # ----------------------------------------------------------
+ cmake_minimum_required(VERSION 3.13...3.18)
+ 
+-project(nanothread
+-  DESCRIPTION
+-    "nanothread"
+-  LANGUAGES
+-    CXX C
+-)
++project(
++  nanothread
++  DESCRIPTION "nanothread"
++  LANGUAGES CXX C)
+ 
+ # ----------------------------------------------------------
+-#  Optional features available to users
++# Optional features available to users
+ # ----------------------------------------------------------
+ 
+ option(NANOTHREAD_ENABLE_TESTS "Build test suite?" OFF)
+ 
+ # ----------------------------------------------------------
+-#  Check if submodules have been checked out, or fail early
++# Check if submodules have been checked out, or fail early
+ # ----------------------------------------------------------
+ 
+-if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ext/cmake-defaults/CMakeLists.txt")
+-  message(FATAL_ERROR "The nanothread dependencies are missing! "
+-    "You probably did not clone the project with --recursive. It is possible to recover "
+-    "by invoking\n$ git submodule update --init --recursive")
++if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ext/cmake-defaults/CMakeLists.txt")
++  message(
++    FATAL_ERROR
++      "The nanothread dependencies are missing! "
++      "You probably did not clone the project with --recursive. It is possible to recover "
++      "by invoking\n$ git submodule update --init --recursive")
+ endif()
+ 
+ # ----------------------------------------------------------
+-#  Build defaults for projects by the Realistic Graphics Lab
++# Build defaults for projects by the Realistic Graphics Lab
+ # ----------------------------------------------------------
+ 
+ include(ext/cmake-defaults/CMakeLists.txt)
+ 
+ # ----------------------------------------------------------
+-#  Compile the nanothread library
++# Compile the nanothread library
+ # ----------------------------------------------------------
+ 
+-add_library(
+-  nanothread SHARED
+-  include/nanothread/nanothread.h
+-  src/queue.cpp src/queue.h
+-  src/nanothread.cpp
+-)
++add_library(nanothread SHARED include/nanothread/nanothread.h src/queue.cpp
++                              src/queue.h src/nanothread.cpp)
+ 
+ target_compile_features(nanothread PRIVATE cxx_std_11)
+ target_include_directories(nanothread PRIVATE include)
+ 
+-if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+-  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
++if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
++  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+     target_compile_options(nanothread PRIVATE -mcx16)
+   endif()
+ endif()
+ 
+-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
++if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+   # GCC needs libatomic for 16 byte CSA
+   find_library(LIBATOMIC NAMES libatomic.so libatomic.so.1)
+-  if (NOT LIBATOMIC)
++  if(NOT LIBATOMIC)
+     message(FATAL_ERROR "libatomic could not be found!")
+   endif()
+   target_link_libraries(nanothread PRIVATE ${LIBATOMIC})
+   mark_as_advanced(LIBATOMIC)
+ endif()
+ 
+-target_include_directories(nanothread
+-  PUBLIC
+-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++target_include_directories(
++  nanothread PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ target_compile_definitions(nanothread PRIVATE -DNANOTHREAD_BUILD=1)
+-set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
++set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE
++                                            TRUE)
+ 
+-if (NANOTHREAD_ENABLE_TESTS)
+-   add_subdirectory(tests)
++if(NANOTHREAD_ENABLE_TESTS)
++  add_subdirectory(tests)
+ endif()
++
++configure_file(
++  nanothreadConfig.cmake
++  "${CMAKE_CURRENT_BINARY_DIR}/nanothread/nanothreadConfig.cmake" COPYONLY)
++install(FILES nanothreadConfig.cmake DESTINATION lib/cmake/nanothread)
++install(TARGETS nanothread EXPORT nanothreadTargets)
++install(
++  EXPORT nanothreadTargets
++  FILE nanothreadTargets.cmake
++  DESTINATION lib/cmake/nanothread)
+diff --git a/nanothreadConfig.cmake b/nanothreadConfig.cmake
+new file mode 100644
+index 0000000..532c84e
+--- /dev/null
++++ b/nanothreadConfig.cmake
+@@ -0,0 +1 @@
++include("${CMAKE_CURRENT_LIST_DIR}/nanothreadTargets.cmake")
+-- 
+2.42.0
+

--- a/pkgs/by-name/na/nanothread/0002-cmake-installable-and-relocatable-include.patch
+++ b/pkgs/by-name/na/nanothread/0002-cmake-installable-and-relocatable-include.patch
@@ -1,0 +1,38 @@
+From 47614d6dc5280ba15258af51edb478a8eb91b02f Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Tue, 21 Nov 2023 20:16:16 +0000
+Subject: [PATCH 2/2] cmake: installable and relocatable include/
+
+---
+ CMakeLists.txt | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d6dd11..8ba73e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,7 +60,7 @@ endif()
+ 
+ target_include_directories(
+   nanothread PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++                    $<INSTALL_INTERFACE:include>)
+ 
+ target_compile_definitions(nanothread PRIVATE -DNANOTHREAD_BUILD=1)
+ set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE
+@@ -74,7 +74,11 @@ configure_file(
+   nanothreadConfig.cmake
+   "${CMAKE_CURRENT_BINARY_DIR}/nanothread/nanothreadConfig.cmake" COPYONLY)
+ install(FILES nanothreadConfig.cmake DESTINATION lib/cmake/nanothread)
+-install(TARGETS nanothread EXPORT nanothreadTargets)
++install(
++  TARGETS nanothread
++  EXPORT nanothreadTargets
++  INCLUDES DESTINATION include)
++install(DIRECTORY include/nanothread DESTINATION include)
+ install(
+   EXPORT nanothreadTargets
+   FILE nanothreadTargets.cmake
+-- 
+2.42.0
+

--- a/pkgs/by-name/na/nanothread/package.nix
+++ b/pkgs/by-name/na/nanothread/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nanothread";
+  version = "unstable-2023-02-04";
+
+  src = fetchFromGitHub {
+    owner = "mitsuba-renderer";
+    repo = "nanothread";
+
+    # An old revision that still uses pybind11 instead of nanobind because some
+    # of the other dependencies are lagging behind
+    rev = "01c6ff7e4419b856602e590411860dc7206f8fb6";
+    hash = "sha256-05y0/k0j8qS1yoVrJ+nkGR30N8MJ5283adABU5pz82I=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    ./0001-CMakeLists.txt-add-install-targets.patch
+    ./0002-cmake-installable-and-relocatable-include.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib # libatomic
+  ];
+
+  meta = with lib; {
+    description = "Nanothread — Minimal thread pool for task parallelism";
+    homepage = "https://github.com/mitsuba-renderer/nanothread";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+    mainProgram = "nanothread";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/ti/tinyformat/0001-cmake-unbreak-and-add-install-targets.patch
+++ b/pkgs/by-name/ti/tinyformat/0001-cmake-unbreak-and-add-install-targets.patch
@@ -1,0 +1,75 @@
+From 95b72dbdc5dd79b8626bc8bd4269a60c3f95a85d Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Wed, 22 Nov 2023 20:32:40 +0000
+Subject: [PATCH] cmake: unbreak and add install targets
+
+---
+ CMakeLists.txt         | 28 ++++++++++++++++++----------
+ tinyformatConfig.cmake |  1 +
+ 2 files changed, 19 insertions(+), 10 deletions(-)
+ create mode 100644 tinyformatConfig.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7715dd0..51442fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,17 +9,16 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+     "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."
+ )
+ 
+-set(CXX_STD "c++11" CACHE STRING "Version of C++ standard in use")
+-
+-# This project is infrastructure.  Warnings from common warning levels should
+-# be errors on all compilers, unless explicitly silenced.
+-if(NOT WIN32)
+-    set(CMAKE_CXX_FLAGS "-Wall -Werror -std=${CXX_STD}" CACHE STRING "Flags used by the compiler during all build types.")
+-endif()
+-
+ project(tinyformat)
+ cmake_minimum_required(VERSION 2.8)
+-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
++
++add_library(tinyformat INTERFACE)
++target_compile_features(tinyformat INTERFACE cxx_std_11)
++target_include_directories(
++  tinyformat
++  INTERFACE
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
++  $<INSTALL_INTERFACE:include>)
+ 
+ if(WIN32)
+     # Treat warnings as errors.  Would set this above, but need the default
+@@ -28,9 +27,10 @@ if(WIN32)
+ endif()
+ 
+ # Dummy translation unit to test for missing `inline`s
+-include_directories(${CMAKE_SOURCE_DIR})
+ file(WRITE ${CMAKE_BINARY_DIR}/_empty.cpp "#include \"tinyformat.h\"")
+ add_executable(tinyformat_test tinyformat_test.cpp ${CMAKE_BINARY_DIR}/_empty.cpp)
++target_link_libraries(tinyformat_test tinyformat)
++
+ enable_testing()
+ if(CMAKE_CONFIGURATION_TYPES)
+     set(ctest_config_opt -C ${CMAKE_BUILD_TYPE})
+@@ -42,3 +42,11 @@ option(COMPILE_SPEED_TEST FALSE)
+ if (COMPILE_SPEED_TEST)
+     add_executable(tinyformat_speed_test tinyformat_speed_test.cpp)
+ endif ()
++
++install(TARGETS tinyformat EXPORT tinyformatTargets)
++install(FILES tinyformat.h DESTINATION include)
++install(FILES tinyformatConfig.cmake DESTINATION lib/cmake/tinyformat)
++install(
++  EXPORT tinyformatTargets
++  FILE tinyformatTargets.cmake
++  DESTINATION lib/cmake/tinyformat)
+diff --git a/tinyformatConfig.cmake b/tinyformatConfig.cmake
+new file mode 100644
+index 0000000..877f0e9
+--- /dev/null
++++ b/tinyformatConfig.cmake
+@@ -0,0 +1 @@
++include("${CMAKE_CURRENT_LIST_DIR}/tinyformatTargets.cmake")
+-- 
+2.42.0
+

--- a/pkgs/by-name/ti/tinyformat/package.nix
+++ b/pkgs/by-name/ti/tinyformat/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tinyformat";
+  version = "unstable-2023-11-22";
+
+  src = fetchFromGitHub {
+    owner = "c42f";
+    repo = "tinyformat";
+    rev = "aef402d85c1e8f9bf491b72570bfe8938ae26727";
+    hash = "sha256-Ka7fp5ZviTMgCXHdS/OKq+P871iYqoDOsj8HtJGAU3Y=";
+  };
+  patches = [
+    ./0001-cmake-unbreak-and-add-install-targets.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  meta = with lib; {
+    description = "Minimal, type safe printf replacement library for C";
+    homepage = "https://github.com/c42f/tinyformat";
+    license = licenses.boost;
+    maintainers = with maintainers; [ SomeoneSerge ];
+    mainProgram = "tinyformat";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/embree/default.nix
+++ b/pkgs/development/libraries/embree/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, ispc, tbb, glfw,
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, ispc, tbbLatest, glfw,
   openimageio, libjpeg, libpng, libpthreadstubs, libX11, glib }:
 
 stdenv.mkDerivation rec {
@@ -32,12 +32,12 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DEMBREE_TUTORIALS=OFF"
     "-DEMBREE_RAY_MASK=ON"
-    "-DTBB_ROOT=${tbb}"
-    "-DTBB_INCLUDE_DIR=${tbb.dev}/include"
+    "-DTBB_ROOT=${tbbLatest}"
+    "-DTBB_INCLUDE_DIR=${tbbLatest.dev}/include"
   ];
 
   nativeBuildInputs = [ ispc pkg-config cmake ];
-  buildInputs = [ tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ]
+  buildInputs = [ tbbLatest glfw openimageio libjpeg libpng libX11 libpthreadstubs ]
                 ++ lib.optionals stdenv.isDarwin [ glib ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/drjit/0001-cmake-try-find_package-drjit-core-first.patch
+++ b/pkgs/development/python-modules/drjit/0001-cmake-try-find_package-drjit-core-first.patch
@@ -1,0 +1,102 @@
+From 7fa6f3ce325352d171b98cb705adbc66729389a1 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Wed, 22 Nov 2023 18:15:53 +0000
+Subject: [PATCH 1/4] cmake: try find_package(drjit-core) first
+
+---
+ CMakeLists.txt            | 39 ++++++++++++++++++++++++++-------------
+ src/python/CMakeLists.txt |  2 +-
+ 2 files changed, 27 insertions(+), 14 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 741d8c5a..6fd0de05 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,8 @@ if (NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ext/drjit-core/ext/nanothread/
+     "by invoking\n$ git submodule update --init --recursive")
+ endif()
+ 
++find_package(drjit-core)
++
+ set(DRJIT_VERSION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/include/drjit/fwd.h")
+ include(ext/drjit-core/ext/nanothread/ext/cmake-defaults/CMakeLists.txt)
+ 
+@@ -44,13 +46,21 @@ endif()
+ 
+ add_library(drjit INTERFACE)
+ target_compile_features(drjit INTERFACE cxx_std_17)
++
+ target_include_directories(drjit
+   INTERFACE
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext/drjit-core/include>
+-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext/drjit-core/ext/nanothread/include>
+-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-)
++  $<INSTALL_INTERFACE:include>)
++
++if (drjit-core_FOUND)
++  target_link_libraries(drjit INTERFACE drjit-core)
++else()
++  target_include_directories(drjit
++    INTERFACE
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext/drjit-core/include>
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext/drjit-core/ext/nanothread/include>
++  )
++endif()
+ 
+ if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+   target_compile_options(drjit INTERFACE -fno-strict-aliasing)
+@@ -79,16 +89,19 @@ if (DRJIT_ENABLE_JIT)
+   else()
+     message(STATUS "Dr.Jit: building the CUDA & LLVM JIT backend.")
+   endif()
+-  add_subdirectory(ext/drjit-core)
+-  set_target_properties(drjit-core PROPERTIES ${DRJIT_OUTPUT_DIRECTORY})
+-  set_target_properties(nanothread PROPERTIES ${DRJIT_OUTPUT_DIRECTORY})
+ 
+-  if (DRJIT_MASTER_PROJECT)
+-    install(TARGETS drjit-core EXPORT drjitTargets)
+-    install(TARGETS nanothread EXPORT drjitTargets)
+-  endif()
++  if (NOT drjit-core_FOUND)
++    add_subdirectory(ext/drjit-core)
++    set_target_properties(drjit-core PROPERTIES ${DRJIT_OUTPUT_DIRECTORY})
++    set_target_properties(nanothread PROPERTIES ${DRJIT_OUTPUT_DIRECTORY})
+ 
+-  mark_as_advanced(DRJIT_THREAD_ENABLE_TESTS)
++    if (DRJIT_MASTER_PROJECT)
++      install(TARGETS drjit-core EXPORT drjitTargets)
++      install(TARGETS nanothread EXPORT drjitTargets)
++    endif()
++
++    mark_as_advanced(DRJIT_THREAD_ENABLE_TESTS)
++  endif()
+ else()
+   message(STATUS "Dr.Jit: *not* building the CUDA & LLVM JIT backend.")
+ endif()
+@@ -141,7 +154,7 @@ endif()
+ 
+ if (DRJIT_MASTER_PROJECT)
+   install(DIRECTORY include/drjit DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-  if (DRJIT_ENABLE_JIT)
++  if (NOT drjit-core_FOUND AND DRJIT_ENABLE_JIT)
+     install(DIRECTORY ext/drjit-core/include/drjit-core DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+     install(DIRECTORY ext/drjit-core/ext/nanothread/include/nanothread DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+   endif()
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index b152c914..0f6311a8 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -30,7 +30,7 @@ endif()
+ target_compile_definitions(drjit-python PRIVATE "-DDRJIT_UNROLL= ")
+ 
+ if (DRJIT_ENABLE_JIT)
+-  target_link_libraries(drjit-python PRIVATE drjit-core)
++  target_link_libraries(drjit-python PUBLIC drjit-core)
+   target_compile_definitions(drjit-python PRIVATE -DDRJIT_ENABLE_JIT=1)
+ 
+   if (NOT APPLE)
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/drjit/0002-autodiff-link-tsl-xxhash-lz4-directly.patch
+++ b/pkgs/development/python-modules/drjit/0002-autodiff-link-tsl-xxhash-lz4-directly.patch
@@ -1,0 +1,39 @@
+From b95195b66c8c7d91004cfff8e24de7a0256eed65 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Wed, 22 Nov 2023 18:32:12 +0000
+Subject: [PATCH 2/4] autodiff: link tsl/xxhash/lz4 directly
+
+---
+ src/autodiff/CMakeLists.txt | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/autodiff/CMakeLists.txt b/src/autodiff/CMakeLists.txt
+index dc6c3de3..13d9d84b 100644
+--- a/src/autodiff/CMakeLists.txt
++++ b/src/autodiff/CMakeLists.txt
+@@ -1,9 +1,9 @@
+ set(DRJIT_AUTODIFF_VARIANTS drjit-autodiff-scalar-f32:float drjit-autodiff-scalar-f64:double)
+ 
+-include_directories(
+-  ../../ext/drjit-core/ext/robin_map/include
+-  ../../ext/drjit-core/ext/lz4
+-)
++find_package(xxHash REQUIRED)
++find_package(tsl-robin-map REQUIRED)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(lz4 liblz4 IMPORTED_TARGET REQUIRED)
+ 
+ if (DRJIT_ENABLE_JIT)
+   set(DRJIT_AUTODIFF_VARIANTS ${DRJIT_AUTODIFF_VARIANTS}
+@@ -35,7 +35,7 @@ foreach(DRJIT_AUTODIFF_VARIANT ${DRJIT_AUTODIFF_VARIANTS})
+   else()
+     target_compile_options(${DRJIT_AUTODIFF_VARIANT_NAME} PRIVATE -fvisibility=hidden)
+   endif()
+-  target_link_libraries(${DRJIT_AUTODIFF_VARIANT_NAME} PRIVATE drjit)
++  target_link_libraries(${DRJIT_AUTODIFF_VARIANT_NAME} PRIVATE drjit xxHash::xxhash tsl::robin_map PkgConfig::lz4)
+   if (DRJIT_ENABLE_JIT)
+     target_link_libraries(${DRJIT_AUTODIFF_VARIANT_NAME} PRIVATE drjit-core)
+     target_compile_definitions(${DRJIT_AUTODIFF_VARIANT_NAME} PRIVATE -DDRJIT_ENABLE_JIT=1)
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/drjit/0003-cmake-export-the-drjit-python-target-too.patch
+++ b/pkgs/development/python-modules/drjit/0003-cmake-export-the-drjit-python-target-too.patch
@@ -1,0 +1,25 @@
+From 89b47030133efb41f109dc068da17a3776c011b6 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Thu, 23 Nov 2023 02:18:58 +0000
+Subject: [PATCH 3/4] cmake: export the drjit-python target too
+
+---
+ src/python/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index 0f6311a8..cae62fad 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -54,7 +54,7 @@ set_target_properties(drjit-python PROPERTIES
+ target_compile_options(drjit-python PRIVATE ${DRJIT_NATIVE_FLAGS})
+ 
+ if (DRJIT_MASTER_PROJECT)
+-  install(TARGETS drjit-python LIBRARY DESTINATION drjit)
++  install(TARGETS drjit-python EXPORT drjitTargets LIBRARY DESTINATION drjit)
+ endif()
+ 
+ configure_file(
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/drjit/0004-cmake-dont-override-install-directories-on-nix.patch
+++ b/pkgs/development/python-modules/drjit/0004-cmake-dont-override-install-directories-on-nix.patch
@@ -1,0 +1,77 @@
+From f6be0a8f2cfcd970ccd78a8f5746e17effb4659a Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Thu, 23 Nov 2023 06:29:48 +0000
+Subject: [PATCH 4/4] cmake: dont override install directories on *nix
+
+---
+ CMakeLists.txt            |  9 ++++++---
+ src/python/CMakeLists.txt | 12 +++++++++---
+ 2 files changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6fd0de05..dc130151 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,6 +12,10 @@ option(DRJIT_ENABLE_AUTODIFF      "Build Dr.Jit automatic differentation library
+ option(DRJIT_ENABLE_PYTHON        "Build Python extension library?" ON)
+ option(DRJIT_ENABLE_PYTHON_PACKET "Enable packet mode in Python extension library?" OFF)
+ option(DRJIT_ENABLE_TESTS         "Build Dr.Jit test suite? (Warning, this takes *very* long to compile)" OFF)
++option(
++  CLEANUP_AFTER_SKBUILD
++  "Disable the paths hard-coding used for scikit-build and omit python components from the install targets"
++  OFF)
+ 
+ # ----------------------------------------------------------
+ #  Check if submodules have been checked out, or fail early
+@@ -39,9 +43,8 @@ if (MSVC)
+     LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_CURRENT_BINARY_DIR}/drjit
+     LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL     ${CMAKE_CURRENT_BINARY_DIR}/drjit
+   )
+-else()
+-  set(DRJIT_OUTPUT_DIRECTORY
+-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/drjit)
++else ()
++  set(DRJIT_OUTPUT_DIRECTORY LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/drjit)
+ endif()
+ 
+ add_library(drjit INTERFACE)
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index cae62fad..1cd2a0f1 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -54,7 +54,13 @@ set_target_properties(drjit-python PROPERTIES
+ target_compile_options(drjit-python PRIVATE ${DRJIT_NATIVE_FLAGS})
+ 
+ if (DRJIT_MASTER_PROJECT)
+-  install(TARGETS drjit-python EXPORT drjitTargets LIBRARY DESTINATION drjit)
++  if (CLEANUP_AFTER_SKBUILD)
++     # A copy of drjit_ext for find_package(drjit):
++     install(TARGETS drjit-python EXPORT drjitTargets LIBRARY DESTINATION lib)
++  else ()
++     # A copy for site-packages:
++     install(TARGETS drjit-python EXPORT drjitTargets LIBRARY DESTINATION drjit)
++  endif()
+ endif()
+ 
+ configure_file(
+@@ -62,7 +68,7 @@ configure_file(
+   ${CMAKE_CURRENT_SOURCE_DIR}/../../drjit/config.py
+ )
+ 
+-if (DRJIT_MASTER_PROJECT AND NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
++if (DRJIT_MASTER_PROJECT AND NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}" AND NOT CLEANUP_AFTER_SKBUILD)
+   set(DRJIT_PYTHON_FILES
+      __init__.py const.py detail.py generic.py
+      matrix.py router.py traits.py tensor.py config.py
+@@ -87,7 +93,7 @@ endif()
+ #   Generate type information stubs
+ # ----------------------------------------------------------
+ 
+-if (DRJIT_MASTER_PROJECT)
++if (DRJIT_MASTER_PROJECT AND NOT CLEANUP_AFTER_SKBUILD)
+   set(DRJIT_PYTHON_STUBS_DIR "" CACHE STRING "Location of the Python typing fle stubs directory to use if the files should not be generated during the build.")
+   mark_as_advanced(DRJIT_PYTHON_STUBS_DIR)
+   if ("${DRJIT_PYTHON_STUBS_DIR}" STREQUAL "")
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/drjit/default.nix
+++ b/pkgs/development/python-modules/drjit/default.nix
@@ -1,0 +1,126 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, stdenv
+, cmake
+, ninja
+, pybind11
+, scikit-build
+, setuptools
+, pkg-config
+, wheel
+, nanobind
+, drjit-core
+, nanothread
+, pkgs
+, pytestCheckHook
+, python
+, robin-map
+, xxHash
+}:
+
+buildPythonPackage rec {
+  pname = "drjit";
+  version = "unstable-2023-11-23";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mitsuba-renderer";
+    repo = "drjit";
+    rev = "82dc821d63da02a2a1428ce2533ed317c051a048";
+    hash = "sha256-EH7W007hcavhYrMPWlB2EaW6TKq3bUaDfbC743wZTwY=";
+  };
+
+  patches = [
+    ./0001-cmake-try-find_package-drjit-core-first.patch
+    ./0002-autodiff-link-tsl-xxhash-lz4-directly.patch
+    ./0003-cmake-export-the-drjit-python-target-too.patch
+    ./0004-cmake-dont-override-install-directories-on-nix.patch
+  ];
+
+  # I don't have the energies to fix this mess:
+  postPatch = ''
+    substituteInPlace drjit/router.py \
+      --replace \
+        "path.abspath(path.dirname(__file__))" \
+        "\"$out\""
+
+    mkdir -p ext/drjit-core/ext/nanothread/ext/cmake-defaults
+    cp "${nanothread.src}/ext/cmake-defaults/CMakeLists.txt" ext/drjit-core/ext/nanothread/ext/cmake-defaults/
+  '' + (
+    let useNanobind = false; in lib.optionalString useNanobind ''
+      substituteInPlace ext/drjit-core/ext/nanothread/ext/cmake-defaults/CMakeLists.txt \
+        --replace \
+          "get_cmake_dir()" \
+          "cmake_dir()"
+    ''
+  );
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    pybind11
+    scikit-build
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    drjit-core
+    nanobind
+    robin-map
+    xxHash
+    pkgs.lz4
+
+    # libatomic, although they do not actually use it
+    stdenv.cc.cc.lib
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+
+  # resources/generate_stub_files.py attempts writing to ~/.drjit at build
+  # time; generate_stub_files is also the reason that cross-compilation is
+  # kind of broken upstream
+  preConfigure = ''
+    export HOME=$TMPDIR
+  '';
+  dontUseCmakeConfigure = true;
+
+  # Ensure drjit.drjit_ext is imported from $out/${python.sitePackages} and not CWD:
+  preCheck = ''
+    cd tests
+  '';
+
+  # Now that scikit-build is done installing its useless cmake targets into the
+  # wheel (transitively, site-packages), we reconfigure and install into $out.
+  cmakeFlags = [
+    (lib.cmakeBool "CLEANUP_AFTER_SKBUILD" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "${placeholder "out"}/lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "${placeholder "out"}/include")
+    (lib.cmakeFeature "CMAKE_INSTALL_DATAROOTDIR" "${placeholder "out"}/share")
+  ];
+  postInstall = ''
+    for skBuildDir in _skbuild/* ; do
+        cmake -S . -B "$skBuildDir/cmake-build" $cmakeFlags "''${cmakeFlagsArray[@]}"
+        cmake --build "$skBuildDir/cmake-build"
+        cmake --install "$skBuildDir/cmake-build"
+    done
+  '';
+
+  pythonImportsCheck = [
+    "drjit"
+    "drjit.drjit_ext"
+  ];
+
+  meta = with lib; {
+    description = "Dr.Jit — A Just-In-Time-Compiler for Differentiable Rendering";
+    homepage = "https://github.com/mitsuba-renderer/drjit";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/mitsuba3/0001-cmake-try-find_package-first.patch
+++ b/pkgs/development/python-modules/mitsuba3/0001-cmake-try-find_package-first.patch
@@ -1,0 +1,482 @@
+From f403bbc9af374962690ef7676ec592831d71fb51 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Wed, 22 Nov 2023 20:53:58 +0000
+Subject: [PATCH 1/4] cmake: try find_package first
+
+---
+ CMakeLists.txt          |  51 ++++++++++---
+ ext/CMakeLists.txt      | 159 ++++++++++++++++++++++++++++++----------
+ src/core/CMakeLists.txt |   4 +-
+ 3 files changed, 165 insertions(+), 49 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 15103e22..17756990 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,6 +14,8 @@ project(mitsuba
+ #  Optional features available to users
+ # ----------------------------------------------------------
+ 
++option(MI_USE_SUBMODULES "Use the dependencies vendored in git-submodules instead of find_package" ON)
++
+ # A number of Mitsuba 3 features (scripting, differentiable rendering, testing
+ # infrastructure, etc.) are only available if Python bindings are built.
+ option(MI_ENABLE_PYTHON "Build Python bindings for Mitsuba, Dr.Jit, and NanoGUI?" ON)
+@@ -282,6 +284,31 @@ set(CMAKE_INSTALL_RPATH "${MI_ORIGIN};${MI_ORIGIN}/../drjit")
+ # Build the dependencies
+ add_subdirectory(ext)
+ 
++if (NOT MI_USE_SUBMODULES)
++  find_package(asmjit REQUIRED)
++  find_package(drjit REQUIRED)
++  find_package(drjit-core REQUIRED)
++  find_package(FastFloat REQUIRED)
++  find_package(JPEG REQUIRED)
++  find_package(nanothread REQUIRED)
++  find_package(OpenEXR REQUIRED)
++  find_package(PNG REQUIRED)
++  find_package(pugixml REQUIRED)
++  find_package(tinyformat REQUIRED)
++endif()
++
++if (MI_ENABLE_EMBREE AND NOT MI_USE_SUBMODULES)
++  find_package(embree REQUIRED)
++endif()
++
++if (WIN32)
++  find_package(zlib)
++endif()
++
++if (NOT TARGET OpenEXR::IlmImf)
++  message(FATAL_ERROR "NO IlmImf, something went super wrong")
++endif()
++
+ # Always add the include directories for tinyformat, Dr.Jit and Eigen
+ include_directories(include
+   ${TINYFORMAT_INCLUDE_DIRS}
+@@ -457,25 +484,27 @@ if (MI_COPIED_CONFIG_FILE AND NOT SKBUILD)
+ endif()
+ 
+ # Installation targets
++if (MI_USE_SUBMODULES)
+ set(MI_DEPEND
+-  IlmImf IlmThread Imath Iex IexMath Half pugixml
++  OpenEXR::IlmImf IlmBase::IlmThread IlmBase::Imath IlmBase::Iex IlmBase::IexMath IlmBase::Half pugixml
+ )
+ 
+ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
+-  set(MI_DEPEND ${MI_DEPEND} asmjit)
++  set(MI_DEPEND ${MI_DEPEND} asmjit::asmjit)
+ endif()
+ 
+-list(APPEND MI_DEPEND png jpeg)
++list(APPEND MI_DEPEND PNG::PNG JPEG::JPEG)
++endif()
+ 
+-if (WIN32)
++if (WIN32 AND MI_USE_SUBMODULES)
+ list(APPEND MI_DEPEND zlib)
+ endif()
+ 
+-if (MI_ENABLE_EMBREE)
++if (MI_ENABLE_EMBREE AND MI_USE_SUBMODULES)
+   list(APPEND MI_DEPEND embree)
+ endif()
+ 
+-if (NOT SKBUILD)
++if (NOT SKBUILD AND MI_USE_SUBMODULES)
+   list(APPEND MI_DEPEND nanothread)
+ 
+   if (MI_ENABLE_JIT)
+@@ -538,10 +567,12 @@ install(
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+ )
+ 
+-install(
+-  FILES ${TINYFORMAT_INCLUDE_DIRS}/tinyformat.h
+-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+-)
++if (MI_USE_SUBMODULES)
++  install(
++    FILES ${TINYFORMAT_INCLUDE_DIRS}/tinyformat.h
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++  )
++endif()
+ 
+ install(
+   FILES ${CMAKE_CURRENT_BINARY_DIR}/include/mitsuba/core/config.h
+diff --git a/ext/CMakeLists.txt b/ext/CMakeLists.txt
+index 65ccfe79..c1d3d1e6 100644
+--- a/ext/CMakeLists.txt
++++ b/ext/CMakeLists.txt
+@@ -12,7 +12,10 @@ list(REMOVE_ITEM MI_EXT_COMPILE_OPTIONS_NOWARN -Wall -Wextra /W4)
+ 
+ if (MI_PROFILER_ITTNOTIFY)
+   set_directory_properties(PROPERTIES COMPILE_OPTIONS "${MI_EXT_COMPILE_OPTIONS_NOWARN}")
++
++  # Discontinued since January 2023, https://github.com/intel/IntelSEAPI
+   add_subdirectory(ittnotify/ittnotify)
++
+   set(ITT_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/ittnotify/ittnotify/include)
+   set(ITT_INCLUDE_DIRS ${ITT_INCLUDE_DIRS} PARENT_SCOPE)
+   set_property(TARGET ittnotify PROPERTY FOLDER "dependencies")
+@@ -32,50 +35,74 @@ if (MI_PROFILER_NVTX)
+     set(DRJIT_ENABLE_NVTX ON)
+ endif()
+ 
++if (NOT MI_USE_SUBMODULES)
++    find_package(drjit REQUIRED)
++    find_package(drjit-core REQUIRED)
++    find_package(nanothread REQUIRED)
++
++    if (NOT TARGET drjit-python OR NOT TARGET drjit-autodiff)
++      message(FATAL_ERROR "Found drjit, but the targets (drjit-python or drjit-autodiff) weren't exposed")
++    endif()
++endif()
++
+ if (NOT SKBUILD)
+-  add_subdirectory(drjit)
++  if (MI_USE_SUBMODULES)
++    add_subdirectory(drjit)
++  endif()
+ 
+-  if (NOT MI_ENABLE_JIT)
++  if (NOT MI_ENABLE_JIT AND MI_USE_SUBMODULES)
+     add_subdirectory(drjit/ext/drjit-core/ext/nanothread)
+     set_target_properties(nanothread PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/drjit")
+   endif()
+ 
+-  set_target_properties(nanothread PROPERTIES FOLDER "drjit")
+-
+-  if (MI_ENABLE_JIT)
+-    set_target_properties(drjit-core PROPERTIES FOLDER "drjit")
+-  endif()
++  if (MI_USE_SUBMODULES)
++    set_target_properties(nanothread PROPERTIES FOLDER "drjit")
+ 
+-  if (MI_ENABLE_AUTODIFF)
+-    set_target_properties(drjit-autodiff PROPERTIES FOLDER "drjit")
+-    if (TARGET drjit-autodiff-scalar-f32)
+-      set_target_properties(drjit-autodiff-scalar-f32 drjit-autodiff-scalar-f64 PROPERTIES FOLDER "drjit")
++    if (MI_ENABLE_JIT)
++      set_target_properties(drjit-core PROPERTIES FOLDER "drjit")
+     endif()
+-    if (TARGET drjit-autodiff-cuda-f32)
+-      set_target_properties(drjit-autodiff-cuda-f32 drjit-autodiff-cuda-f64 PROPERTIES FOLDER "drjit")
+-    endif()
+-    if (TARGET drjit-autodiff-llvm-f32)
+-      set_target_properties(drjit-autodiff-llvm-f32 drjit-autodiff-llvm-f64 PROPERTIES FOLDER "drjit")
++
++    if (MI_ENABLE_AUTODIFF)
++      set_target_properties(drjit-autodiff PROPERTIES FOLDER "drjit")
++      if (TARGET drjit-autodiff-scalar-f32)
++        set_target_properties(drjit-autodiff-scalar-f32 drjit-autodiff-scalar-f64 PROPERTIES FOLDER "drjit")
++      endif()
++      if (TARGET drjit-autodiff-cuda-f32)
++        set_target_properties(drjit-autodiff-cuda-f32 drjit-autodiff-cuda-f64 PROPERTIES FOLDER "drjit")
++      endif()
++      if (TARGET drjit-autodiff-llvm-f32)
++        set_target_properties(drjit-autodiff-llvm-f32 drjit-autodiff-llvm-f64 PROPERTIES FOLDER "drjit")
++      endif()
+     endif()
+-  endif()
+ 
+-  if (MI_ENABLE_PYTHON)
+-    set_target_properties(drjit-python PROPERTIES FOLDER "drjit")
++    if (MI_ENABLE_PYTHON)
++      set_target_properties(drjit-python PROPERTIES FOLDER "drjit")
++    endif()
+   endif()
+ endif()
+ 
++if (MI_USE_SUBMODULES)
+ mark_as_advanced(
+   DRJIT_ENABLE_AUTODIFF DRJIT_ENABLE_JIT
+   DRJIT_ENABLE_PYTHON DRJIT_ENABLE_PYTHON_PACKET DRJIT_ENABLE_TESTS
+   DRJIT_JIT_DYNAMIC_CUDA DRJIT_JIT_DYNAMIC_LLVM DRJIT_JIT_ENABLE_OPTIX
+   DRJIT_THREAD_ENABLE_TESTS
+ )
++endif()
+ 
+ # ----------------------------------------------------------
+ #  Compile Intel Embree (optional)
+ # ----------------------------------------------------------
+ 
+-if (MI_ENABLE_EMBREE)
++if (MI_ENABLE_EMBREE AND NOT MI_USE_SUBMODULES)
++    find_package(embree REQUIRED)
++endif()
++
++if (MI_ENABLE_EMBREE AND MI_USE_SUBMODULES)
++  set_property(TARGET
++    lexers math simd sys tasking embree ${EMBREE_TARGET}
++    PROPERTY FOLDER "dependencies/embree")
++
+   set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
+ 
+   set(EMBREE_ISPC_SUPPORT              OFF CACHE BOOL " " FORCE)
+@@ -138,6 +165,7 @@ if (MI_ENABLE_EMBREE)
+     PROPERTY FOLDER "dependencies/embree")
+ endif()
+ 
++if (MI_USE_SUBMODULES)
+ mark_as_advanced(FORCE EMBREE_ADDRESS_SANITIZER EMBREE_API_NAMESPACE
+   EMBREE_BACKFACE_CULLING EMBREE_COMPACT_POLYS
+   EMBREE_CURVE_SELF_INTERSECTION_AVOIDANCE_FACTOR EMBREE_FILTER_FUNCTION
+@@ -154,6 +182,7 @@ mark_as_advanced(FORCE EMBREE_ADDRESS_SANITIZER EMBREE_API_NAMESPACE
+   EMBREE_TESTING_INTENSITY EMBREE_TESTING_KLOCWORK EMBREE_TESTING_MEMCHECK
+   EMBREE_TESTING_MODEL_DIR EMBREE_TESTING_PACKAGE EMBREE_TESTING_SDE
+   EMBREE_TUTORIALS EMBRE_STATIC_LIB EMBREE_STATIC_RUNTIME)
++endif()
+ 
+ # ----------------------------------------------------------
+ #  Build OpenEXR (and zlib on Windows)
+@@ -161,12 +190,17 @@ mark_as_advanced(FORCE EMBREE_ADDRESS_SANITIZER EMBREE_API_NAMESPACE
+ 
+ set_directory_properties(PROPERTIES COMPILE_OPTIONS "${MI_EXT_COMPILE_OPTIONS_NOWARN}")
+ if (WIN32)
++  find_package(zlib)
++  if (NOT zlib_FOUND)
+   set(ZLIB_BUILD_STATIC_LIBS OFF CACHE BOOL " " FORCE)
+   set(ZLIB_BUILD_SHARED_LIBS ON  CACHE BOOL " " FORCE)
+   add_subdirectory(zlib)
++  endif()
+ 
+   set_property(TARGET zlib PROPERTY FOLDER "dependencies")
+   set(ZLIB_LIBRARY zlib)
++
++  if (NOT zlib_FOUND)
+   set(ZLIB_INCLUDE_DIR
+       ${CMAKE_CURRENT_SOURCE_DIR}/zlib
+       ${CMAKE_CURRENT_BINARY_DIR}/zlib
+@@ -174,9 +208,11 @@ if (WIN32)
+ 
+   mark_as_advanced(ZLIB_BUILD_AMD64 ZLIB_BUILD_ASM686 ZLIB_BUILD_EXAMPLES
+     ZLIB_BUILD_SHARED_LIBS ZLIB_BUILD_STATIC_LIBS)
++  endif()
+ endif()
+ 
+ # Prevents openexr to set the DEBUG_POSTFIX "_d"
++if (MI_USE_SUBMODULES)
+ set(CMAKE_DEBUG_POSTFIX "" CACHE STRING " " FORCE)
+ set(ILMBASE_LIB_SUFFIX  "" CACHE STRING "" FORCE)
+ set(OPENEXR_LIB_SUFFIX  "" CACHE STRING "" FORCE)
+@@ -187,20 +223,28 @@ set(PYILMBASE_ENABLE           OFF CACHE BOOL "" FORCE)
+ set(INSTALL_OPENEXR_DOCS OFF CACHE BOOL "" FORCE)
+ set(INSTALL_OPENEXR_EXAMPLES OFF CACHE BOOL "" FORCE)
+ set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
++endif()
+ 
+ unset(CMAKE_CXX_VISIBILITY_PRESET)
+-add_subdirectory(openexr)
++
++if (MI_USE_SUBMODULES)
++  add_subdirectory(openexr)
++else()
++  find_package(OpenEXR REQUIRED)
++endif()
+ set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+ 
++
++if (MI_USE_SUBMODULES)
+ set_property(TARGET
+-  IexMath IlmThread Half Iex Imath IlmImf IexMath IlmImfUtil
++  IlmBase::IexMath IlmBase::IlmThread IlmBase::Half IlmBase::Iex IlmBase::Imath OpenEXR::IlmImf IlmBase::IexMath OpenEXR::IlmImfUtil
+   PROPERTY FOLDER "dependencies/openexr")
+ 
+ set_property(TARGET
+-  IexMath IlmThread Half Iex Imath IlmImf IexMath
++  IlmBase::IexMath IlmBase::IlmThread IlmBase::Half IlmBase::Iex IlmBase::Imath OpenEXR::IlmImf IlmBase::IexMath
+   PROPERTY PUBLIC_HEADER "")
+ 
+-foreach(X IexMath IlmThread Half Iex Imath IlmImf IexMath IlmImfUtil)
++foreach(X IlmBase::IexMath IlmBase::IlmThread IlmBase::Half IlmBase::Iex IlmBase::Imath OpenEXR::IlmImf IlmBase::IexMath OpenEXR::IlmImfUtil)
+   set_property(TARGET ${X} PROPERTY OUTPUT_NAME "${X}-mitsuba")
+ endforeach()
+ 
+@@ -232,11 +276,19 @@ mark_as_advanced(
+   OPENEXR_USE_CLANG_TIDY OpenEXR_DIR INSTALL_OPENEXR_DOCS
+   INSTALL_OPENEXR_EXAMPLES
+ )
++endif()
+ 
+ # ----------------------------------------------------------
+ #  libpng
+ # ----------------------------------------------------------
+ 
++if (NOT MI_USE_SUBMODULES)
++  find_package(PNG REQUIRED)
++  add_library(png ALIAS PNG::PNG)
++  set(PNG_LIBRARIES PNG::PNG PARENT_SCOPE)
++endif()
++
++if (MI_USE_SUBMODULES)
+ set(PNG_SHARED ON CACHE BOOL " " FORCE)
+ set(PNG_STATIC OFF CACHE BOOL " " FORCE)
+ set(PNG_TESTS OFF CACHE BOOL " " FORCE)
+@@ -245,8 +297,9 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+ set(PNG_ARM_NEON "on" CACHE STRING " " FORCE)
+ endif()
+ add_subdirectory(libpng)
+-set_property(TARGET png genfiles PROPERTY FOLDER "dependencies")
+-set_property(TARGET png PROPERTY OUTPUT_NAME "png-mitsuba")
++
++set_property(TARGET PNG::PNG PROPERTY FOLDER "dependencies")
++set_property(TARGET PNG::PNG PROPERTY OUTPUT_NAME "png-mitsuba")
+ 
+ set(PNG_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/libpng;${CMAKE_CURRENT_BINARY_DIR}/libpng" PARENT_SCOPE)
+ set(PNG_LIBRARIES    "png" PARENT_SCOPE)
+@@ -255,48 +308,70 @@ set(PNG_DEFINES      -DMI_HAS_LIBPNG PARENT_SCOPE)
+ mark_as_advanced(DFA_XTRA AWK PNG_FRAMEWORK PNG_HARDWARE_OPTIMIZATIONS
+   PNG_PREFIX PNG_SHARED PNG_STATIC PNG_TESTS PNG_BUILD_ZLIB PNG_DEBUG
+   PNG_INTEL_SSE M_LIBRARY ld-version-script)
++endif()
+ 
+ # ----------------------------------------------------------
+ #  libjpeg 7
+ # ----------------------------------------------------------
+ 
++if (MI_USE_SUBMODULES)
+ set(LIBJPEG_BUILD_SHARED ON CACHE BOOL " " FORCE)
+ set(LIBJPEG_BUILD_EXECUTABLES OFF CACHE BOOL " " FORCE)
+ add_subdirectory(libjpeg)
+-set_property(TARGET jpeg PROPERTY FOLDER "dependencies")
+-set(JPEG_LIBRARIES libjpeg PARENT_SCOPE)
++
++set_property(TARGET JPEG::JPEG PROPERTY FOLDER "dependencies")
+ 
+ set(JPEG_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/libjpeg;${CMAKE_CURRENT_BINARY_DIR}/libjpeg" PARENT_SCOPE)
+-set(JPEG_LIBRARIES    "jpeg" PARENT_SCOPE)
++set(JPEG_LIBRARIES    JPEG::JPEG PARENT_SCOPE)
+ set(JPEG_DEFINES      -DMI_HAS_LIBJPEG PARENT_SCOPE)
++else()
++  find_package(JPEG REQUIRED)
++  add_library(jpeg ALIAS JPEG::JPEG)
++  set(JPEG_LIBRARIES JPEG::JPEG PARENT_SCOPE)
++endif()
+ 
+ # Give libpng & libjpeg a name that's guaranteeed not to match other
+ # libraries that may already be loaded (e.g. into a Python interpreter)
+-set_property(TARGET jpeg PROPERTY OUTPUT_NAME "jpeg-mitsuba")
++set_property(TARGET JPEG::JPEG PROPERTY OUTPUT_NAME "jpeg-mitsuba")
+ 
++if (MI_USE_SUBMODULES)
+ mark_as_advanced(
+   LIBJPEG_BUILD_EXECUTABLES
+   LIBJPEG_BUILD_SHARED
+ )
++endif()
+ 
+ # ----------------------------------------------------------
+ #  pugixml XML parser
+ # ----------------------------------------------------------
+ 
++if (MI_USE_SUBMODULES)
+ add_library(pugixml SHARED pugixml/src/pugixml.cpp)
+ set_property(TARGET pugixml PROPERTY
+   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pugixml")
+ set_property(TARGET pugixml PROPERTY FOLDER "dependencies")
+ set(PUGIXML_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/pugixml/src PARENT_SCOPE)
+ target_compile_options(pugixml PRIVATE -DPUGIXML_BUILD_DLL)
++else()
++  find_package(pugixml REQUIRED)
++endif()
+ 
+-# tinyformat include path
+-set(TINYFORMAT_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/tinyformat PARENT_SCOPE)
++if (MI_USE_SUBMODULES)
++  set(TINYFORMAT_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/tinyformat PARENT_SCOPE)
++else()
++  find_package(tinyformat REQUIRED)
++  get_target_property(TINYFORMAT_INCLUDE_DIRS tinyformat INTERFACE_INCLUDE_DIRECTORIES)
++endif()
+ 
+ # ----------------------------------------------------------
+ #  asmjit -- x86/64 JIT compiler
+ # ----------------------------------------------------------
+ 
++if (NOT MI_USE_SUBMODULES)
++  find_package(asmjit)
++  add_library(asmjit ALIAS asmjit::asmjit)
++endif()
++
+ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
+   # Build asmjit
+   set(ASMJIT_NO_AARCH32    TRUE CACHE BOOL "" FORCE)
+@@ -306,23 +381,29 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
+   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-undefined-inline")
+   endif()
++
++  if (MI_USE_SUBMODULES)
+   add_subdirectory(asmjit)
+   set(ASMJIT_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/asmjit/src PARENT_SCOPE)
+-  set_property(TARGET asmjit PROPERTY FOLDER "dependencies")
+-  if (MSVC)
+-    target_compile_options(asmjit PRIVATE "/wd4804" "/wd4838")
++  endif()
++
++  set_property(TARGET asmjit::asmjit PROPERTY FOLDER "dependencies")
++  if (MSVC AND MI_USE_SUBMODULES)
++    target_compile_options(asmjit::asmjit PRIVATE "/wd4804" "/wd4838")
+     # Don't complain about ignoring '/INCREMENTAL'
+-    set_target_properties(asmjit PROPERTIES LINK_FLAGS "/ignore:4075")
++    set_target_properties(asmjit::asmjit PROPERTIES LINK_FLAGS "/ignore:4075")
+   endif()
+   # Avoid name clashes with pytorch (which also includes asmjit)
+-  set_property(TARGET asmjit PROPERTY OUTPUT_NAME "asmjit-mitsuba")
++  set_property(TARGET asmjit::asmjit PROPERTY OUTPUT_NAME "asmjit-mitsuba")
+ endif()
+ 
++if (MI_USE_SUBMODULES)
+ mark_as_advanced(
+   ASMJIT_DIR ASMJIT_EMBED ASMJIT_STATIC ASMJIT_NO_AARCH32 ASMJIT_NO_AARCH64
+   ASMJIT_NO_DEPRECATED ASMJIT_NO_CUSTOM_FLAGS ASMJIT_NO_FOREIGN ASMJIT_NO_NATVIS
+   ASMJIT_NO_X86 ASMJIT_TEST ASMJIT_SANITIZE
+ )
++endif()
+ 
+ # ----------------------------------------------------------
+ #  sRGB spectral upsampling model
+@@ -337,12 +418,16 @@ set_target_properties(rgb2spec rgb2spec_opt rgb2spec_opt_run PROPERTIES FOLDER "
+ #  Fast floating point parser (interface library)
+ # ----------------------------------------------------------
+ 
++if (MI_USE_SUBMODULES)
+ add_subdirectory(fastfloat EXCLUDE_FROM_ALL)
+ mark_as_advanced(
+   FASTFLOAT_SANITIZE
+   FASTFLOAT_TEST
+ )
+ unset(CMAKE_CXX_STANDARD CACHE)
++else()
++  find_package(FastFloat REQUIRED)
++endif()
+ 
+ # ----------------------------------------------------------
+ #  Hide a few more settings that aren't relevant for users
+diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
+index 9da1b648..f6087844 100644
+--- a/src/core/CMakeLists.txt
++++ b/src/core/CMakeLists.txt
+@@ -90,7 +90,7 @@ target_link_libraries(mitsuba-core PRIVATE
+   # Link pugixml parser
+   pugixml
+   # Image libraries: link to libjpeg, libpng, OpenEXR
+-  ${PNG_LIBRARIES} ${JPEG_LIBRARIES} IlmImf
++  ${PNG_LIBRARIES} ${JPEG_LIBRARIES} OpenEXR::IlmImf
+ )
+ 
+ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
+@@ -102,7 +102,7 @@ if (NOT MSVC)
+ endif()
+ 
+ target_link_libraries(mitsuba-core PUBLIC drjit)
+-target_link_libraries(mitsuba-core PRIVATE fast_float)
++target_link_libraries(mitsuba-core PRIVATE FastFloat::fast_float)
+ 
+ if (MI_ENABLE_JIT)
+   target_link_libraries(mitsuba-core PUBLIC drjit-core)
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/mitsuba3/0002-setup.py-try-PYTHONPATH-before-git-submodules.patch
+++ b/pkgs/development/python-modules/mitsuba3/0002-setup.py-try-PYTHONPATH-before-git-submodules.patch
@@ -1,0 +1,37 @@
+From 6938fada92f22285698ad57e2fac9476487c08a0 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Thu, 23 Nov 2023 05:21:31 +0000
+Subject: [PATCH 2/4] setup.py: try PYTHONPATH before git-submodules
+
+---
+ setup.py | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 89f3a33a..7309e1a9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -22,11 +22,15 @@ with open(os.path.join(this_directory, "include/mitsuba/mitsuba.h")) as f:
+     matches = dict(mi_version_regex.findall(f.read()))
+     mitsuba_version = "{MAJOR}.{MINOR}.{PATCH}".format(**matches)
+ 
+-with open(os.path.join(this_directory, "ext/drjit/include/drjit/fwd.h")) as f:
+-    drjit_version_regex = re.compile(
+-        r"^\s*#\s*define\s+DRJIT_VERSION_([A-Z]+)\s+(.*)$", re.MULTILINE)
+-    matches = dict(drjit_version_regex.findall(f.read()))
+-    drjit_version = "{MAJOR}.{MINOR}.{PATCH}".format(**matches)
++try:
++    import drjit
++    drjit_version = drjit.__version__
++except ImportError:
++    with open(os.path.join(this_directory, "ext/drjit/include/drjit/fwd.h")) as f:
++        drjit_version_regex = re.compile(
++            r"^\s*#\s*define\s+DRJIT_VERSION_([A-Z]+)\s+(.*)$", re.MULTILINE)
++        matches = dict(drjit_version_regex.findall(f.read()))
++        drjit_version = "{MAJOR}.{MINOR}.{PATCH}".format(**matches)
+ 
+ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+     long_description = f.read()
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/mitsuba3/0003-python-tests-allow-running-with-mitsuba-in-site-pack.patch
+++ b/pkgs/development/python-modules/mitsuba3/0003-python-tests-allow-running-with-mitsuba-in-site-pack.patch
@@ -1,0 +1,26 @@
+From 89c1f5edc6602e6b08c5c7590ae47ac549de6961 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Thu, 23 Nov 2023 20:13:29 +0000
+Subject: [PATCH 3/4] python tests: allow running with mitsuba in site-packages
+ instead of _skbuild
+
+---
+ src/python/python/test/util.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python/python/test/util.py b/src/python/python/test/util.py
+index b5ae0d90..2e744f31 100644
+--- a/src/python/python/test/util.py
++++ b/src/python/python/test/util.py
+@@ -11,7 +11,7 @@ import pytest
+ import drjit as dr
+ 
+ def find_resource(fname):
+-    path = os.path.dirname(os.path.realpath(__file__))
++    path = os.environ.get("MI_FIND_RESOURCE_ROOT", os.path.dirname(os.path.realpath(__file__)))
+     while True:
+         full = os.path.join(path, fname)
+         if os.path.exists(full):
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/mitsuba3/0004-mitsuba-s-__init__.py-don-t-check-the-expected-locat.patch
+++ b/pkgs/development/python-modules/mitsuba3/0004-mitsuba-s-__init__.py-don-t-check-the-expected-locat.patch
@@ -1,0 +1,26 @@
+From d8ee6b78106a910ca8613c44bfec822b9435b82c Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Fri, 24 Nov 2023 00:56:52 +0000
+Subject: [PATCH 4/4] mitsuba's __init__.py: don't check the 'expected
+ location' if drjit comes from the nix store
+
+---
+ src/python/__init__.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python/__init__.py b/src/python/__init__.py
+index dca9c8c9..ac0e06b8 100644
+--- a/src/python/__init__.py
++++ b/src/python/__init__.py
+@@ -15,7 +15,7 @@ if _sys.version_info < (3, 8):
+ mi_dir = _os.path.dirname(_os.path.realpath(__file__))
+ drjit_expected_loc = _os.path.realpath(_os.path.join(mi_dir, "..", "drjit"))
+ drjit_loc = _os.path.realpath(_dr.__path__[0])
+-if _os.name != 'nt' and drjit_expected_loc != drjit_loc:
++if _os.name != 'nt' and drjit_expected_loc != drjit_loc and not drjit_loc.startswith("/nix/store/"):
+     logging.warning("The `mitsuba` package relies on `drjit` and needs it "
+                     "to be installed at a specific location. Currently, "
+                     "`drjit` is located at \"%s\" when it is expected to be "
+-- 
+2.42.0
+

--- a/pkgs/development/python-modules/mitsuba3/default.nix
+++ b/pkgs/development/python-modules/mitsuba3/default.nix
@@ -1,0 +1,161 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, stdenv
+, ninja
+, pybind11
+, nanobind
+, scikit-build
+, setuptools
+, wheel
+, asmjit
+, drjit
+, drjit-core
+, embree
+, fast-float
+, libjpeg
+, libpng
+, nanothread
+, numpy
+, openexr
+, pugixml
+, python
+, tbbLatest
+, tinyformat
+, zlib
+, pytestCheckHook
+, enableEmbree ? false # The tests currently segfault with embree/tbb on
+, enableVariants ? [ "scalar_rgb" ]
+}:
+
+buildPythonPackage rec {
+  pname = "mitsuba3";
+  version = "unstable-2023-11-23";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mitsuba-renderer";
+    repo = "mitsuba3";
+    rev = "3549783b37a9d831997f9c39a2a8d5affcbf2c50";
+    hash = "sha256-8iot1hivS01OvDI9VpxKBVhgvKw7XTjK1LPhv7kTVm4=";
+    fetchSubmodules = true;
+  };
+  patches = [
+    ./0001-cmake-try-find_package-first.patch
+    ./0002-setup.py-try-PYTHONPATH-before-git-submodules.patch
+    ./0003-python-tests-allow-running-with-mitsuba-in-site-pack.patch
+    ./0004-mitsuba-s-__init__.py-don-t-check-the-expected-locat.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    scikit-build
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    asmjit
+    drjit-core
+    fast-float
+    libjpeg
+    libpng
+    nanothread
+    openexr
+    pugixml
+    tbbLatest.dev
+    tinyformat
+    zlib
+
+    pybind11
+    # nanobind
+
+    # find_library(... libatomic.so)
+    stdenv.cc.cc.lib
+  ] ++ lib.optionals enableEmbree [
+    embree
+  ];
+
+  propagatedBuildInputs = [
+    drjit
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+  ];
+
+  # CMAKE_ARGS for scikit-build.
+  # Writable ~/.drjit, probably for the stub generation
+  preConfigure = ''
+    export CMAKE_ARGS=$cmakeFlags "''${cmakeFlagsArray[@]}"
+    export HOME=$TMPDIR
+  '';
+
+  dontUseCmakeConfigure = true;
+  # cmakeFlags = [ "-GNinja" ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "MI_USE_SUBMODULES" false)
+    (lib.cmakeBool "MI_ENABLE_EMBREE" enableEmbree)
+    (lib.cmakeFeature "MI_DEFAULT_VARIANTS" (builtins.concatStringsSep ";" enableVariants))
+  ];
+
+  # The tests pick up mitsuba.test.util installed into the site-packages, and
+  # then try to locate resources/data/* in one of the module's parent paths.
+  # The "resources" are installed under a different name and only partially, so
+  # we should use the directory from the source tree. We'd also probably have
+  # to do something hacky if we wanted to use mitsuba.test.util from the source
+  # tree because of the directory structure and the __path__ hacks
+  preCheck = ''
+    export MI_FIND_RESOURCE_ROOT=$PWD
+
+    IFS=" " read -r -a disabledTestsEx <<< "$disabledTestsEx"
+    pytestFlagsArray+=( "''${disabledTestsEx[@]/#/--deselect=}" )
+  '';
+  pytestFlagsArray = [
+    "src/"
+    "-m"
+    ''"not slow"''
+  ];
+  disabledTestsEx = lib.optionals (!enableEmbree) [
+    "src/shapes/tests/test_bsplinecurve.py::test01_create"
+    "src/shapes/tests/test_bsplinecurve.py::test02_create_multiple_curves"
+    "src/shapes/tests/test_bsplinecurve.py::test03_bbox"
+    "src/shapes/tests/test_bsplinecurve.py::test05_ray_intersect"
+    "src/shapes/tests/test_linearcurve.py::test01_create"
+    "src/shapes/tests/test_linearcurve.py::test02_create_multiple_curves"
+    "src/shapes/tests/test_linearcurve.py::test02_bbox"
+    "src/shapes/tests/test_linearcurve.py::test04_ray_intersect"
+    "src/shapes/tests/test_linearcurve.py::test08_instancing"
+    "src/shapes/tests/test_sdfgrid.py::test01_create"
+    "src/shapes/tests/test_sdfgrid.py::test02_bbox"
+    "src/shapes/tests/test_sdfgrid.py::test03_parameters_changed"
+    "src/shapes/tests/test_bsplinecurve.py::test02_create_multiple_curves"
+    "src/shapes/tests/test_bsplinecurve.py::test03_bbox"
+    "src/shapes/tests/test_bsplinecurve.py::test05_ray_intersect"
+    "src/shapes/tests/test_linearcurve.py::test01_create"
+    "src/shapes/tests/test_linearcurve.py::test02_create_multiple_curves"
+    "src/shapes/tests/test_linearcurve.py::test02_bbox"
+    "src/shapes/tests/test_linearcurve.py::test04_ray_intersect"
+    "src/shapes/tests/test_linearcurve.py::test08_instancing"
+    "src/shapes/tests/test_sdfgrid.py::test01_create"
+    "src/shapes/tests/test_sdfgrid.py::test02_bbox"
+    "src/shapes/tests/test_sdfgrid.py::test03_parameters_changed"
+  ];
+  postCheck = ''
+    unset MI_FIND_RESOURCE_ROOT
+  '';
+
+  pythonImportsCheck = [ "mitsuba" ];
+
+  meta = with lib; {
+    description = "Mitsuba 3: A Retargetable Forward and Inverse Renderer";
+    homepage = "https://github.com/mitsuba-renderer/mitsuba3/";
+    license = licenses.bsd3;
+    mainProgram = "mitsuba";
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/nanobind/default.nix
+++ b/pkgs/development/python-modules/nanobind/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, python
+, ninja
+, scikit-build
+, setuptools
+, wheel
+, robin-map
+}:
+
+buildPythonPackage rec {
+  pname = "nanobind";
+  version = "unstable-2023-11-16";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "wjakob";
+    repo = "nanobind";
+    # Use HEAD until there's a tag that includes https://github.com/wjakob/nanobind/pull/356
+    rev = "ea2569f705b9d12185eea67db399a373d37c75aa";
+    hash = "sha256-f4Y/roXSOSXIHCSyoS+RzBZdxJe6tIz6yAKZl4gDmz8=";
+  };
+
+  # Work around https://github.com/wjakob/nanobind/blob/ea2569f705b9d12185eea67db399a373d37c75aa/CMakeLists.txt#L50C29-L50C50
+  postPatch = ''
+    substituteInPlace src/__init__.py \
+      --replace \
+        "os.path.dirname(__file__)" \
+        "\"$out/share/nanobind\""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    scikit-build
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    robin-map
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "NB_USE_SUBMODULE_DEPS" false)
+  ];
+
+  postInstall = ''
+    mkdir -p $out/${python.sitePackages}/nanobind/
+    cp ../src/*.py $out/${python.sitePackages}/nanobind/
+  '';
+
+  pythonImportsCheck = [ "nanobind" ];
+
+  meta = with lib; {
+    description = "Nanobind: tiny and efficient C++/Python bindings";
+    homepage = "https://github.com/wjakob/nanobind";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17307,8 +17307,10 @@ with pkgs;
 
   tbb_2020_3 = callPackage ../development/libraries/tbb/2020_3.nix { };
   tbb_2021_8 = callPackage ../development/libraries/tbb { };
+
   # many packages still fail with latest version
   tbb = tbb_2020_3;
+  tbbLatest = tbb_2021_8;
 
   terra = callPackage ../development/compilers/terra {
     llvmPackages = llvmPackages_11;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3324,6 +3324,8 @@ self: super: with self; {
 
   drf-yasg = callPackage ../development/python-modules/drf-yasg { };
 
+  drjit = callPackage ../development/python-modules/drjit { };
+
   drivelib = callPackage ../development/python-modules/drivelib { };
 
   drms = callPackage ../development/python-modules/drms { };
@@ -6903,6 +6905,8 @@ self: super: with self; {
 
   mitogen = callPackage ../development/python-modules/mitogen { };
 
+  mitsuba3 = callPackage ../development/python-modules/mitsuba3 { };
+
   mixins = callPackage ../development/python-modules/mixins { };
 
   mixpanel = callPackage ../development/python-modules/mixpanel { };
@@ -7951,6 +7955,8 @@ self: super: with self; {
   name-that-hash = callPackage ../development/python-modules/name-that-hash { };
 
   nampa = callPackage ../development/python-modules/nampa { };
+
+  nanobind = callPackage ../development/python-modules/nanobind { };
 
   nanoid = callPackage ../development/python-modules/nanoid { };
 


### PR DESCRIPTION
## Description of changes

I didn't bother introducing the dependencies in separate commits, because these dependencies are only needed for mitsuba itself. Took a bit of patching, but I'm hopeful that we'll work something out with the upstream later

Testing in progress. I'll also need to have a look at the hardware acceleration support.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested basic functionality of all binary files (`./result/bin/mitsuba`)
  - [x] cornell box with using the `scalar_rgb` variant, embree turned off
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
