### PR TITLE
zfs: backport patches for block cloning tunable and default disable; zfsUnstable: 2.2.1-unstable-2023-10-21 -> 2.2.1

### DIFF
--- a/pkgs/os-specific/linux/zfs/brt-tunable.patch
+++ b/pkgs/os-specific/linux/zfs/brt-tunable.patch
@@ -1,0 +1,203 @@
+From 04bb75ca7d95459ea14f6fde112c9ae0128c722d Mon Sep 17 00:00:00 2001
+From: Rich Ercolani <214141+rincebrain@users.noreply.github.com>
+Date: Thu, 16 Nov 2023 14:35:22 -0500
+Subject: [PATCH] Add a tunable to disable BRT support.
+
+Copy the disable parameter that FreeBSD implemented, and extend it to
+work on Linux as well, until we're sure this is stable.
+
+Reviewed-by: Alexander Motin <mav@FreeBSD.org>
+Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Signed-off-by: Rich Ercolani <rincebrain@gmail.com>
+Closes #15529
+(cherry picked from commit 03e9caaec006134b3db9d02ac40fe9369ee78b03)
+---
+ include/os/freebsd/zfs/sys/zfs_vfsops_os.h        |  1 +
+ include/os/linux/zfs/sys/zfs_vfsops_os.h          |  2 ++
+ man/man4/zfs.4                                    |  5 +++++
+ module/os/freebsd/zfs/zfs_vfsops.c                |  4 ++++
+ module/os/freebsd/zfs/zfs_vnops_os.c              |  5 +++++
+ module/os/linux/zfs/zfs_vnops_os.c                |  4 ++++
+ module/os/linux/zfs/zpl_file_range.c              |  5 +++++
+ tests/zfs-tests/include/libtest.shlib             | 15 +++++++++++++++
+ tests/zfs-tests/include/tunables.cfg              |  1 +
+ .../tests/functional/block_cloning/cleanup.ksh    |  4 ++++
+ .../tests/functional/block_cloning/setup.ksh      |  5 +++++
+ 11 files changed, 51 insertions(+)
+
+diff --git a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+index 24bb03575..56a0ac96a 100644
+--- a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
++++ b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+@@ -286,6 +286,7 @@ typedef struct zfid_long {
+ 
+ extern uint_t zfs_fsyncer_key;
+ extern int zfs_super_owner;
++extern int zfs_bclone_enabled;
+ 
+ extern void zfs_init(void);
+ extern void zfs_fini(void);
+diff --git a/include/os/linux/zfs/sys/zfs_vfsops_os.h b/include/os/linux/zfs/sys/zfs_vfsops_os.h
+index b4d5db21f..220466550 100644
+--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
++++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
+@@ -45,6 +45,8 @@ extern "C" {
+ typedef struct zfsvfs zfsvfs_t;
+ struct znode;
+ 
++extern int zfs_bclone_enabled;
++
+ /*
+  * This structure emulates the vfs_t from other platforms.  It's purpose
+  * is to facilitate the handling of mount options and minimize structural
+diff --git a/man/man4/zfs.4 b/man/man4/zfs.4
+index 71a3e67ee..e26d92526 100644
+--- a/man/man4/zfs.4
++++ b/man/man4/zfs.4
+@@ -1137,6 +1137,11 @@ Selecting any option other than
+ results in vector instructions
+ from the respective CPU instruction set being used.
+ .
++.It Sy zfs_bclone_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
++Enable the experimental block cloning feature.
++If this setting is 0, then even if feature@block_cloning is enabled,
++attempts to clone blocks will act as though the feature is disabled.
++.
+ .It Sy zfs_blake3_impl Ns = Ns Sy fastest Pq string
+ Select a BLAKE3 implementation.
+ .Pp
+diff --git a/module/os/freebsd/zfs/zfs_vfsops.c b/module/os/freebsd/zfs/zfs_vfsops.c
+index e8b9ada13..09e18de81 100644
+--- a/module/os/freebsd/zfs/zfs_vfsops.c
++++ b/module/os/freebsd/zfs/zfs_vfsops.c
+@@ -89,6 +89,10 @@ int zfs_debug_level;
+ SYSCTL_INT(_vfs_zfs, OID_AUTO, debug, CTLFLAG_RWTUN, &zfs_debug_level, 0,
+ 	"Debug level");
+ 
++int zfs_bclone_enabled = 1;
++SYSCTL_INT(_vfs_zfs, OID_AUTO, bclone_enabled, CTLFLAG_RWTUN,
++	&zfs_bclone_enabled, 0, "Enable block cloning");
++
+ struct zfs_jailparam {
+ 	int mount_snapshot;
+ };
+diff --git a/module/os/freebsd/zfs/zfs_vnops_os.c b/module/os/freebsd/zfs/zfs_vnops_os.c
+index c498a1328..f672deed3 100644
+--- a/module/os/freebsd/zfs/zfs_vnops_os.c
++++ b/module/os/freebsd/zfs/zfs_vnops_os.c
+@@ -6243,6 +6243,11 @@ zfs_freebsd_copy_file_range(struct vop_copy_file_range_args *ap)
+ 	int error;
+ 	uint64_t len = *ap->a_lenp;
+ 
++	if (!zfs_bclone_enabled) {
++		mp = NULL;
++		goto bad_write_fallback;
++	}
++
+ 	/*
+ 	 * TODO: If offset/length is not aligned to recordsize, use
+ 	 * vn_generic_copy_file_range() on this fragment.
+diff --git a/module/os/linux/zfs/zfs_vnops_os.c b/module/os/linux/zfs/zfs_vnops_os.c
+index 33baac9db..76fac3a02 100644
+--- a/module/os/linux/zfs/zfs_vnops_os.c
++++ b/module/os/linux/zfs/zfs_vnops_os.c
+@@ -4229,4 +4229,8 @@ EXPORT_SYMBOL(zfs_map);
+ module_param(zfs_delete_blocks, ulong, 0644);
+ MODULE_PARM_DESC(zfs_delete_blocks, "Delete files larger than N blocks async");
+ 
++/* CSTYLED */
++module_param(zfs_bclone_enabled, uint, 0644);
++MODULE_PARM_DESC(zfs_bclone_enabled, "Enable block cloning");
++
+ #endif
+diff --git a/module/os/linux/zfs/zpl_file_range.c b/module/os/linux/zfs/zpl_file_range.c
+index c47fe99da..73476ff40 100644
+--- a/module/os/linux/zfs/zpl_file_range.c
++++ b/module/os/linux/zfs/zpl_file_range.c
+@@ -31,6 +31,8 @@
+ #include <sys/zfs_vnops.h>
+ #include <sys/zfeature.h>
+ 
++int zfs_bclone_enabled = 1;
++
+ /*
+  * Clone part of a file via block cloning.
+  *
+@@ -50,6 +52,9 @@ __zpl_clone_file_range(struct file *src_file, loff_t src_off,
+ 	fstrans_cookie_t cookie;
+ 	int err;
+ 
++	if (!zfs_bclone_enabled)
++		return (-EOPNOTSUPP);
++
+ 	if (!spa_feature_is_enabled(
+ 	    dmu_objset_spa(ITOZSB(dst_i)->z_os), SPA_FEATURE_BLOCK_CLONING))
+ 		return (-EOPNOTSUPP);
+diff --git a/tests/zfs-tests/include/libtest.shlib b/tests/zfs-tests/include/libtest.shlib
+index 844caa17d..d5d7bb6c8 100644
+--- a/tests/zfs-tests/include/libtest.shlib
++++ b/tests/zfs-tests/include/libtest.shlib
+@@ -3334,6 +3334,21 @@ function set_tunable_impl
+ 	esac
+ }
+ 
++function save_tunable
++{
++	[[ ! -d $TEST_BASE_DIR ]] && return 1
++	[[ -e $TEST_BASE_DIR/tunable-$1 ]] && return 2
++	echo "$(get_tunable """$1""")" > "$TEST_BASE_DIR"/tunable-"$1"
++}
++
++function restore_tunable
++{
++	[[ ! -e $TEST_BASE_DIR/tunable-$1 ]] && return 1
++	val="$(cat $TEST_BASE_DIR/tunable-"""$1""")"
++	set_tunable64 "$1" "$val"
++	rm $TEST_BASE_DIR/tunable-$1
++}
++
+ #
+ # Get a global system tunable
+ #
+diff --git a/tests/zfs-tests/include/tunables.cfg b/tests/zfs-tests/include/tunables.cfg
+index 8010a9451..1e8c8fd71 100644
+--- a/tests/zfs-tests/include/tunables.cfg
++++ b/tests/zfs-tests/include/tunables.cfg
+@@ -90,6 +90,7 @@ VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
+ VOL_MODE			vol.mode			zvol_volmode
+ VOL_RECURSIVE			vol.recursive			UNSUPPORTED
+ VOL_USE_BLK_MQ			UNSUPPORTED			UNSUPPORTED
++BCLONE_ENABLED			zfs_bclone_enabled		zfs_bclone_enabled
+ XATTR_COMPAT			xattr_compat			zfs_xattr_compat
+ ZEVENT_LEN_MAX			zevent.len_max			zfs_zevent_len_max
+ ZEVENT_RETAIN_MAX		zevent.retain_max		zfs_zevent_retain_max
+diff --git a/tests/zfs-tests/tests/functional/block_cloning/cleanup.ksh b/tests/zfs-tests/tests/functional/block_cloning/cleanup.ksh
+index 7ac13adb6..b985445a5 100755
+--- a/tests/zfs-tests/tests/functional/block_cloning/cleanup.ksh
++++ b/tests/zfs-tests/tests/functional/block_cloning/cleanup.ksh
+@@ -31,4 +31,8 @@ verify_runnable "global"
+ 
+ default_cleanup_noexit
+ 
++if tunable_exists BCLONE_ENABLED ; then
++	log_must restore_tunable BCLONE_ENABLED
++fi
++
+ log_pass
+diff --git a/tests/zfs-tests/tests/functional/block_cloning/setup.ksh b/tests/zfs-tests/tests/functional/block_cloning/setup.ksh
+index 512f5a064..58441bf8f 100755
+--- a/tests/zfs-tests/tests/functional/block_cloning/setup.ksh
++++ b/tests/zfs-tests/tests/functional/block_cloning/setup.ksh
+@@ -33,4 +33,9 @@ fi
+ 
+ verify_runnable "global"
+ 
++if tunable_exists BCLONE_ENABLED ; then
++    log_must save_tunable BCLONE_ENABLED
++    log_must set_tunable32 BCLONE_ENABLED 1
++fi
++
+ log_pass
+-- 
+2.42.0
+

--- a/pkgs/os-specific/linux/zfs/stable.nix
+++ b/pkgs/os-specific/linux/zfs/stable.nix
@@ -3,7 +3,7 @@
 , stdenv
 , linuxKernel
 , removeLinuxDRM ? false
-, fetchpatch
+, fetchpatch2
 , ...
 } @ args:
 
@@ -25,4 +25,12 @@ callPackage ./generic.nix args {
   version = "2.2.0";
 
   sha256 = "sha256-s1sdXSrLu6uSOmjprbUa4cFsE2Vj7JX5i75e4vRnlvg=";
+
+  extraPatches = [
+    ./brt-tunable.patch
+    (fetchpatch2 {
+      url = "https://github.com/openzfs/zfs/commit/479dca51c66a731e637bd2d4f9bba01a05f9ac9f.patch";
+      hash = "sha256-Qil4sm2h+d2fjwuiQO1nJ63/M83K3XH2A3wEFNr2f5M=";
+    })
+  ];
 }

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -12,21 +12,20 @@ in
 callPackage ./generic.nix args {
   # check the release notes for compatible kernels
   kernelCompatible = if stdenv'.isx86_64 || removeLinuxDRM
-    then kernel.kernelOlder "6.6"
+    then kernel.kernelOlder "6.7"
     else kernel.kernelOlder "6.2";
 
   latestCompatibleLinuxPackages = if stdenv'.isx86_64 || removeLinuxDRM
-    then linuxKernel.packages.linux_6_5
+    then linuxKernel.packages.linux_6_6
     else linuxKernel.packages.linux_6_1;
 
   # this package should point to a version / git revision compatible with the latest kernel release
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.2.1-unstable-2023-10-21";
-  rev = "95785196f26e92d82cf4445654ba84e4a9671c57";
+  version = "2.2.1";
 
-  sha256 = "sha256-s1sdXSrLu6uSOmjprbUa4cFsE2Vj7JX5i75e4vRnlvg=";
+  sha256 = "sha256-2Q/Nhp3YKgMCLPNRNBq5r9U4GeuYlWMWAsjsQy3vFW4=";
 
   isUnstable = true;
 }


### PR DESCRIPTION
## Description of changes

Alternative to https://github.com/NixOS/nixpkgs/pull/269097. Still bumping zfsUnstable to 2.2.1 as I feel that probably still makes sense.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
