### PR TITLE
clj-kondo: Remove references to GraalVM derivation

### DIFF
--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -1,25 +1,34 @@
-{ lib, buildGraalvmNativeImage, fetchurl }:
+{ lib, buildGraalvmNativeImage, graalvmCEPackages, removeReferencesTo, fetchurl
+}:
 
 buildGraalvmNativeImage rec {
   pname = "clj-kondo";
   version = "2023.10.20";
 
   src = fetchurl {
-    url = "https://github.com/clj-kondo/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
+    url =
+      "https://github.com/clj-kondo/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
     sha256 = "sha256-f9u/pk3CEEmiLgnS2biaUHpsMHjVEwZL2jyB/1PiZUY=";
   };
 
-  extraNativeImageBuildArgs = [
-    "-H:+ReportExceptionStackTraces"
-    "--no-fallback"
-  ];
+  graalvmDrv = graalvmCEPackages.graalvm-ce;
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
+  extraNativeImageBuildArgs =
+    [ "-H:+ReportExceptionStackTraces" "--no-fallback" ];
+
+  postInstall = ''
+    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
+  '';
 
   meta = with lib; {
     description = "A linter for Clojure code that sparks joy";
     homepage = "https://github.com/clj-kondo/clj-kondo";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
-    changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${version}/CHANGELOG.md";
+    changelog =
+      "https://github.com/clj-kondo/clj-kondo/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [ jlesquembre bandresen thiagokokada ];
   };
 }


### PR DESCRIPTION
## Description of changes

Remove references to GraalVM derivation. Fixes https://github.com/NixOS/nixpkgs/issues/269029.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Maintainers

@jlesquembre @bennyandresen @thiagokokada 

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
