### PR TITLE
azure-agent: move runtime dependencies to `pkgs.waagent`

### DIFF
--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -241,16 +241,6 @@ in
       after = [ "network-online.target" "sshd.service" ];
       wants = [ "network-online.target" ];
 
-      path = [
-        pkgs.e2fsprogs
-        pkgs.bash
-
-        # waagent's Microsoft.OSTCExtensions.VMAccessForLinux needs Python 3
-        pkgs.python39
-
-        # waagent's Microsoft.CPlat.Core.RunCommandLinux needs lsof
-        pkgs.lsof
-      ];
       description = "Windows Azure Agent Service";
       unitConfig.ConditionPathExists = "/etc/waagent.conf";
       serviceConfig = {

--- a/pkgs/applications/networking/cluster/waagent/default.nix
+++ b/pkgs/applications/networking/cluster/waagent/default.nix
@@ -10,33 +10,47 @@
   openssl,
   parted,
   procps, # for pidof,
-  python39, # the latest python version that waagent test against according to https://github.com/Azure/WALinuxAgent/blob/28345a55f9b21dae89472111635fd6e41809d958/.github/workflows/ci_pr.yml#L75
+  python39, # the latest python version that waagent tests against, according to https://github.com/Azure/WALinuxAgent/blob/28345a55f9b21dae89472111635fd6e41809d958/.github/workflows/ci_pr.yml#L75
   shadow, # for useradd, usermod
   util-linux, # for (u)mount, fdisk, sfdisk, mkswap
+  e2fsprogs,
+  bash,
+  lsof,
+  writeShellApplication,
 }:
 
 let
-  inherit (lib) makeBinPath;
+  walinuxagent = python39.pkgs.buildPythonPackage rec {
+    pname = "WALinuxAgent";
+    version = "2.8.0.11";
+    src = fetchFromGitHub {
+      owner = "Azure";
+      repo = "WALinuxAgent";
+      rev = "04ded9f0b708cfaf4f9b68eead1aef4cc4f32eeb";
+      sha256 = "0fvjanvsz1zyzhbjr2alq5fnld43mdd776r2qid5jy5glzv0xbhf";
+    };
+    patches = [
+      # Suppress the following error when waagent try to configure sshd:
+      # Read-only file system: '/etc/ssh/sshd_config'
+      ./dont-configure-sshd.patch
+    ];
+    doCheck = false;
 
-in
-python39.pkgs.buildPythonPackage rec {
-  pname = "waagent";
-  version = "2.8.0.11";
-  src = fetchFromGitHub {
-    owner = "Azure";
-    repo = "WALinuxAgent";
-    rev = "04ded9f0b708cfaf4f9b68eead1aef4cc4f32eeb";
-    sha256 = "0fvjanvsz1zyzhbjr2alq5fnld43mdd776r2qid5jy5glzv0xbhf";
+    propagatedBuildInputs = with python39.pkgs; [ distro ];
+
+    fixupPhase = ''
+      mkdir -p $out/bin/
+      WAAGENT=$(find $out -name waagent | grep sbin)
+      ln -s "$WAAGENT" $out/bin/waagent
+    '';
+
   };
-  patches = [
-    # Suppress the following error when waagent try to configure sshd:
-    # Read-only file system: '/etc/ssh/sshd_config'
-    ./dont-configure-sshd.patch
-  ];
-  doCheck = false;
 
-  buildInputs = with python39.pkgs; [ distro ];
-  runtimeDeps = [
+  pythonEnv = walinuxagent.pythonModule.withPackages (ps: [ walinuxagent ]);
+in writeShellApplication {
+  name = "waagent-${walinuxagent.version}";
+  runtimeInputs = [
+    pythonEnv
     findutils
     gnugrep
     gnused
@@ -49,18 +63,13 @@ python39.pkgs.buildPythonPackage rec {
     procps # for pidof
     shadow # for useradd, usermod
     util-linux # for (u)mount, fdisk, sfdisk, mkswap
+    e2fsprogs
+    bash
+    lsof # Microsoft.CPlat.Core.RunCommandLinux needs lsof
   ];
-
-  fixupPhase = ''
-     mkdir -p $out/bin/
-     WAAGENT=$(find $out -name waagent | grep sbin)
-     cp $WAAGENT $out/bin/waagent
-     wrapProgram "$out/bin/waagent" \
-         --prefix PYTHONPATH : $PYTHONPATH \
-         --prefix PATH : "${makeBinPath runtimeDeps}"
-     patchShebangs --build "$out/bin/"
+  text = ''
+    exec waagent "$@"
   '';
-
   meta = {
     description = "The Microsoft Azure Linux Agent (waagent)
                    manages Linux provisioning and VM interaction with the Azure


### PR DESCRIPTION
## Description of changes

This PR is to address the comment https://github.com/NixOS/nixpkgs/pull/266310#issuecomment-1802513544. As discussed in #266310, I think we should put runtime dependencies into `pkgs/applications/networking/cluster/waagent/default.nix`, because `udev` also uses `waagent` [here](https://github.com/Atry/nixpkgs/blob/05a19f48a9f72d71954784ca6adaa365e95738e9/nixos/modules/virtualisation/azure-agent.nix#L203). The dependencies added to `services.waagent` should be avoided because they would not be visible to `udev`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
