### PR TITLE
buildLuarocksPackage: save luarocks config as derivation

### DIFF
--- a/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
@@ -114,7 +114,7 @@ let
   rocksSubdir = "${self.pname}-${self.version}-rocks";
 
   configFile = writeTextFile {
-    name = pname + "-luarocks-config";
+    name = pname + "-luarocks-config.lua";
     text = self.luarocks_content;
   };
 

--- a/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
@@ -3,6 +3,7 @@
 , lua
 , wrapLua
 , luarocks
+, writeTextFile
 
 # Whether the derivation provides a lua module or not.
 , luarocksCheckHook
@@ -83,7 +84,7 @@ let
 
   __structuredAttrs = true;
   env = {
-    LUAROCKS_CONFIG="$PWD/${luarocks_config}";
+    LUAROCKS_CONFIG = self.configFile;
   } // attrs.env or {};
 
   generatedRockspecFilename = "${rockspecDir}/${pname}-${rockspecVersion}.rockspec";
@@ -111,6 +112,12 @@ let
   # explicitly inherit this for it to be available as a shell variable in the
   # builder
   rocksSubdir = "${self.pname}-${self.version}-rocks";
+
+  configFile = writeTextFile {
+    name = pname + "-luarocks-config";
+    text = self.luarocks_content;
+  };
+
   luarocks_content = let
       externalDepsGenerated = lib.filter (drv: !drv ? luaModule)
         (self.nativeBuildInputs ++ self.propagatedBuildInputs ++ self.buildInputs);
@@ -131,12 +138,6 @@ let
 
   configurePhase = ''
     runHook preConfigure
-
-    cat > ${luarocks_config} <<EOF
-    ${self.luarocks_content}
-    EOF
-    export LUAROCKS_CONFIG="$PWD/${luarocks_config}";
-    cat "$LUAROCKS_CONFIG"
   ''
   + lib.optionalString (self.rockspecFilename == null) ''
     rockspecFilename="${self.generatedRockspecFilename}"


### PR DESCRIPTION
while debugging luarocks packages, it's exhausting to have to build them, look at what random folder they've been built to finally look for their config.

With this you can run 
` nix build lua51Packages.plenary-nvim.configFile -f .` and infer what luarocks will want to do.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
