### PR TITLE
[23.05] teleport_11: add patch for recursive chown vulnerability

### DIFF
--- a/pkgs/servers/teleport/11/default.nix
+++ b/pkgs/servers/teleport/11/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, ... }@args:
+{ callPackage, fetchpatch, ... }@args:
 callPackage ../generic.nix ({
   version = "11.3.25";
   hash = "sha256-KIbRn90BUJp8Uc8GMHuIMMSn5tJQbxzE0ntngx1ELaE=";
@@ -10,4 +10,11 @@ callPackage ../generic.nix ({
       "rdp-rs-0.1.0" = "sha256-GJfUyiYQwcDTMqt+iik3mFI0f6mu13RJ2XuoDzlg9sU=";
     };
   };
-} // builtins.removeAttrs args [ "callPackage" ])
+  goPatches = [
+    (fetchpatch {
+      name = "recursive-chown-vuln-fix.patch";
+      url = "https://github.com/gravitational/teleport/commit/1ffde1695bf9614df87a40a4845e315e227bb35d.patch";
+      hash = "sha256-fcAlaJEcQJQl0TuzfXKg1nNdnDYmppD+ntDOLAT8xAY=";
+    })
+  ];
+} // builtins.removeAttrs args [ "callPackage" "fetchpatch" ])

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -17,6 +17,8 @@
 , yarn2nix-moretea
 , nixosTests
 
+, goPatches ? []
+
 , withRdpClient ? true
 
 , version
@@ -118,7 +120,7 @@ buildGoModule rec {
     ./test.patch
     ./0001-fix-add-nix-path-to-exec-env.patch
     ./rdpclient.patch
-  ];
+  ] ++ goPatches;
 
   # Reduce closure size for client machines
   outputs = [ "out" "client" ];


### PR DESCRIPTION
## Description of changes
No known CVE, but warranted a security release of teleport 12+ (addressed in #267271)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
