### PR TITLE
python3Packages.pyside6-essentials: init at 6.7.0

### DIFF
--- a/pkgs/development/python-modules/pyside6-essentials/default.nix
+++ b/pkgs/development/python-modules/pyside6-essentials/default.nix
@@ -1,0 +1,51 @@
+{ autoPatchelfHook
+, buildPythonPackage
+, fetchurl
+, lib
+, shiboken6
+
+  # libraries
+, gtk3
+, libxkbcommon
+, mysql80
+, postgresql
+, qt6
+, unixODBC
+}:
+
+buildPythonPackage rec {
+  pname = "pyside6-essentials";
+  inherit (shiboken6) version;
+  format = "wheel";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/d8/f7/7a8a0c3a87fc9a898a521ae34aea5806f71f7bef1a0e032a6d954550fcea/PySide6_Essentials-${version}-cp39-abi3-manylinux_2_28_x86_64.whl";
+    sha256 = "sha256-4BMjj+QFlrgEBo40rBc1FJQ6Qb+OX7tO38fDCwBDG9U=";
+  };
+
+  propagatedBuildInputs = [
+    shiboken6
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    gtk3 # libgtk-3.so.0 and more
+    libxkbcommon # libxkbcommon.so.0
+    mysql80 # libmysqlclient.so.21
+    postgresql.lib # libpq.so.5
+    qt6.full # libGL.so.1, and more
+    unixODBC # libodbc.so.2
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [ "libmimerapi.so" ]; # not in nixpkgs yet
+
+  meta = with lib; {
+    description = "Python bindings for Qt (Essentials)";
+    homepage = "https://www.pyside.org";
+    license = licenses.lgpl3; # unsure which LGPL version
+    maintainers = with maintainers; [ getpsyched ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11832,6 +11832,8 @@ self: super: with self; {
     inherit (pkgs) cmake ninja;
   });
 
+  pyside6-essentials = callPackage ../development/python-modules/pyside6-essentials { };
+
   pysigma = callPackage ../development/python-modules/pysigma { };
 
   pysigma-backend-elasticsearch = callPackage ../development/python-modules/pysigma-backend-elasticsearch { };


### PR DESCRIPTION
## Description of changes

Adds `pyside6-essentials`. This includes some binaries that are not present in the `pyside6` Python module such as `pyside6-uic`, `pyside6-lrelease`, etc.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
