### PR TITLE
river: 0.2.4 -> 0.2.5, rivercarro: 0.1.4 -> 0.3.0

### DIFF
--- a/pkgs/applications/misc/rivercarro/default.nix
+++ b/pkgs/applications/misc/rivercarro/default.nix
@@ -4,26 +4,28 @@
 , pkg-config
 , river
 , wayland
-, zig_0_9
+, wayland-protocols
+, zig_0_11
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rivercarro";
-  version = "0.1.4";
+  version = "0.3.0";
 
   src = fetchFromSourcehut {
     owner = "~novakane";
     repo = "rivercarro";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-eATbbwIt5ytEVLPodyq9vFF9Rs5S1xShpvNYQnfwdV4=";
+    hash = "sha256-lucwn9MmyVd4pynuG/ZAXnZ384wdS0gi7JN44vNQA1I=";
   };
 
   nativeBuildInputs = [
     pkg-config
     river
     wayland
-    zig_0_9.hook
+    wayland-protocols
+    zig_0_11.hook
   ];
 
   meta = with lib; {
@@ -42,6 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.sr.ht/~novakane/rivercarro/refs/v${finalAttrs.version}";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ kraem ];
-    inherit (zig_0_9.meta) platforms;
+    inherit (zig_0_11.meta) platforms;
   };
 })

--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -14,14 +14,14 @@
 , wayland-protocols
 , wlroots_0_16
 , xwayland
-, zig_0_10
+, zig_0_11
 , withManpages ? true
 , xwaylandSupport ? true
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "river";
-  version = "0.2.4";
+  version = "0.2.5";
 
   outputs = [ "out" ] ++ lib.optionals withManpages [ "man" ];
 
@@ -30,14 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "river";
     rev = "refs/tags/v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-cIcO6owM6eYn+obYVaBOVQpnBx4++KOqQk5Hzo3GcNs=";
+    hash = "sha256-Xd9hg7UGTBlEyw8BDpTQYq/IRC7vUXhMx9j7YcCaQ20=";
   };
 
   nativeBuildInputs = [
     pkg-config
     wayland
     xwayland
-    zig_0_10.hook
+    zig_0_11.hook
   ]
   ++ lib.optional withManpages scdoc;
 


### PR DESCRIPTION
## Description of changes

Changelog `river`: https://github.com/riverwm/river/releases/tag/v0.2.5
Changelog `rivercarro`: https://git.sr.ht/~novakane/rivercarro/refs/v0.3.0

cc @adamcstephens @moni-dz @rodrgz 
cc @kraem 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
