### PR TITLE
bazel_5: fix CLang 16 Werror-s on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -166,6 +166,8 @@ stdenv.mkDerivation rec {
   inherit src;
   inherit sourceRoot;
   patches = [
+    ./upb-clang16.patch
+
     # On Darwin, the last argument to gcc is coming up as an empty string. i.e: ''
     # This is breaking the build of any C target. This patch removes the last
     # argument if it's found to be an empty string.
@@ -364,6 +366,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in external/{absl,upb} dependencies and in execlog
+      export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions -Wno-implicit-function-declaration"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/upb-clang16.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/upb-clang16.patch
@@ -1,0 +1,83 @@
+diff --git a/distdir_deps.bzl b/distdir_deps.bzl
+index 9068f50537..b3f45e8653 100644
+--- a/distdir_deps.bzl
++++ b/distdir_deps.bzl
+@@ -110,6 +110,8 @@ DIST_DEPS = {
+     "protocolbuffers": {
+         "archive": "2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
+         "sha256": "6a5f67874af66b239b709c572ac1a5a00fdb1b29beaf13c3e6f79b1ba10dc7c4",
++        "patches": ["//:upb-clang16.patch"],
++        "patch_args": ["-p1"],
+         "urls": [
+             "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
+             "https://github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
+@@ -131,6 +133,7 @@ DIST_DEPS = {
+         "patches": [
+             "//third_party/grpc:grpc_1.41.0.patch",
+             "//third_party/grpc:grpc_1.41.0.win_arm64.patch",
++            "//:grpc-upb-clang16.patch",
+         ],
+         "used_in": [
+             "additional_distfiles",
+diff --git a/grpc-upb-clang16.patch b/grpc-upb-clang16.patch
+new file mode 100644
+index 0000000000..69194099db
+--- /dev/null
++++ b/grpc-upb-clang16.patch
+@@ -0,0 +1,13 @@
++diff -r -u a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
++--- a/bazel/grpc_deps.bzl
+++++ b/bazel/grpc_deps.bzl
++@@ -340,6 +340,8 @@
++             name = "upb",
++             sha256 = "6a5f67874af66b239b709c572ac1a5a00fdb1b29beaf13c3e6f79b1ba10dc7c4",
++             strip_prefix = "upb-2de300726a1ba2de9a468468dc5ff9ed17a3215f",
+++            patches = ["//:upb-clang16.patch"],
+++            patch_args = ["-p1"],
++             urls = [
++                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
++                 "https://github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
++
++diff -r -u a/third_party/upb/bazel/build_defs.bzl b/third_party/upb/bazel/build_defs.bzl
++--- a/third_party/upb/bazel/build_defs.bzl	2021-09-25 04:33:41.000000000 +0200
+++++ b/third_party/upb/bazel/build_defs.bzl	2023-11-22 22:27:39.421459688 +0100
++@@ -34,6 +34,7 @@
++         "-Wextra",
++         # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++         "-Werror",
+++        "-Wno-gnu-offsetof-extensions",
++         "-Wno-long-long",
++         # copybara:strip_end
++     ],
++@@ -48,6 +49,7 @@
++         "-pedantic",
++         "-Werror=pedantic",
++         "-Wall",
+++        "-Wno-gnu-offsetof-extensions",
++         "-Wstrict-prototypes",
++         # GCC (at least) emits spurious warnings for this that cannot be fixed
++         # without introducing redundant initialization (with runtime cost):
+diff --git a/upb-clang16.patch b/upb-clang16.patch
+new file mode 100644
+index 0000000000..f81855181f
+--- /dev/null
++++ upb-clang16.patch
+@@ -0,0 +1,18 @@
++--- a/bazel/build_defs.bzl
+++++ b/bazel/build_defs.bzl
++@@ -34,6 +34,7 @@
++         "-Wextra",
++         # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++         "-Werror",
+++        "-Wno-gnu-offsetof-extensions",
++         "-Wno-long-long",
++         # copybara:strip_end
++     ],
++@@ -48,6 +49,7 @@
++         "-pedantic",
++         "-Werror=pedantic",
++         "-Wall",
+++        "-Wno-gnu-offsetof-extensions",
++         "-Wstrict-prototypes",
++         # GCC (at least) emits spurious warnings for this that cannot be fixed
++         # without introducing redundant initialization (with runtime cost):


### PR DESCRIPTION
## Description of changes

Fixing `bazel_5` after #234710

Error example
https://hydra.nixos.org/build/241240612/nixlog/1
```
external/com_google_absl/absl/meta/type_traits.h:560:8: error: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Werror,-Wdeprecated-builtins]
      (__has_trivial_assign(ExtentsRemoved) || !kIsCopyOrMoveAssignable) &&
```

Similar to #269297, and remaining `bazel_4` is WIP for another PR

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
