### PR TITLE
libbpf: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbpf";
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "libbpf";
     repo = "libbpf";
     rev = "v${version}";
-    sha256 = "sha256-SDDdz2HKEfzHloLkb0sv5ldTo+1yJDVc9O7nj4Cjznk=";
+    sha256 = "sha256-wVCBLJK9nlS1N9/DrQtogoZmgWW4ECqInSeQTjUFhcY=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## Description of changes

Regular update; there's no API breakage so shouldn't cause any problem. Tested bpftrace/bcc/pahole build and bpftrace binaries

(staging as it's not urgent and builds a lot of reverse dependencies (systemd, linux..))

changelog:
# libbpf v1.3.0                                                                                        

## User space-side features and APIs                                                                   

- support for `netfilter` programs is added:
  - `SEC("netfilter")` is now available
  - API function `bpf_program__attach_netfilter()` is now available
- support for `tcx` BPF programs is added:
  - the following new SEC definitions are now available:
    - `SEC("tc/egress")`
    - `SEC("tc/ingress")`
    - `SEC("tcx/egress")`
    - `SEC("tcx/ingress")`
  - the following SEC definitions are now considered legacy:
    - `SEC("tc")`
    - `SEC("action")`
    - `SEC("classifier")`
  - functions `bpf_prog_attach_opts()` and `bpf_prog_query_opts()` are extended to work with `tcx`
programs, plus two new API functions are added:
    - `bpf_prog_detach_opts()`
    - `bpf_program__attach_tcx()`
- support for multi-uprobe programs is added:
  - the following new SEC definitions are now available:
    - `SEC("uprobe.multi")`
    - `SEC("uprobe.multi.s")`
    - `SEC("uretprobe.multi")`
    - `SEC("uretprobe.multi.s")`
  - plus a new API function:
    - `bpf_program__attach_uprobe_multi()`
- support for section `SEC("usdt.s")` is added for sleepable `usdt` programs;
- support for Unix domain socket cgroup BPF programs is added the following new SEC definitions are now
available:
  - `SEC("cgroup/connect_unix")`
  - `SEC("cgroup/sendmsg_unix")`
  - `SEC("cgroup/recvmsg_unix")`
  - `SEC("cgroup/getpeername_unix")`
  - `SEC("cgroup/getsockname_unix")`
- new `LIBBPF_OPTS_RESET()` utility macro;
- new `bpf_object__unpin()` function to complement existing `bpf_object__pin()`;
- new API functions for work with ring buffers:
  - `ring_buffer__ring()`
  - `ring__producer_pos()`
  - `ring__consumer_pos()`
  - `ring__avail_data_size()`
  - `ring__size()`
  - `ring__map_fd()`
  - `ring__consume()`
- `path_fd` support for `bpf_obj_pin()` and `bpf_obj_get()`;
- uprobe SEC matcher extended to allow golang symbols;
- uprobe support for symbols versioning;
- `bpf_map__set_value_size()` can now be used to resize memory mapped region for memory mapped maps;
- `struct bpf_xdp_query_opts` extended with `xdp_zc_max_segs` output field;
- basic BTF sanity check pass added to reject bogus BTF.
- 
## BPF-side features and APIs                                                                          

- triple-underscore flavors for kfunc relocation: like with CO-RE structs `___.*` suffix is ignored
when kfunc relocations are resolved;
- `__percpu_kptr` macro definition in `bpf_helpers.h`;
- support for exception callbacks, use `__attribute__(btf_decl_tag("exception_callback:<func_name>"))` 
to specify exception callback for a program;

## Bug fixes                                                                                           

- fix for btf_dump__dump_type_data() when type contains bitfields;
- fix for correct work of offsetof() and container_of() macro with CO-RE;
- no longer attempt to load modules BTF when resolving CO-RE relocations if CAP_SYS_ADMIN are absent;  
- regex based function search for "kprobe.multi/" programs no longer attempts to trace functions that
cannot be traced;
- bpf_program__set_type() no longer resets sec_def if it is set to a custom fallback SEC handler;
- fix for memory leak possible after bpf_program__set_attach_target() call;



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
