### PR TITLE
shotcut: 21.09.20 -> 23.11.29

### DIFF
--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -1,6 +1,8 @@
 { lib
 , fetchFromGitHub
-, mkDerivation
+, stdenv
+, wrapQtAppsHook
+, substituteAll
 , SDL2
 , frei0r
 , ladspaPlugins
@@ -8,71 +10,53 @@
 , mlt
 , jack1
 , pkg-config
+, fftw
 , qtbase
-, qtmultimedia
-, qtx11extras
-, qtwebsockets
-, qtquickcontrols2
-, qtgraphicaleffects
-, qmake
 , qttools
+, qtmultimedia
+, qtcharts
+, cmake
 , gitUpdater
 }:
-
-assert lib.versionAtLeast mlt.version "6.24.0";
-
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "shotcut";
-  version = "21.09.20";
+  version = "23.11.29";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "shotcut";
     rev = "v${version}";
-    sha256 = "1y46n5gmlayfl46l0vhg5g5dbbc0sg909mxb68sia0clkaas8xrh";
+    hash = "sha256-szWXX/DIJk5ktESgecglptU1qrnrd/u0N6AffwZ5Tos=";
   };
 
-  nativeBuildInputs = [ pkg-config qmake ];
+  nativeBuildInputs = [ pkg-config cmake wrapQtAppsHook ];
   buildInputs = [
     SDL2
     frei0r
     ladspaPlugins
     gettext
     mlt
+    fftw
     qtbase
+    qttools
     qtmultimedia
-    qtx11extras
-    qtwebsockets
-    qtquickcontrols2
-    qtgraphicaleffects
+    qtcharts
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-I${mlt.dev}/include/mlt++ -I${mlt.dev}/include/mlt";
-  qmakeFlags = [
-    "QMAKE_LRELEASE=${lib.getDev qttools}/bin/lrelease"
-    "SHOTCUT_VERSION=${version}"
-    "DEFINES+=SHOTCUT_NOUPGRADE"
+  env.NIX_CFLAGS_COMPILE = "-DSHOTCUT_NOUPGRADE";
+  cmakeFlags = [
+    "-DSHOTCUT_VERSION=${version}"
   ];
 
-  prePatch = ''
-    sed 's_shotcutPath, "melt[^"]*"_"${mlt}/bin/melt"_' -i src/jobs/meltjob.cpp
-    sed 's_shotcutPath, "ffmpeg"_"${mlt.ffmpeg}/bin/ffmpeg"_' -i src/jobs/ffmpegjob.cpp
-    sed 's_qApp->applicationDirPath(), "ffmpeg"_"${mlt.ffmpeg}/bin/ffmpeg"_' -i src/docks/encodedock.cpp
-    NICE=$(type -P nice)
-    sed "s_/usr/bin/nice_''${NICE}_" -i src/jobs/meltjob.cpp src/jobs/ffmpegjob.cpp
-  '';
+  patches = [
+    (substituteAll { inherit mlt; src = ./fix-mlt-ffmpeg-path.patch; })
+  ];
 
   qtWrapperArgs = [
-    "--prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1"
-    "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ jack1 SDL2 ]}"
-    "--prefix PATH : ${mlt}/bin"
+    "--set FREI0R_PATH ${frei0r}/lib/frei0r-1"
+    "--set LADSPA_PATH ${ladspaPlugins}/lib/ladspa"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [jack1 SDL2]}"
   ];
-
-  postInstall = ''
-    mkdir -p $out/share/shotcut
-    cp -r src/qml $out/share/shotcut/
-  '';
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";

--- a/pkgs/applications/video/shotcut/fix-mlt-ffmpeg-path.patch
+++ b/pkgs/applications/video/shotcut/fix-mlt-ffmpeg-path.patch
@@ -1,0 +1,80 @@
+diff --git a/src/docks/encodedock.cpp b/src/docks/encodedock.cpp
+index 3359f676..24e44f98 100644
+--- a/src/docks/encodedock.cpp
++++ b/src/docks/encodedock.cpp
+@@ -2177,7 +2177,7 @@ bool EncodeDock::detectHardwareEncoders()
+ {
+     MAIN.showStatusMessage(tr("Detecting hardware encoders..."));
+     QStringList hwlist;
+-    QFileInfo ffmpegPath(qApp->applicationDirPath(), "ffmpeg");
++    QFileInfo ffmpegPath("@ffmpeg@/bin/ffmpeg");
+     foreach (const QString &codec, codecs()) {
+         LOG_INFO() << "checking for" << codec;
+         QProcess proc;
+@@ -2220,7 +2220,7 @@ bool EncodeDock::detectHardwareEncoders()
+ QString &EncodeDock::defaultFormatExtension()
+ {
+     auto format = ui->formatCombo->currentText();
+-    QFileInfo ffmpegPath(qApp->applicationDirPath(), "ffmpeg");
++    QFileInfo ffmpegPath("@ffmpeg@/bin/ffmpeg");
+     QProcess proc;
+     QStringList args;
+     args << "-hide_banner" << "-h" << format.prepend("muxer=");
+diff --git a/src/jobs/ffmpegjob.cpp b/src/jobs/ffmpegjob.cpp
+index 1f15e647..b6ad6633 100644
+--- a/src/jobs/ffmpegjob.cpp
++++ b/src/jobs/ffmpegjob.cpp
+@@ -54,7 +54,7 @@ FfmpegJob::~FfmpegJob()
+ void FfmpegJob::start()
+ {
+     QString shotcutPath = qApp->applicationDirPath();
+-    QFileInfo ffmpegPath(shotcutPath, "ffmpeg");
++    QFileInfo ffmpegPath("@ffmpeg@/bin/ffmpeg");
+     setReadChannel(QProcess::StandardError);
+     LOG_DEBUG() << ffmpegPath.absoluteFilePath() + " " + m_args.join(' ');
+     AbstractJob::start(ffmpegPath.absoluteFilePath(), m_args);
+diff --git a/src/jobs/meltjob.cpp b/src/jobs/meltjob.cpp
+index fd8c00b8..9150fe7b 100644
+--- a/src/jobs/meltjob.cpp
++++ b/src/jobs/meltjob.cpp
+@@ -98,9 +98,9 @@ void MeltJob::start()
+     }
+     QString shotcutPath = qApp->applicationDirPath();
+ #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+-    QFileInfo meltPath(shotcutPath, "melt-7");
++    QFileInfo meltPath("@mlt@/bin/melt");
+ #else
+-    QFileInfo meltPath(shotcutPath, "melt");
++    QFileInfo meltPath("@mlt@/bin/melt");
+ #endif
+     setReadChannel(QProcess::StandardError);
+     QStringList args;
+diff --git a/src/mltcontroller.cpp b/src/mltcontroller.cpp
+index 1e2299ac..b8f39f12 100644
+--- a/src/mltcontroller.cpp
++++ b/src/mltcontroller.cpp
+@@ -1555,9 +1555,9 @@ int Controller::checkFile(const QString &path)
+             || path.endsWith(".aep")) {
+         QString shotcutPath = qApp->applicationDirPath();
+ #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+-        QFileInfo meltPath(shotcutPath, "melt-7");
++        QFileInfo meltPath("@mlt@/bin/melt");
+ #else
+-        QFileInfo meltPath(shotcutPath, "melt");
++        QFileInfo meltPath("@mlt@/bin/melt");
+ #endif
+         QStringList args;
+         args << "-quiet" << "-consumer" << "null" << "real_time=0" << "out=0" << "terminate_on_pause=1" <<
+diff --git a/src/widgets/directshowvideowidget.cpp b/src/widgets/directshowvideowidget.cpp
+index c91ba821..73dd5a61 100644
+--- a/src/widgets/directshowvideowidget.cpp
++++ b/src/widgets/directshowvideowidget.cpp
+@@ -35,7 +35,7 @@ DirectShowVideoWidget::DirectShowVideoWidget(QWidget *parent) :
+     ui->setupUi(this);
+     Util::setColorsToHighlight(ui->label);
+ #ifdef Q_OS_WIN
+-    QFileInfo ffmpegPath(qApp->applicationDirPath(), "ffmpeg");
++    QFileInfo ffmpegPath("@ffmpeg@/bin/ffmpeg");
+     QProcess proc;
+     QStringList args;
+     args << "-hide_banner" << "-list_devices" << "true" << "-f" << "dshow" << "-i" << "dummy";

--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -24,6 +24,7 @@
 , cudaSupport ? config.cudaSupport
 , cudaPackages ? { }
 , enableJackrack ? stdenv.isLinux
+, glib
 , ladspa-sdk
 , ladspaPlugins
 , enablePython ? false
@@ -83,6 +84,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
   ] ++ lib.optionals enableJackrack [
+    glib
     ladspa-sdk
     ladspaPlugins
   ] ++ lib.optionals enableQt [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34225,7 +34225,7 @@ with pkgs;
 
   shod = callPackage ../applications/window-managers/shod { };
 
-  shotcut = libsForQt5.callPackage ../applications/video/shotcut { };
+  shotcut = qt6Packages.callPackage ../applications/video/shotcut { };
 
   shogun = callPackage ../applications/science/machine-learning/shogun {
     protobuf = protobuf_21;


### PR DESCRIPTION
## Description of changes

Updates shotcut to the most recent version, 23.09.29, also making the switch from qmake to cmake, and from Qt5 to Qt6.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
