### PR TITLE
nix-unit: init at 2.18.0

### DIFF
--- a/pkgs/by-name/ni/nix-unit/package.nix
+++ b/pkgs/by-name/ni/nix-unit/package.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, lib
+, boost
+, clang-tools
+, cmake
+, difftastic
+, makeWrapper
+, meson
+, ninja
+, nixVersions
+, nlohmann_json
+, pkg-config
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nix-unit";
+  version = "2.18.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nix-unit";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-9wq14p+85oW4HlD42NJ0jyA++z3nEYjFQ6uT40xdfbc=";
+  };
+
+  buildInputs = [
+    nlohmann_json
+    # We pin the nix version to a known working one here as upgrades can likely break the build.
+    # Since the nix language is rather stable we don't always need to have the latest and greatest for unit tests
+    # On each update of nix unit we should re-evaluate what version we need.
+    nixVersions.nix_2_18
+    boost
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    meson
+    pkg-config
+    ninja
+    # nlohmann_json can be only discovered via cmake files
+    cmake
+  ] ++ lib.optional stdenv.cc.isClang [ clang-tools ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/nix-unit" --prefix PATH : ${difftastic}/bin
+  '';
+
+  meta = {
+    description = "Nix unit test runner";
+    homepage = "https://github.com/nix-community/nix-unit";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ mic92 adisbladis ];
+    platforms = lib.platforms.unix;
+    mainProgram = "nix-unit";
+  };
+})


### PR DESCRIPTION
This is now used by several projects including dream2nix. Having not to compile from source is a big win. It might be also a good fit for some nix library tests that we have in nixpkgs itself.

cc @adisbladis 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
