### PR TITLE
photofield: 0.11.0 -> 0.13.0

### DIFF
--- a/pkgs/servers/photofield/default.nix
+++ b/pkgs/servers/photofield/default.nix
@@ -9,13 +9,13 @@
 
 let
   pname = "photofield-ui";
-  version = "0.11.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "SmilyOrg";
     repo = "photofield";
-    rev = "v${version}";
-    hash = "sha256-AqOhagqH0wRKjwcRHFVw0izC0DBv9uY3B5MMDBJoFVE=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-6pJvOn3sN6zfjt2dVZ/xH6pSXM0WgbG7au9tSVUGYys=";
   };
 
   webui = buildNpmPackage {
@@ -24,7 +24,7 @@ let
 
     sourceRoot = "${src.name}/ui";
 
-    npmDepsHash = "sha256-YVyaZsFh5bolDzMd5rXWrbbXQZBeEIV6Fh/kwN+rvPk=";
+    npmDepsHash = "sha256-trKcNuhRdiabFKMafOLtPg8x1bQHLOif6Hm4k5bTAYc=";
 
     installPhase = ''
       mkdir -p $out/share
@@ -37,7 +37,7 @@ buildGoModule rec {
   pname = "photofield";
   inherit version src;
 
-  vendorHash = "sha256-0rrBHkKZfStwzIv5Us/8Db6z3ZSqassCMWQMpScZq7Y=";
+  vendorHash = "sha256-4JFP3vs/Z8iSKgcwfxpdnQpO9kTF68XQArFHYP8IoDQ=";
 
   preBuild = ''
     cp -r ${webui}/share/photofield-ui ui/dist
@@ -50,7 +50,7 @@ buildGoModule rec {
     "-X main.builtBy=Nix"
   ];
 
-  tags = [ "embedstatic" ];
+  tags = [ "embedui" ];
 
   doCheck = false; # tries to modify filesytem
 

--- a/pkgs/servers/photofield/default.nix
+++ b/pkgs/servers/photofield/default.nix
@@ -5,6 +5,8 @@
 , makeWrapper
 , exiftool
 , ffmpeg
+, testers
+, photofield
 }:
 
 let
@@ -60,6 +62,11 @@ buildGoModule rec {
     wrapProgram $out/bin/photofield \
       --prefix PATH : "${lib.makeBinPath [exiftool ffmpeg]}"
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = photofield;
+    command = "photofield -version";
+  };
 
   meta = with lib; {
     description = "Experimental fast photo viewer";

--- a/pkgs/servers/photofield/default.nix
+++ b/pkgs/servers/photofield/default.nix
@@ -72,6 +72,7 @@ buildGoModule rec {
     description = "Experimental fast photo viewer";
     homepage = "https://github.com/SmilyOrg/photofield";
     license = licenses.mit;
+    mainProgram = "photofield";
     maintainers = with maintainers; [ dit7ya ];
   };
 }


### PR DESCRIPTION
## Description of changes
https://github.com/SmilyOrg/photofield/compare/v0.11.0...v0.13.0

Fixes https://hydra.nixos.org/build/241777169

ZHF: https://github.com/NixOS/nixpkgs/issues/265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
