### PR TITLE
zfs_2_1: init at 2.1.13

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -322,9 +322,8 @@ pkgs/applications/version-management/forgejo @bendlas @emilylange
 /pkgs/development/ocaml-modules     @ulrikstrid
 
 # ZFS
-pkgs/os-specific/linux/zfs                @raitobezarius
-nixos/lib/make-single-disk-zfs-image.nix  @raitobezarius
-nixos/lib/make-multi-disk-zfs-image.nix   @raitobezarius
+pkgs/os-specific/linux/zfs/2_1.nix        @raitobezarius
+pkgs/os-specific/linux/zfs/generic.nix    @raitobezarius
 nixos/modules/tasks/filesystems/zfs.nix   @raitobezarius
 nixos/tests/zfs.nix                       @raitobezarius
 

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -13,6 +13,7 @@ let
                       else pkgs.linuxPackages
     , enableUnstable ? false
     , enableSystemdStage1 ? false
+    , zfsPackage ? if enableUnstable then pkgs.zfs else pkgs.zfsUnstable
     , extraTest ? ""
     }:
     makeTest {
@@ -21,7 +22,7 @@ let
         maintainers = [ adisbladis elvishjerricco ];
       };
 
-      nodes.machine = { pkgs, lib, ... }:
+      nodes.machine = { config, pkgs, lib, ... }:
         let
           usersharePath = "/var/lib/samba/usershares";
         in {
@@ -35,8 +36,8 @@ let
         boot.loader.efi.canTouchEfiVariables = true;
         networking.hostId = "deadbeef";
         boot.kernelPackages = kernelPackage;
+        boot.zfs.package = zfsPackage;
         boot.supportedFilesystems = [ "zfs" ];
-        boot.zfs.enableUnstable = enableUnstable;
         boot.initrd.systemd.enable = enableSystemdStage1;
 
         environment.systemPackages = [ pkgs.parted ];
@@ -192,6 +193,11 @@ let
 
 
 in {
+
+  # maintainer: @raitobezarius
+  series_2_1 = makeZfsTest "2.1-series" {
+    zfsPackage = pkgs.zfs_2_1;
+  };
 
   stable = makeZfsTest "stable" { };
 

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -1,222 +1,241 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, fetchpatch
-, autoreconfHook269, util-linux, nukeReferences, coreutils
-, perl, nixosTests
-, configFile ? "all"
-
-# Userspace dependencies
-, zlib, libuuid, python3, attr, openssl
-, libtirpc
-, nfs-utils, samba
-, gawk, gnugrep, gnused, systemd
-, smartmontools, enableMail ? false
-, sysstat, pkg-config
-, curl
-, pam
-
-# Kernel dependencies
-, kernel ? null
-, enablePython ? true
-, ...
-}:
-
-{ version
-, sha256
-, extraPatches ? []
-, rev ? "zfs-${version}"
-, isUnstable ? false
-, latestCompatibleLinuxPackages
-, kernelCompatible ? null
-}:
-
 let
-  inherit (lib) any optionalString optionals optional makeBinPath;
+  genericBuild =
+  { pkgs, lib, stdenv, fetchFromGitHub, fetchpatch
+  , autoreconfHook269, util-linux, nukeReferences, coreutils
+  , perl
+  , configFile ? "all"
 
-  smartmon = smartmontools.override { inherit enableMail; };
+  # Userspace dependencies
+  , zlib, libuuid, python3, attr, openssl
+  , libtirpc
+  , nfs-utils, samba
+  , gawk, gnugrep, gnused, systemd
+  , smartmontools, enableMail ? false
+  , sysstat, pkg-config
+  , curl
+  , pam
 
-  buildKernel = any (n: n == configFile) [ "kernel" "all" ];
-  buildUser = any (n: n == configFile) [ "user" "all" ];
+  # Kernel dependencies
+  , kernel ? null
+  , enablePython ? true
+  , ...
+  }@outerArgs:
 
-  # XXX: You always want to build kernel modules with the same stdenv as the
-  # kernel was built with. However, since zfs can also be built for userspace we
-  # need to correctly pick between the provided/default stdenv, and the one used
-  # by the kernel.
-  # If you don't do this your ZFS builds will fail on any non-standard (e.g.
-  # clang-built) kernels.
-  stdenv' = if kernel == null then stdenv else kernel.stdenv;
-in
+  assert (configFile == "kernel") -> (kernel != null);
+  { version
+  , hash
+  , kernelModuleAttribute
+  , extraPatches ? []
+  , rev ? "zfs-${version}"
+  , isUnstable ? false
+  , latestCompatibleLinuxPackages
+  , kernelCompatible ? null
+  , maintainers ? (with lib.maintainers; [ amarshall adamcstephens ])
+  , tests
+  }@innerArgs:
 
-stdenv'.mkDerivation {
-  name = "zfs-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
+  let
+    inherit (lib) any optionalString optionals optional makeBinPath versionAtLeast;
 
-  src = fetchFromGitHub {
-    owner = "openzfs";
-    repo = "zfs";
-    inherit rev sha256;
-  };
+    smartmon = smartmontools.override { inherit enableMail; };
 
-  patches = extraPatches;
+    buildKernel = any (n: n == configFile) [ "kernel" "all" ];
+    buildUser = any (n: n == configFile) [ "user" "all" ];
+    isAtLeast22Series = versionAtLeast version "2.2.0";
 
-  postPatch = optionalString buildKernel ''
-    patchShebangs scripts
-    # The arrays must remain the same length, so we repeat a flag that is
-    # already part of the command and therefore has no effect.
-    substituteInPlace ./module/os/linux/zfs/zfs_ctldir.c \
-      --replace '"/usr/bin/env", "umount"' '"${util-linux}/bin/umount", "-n"' \
-      --replace '"/usr/bin/env", "mount"'  '"${util-linux}/bin/mount", "-n"'
-  '' + optionalString buildUser ''
-    substituteInPlace ./lib/libshare/os/linux/nfs.c --replace "/usr/sbin/exportfs" "${
-      # We don't *need* python support, but we set it like this to minimize closure size:
-      # If it's disabled by default, no need to enable it, even if we have python enabled
-      # And if it's enabled by default, only change that if we explicitly disable python to remove python from the closure
-      nfs-utils.override (old: { enablePython = old.enablePython or true && enablePython; })
-    }/bin/exportfs"
-    substituteInPlace ./lib/libshare/smb.h        --replace "/usr/bin/net"            "${samba}/bin/net"
-    # Disable dynamic loading of libcurl
-    substituteInPlace ./config/user-libfetch.m4   --replace "curl-config --built-shared" "true"
-    substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
-    substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d" \
-                                                  --replace "/etc/default"            "$out/etc/default"
-    substituteInPlace ./contrib/initramfs/Makefile.am \
-      --replace "/usr/share/initramfs-tools" "$out/usr/share/initramfs-tools"
-    substituteInPlace ./udev/vdev_id \
-      --replace "PATH=/bin:/sbin:/usr/bin:/usr/sbin" \
-       "PATH=${makeBinPath [ coreutils gawk gnused gnugrep systemd ]}"
-    substituteInPlace ./config/zfs-build.m4 \
-      --replace "bashcompletiondir=/etc/bash_completion.d" \
-        "bashcompletiondir=$out/share/bash-completion/completions"
-  '';
+    # XXX: You always want to build kernel modules with the same stdenv as the
+    # kernel was built with. However, since zfs can also be built for userspace we
+    # need to correctly pick between the provided/default stdenv, and the one used
+    # by the kernel.
+    # If you don't do this your ZFS builds will fail on any non-standard (e.g.
+    # clang-built) kernels.
+    stdenv' = if kernel == null then stdenv else kernel.stdenv;
+  in
 
-  nativeBuildInputs = [ autoreconfHook269 nukeReferences ]
-    ++ optionals buildKernel (kernel.moduleBuildDependencies ++ [ perl ])
-    ++ optional buildUser pkg-config;
-  buildInputs = optionals buildUser [ zlib libuuid attr libtirpc pam ]
-    ++ optional buildUser openssl
-    ++ optional buildUser curl
-    ++ optional (buildUser && enablePython) python3;
+  stdenv'.mkDerivation {
+    name = "zfs-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
+    pname = "zfs";
+    inherit version;
 
-  # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
-  NIX_CFLAGS_LINK = "-lgcc_s";
+    src = fetchFromGitHub {
+      owner = "openzfs";
+      repo = "zfs";
+      inherit rev hash;
+    };
 
-  hardeningDisable = [ "fortify" "stackprotector" "pic" ];
+    patches = extraPatches;
 
-  configureFlags = [
-    "--with-config=${configFile}"
-    "--with-tirpc=1"
-    (lib.withFeatureAs (buildUser && enablePython) "python" python3.interpreter)
-  ] ++ optionals buildUser [
-    "--with-dracutdir=$(out)/lib/dracut"
-    "--with-udevdir=$(out)/lib/udev"
-    "--with-systemdunitdir=$(out)/etc/systemd/system"
-    "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
-    "--with-systemdgeneratordir=$(out)/lib/systemd/system-generator"
-    "--with-mounthelperdir=$(out)/bin"
-    "--libexecdir=$(out)/libexec"
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--enable-systemd"
-    "--enable-pam"
-  ] ++ optionals buildKernel ([
-    "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
-    "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ] ++ kernel.makeFlags);
+    postPatch = optionalString buildKernel ''
+      patchShebangs scripts
+      # The arrays must remain the same length, so we repeat a flag that is
+      # already part of the command and therefore has no effect.
+      substituteInPlace ./module/os/linux/zfs/zfs_ctldir.c \
+        --replace '"/usr/bin/env", "umount"' '"${util-linux}/bin/umount", "-n"' \
+        --replace '"/usr/bin/env", "mount"'  '"${util-linux}/bin/mount", "-n"'
+    '' + optionalString buildUser ''
+      substituteInPlace ./lib/libshare/os/linux/nfs.c --replace "/usr/sbin/exportfs" "${
+        # We don't *need* python support, but we set it like this to minimize closure size:
+        # If it's disabled by default, no need to enable it, even if we have python enabled
+        # And if it's enabled by default, only change that if we explicitly disable python to remove python from the closure
+        nfs-utils.override (old: { enablePython = old.enablePython or true && enablePython; })
+      }/bin/exportfs"
+      substituteInPlace ./lib/libshare/smb.h        --replace "/usr/bin/net"            "${samba}/bin/net"
+      # Disable dynamic loading of libcurl
+      substituteInPlace ./config/user-libfetch.m4   --replace "curl-config --built-shared" "true"
+      substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
+      substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d" \
+                                                    --replace "/etc/default"            "$out/etc/default"
+      substituteInPlace ./contrib/initramfs/Makefile.am \
+        --replace "/usr/share/initramfs-tools" "$out/usr/share/initramfs-tools"
+    '' + optionalString isAtLeast22Series ''
+      substituteInPlace ./udev/vdev_id \
+        --replace "PATH=/bin:/sbin:/usr/bin:/usr/sbin" \
+         "PATH=${makeBinPath [ coreutils gawk gnused gnugrep systemd ]}"
+    '' + optionalString (!isAtLeast22Series) ''
+      substituteInPlace ./etc/zfs/Makefile.am --replace "\$(sysconfdir)/zfs" "$out/etc/zfs"
 
-  makeFlags = optionals buildKernel kernel.makeFlags;
+      find ./contrib/initramfs -name Makefile.am -exec sed -i -e 's|/usr/share/initramfs-tools|'$out'/share/initramfs-tools|g' {} \;
 
-  enableParallelBuilding = true;
-
-  installFlags = [
-    "sysconfdir=\${out}/etc"
-    "DEFAULT_INITCONF_DIR=\${out}/default"
-    "INSTALL_MOD_PATH=\${out}"
-  ];
-
-  preConfigure = ''
-    # The kernel module builds some tests during the configurePhase, this envvar controls their parallelism
-    export TEST_JOBS=$NIX_BUILD_CORES
-    if [ -z "$enableParallelBuilding" ]; then
-      export TEST_JOBS=1
-    fi
-  '';
-
-  # Enabling BTF causes zfs to be build with debug symbols.
-  # Since zfs compress kernel modules on installation, our strip hooks skip stripping them.
-  # Hence we strip modules prior to compression.
-  postBuild = optionalString buildKernel ''
-     find . -name "*.ko" -print0 | xargs -0 -P$NIX_BUILD_CORES ${stdenv.cc.targetPrefix}strip --strip-debug
-  '';
-
-  postInstall = optionalString buildKernel ''
-    # Add reference that cannot be detected due to compressed kernel module
-    mkdir -p "$out/nix-support"
-    echo "${util-linux}" >> "$out/nix-support/extra-refs"
-  '' + optionalString buildUser ''
-    # Remove provided services as they are buggy
-    rm $out/etc/systemd/system/zfs-import-*.service
-
-    for i in $out/etc/systemd/system/*; do
-       if [ -L $i ]; then
-         continue
-       fi
-       sed -i '/zfs-import-scan.service/d' $i
-       substituteInPlace $i --replace "zfs-import-cache.service" "zfs-import.target"
-    done
-
-    # Remove tests because they add a runtime dependency on gcc
-    rm -rf $out/share/zfs/zfs-tests
-
-    # Add Bash completions.
-    install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
-    (cd $out/share/bash-completion/completions; ln -s zfs zpool)
-  '';
-
-  postFixup = let
-    path = "PATH=${makeBinPath [ coreutils gawk gnused gnugrep util-linux smartmon sysstat ]}:$PATH";
-  in ''
-    for i in $out/libexec/zfs/zpool.d/*; do
-      sed -i '2i${path}' $i
-    done
-  '';
-
-  outputs = [ "out" ] ++ optionals buildUser [ "dev" ];
-
-  passthru = {
-    inherit enableMail latestCompatibleLinuxPackages;
-
-    tests =
-      if isUnstable then [
-        nixosTests.zfs.unstable
-      ] else [
-        nixosTests.zfs.installer
-        nixosTests.zfs.stable
-      ];
-  };
-
-  meta = {
-    description = "ZFS Filesystem Linux Kernel module";
-    longDescription = ''
-      ZFS is a filesystem that combines a logical volume manager with a
-      Copy-On-Write filesystem with data integrity detection and repair,
-      snapshotting, cloning, block devices, deduplication, and more.
+      substituteInPlace ./cmd/vdev_id/vdev_id \
+        --replace "PATH=/bin:/sbin:/usr/bin:/usr/sbin" \
+        "PATH=${makeBinPath [ coreutils gawk gnused gnugrep systemd ]}"
+    '' + ''
+      substituteInPlace ./config/zfs-build.m4 \
+        --replace "bashcompletiondir=/etc/bash_completion.d" \
+          "bashcompletiondir=$out/share/bash-completion/completions"
     '';
-    homepage = "https://github.com/openzfs/zfs";
-    changelog = "https://github.com/openzfs/zfs/releases/tag/zfs-${version}";
-    license = lib.licenses.cddl;
 
-    # The case-block for TARGET_CPU has branches for only some CPU families,
-    # which prevents ZFS from building on any other platform.  Since the NixOS
-    # `boot.zfs.enabled` property is `readOnly`, excluding platforms where ZFS
-    # does not build is the only way to produce a NixOS installer on such
-    # platforms.
-    # https://github.com/openzfs/zfs/blob/6723d1110f6daf93be93db74d5ea9f6b64c9bce5/config/always-arch.m4#L12
-    platforms =
-      with lib.systems.inspect.patterns;
-      map (p: p // isLinux) ([ isx86_32 isx86_64 isPower isAarch64 isSparc ] ++ isArmv7);
+    nativeBuildInputs = [ autoreconfHook269 nukeReferences ]
+      ++ optionals buildKernel (kernel.moduleBuildDependencies ++ [ perl ])
+      ++ optional buildUser pkg-config;
+    buildInputs = optionals buildUser [ zlib libuuid attr libtirpc pam ]
+      ++ optional buildUser openssl
+      ++ optional buildUser curl
+      ++ optional (buildUser && enablePython) python3;
 
-    maintainers = with lib.maintainers; [ jcumming jonringer globin raitobezarius ];
-    mainProgram = "zfs";
-    # If your Linux kernel version is not yet supported by zfs, try zfsUnstable.
-    # On NixOS set the option boot.zfs.enableUnstable.
-    broken = buildKernel && (kernelCompatible != null) && !kernelCompatible;
+    # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
+    NIX_CFLAGS_LINK = "-lgcc_s";
+
+    hardeningDisable = [ "fortify" "stackprotector" "pic" ];
+
+    configureFlags = [
+      "--with-config=${configFile}"
+      "--with-tirpc=1"
+      (lib.withFeatureAs (buildUser && enablePython) "python" python3.interpreter)
+    ] ++ optionals buildUser [
+      "--with-dracutdir=$(out)/lib/dracut"
+      "--with-udevdir=$(out)/lib/udev"
+      "--with-systemdunitdir=$(out)/etc/systemd/system"
+      "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
+      "--with-systemdgeneratordir=$(out)/lib/systemd/system-generator"
+      "--with-mounthelperdir=$(out)/bin"
+      "--libexecdir=$(out)/libexec"
+      "--sysconfdir=/etc"
+      "--localstatedir=/var"
+      "--enable-systemd"
+      "--enable-pam"
+    ] ++ optionals buildKernel ([
+      "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+      "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    ] ++ kernel.makeFlags);
+
+    makeFlags = optionals buildKernel kernel.makeFlags;
+
+    enableParallelBuilding = true;
+
+    installFlags = [
+      "sysconfdir=\${out}/etc"
+      "DEFAULT_INITCONF_DIR=\${out}/default"
+      "INSTALL_MOD_PATH=\${out}"
+    ];
+
+    preConfigure = ''
+      # The kernel module builds some tests during the configurePhase, this envvar controls their parallelism
+      export TEST_JOBS=$NIX_BUILD_CORES
+      if [ -z "$enableParallelBuilding" ]; then
+        export TEST_JOBS=1
+      fi
+    '';
+
+    # Enabling BTF causes zfs to be build with debug symbols.
+    # Since zfs compress kernel modules on installation, our strip hooks skip stripping them.
+    # Hence we strip modules prior to compression.
+    postBuild = optionalString buildKernel ''
+       find . -name "*.ko" -print0 | xargs -0 -P$NIX_BUILD_CORES ${stdenv.cc.targetPrefix}strip --strip-debug
+    '';
+
+    postInstall = optionalString buildKernel ''
+      # Add reference that cannot be detected due to compressed kernel module
+      mkdir -p "$out/nix-support"
+      echo "${util-linux}" >> "$out/nix-support/extra-refs"
+    '' + optionalString buildUser ''
+      # Remove provided services as they are buggy
+      rm $out/etc/systemd/system/zfs-import-*.service
+
+      for i in $out/etc/systemd/system/*; do
+         if [ -L $i ]; then
+           continue
+         fi
+         sed -i '/zfs-import-scan.service/d' $i
+         substituteInPlace $i --replace "zfs-import-cache.service" "zfs-import.target"
+      done
+
+      # Remove tests because they add a runtime dependency on gcc
+      rm -rf $out/share/zfs/zfs-tests
+
+      # Add Bash completions.
+      install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
+      (cd $out/share/bash-completion/completions; ln -s zfs zpool)
+    '';
+
+    postFixup = let
+      path = "PATH=${makeBinPath [ coreutils gawk gnused gnugrep util-linux smartmon sysstat ]}:$PATH";
+    in ''
+      for i in $out/libexec/zfs/zpool.d/*; do
+        sed -i '2i${path}' $i
+      done
+    '';
+
+    outputs = [ "out" ] ++ optionals buildUser [ "dev" ];
+
+    passthru = {
+      inherit enableMail latestCompatibleLinuxPackages kernelModuleAttribute;
+      # The corresponding userspace tools to this instantiation
+      # of the ZFS package set.
+      userspaceTools = genericBuild (outerArgs // {
+        configFile = "user";
+      }) innerArgs;
+
+      inherit tests;
+    };
+
+    meta = {
+      description = "ZFS Filesystem Linux Kernel module";
+      longDescription = ''
+        ZFS is a filesystem that combines a logical volume manager with a
+        Copy-On-Write filesystem with data integrity detection and repair,
+        snapshotting, cloning, block devices, deduplication, and more.
+      '';
+      homepage = "https://github.com/openzfs/zfs";
+      changelog = "https://github.com/openzfs/zfs/releases/tag/zfs-${version}";
+      license = lib.licenses.cddl;
+
+      # The case-block for TARGET_CPU has branches for only some CPU families,
+      # which prevents ZFS from building on any other platform.  Since the NixOS
+      # `boot.zfs.enabled` property is `readOnly`, excluding platforms where ZFS
+      # does not build is the only way to produce a NixOS installer on such
+      # platforms.
+      # https://github.com/openzfs/zfs/blob/6723d1110f6daf93be93db74d5ea9f6b64c9bce5/config/always-arch.m4#L12
+      platforms =
+        with lib.systems.inspect.patterns;
+        map (p: p // isLinux) ([ isx86_32 isx86_64 isPower isAarch64 isSparc ] ++ isArmv7);
+
+      inherit maintainers;
+      mainProgram = "zfs";
+      # If your Linux kernel version is not yet supported by zfs, try zfsUnstable.
+      # On NixOS set the option boot.zfs.enableUnstable.
+      broken = buildKernel && (kernelCompatible != null) && !kernelCompatible;
+    };
   };
-}
-
+in
+  genericBuild

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -210,11 +210,13 @@ let
     };
 
     meta = {
-      description = "ZFS Filesystem Linux Kernel module";
+      description = "ZFS Filesystem Linux" + (if buildUser then " Userspace Tools" else " Kernel Module");
       longDescription = ''
         ZFS is a filesystem that combines a logical volume manager with a
         Copy-On-Write filesystem with data integrity detection and repair,
         snapshotting, cloning, block devices, deduplication, and more.
+
+        ${if buildUser then "This is the userspace tools package." else "This is the kernel module package."}
       '';
       homepage = "https://github.com/openzfs/zfs";
       changelog = "https://github.com/openzfs/zfs/releases/tag/zfs-${version}";

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -3,6 +3,7 @@
 , stdenv
 , linuxKernel
 , removeLinuxDRM ? false
+, nixosTests
 , ...
 } @ args:
 
@@ -10,6 +11,9 @@ let
   stdenv' = if kernel == null then stdenv else kernel.stdenv;
 in
 callPackage ./generic.nix args {
+  # You have to ensure that in `pkgs/top-level/linux-kernels.nix`
+  # this attribute is the correct one for this package.
+  kernelModuleAttribute = "zfsUnstable";
   # check the release notes for compatible kernels
   kernelCompatible = if stdenv'.isx86_64 || removeLinuxDRM
     then kernel.kernelOlder "6.6"
@@ -26,7 +30,10 @@ callPackage ./generic.nix args {
   version = "2.2.1-unstable-2023-10-21";
   rev = "95785196f26e92d82cf4445654ba84e4a9671c57";
 
-  sha256 = "sha256-s1sdXSrLu6uSOmjprbUa4cFsE2Vj7JX5i75e4vRnlvg=";
+  hash = "sha256-s1sdXSrLu6uSOmjprbUa4cFsE2Vj7JX5i75e4vRnlvg=";
 
   isUnstable = true;
+  tests = [
+    nixosTests.zfs.unstable
+  ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28985,6 +28985,9 @@ with pkgs;
 
   zenmonitor = callPackage ../os-specific/linux/zenmonitor { };
 
+  zfs_2_1 = callPackage ../os-specific/linux/zfs/2_1.nix {
+    configFile = "user";
+  };
   zfsStable = callPackage ../os-specific/linux/zfs/stable.nix {
     configFile = "user";
   };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -546,6 +546,10 @@ in {
 
     zenpower = callPackage ../os-specific/linux/zenpower { };
 
+    zfs_2_1 = callPackage ../os-specific/linux/zfs/2_1.nix {
+      configFile = "kernel";
+      inherit pkgs kernel;
+    };
     zfsStable = callPackage ../os-specific/linux/zfs/stable.nix {
       configFile = "kernel";
       inherit pkgs kernel;


### PR DESCRIPTION
## Description of changes

This re-introduces the old "super" (in the sense more stable than the average stable ZFS version.) stable ZFS version we had in the past following the many predicted issues of ZFS 2.2.x series.

I am also removing myself from maintenance of any further ZFS versions as I am planning to quit ZFS maintenance at some point.

In the meantime, for users like me who depend on ZFS for critical operations, here is a ZFS version that is known to work for LTS kernels.

I invite anyone who care about ZFS to mention themselves in this issue or to add themselves as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
