### PR TITLE
config.replaceCrossStdenv: add

### DIFF
--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -10,6 +10,7 @@ let
     crossOverlays = [];
 
     # Ignore custom stdenvs when cross compiling for compatibility
+    # Use replaceCrossStdenv instead.
     config = builtins.removeAttrs config [ "replaceStdenv" ];
   };
 
@@ -44,47 +45,49 @@ in lib.init bootStages ++ [
     inherit config;
     overlays = overlays ++ crossOverlays;
     selfBuild = false;
-    stdenv = adaptStdenv (buildPackages.stdenv.override (old: rec {
-      buildPlatform = localSystem;
-      hostPlatform = crossSystem;
-      targetPlatform = crossSystem;
+    stdenv = let
+      baseStdenv = adaptStdenv (buildPackages.stdenv.override (old: rec {
+        buildPlatform = localSystem;
+        hostPlatform = crossSystem;
+        targetPlatform = crossSystem;
 
-      # Prior overrides are surely not valid as packages built with this run on
-      # a different platform, and so are disabled.
-      overrides = _: _: {};
-      extraBuildInputs = [ ] # Old ones run on wrong platform
-         ++ lib.optionals hostPlatform.isDarwin [ buildPackages.targetPackages.darwin.apple_sdk.frameworks.CoreFoundation ]
-         ;
-      allowedRequisites = null;
+        # Prior overrides are surely not valid as packages built with this run on
+        # a different platform, and so are disabled.
+        overrides = _: _: {};
+        extraBuildInputs = [ ] # Old ones run on wrong platform
+           ++ lib.optionals hostPlatform.isDarwin [ buildPackages.targetPackages.darwin.apple_sdk.frameworks.CoreFoundation ]
+           ;
+        allowedRequisites = null;
 
-      hasCC = !targetPlatform.isGhcjs;
+        hasCC = !targetPlatform.isGhcjs;
 
-      cc = if crossSystem.useiOSPrebuilt or false
-             then buildPackages.darwin.iosSdkPkgs.clang
-           else if crossSystem.useAndroidPrebuilt or false
-             then buildPackages."androidndkPkgs_${crossSystem.ndkVer}".clang
-           else if targetPlatform.isGhcjs
-             # Need to use `throw` so tryEval for splicing works, ugh.  Using
-             # `null` or skipping the attribute would cause an eval failure
-             # `tryEval` wouldn't catch, wrecking accessing previous stages
-             # when there is a C compiler and everything should be fine.
-             then throw "no C compiler provided for this platform"
-           else if crossSystem.isDarwin
-             then buildPackages.llvmPackages.libcxxClang
-           else if crossSystem.useLLVM or false
-             then buildPackages.llvmPackages.clang
-           else buildPackages.gcc;
+        cc = if crossSystem.useiOSPrebuilt or false
+               then buildPackages.darwin.iosSdkPkgs.clang
+             else if crossSystem.useAndroidPrebuilt or false
+               then buildPackages."androidndkPkgs_${crossSystem.ndkVer}".clang
+             else if targetPlatform.isGhcjs
+               # Need to use `throw` so tryEval for splicing works, ugh.  Using
+               # `null` or skipping the attribute would cause an eval failure
+               # `tryEval` wouldn't catch, wrecking accessing previous stages
+               # when there is a C compiler and everything should be fine.
+               then throw "no C compiler provided for this platform"
+             else if crossSystem.isDarwin
+               then buildPackages.llvmPackages.libcxxClang
+             else if crossSystem.useLLVM or false
+               then buildPackages.llvmPackages.clang
+             else buildPackages.gcc;
 
-      extraNativeBuildInputs = old.extraNativeBuildInputs
-        ++ lib.optionals
-             (hostPlatform.isLinux && !buildPlatform.isLinux)
-             [ buildPackages.patchelf ]
-        ++ lib.optional
-             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
-               in f hostPlatform && !(f buildPlatform) )
-             buildPackages.updateAutotoolsGnuConfigScriptsHook
-        ;
-    }));
+        extraNativeBuildInputs = old.extraNativeBuildInputs
+          ++ lib.optionals
+               (hostPlatform.isLinux && !buildPlatform.isLinux)
+               [ buildPackages.patchelf ]
+          ++ lib.optional
+               (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
+                 in f hostPlatform && !(f buildPlatform) )
+               buildPackages.updateAutotoolsGnuConfigScriptsHook
+          ;
+      }));
+    in if config ? replaceCrossStdenv then config.replaceCrossStdenv { inherit buildPackages baseStdenv; } else baseStdenv;
   })
 
 ]


### PR DESCRIPTION
Example with `clangUseLLVM` which is the default when using `useLLVM`

```nix
config.replaceCrossStdenv = { buildPackages, baseStdenv }:
  if baseStdenv.targetPlatform.useLLVM or false
  then (buildPackages.stdenvAdapters.overrideCC baseStdenv buildPackages.llvmPackages_16.clangUseLLVM)
  else baseStdenv;
```

The conditional necessary, otherwise the other sets(such as `pkgsCross.aarch64-multiplatform.llvmPackages`)
without `useLLVM` will use the stdenv without the necessary conditions to avoid infinite
recursion because of [targetLlvmLibraries](https://github.com/NixOS/nixpkgs/blob/644b234e1c17aad539c03ac8020f831e20241d50/pkgs/development/compilers/llvm/16/default.nix#L208)
usage.

[`replaceStdenv` is not used when cross-compiling](https://github.com/NixOS/nixpkgs/blob/d77bda728d5041c1294a68fb25c79e2d161f62b9/pkgs/stdenv/cross/default.nix#L12-L13)

`replaceStdenv` uses an additional stage to replace the stdenv to avoid
infinite recursion and other issues but that should not be necessary for cross.


Hide whitespace changes

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
