### PR TITLE
addDriverRunpath: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -34,6 +34,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `addDriverRunpath` has been added to facilitate the deprecation of the old `addOpenGLRunpath` setuphook. This change is motivated by the evolution of the setuphook to include all hardware acceleration.
+
 - Cinnamon has been updated to 6.0. Please beware that the [Wayland session](https://blog.linuxmint.com/?p=4591) is still experimental in this release.
 
 - Programs written in [Nim](https://nim-lang.org/) are built with libraries selected by lockfiles.
@@ -50,3 +52,4 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - New instances of Gitea using MySQL now ignore the `[database].CHARSET` config option and always use the `utf8mb4` charset, existing instances should migrate via the `gitea doctor convert` CLI command.
 
 - The `hardware.pulseaudio` module now sets permission of pulse user home directory to 755 when running in "systemWide" mode. It fixes [issue 114399](https://github.com/NixOS/nixpkgs/issues/114399).
+

--- a/pkgs/build-support/add-driver-runpath/default.nix
+++ b/pkgs/build-support/add-driver-runpath/default.nix
@@ -1,0 +1,14 @@
+{ lib, stdenv }:
+
+stdenv.mkDerivation {
+  name = "add-driver-runpath";
+
+  # Named "opengl-driver" for legacy reasons, but it is the path to
+  # hardware drivers installed by NixOS
+  driverLink = "/run/opengl-driver" + lib.optionalString stdenv.isi686 "-32";
+
+  buildCommand = ''
+    mkdir -p $out/nix-support
+    substituteAll ${./setup-hook.sh} $out/nix-support/setup-hook
+  '';
+}

--- a/pkgs/build-support/add-driver-runpath/setup-hook.sh
+++ b/pkgs/build-support/add-driver-runpath/setup-hook.sh
@@ -1,0 +1,29 @@
+# Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
+# This is needed to not rely on LD_LIBRARY_PATH which does not work with setuid
+# executables. Fixes https://github.com/NixOS/nixpkgs/issues/22760. It must be run
+# in postFixup because RUNPATH stripping in fixup would undo it. Note that patchelf
+# actually sets RUNPATH not RPATH, which applies only to dependencies of the binary
+# it set on (including for dlopen), so the RUNPATH must indeed be set on these
+# libraries and would not work if set only on executables.
+addDriverRunpath() {
+    local forceRpath=
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --) shift; break;;
+            --force-rpath) shift; forceRpath=1;;
+            --*)
+                echo "addDriverRunpath: ERROR: Invalid command line" \
+                     "argument: $1" >&2
+                return 1;;
+            *) break;;
+        esac
+    done
+
+    for file in "$@"; do
+        if ! isELF "$file"; then continue; fi
+        local origRpath="$(patchelf --print-rpath "$file")"
+        patchelf --set-rpath "@driverLink@/lib:$origRpath" ${forceRpath:+--force-rpath} "$file"
+    done
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -230,6 +230,8 @@ with pkgs;
   # many more scenarios than just opengl now.
   addDriverRunpath = callPackage ../build-support/add-driver-runpath { };
 
+  # addOpenGLRunpath should be added to aliases.nix after the 24.05 branch-off.
+  # Post 24.11 branch-off, this should throw an error in aliases.nix.
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 
   quickemu = callPackage ../development/quickemu { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -226,6 +226,10 @@ with pkgs;
 
   chkservice = callPackage ../tools/admin/chkservice { };
 
+  # addDriverRunpath is the preferred package name, as this enables
+  # many more scenarios than just opengl now.
+  addDriverRunpath = callPackage ../build-support/add-driver-runpath { };
+
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 
   quickemu = callPackage ../development/quickemu { };


### PR DESCRIPTION
## Description of changes

Less opinionated version of https://github.com/NixOS/nixpkgs/pull/196174

Allows for usage of `addDriverRunapth`, this way the setuphook is available to allow for a larger window for people to transition from `addOpenGLRunpath` setuphook.

Additional Context: [rfc #121](https://github.com/NixOS/rfcs/pull/121)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
