### PR TITLE
bazel_4: fix CLang 16 Werror-s on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -204,6 +204,8 @@ stdenv.mkDerivation rec {
   inherit src;
   inherit sourceRoot;
   patches = [
+    ./upb-clang16.patch
+
     # On Darwin, the last argument to gcc is coming up as an empty string. i.e: ''
     # This is breaking the build of any C target. This patch removes the last
     # argument if it's found to be an empty string.
@@ -399,6 +401,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in third_party/{zlib}, external/{upb} dependencies
+      export NIX_CFLAGS_COMPILE+=" -Wno-implicit-function-declaration -Wno-gnu-offsetof-extensions"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/upb-clang16.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/upb-clang16.patch
@@ -1,0 +1,57 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 2d995f095e..55fddef663 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -1232,7 +1232,7 @@ register_toolchains("//src/main/res:empty_rc_toolchain")
+ http_archive(
+     name = "com_github_grpc_grpc",
+     patch_args = ["-p1"],
+-    patches = ["//third_party/grpc:grpc_1.33.1.patch"],
++    patches = ["//third_party/grpc:grpc_1.33.1.patch", "//:grpc-upb-clang16.patch"],
+     sha256 = "58eaee5c0f1bd0b92ebe1fa0606ec8f14798500620e7444726afcaf65041cb63",
+     strip_prefix = "grpc-1.33.1",
+     urls = [
+diff --git a/grpc-upb-clang16.patch b/grpc-upb-clang16.patch
+new file mode 100644
+index 0000000000..ae6a7ad0e0
+--- /dev/null
++++ b/grpc-upb-clang16.patch
+@@ -0,0 +1,13 @@
++diff -r -u a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
++--- a/bazel/grpc_deps.bzl
+++++ b/bazel/grpc_deps.bzl
++@@ -285,6 +285,8 @@
++             name = "upb",
++             sha256 = "7992217989f3156f8109931c1fc6db3434b7414957cb82371552377beaeb9d6c",
++             strip_prefix = "upb-382d5afc60e05470c23e8de19b19fc5ad231e732",
+++            patches = ["//:upb-clang16.patch"],
+++            patch_args = ["-p1"],
++             urls = [
++                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
++                 "https://github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
++
+diff --git a/upb-clang16.patch b/upb-clang16.patch
+new file mode 100644
+index 0000000000..b799737fac
+--- /dev/null
++++ b/upb-clang16.patch
+@@ -0,0 +1,18 @@
++--- a/BUILD
+++++ b/BUILD
++@@ -34,6 +34,7 @@
++     "-Wextra",
++     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
++     "-Werror",
+++    "-Wno-gnu-offsetof-extensions",
++     "-Wno-long-long",
++     # copybara:strip_end
++ ]
++@@ -42,6 +43,7 @@
++     # copybara:strip_for_google3_begin
++     "-pedantic",
++     "-Werror=pedantic",
+++    "-Wno-gnu-offsetof-extensions",
++     "-Wstrict-prototypes",
++     # copybara:strip_end
++ ]
+

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -364,6 +364,8 @@ stdenv.mkDerivation rec {
       # libcxx includes aren't added by libcxx hook
       # https://github.com/NixOS/nixpkgs/pull/41589
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+      # for CLang 16 compatibility in external/{absl,upb} dependencies and in execlog
+      export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions -Wno-implicit-function-declaration"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
       sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \


### PR DESCRIPTION
Fixing `bazel_4` after #234710

Error example
https://hydra.nixos.org/build/241174862/nixlog/1
```
Execution platform: //:default_host_platform
third_party/zlib/gzwrite.c:89:20: error: call to undeclared function 'write'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            writ = write(state->fd, strm->next_in, put);
                   ^
```

Similar to #269481 and #269297

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
