### PR TITLE
databricks-cli: init at 0.209.1

### DIFF
--- a/pkgs/by-name/da/databricks-cli/package.nix
+++ b/pkgs/by-name/da/databricks-cli/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "databricks-cli";
+  version = "0.209.1";
+
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/databricks/cli/releases/download/v${version}/databricks_cli_${version}_linux_amd64.zip";
+      sha256 = "sha256-E69QpKsZxysc6duq3sz392qG/AtfvYEwzyvUgDWxkVE=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/databricks/cli/releases/download/v${version}/databricks_cli_${version}_linux_arm64.zip";
+      sha256 = "sha256-UTPXMnrma66+lrXFKdfih5yJfAoQVBIHawzZ3yEdXOM=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/databricks/cli/releases/download/v${version}/databricks_cli_${version}_darwin_amd64.zip";
+      sha256 = "sha256-GDoxPpfqsJShxtNeQ7uZTZw7sRlaNRES+sPribxNllI=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/databricks/cli/releases/download/v${version}/databricks_cli_${version}_darwin_arm64.zip";
+      sha256 = "sha256-jyIoYTHJ/8lbBBVB5sUCCOdC7LCcTWywE5g3fOHa7XY=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    $installPhase/databricks --version
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp databricks $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A command-line interface for Databricks";
+    homepage = "https://github.com/databricks/cli";
+    license = licenses.asl20;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ jl178 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Added the databricks CLI as a separate package, since the previous [Python package](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/development/python-modules/databricks-cli/default.nix#L60) is deprecated per: https://docs.databricks.com/en/archive/dev-tools/cli/index.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
