### PR TITLE
rvz: init at 1.0.3

### DIFF
--- a/pkgs/by-name/rv/rvz/package.nix
+++ b/pkgs/by-name/rv/rvz/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  zlib,
+}:
+
+buildGoModule rec {
+  pname = "rvz";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "bodgit";
+    repo = "rvz";
+    rev = "v${version}";
+    hash = "sha256-OxU+Pm9OfFuwmmc2+b7eLhN8JR3SB8cjvh9lPS0qJ5Y=";
+  };
+
+  vendorHash = "sha256-Spmp0ZuvC0IpbfZrXNzJQ18LIuRRfwvuwf3E7S+30GY=";
+
+  buildInputs = [ zlib ];
+
+  rev = "aa4ae9eeff06cd2942db0d5af5f4fa5872530256";
+  buildDate = "2022-11-18T23:11:47Z";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=${rev}"
+    "-X main.date=${buildDate}"
+  ];
+
+  subPackages = [ "cmd/rvz" ];
+
+  checkPhase = ''
+    go test -v -short -coverprofile=cover.out ./...
+  '';
+
+  meta = {
+    description = "Golang library for reading RVZ disc images";
+    homepage = "https://github.com/bodgit/rvz";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ dansbandit ];
+    mainProgram = "rvz";
+  };
+}


### PR DESCRIPTION
## Description of changes

Tool to decompress an .rvz file back to its original .iso format. Good alternative to `dolphin-tool`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
