### PR TITLE
python3Packages.keyring-pass: init at 0.9.2

### DIFF
--- a/pkgs/development/python-modules/keyring-pass/default.nix
+++ b/pkgs/development/python-modules/keyring-pass/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, gnupg
+, keyring
+, pass
+, poetry-core
+, pythonOlder
+}:
+buildPythonPackage rec {
+  pname = "keyring-pass";
+  version = "0.9.2";
+  disabled = pythonOlder "3.6";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nazarewk";
+    repo = "keyring_pass";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Sf7eDOB3prH2s6BzdBtxewSweC0ibLXVxNHBJRRaJe4=";
+  };
+
+  postPatch = ''
+    substituteInPlace keyring_pass/__init__.py \
+      --replace 'pass_binary = "pass"' 'pass_binary = "${lib.getExe pass}"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    keyring
+    gnupg
+  ];
+
+  checkPhase = ''
+    export HOME="$TMPDIR"
+
+    # generate temporary GPG identity
+    cat <<EOF | gpg --gen-key --batch /dev/stdin
+    %no-protection
+    %transient-key
+    Key-Type: 1
+    Key-Length: 1024
+    Subkey-Type: 1
+    Subkey-Length: 1024
+    Name-Real: test
+    Name-Email: test@example.com
+    Expire-Date: 1
+    EOF
+
+    # configure password store
+    ${lib.getExe pass} init test@example.com
+
+    # Configure `keyring` CLI
+    # first make sure `keyring-pass` is in "$PYTHONPATH"
+    [[ "$PYTHONPATH" == *"$out"/lib/python*/site-packages* ]]
+    export PYTHON_KEYRING_BACKEND="keyring_pass.PasswordStoreBackend"
+
+    # confirm set/get/del works
+    keyring set test-service test-username <<<"test-password"
+    test "$(keyring get test-service test-username)" == "test-password"
+    keyring del test-service test-username
+  '';
+
+  pythonImportsCheck = [
+    "keyring_pass"
+  ];
+
+  meta = {
+    description = "Password Store (pass) backend for python's keyring";
+    homepage = "https://github.com/nazarewk/keyring_pass";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nazarewk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6113,6 +6113,8 @@ self: super: with self; {
 
   keyring = callPackage ../development/python-modules/keyring { };
 
+  keyring-pass = callPackage ../development/python-modules/keyring-pass { };
+
   keyrings-cryptfile = callPackage ../development/python-modules/keyrings-cryptfile { };
 
   keyrings-google-artifactregistry-auth = callPackage ../development/python-modules/keyrings-google-artifactregistry-auth { };


### PR DESCRIPTION
## Description of changes

fixes #241660 
implements https://github.com/nazarewk/keyring_pass/issues/15

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
