### PR TITLE
pkgsStatic.stdenv: fix custom CMake LINKER_LANGUAGE

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -379,6 +379,8 @@ else let
           "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}"
         ] ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
           "-DCMAKE_CROSSCOMPILING_EMULATOR=env"
+        ] ++ lib.optionals stdenv.hostPlatform.isStatic [
+          "-DCMAKE_LINK_SEARCH_START_STATIC=ON"
         ]);
 
       mesonFlags =


### PR DESCRIPTION
## Description of changes

If a CMake target has a non-default LINKER_LANGUAGE set, CMake will manually add the libraries it has detected that language's compiler as linking implicitly.  When it does this, it'll pass -Bstatic and -Bdynamic options based on the vibes it gets from each such detected library.  This in itself isn't a problem, because the compiler toolchain, or our wrapper, or something, seems to be smart enough to ignore -Bdynamic for those libraries.  But it does create a problem if the compiler adds extra libraries to the linker command line after that final -Bdynamic, because those will be linked dynamically.  Since our compiler is static by default, CMake should reset to -Bstatic after it's done manually specifying libraries, but CMake didn't actually know that our compiler is static by default.  The fix for that is to tell it, like so.

Until recently, this problem was difficult to notice, because it would result binaries that worked, but that were dynamically linked.  Since e08ce498f03f ("cc-wrapper: Account for NIX_LDFLAGS and NIX_CFLAGS_LINK in linkType"), though, -Wl,-dynamic-linker is no longer mistakenly passed for executables that are supposed to be static, so they end up created with a /lib interpreter path, and so don't run at all on NixOS.

This fixes pkgsStatic.graphite2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
