### PR TITLE
mouse-actions-gui: init at 0.4.4

### DIFF
--- a/nixos/modules/programs/mouse-actions.nix
+++ b/nixos/modules/programs/mouse-actions.nix
@@ -3,13 +3,39 @@
 let
   cfg = config.programs.mouse-actions;
 in
-  {
-    options.programs.mouse-actions = {
-      enable = lib.mkEnableOption ''
-        mouse-actions udev rules. This is a prerequisite for using mouse-actions without being root
+{
+  options.programs.mouse-actions = {
+    enable = lib.mkEnableOption "" // {
+      description = ''
+        Whether to install and set up mouse-actions and it's udev rules.
+
+        Note that only users in the "uinput" group will be able to use the package
       '';
     };
-    config = lib.mkIf cfg.enable {
-      services.udev.packages = [ pkgs.mouse-actions ];
+    package = lib.mkPackageOption pkgs "mouse-actions" {
+      example = "mouse-actions-gui";
     };
-  }
+    autorun = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to start a user service to run mouse-actions on startup.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+    systemd.user.services.mouse-actions =  lib.mkIf cfg.autorun {
+      description = "mouse-actions launcher";
+      wantedBy = [ "graphical-session.target" ];
+      bindsTo = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      environment.PATH = lib.mkForce null; # don't use the default PATH provided by NixOS
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} start";
+        PassEnvironment = "PATH"; # inherit PATH from user environment
+      };
+    };
+  };
+}

--- a/pkgs/by-name/mo/mouse-actions-gui/80-mouse-actions.rules
+++ b/pkgs/by-name/mo/mouse-actions-gui/80-mouse-actions.rules
@@ -1,0 +1,2 @@
+KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
+KERNEL=="/dev/input/event*", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"

--- a/pkgs/by-name/mo/mouse-actions-gui/package.nix
+++ b/pkgs/by-name/mo/mouse-actions-gui/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  npmHooks,
+  fetchNpmDeps,
+  nodejs,
+
+  rustPlatform,
+  cargo,
+  rustc,
+  cargo-tauri,
+
+  pkg-config,
+  wrapGAppsHook3,
+  libXtst,
+  libevdev,
+  gtk3,
+  libsoup,
+  webkitgtk,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mouse-actions-gui";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "jersou";
+    repo = "mouse-actions";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-02E4HrKIoBV3qZPVH6Tjz9Bv/mh5C8amO1Ilmd+YO5g=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/config-editor";
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    cargo-tauri
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    # Base deps
+    libXtst
+    libevdev
+
+    # Tauri deps
+    gtk3
+    libsoup
+    webkitgtk
+  ];
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src sourceRoot;
+    hash = "sha256-Rnr5jRupdUu6mIsWvdN6AnQnsxB5h31n/24pYslGs5g=";
+  };
+
+  cargoRoot = "src-tauri";
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.sourceRoot}/${finalAttrs.cargoRoot}";
+    hash = "sha256-VQFRatnxzmywAiMLfkVgB7g8AFoqfWFYjt/vezpE1o8=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    cargo-tauri build -b deb
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${./80-mouse-actions.rules} $out/etc/udev/rules.d/80-mouse-actions.rules
+    cp -r src-tauri/target/release/bundle/deb/*/data/usr/* $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/jersou/mouse-actions/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Mouse event based command executor, a mix between Easystroke and Comiz edge commands";
+    homepage = "https://github.com/jersou/mouse-actions";
+    license = lib.licenses.mit;
+    mainProgram = "mouse-actions-gui";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/269212
Connected to https://github.com/NixOS/nixpkgs/issues/264904

Mostly based on the GUI-less solution ([link](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/mo/mouse-actions/package.nix))

This PR adds 1 package: `mouse-actions-gui`
There is a GUI-less version called `mouse-actions`, but this package also has all of that functionality (can be run GUI-less).

The package is a `tauri` app:
I tried to use `buildRustPackage`, like I did for a previous `tauri` app, but for some reason `vite` wanted to connect to the development server even after building. (probably some environment variables I couldn't figure out)
Instead I used `cargo-tauri` to build it as an unwrapped `.deb` package. This actually also takes care of renaming the installed files and the installing of `.desktop` and icons files.

This was inspired by how the [`pot` package](https://github.com/NixOS/nixpkgs/blob/40de5938426b06886a2b441142031c29e0eb8dc1/pkgs/applications/misc/pot/default.nix#L121) did it

I added the necessary `udev` rules based off of the GUI-less solution (@rgri).
(You'll have to add the package to `services.udev.packages` in your configs for the rules to register)
Not exactly sure what the 2nd rule does, as it seems to work without it, but I'll also put it there for parity's sake.

I edited the `programs.mouse-actions` nixod module to be able to take in a different package.

I have also added a systemd service which can autorun the program on launch. It has to do some hacky solutions to use the user's PATH variable, but it works. It is locked behind the `.autorun` option.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
