### PR TITLE
lib.getOptionalAttrs: init

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -7,7 +7,7 @@ let
   inherit (builtins) head length;
   inherit (lib.trivial) mergeAttrs warn;
   inherit (lib.strings) concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName;
-  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl;
+  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl intersectLists;
 in
 
 rec {
@@ -574,6 +574,44 @@ rec {
   getAttrs =
     names:
     attrs: genAttrs names (name: attrs.${name});
+
+  /**
+    Given a list of possible attribute names, return the set of
+    attribuets whose name is in the list from the given set.
+
+    It works like `getAttrs` when the first attribute is a list,
+    but skip attributes not in the input set
+    instead of throwing the "attribute is missing" error.
+
+    # Inputs
+
+    `names`
+
+    : A list of possible attribute names to get out of `attrs`.
+
+    `attrs`
+
+    : The set to get the existing named attribute from.
+
+    # Type
+
+    ```
+    getOptionalAttrs :: [String] -> AttrSet -> AttrSet
+    ```
+
+    # Example
+    :::{.example}
+
+    ## `lib.attrsets.getOptionalAttrs` usage example
+    ```nix
+    getOptionalAttrs [ "a" "b" "d" ] { a = 1; b = 2; c = 3; }
+    => { a = 1; b = 2; }
+    ```
+    :::
+  */
+  getOptionalAttrs =
+    names:
+    attrs: getAttrs (intersectLists (attrNames attrs) names) attrs;
 
   /**
     Collect each attribute named `attr` from a list of attribute

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -548,7 +548,7 @@ rec {
 
     `names`
 
-    : A list of attribute names to get out of `set`
+    : A list of attribute names to get out of `attrs`
 
     `attrs`
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -79,7 +79,7 @@ let
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
-      getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
+      getAttrFromPath attrVals attrValues getAttrs getOptionalAttrs catAttrs filterAttrs
       filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -53,6 +53,7 @@ let
     generators
     genList
     getAttrs
+    getOptionalAttrs
     getExe
     getExe'
     groupBy
@@ -1871,6 +1872,26 @@ runTests {
 
   testGetAttrsEmpty = {
     expr = getAttrs [ ] { };
+    expected = { };
+  };
+
+  testGetOptionalAttrsExample = {
+    expr = getOptionalAttrs [ "a" "b" "d" ] { a = 1; b = 2; c = 3; };
+    expected = { a = 1; b = 2; };
+  };
+
+  testGetOptionalAttrsEmptyNames = {
+    expr = getOptionalAttrs [ ] { a = 1; b = 2; c = 3; };
+    expected = { };
+  };
+
+  testGetOptionalAttrsEmptyValues = {
+    expr = getOptionalAttrs [ "a" "b" "d" ] { };
+    expected = { };
+  };
+
+  testGetOptionalAttrsEmpty = {
+    expr = getOptionalAttrs [ ] { };
     expected = { };
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -52,6 +52,7 @@ let
     functionArgs
     generators
     genList
+    getAttrs
     getExe
     getExe'
     groupBy
@@ -1852,6 +1853,25 @@ runTests {
       a.b = 1;
       a.x = 1;
     };
+  };
+
+  testGetAttrsExample = {
+    expr = [
+      (getAttrs [ "a" "b" ] { a = 1; b = 2; c = 3; })
+    ];
+    expected = [
+      { a = 1; b = 2; }
+    ];
+  };
+
+  testGetAttrsEmptyList = {
+    expr = getAttrs [ ] { a = 1; b = 2; c = 3; };
+    expected = { };
+  };
+
+  testGetAttrsEmpty = {
+    expr = getAttrs [ ] { };
+    expected = { };
   };
 
   ## Levenshtein distance functions and co.


### PR DESCRIPTION
## Description of changes

This PR introduces `lib.getOptionalAttrs`, a handy function that returns a sub- attribute according to the input list of attribute names. Unlike `lib.getAttrs`, it skips attributes that are not in the input attribute set instead of throwing the error of missing attributes. It acts as the complement of `removeAttrs`.

### Changes during PR review:
- Rename `getExistingAttrs` -> `getOptionalAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
