### PR TITLE
python311Packages.pydantic: 1.10.12 -> 2.3.0

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -163,7 +163,7 @@ let
                 zeroconf
                 zipstream-ng
                 class-doc
-                pydantic
+                pydantic_1
               ] ++ lib.optionals stdenv.isDarwin [
                 py.pkgs.appdirs
               ] ++ lib.optionals (!stdenv.isDarwin) [

--- a/pkgs/applications/networking/cloudflare-dyndns/default.nix
+++ b/pkgs/applications/networking/cloudflare-dyndns/default.nix
@@ -24,7 +24,7 @@ python3.pkgs.buildPythonApplication rec {
     attrs
     click
     cloudflare
-    pydantic
+    pydantic_1
     requests
   ];
 

--- a/pkgs/applications/video/frigate/default.nix
+++ b/pkgs/applications/video/frigate/default.nix
@@ -25,6 +25,12 @@ let
 
   python = python3.override {
     packageOverrides = self: super: {
+      pydantic = super.pydantic_1;
+
+      versioningit = super.versioningit.overridePythonAttrs {
+        # checkPhase requires pydantic>=2
+        doCheck = false;
+      };
     };
   };
 

--- a/pkgs/development/python-modules/aionotion/default.nix
+++ b/pkgs/development/python-modules/aionotion/default.nix
@@ -39,6 +39,9 @@ buildPythonPackage rec {
       url = "https://github.com/bachya/aionotion/commit/53c7285110d12810f9b43284295f71d052a81b83.patch";
       hash = "sha256-RLRbHmaR2A8MNc96WHx0L8ccyygoBUaOulAuRJkFuUM=";
     })
+
+    # based on https://github.com/bachya/aionotion/pull/235
+    ./pydantic_2-compatibility.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/aionotion/default.nix
+++ b/pkgs/development/python-modules/aionotion/default.nix
@@ -74,6 +74,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python library for Notion Home Monitoring";
     homepage = "https://github.com/bachya/aionotion";
+    changelog = "https://github.com/bachya/aionotion/releases/tag/${src.rev}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/aionotion/pydantic_2-compatibility.patch
+++ b/pkgs/development/python-modules/aionotion/pydantic_2-compatibility.patch
@@ -1,0 +1,111 @@
+diff --git a/aionotion/bridge/models.py b/aionotion/bridge/models.py
+index 260566d..f2e640c 100644
+--- a/aionotion/bridge/models.py
++++ b/aionotion/bridge/models.py
+@@ -5,7 +5,10 @@ from __future__ import annotations
+ from datetime import datetime
+ from typing import Optional, Union
+ 
+-from pydantic import BaseModel, validator
++try:
++    from pydantic.v1 import BaseModel, validator
++except ModuleNotFoundError:
++    from pydantic import BaseModel, validator
+ 
+ from aionotion.helpers.validators import validate_timestamp
+ 
+diff --git a/aionotion/client.py b/aionotion/client.py
+index 5332334..e2f9035 100644
+--- a/aionotion/client.py
++++ b/aionotion/client.py
+@@ -5,7 +5,10 @@ from typing import Any, cast
+ 
+ from aiohttp import ClientSession, ClientTimeout
+ from aiohttp.client_exceptions import ClientError
+-from pydantic import BaseModel, ValidationError
++try:
++    from pydantic.v1 import BaseModel, ValidationError
++except ModuleNotFoundError:
++    from pydantic import BaseModel, ValidationError
+ 
+ from aionotion.bridge import Bridge
+ from aionotion.const import LOGGER
+diff --git a/aionotion/device/models.py b/aionotion/device/models.py
+index c19bc3e..ea7f577 100644
+--- a/aionotion/device/models.py
++++ b/aionotion/device/models.py
+@@ -4,7 +4,10 @@ from __future__ import annotations
+ 
+ from datetime import datetime
+ 
+-from pydantic import BaseModel, validator
++try:
++    from pydantic.v1 import BaseModel, validator
++except ModuleNotFoundError:
++    from pydantic import BaseModel, validator
+ 
+ from aionotion.helpers.validators import validate_timestamp
+ 
+diff --git a/aionotion/helpers/typing.py b/aionotion/helpers/typing.py
+index 130c5ab..b2c3726 100644
+--- a/aionotion/helpers/typing.py
++++ b/aionotion/helpers/typing.py
+@@ -1,6 +1,9 @@
+ """Define typing helpers."""
+ from typing import TypeVar
+ 
+-from pydantic import BaseModel
++try:
++    from pydantic.v1 import BaseModel
++except ModuleNotFoundError:
++    from pydantic import BaseModel
+ 
+ BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
+diff --git a/aionotion/sensor/models.py b/aionotion/sensor/models.py
+index 3bcfb12..643a282 100644
+--- a/aionotion/sensor/models.py
++++ b/aionotion/sensor/models.py
+@@ -6,7 +6,10 @@ from datetime import datetime
+ from enum import Enum
+ from typing import Any, Literal, Optional
+ 
+-from pydantic import BaseModel, Extra, validator
++try:
++    from pydantic.v1 import BaseModel, Extra, validator
++except ModuleNotFoundError:
++    from pydantic import BaseModel, Extra, validator
+ 
+ from aionotion.const import LOGGER
+ from aionotion.helpers.validators import validate_timestamp
+diff --git a/aionotion/system/models.py b/aionotion/system/models.py
+index d5b27d3..7931959 100644
+--- a/aionotion/system/models.py
++++ b/aionotion/system/models.py
+@@ -5,7 +5,10 @@ from __future__ import annotations
+ from datetime import datetime
+ from typing import Optional
+ 
+-from pydantic import BaseModel, validator
++try:
++    from pydantic.v1 import BaseModel, validator
++except ModuleNotFoundError:
++    from pydantic import BaseModel, validator
+ 
+ from aionotion.helpers.validators import validate_timestamp
+ 
+diff --git a/aionotion/user/models.py b/aionotion/user/models.py
+index 856fbc3..723041e 100644
+--- a/aionotion/user/models.py
++++ b/aionotion/user/models.py
+@@ -2,7 +2,10 @@
+ # pylint: disable=too-few-public-methods
+ from __future__ import annotations
+ 
+-from pydantic import BaseModel
++try:
++    from pydantic.v1 import BaseModel
++except ModuleNotFoundError:
++    from pydantic import BaseModel
+ 
+ 
+ class UserPreferences(BaseModel):

--- a/pkgs/development/python-modules/aiopurpleair/default.nix
+++ b/pkgs/development/python-modules/aiopurpleair/default.nix
@@ -38,6 +38,9 @@ buildPythonPackage rec {
       url = "https://github.com/bachya/aiopurpleair/commit/8c704c51ea50da266f52a7f53198d29d643b30c5.patch";
       hash = "sha256-RLRbHmaR2A8MNc96WHx0L8ccyygoBUaOulAuRJkFuUM=";
     })
+
+    # based on https://github.com/bachya/aiopurpleair/pull/176
+    ./pydantic_2-compatibility.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/aiopurpleair/pydantic_2-compatibility.patch
+++ b/pkgs/development/python-modules/aiopurpleair/pydantic_2-compatibility.patch
@@ -1,0 +1,111 @@
+diff --git a/aiopurpleair/api.py b/aiopurpleair/api.py
+index d3b276b..c557015 100644
+--- a/aiopurpleair/api.py
++++ b/aiopurpleair/api.py
+@@ -5,7 +5,10 @@ from typing import Any, cast
+ 
+ from aiohttp import ClientSession, ClientTimeout
+ from aiohttp.client_exceptions import ClientError
+-from pydantic import BaseModel, ValidationError
++try:
++    from pydantic.v1 import BaseModel, ValidationError
++except ModuleNotFoundError:
++    from pydantic import BaseModel, ValidationError
+ 
+ from aiopurpleair.const import LOGGER
+ from aiopurpleair.endpoints.sensors import SensorsEndpoints
+diff --git a/aiopurpleair/endpoints/__init__.py b/aiopurpleair/endpoints/__init__.py
+index 4d263e1..6632310 100644
+--- a/aiopurpleair/endpoints/__init__.py
++++ b/aiopurpleair/endpoints/__init__.py
+@@ -4,7 +4,10 @@ from __future__ import annotations
+ from collections.abc import Awaitable, Callable, Iterable
+ from typing import Any
+ 
+-from pydantic import BaseModel, ValidationError
++try:
++    from pydantic.v1 import BaseModel, ValidationError
++except ModuleNotFoundError:
++    from pydantic import BaseModel, ValidationError
+ 
+ from aiopurpleair.errors import InvalidRequestError
+ from aiopurpleair.helpers.typing import ModelT
+diff --git a/aiopurpleair/helpers/typing.py b/aiopurpleair/helpers/typing.py
+index 4ae01e6..49f59e6 100644
+--- a/aiopurpleair/helpers/typing.py
++++ b/aiopurpleair/helpers/typing.py
+@@ -1,6 +1,9 @@
+ """Define typing helpers."""
+ from typing import TypeVar
+ 
+-from pydantic import BaseModel
++try:
++    from pydantic.v1 import BaseModel
++except ModuleNotFoundError:
++    from pydantic import BaseModel
+ 
+ ModelT = TypeVar("ModelT", bound=BaseModel)
+diff --git a/aiopurpleair/models/keys.py b/aiopurpleair/models/keys.py
+index 591ae01..ffadbcc 100644
+--- a/aiopurpleair/models/keys.py
++++ b/aiopurpleair/models/keys.py
+@@ -3,7 +3,10 @@ from __future__ import annotations
+ 
+ from datetime import datetime
+ 
+-from pydantic import BaseModel, validator
++try:
++    from pydantic.v1 import BaseModel, validator
++except ModuleNotFoundError:
++    from pydantic import BaseModel, validator
+ 
+ from aiopurpleair.backports.enum import StrEnum
+ from aiopurpleair.helpers.validators import validate_timestamp
+diff --git a/aiopurpleair/models/sensors.py b/aiopurpleair/models/sensors.py
+index 5b99b51..d435996 100644
+--- a/aiopurpleair/models/sensors.py
++++ b/aiopurpleair/models/sensors.py
+@@ -5,7 +5,10 @@ from __future__ import annotations
+ from datetime import datetime
+ from typing import Any, Optional
+ 
+-from pydantic import BaseModel, root_validator, validator
++try:
++    from pydantic.v1 import BaseModel, root_validator, validator
++except ModuleNotFoundError:
++    from pydantic import BaseModel, root_validator, validator
+ 
+ from aiopurpleair.const import SENSOR_FIELDS, ChannelFlag, ChannelState, LocationType
+ from aiopurpleair.helpers.validators import validate_timestamp
+diff --git a/tests/models/test_keys.py b/tests/models/test_keys.py
+index 0d7d7c8..b2e30c1 100644
+--- a/tests/models/test_keys.py
++++ b/tests/models/test_keys.py
+@@ -5,7 +5,10 @@ from datetime import datetime
+ from typing import Any
+ 
+ import pytest
+-from pydantic import ValidationError
++try:
++    from pydantic.v1 import ValidationError
++except ModuleNotFoundError:
++    from pydantic import ValidationError
+ 
+ from aiopurpleair.models.keys import ApiKeyType, GetKeysResponse
+ 
+diff --git a/tests/models/test_sensors.py b/tests/models/test_sensors.py
+index a984b36..7b2c84f 100644
+--- a/tests/models/test_sensors.py
++++ b/tests/models/test_sensors.py
+@@ -5,7 +5,10 @@ from datetime import datetime
+ from typing import Any
+ 
+ import pytest
+-from pydantic import ValidationError
++try:
++    from pydantic.v1 import ValidationError
++except ModuleNotFoundError:
++    from pydantic import ValidationError
+ 
+ from aiopurpleair.models.sensors import (
+     GetSensorsRequest,

--- a/pkgs/development/python-modules/bentoml/default.nix
+++ b/pkgs/development/python-modules/bentoml/default.nix
@@ -204,5 +204,7 @@ buildPythonPackage {
     changelog = "https://github.com/bentoml/BentoML/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ happysalada natsukium ];
+    # https://github.com/bentoml/BentoML/issues/3885
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/correctionlib/default.nix
+++ b/pkgs/development/python-modules/correctionlib/default.nix
@@ -64,5 +64,6 @@ buildPythonPackage rec {
     homepage = "https://cms-nanoaod.github.io/correctionlib/";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ veprbl ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
+++ b/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
@@ -58,5 +58,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbt-labs/dbt-semantic-interfaces";
     license = licenses.asl20;
     maintainers = with maintainers; [ pbsds ];
+    # https://github.com/dbt-labs/dbt-semantic-interfaces/issues/134
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/demetriek/default.nix
+++ b/pkgs/development/python-modules/demetriek/default.nix
@@ -67,6 +67,8 @@ buildPythonPackage rec {
     "demetriek"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Python client for LaMetric TIME devices";
     homepage = "https://github.com/frenck/python-demetriek";

--- a/pkgs/development/python-modules/demetriek/default.nix
+++ b/pkgs/development/python-modules/demetriek/default.nix
@@ -5,6 +5,7 @@
 , buildPythonPackage
 , pydantic
 , fetchFromGitHub
+, fetchpatch
 , poetry-core
 , yarl
 , aresponses
@@ -26,6 +27,16 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-LCHHBcZgO9gw5jyaJiiS4lKyb0ut+PJvKTylIvIKHhc=";
   };
+
+  patches = [
+    # https://github.com/frenck/python-demetriek/pull/531
+    (fetchpatch {
+      name = "pydantic_2-compatibility.patch";
+      url = "https://github.com/frenck/python-demetriek/commit/e677fe5b735b6b28572e3e5fd6aab56fc056f5e6.patch";
+      excludes = [ "pyproject.toml" "poetry.lock" ];
+      hash = "sha256-oMVR45KHDhcPId/0X9obJXCPE8s1gk5IgsGsgZesdZw=";
+    })
+  ];
 
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -78,5 +78,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/ets-labs/python-dependency-injector/blob/${version}/docs/main/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [ gerschtli ];
+    # https://github.com/ets-labs/python-dependency-injector/issues/726
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/django-ninja/default.nix
+++ b/pkgs/development/python-modules/django-ninja/default.nix
@@ -13,15 +13,16 @@
 
 buildPythonPackage rec {
   pname = "django-ninja";
-  version = "0.22.2";
-  format = "pyproject";
+  version = "1.0.1";
+  pyproject = true;
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "vitalik";
     repo = "django-ninja";
     rev = "v${version}";
-    hash = "sha256-oeisurp9seSn3X/5jFF9DMm9nU6uDYIU1b6/J3o2be0=";
+    hash = "sha256-hF6Z8i8M4mQtVPIupTSEIkJh0i/oMFFuE9PpODxq4fw=";
   };
 
   propagatedBuildInputs = [ django pydantic ];
@@ -38,7 +39,7 @@ buildPythonPackage rec {
   meta = with lib; {
     changelog = "https://github.com/vitalik/django-ninja/releases/tag/v${version}";
     description = "Web framework for building APIs with Django and Python type hints";
-    homepage = "https://django-ninja.rest-framework.com/";
+    homepage = "https://django-ninja.dev";
     license = licenses.mit;
     maintainers = with maintainers; [ elohmeier ];
   };

--- a/pkgs/development/python-modules/farm-haystack/default.nix
+++ b/pkgs/development/python-modules/farm-haystack/default.nix
@@ -286,5 +286,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepset-ai/haystack";
     license = licenses.asl20;
     maintainers = with maintainers; [ happysalada ];
+    # https://github.com/deepset-ai/haystack/issues/5304
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/fastapi-mail/default.nix
+++ b/pkgs/development/python-modules/fastapi-mail/default.nix
@@ -11,6 +11,7 @@
 , jinja2
 , poetry-core
 , pydantic
+, pydantic-settings
 , pytest-asyncio
 , pytestCheckHook
 , python-multipart
@@ -19,23 +20,23 @@
 
 buildPythonPackage rec {
   pname = "fastapi-mail";
-  version = "1.3.1";
-  format = "pyproject";
+  version = "1.4.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "sabuhish";
-    repo = pname;
+    repo = "fastapi-mail";
     rev = "refs/tags/${version}";
-    hash = "sha256-m8d4y75+mSh9A+YVaV/yZhN3ckOe2mV1jdtfeNFtU/w=";
+    hash = "sha256-2iTZqZIxlt1GKhElasTcnys18UbNNDwHoZziHBOIGBo=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'version = "1.2.5"' 'version = "${version}"' \
       --replace 'aiosmtplib = "^2.0"' 'aiosmtplib = "*"' \
-      --replace 'pydantic = "^1.8"' 'pydantic = "*"' \
+      --replace 'pydantic = "^2.0"' 'pydantic = "*"' \
   '';
 
   nativeBuildInputs = [
@@ -52,6 +53,7 @@ buildPythonPackage rec {
     httpx
     jinja2
     pydantic
+    pydantic-settings
     python-multipart
   ];
 

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -32,6 +32,8 @@
 , orjson
 , email-validator
 , uvicorn
+, pydantic-settings
+, pydantic-extra-types
 }:
 
 buildPythonPackage rec {
@@ -75,8 +77,9 @@ buildPythonPackage rec {
     orjson
     email-validator
     uvicorn
-    # pydantic-settings
-    # pydantic-extra-types
+  ] ++ lib.optionals (lib.versionAtLeast pydantic.version "2") [
+    pydantic-settings
+    pydantic-extra-types
   ] ++ uvicorn.optional-dependencies.standard;
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -127,5 +127,7 @@ buildPythonPackage rec {
     description = "Simple security for Flask apps (fork)";
     license = licenses.mit;
     maintainers = with maintainers; [ gador ];
+    # https://github.com/Flask-Middleware/flask-security/pull/851
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/ha-mqtt-discoverable/default.nix
+++ b/pkgs/development/python-modules/ha-mqtt-discoverable/default.nix
@@ -49,5 +49,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/unixorn/ha-mqtt-discoverable/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/huum/default.nix
+++ b/pkgs/development/python-modules/huum/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/frwickst/pyhuum/releases/tag/${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/kanidm/default.nix
+++ b/pkgs/development/python-modules/kanidm/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, fetchpatch
+, fetchFromGitHub
 , pythonOlder
 
 # build
@@ -9,6 +8,7 @@
 
 # propagates
 , aiohttp
+, authlib
 , pydantic
 , toml
 
@@ -20,18 +20,22 @@
 
 let
   pname = "kanidm";
-  version = "0.0.3";
+  version = "0.0.3-unstable-2023-08-23";
 in
 buildPythonPackage {
   inherit pname version;
-  format = "pyproject";
+  pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-sTkAKxtJa7CVYKuXC//eMmf3l8ABsrEr2mdf1r2Gf9A=";
+  src = fetchFromGitHub {
+    owner = "kanidm";
+    repo = "kanidm";
+    rev = "def4420c4c5c3ec4f9b02776e1d5fdb07aa3a729";
+    hash = "sha256-5qQb+Itguw2v1Wdvc2vp00zglfvNd3LFEDvaweRJcOc=";
   };
+
+  sourceRoot = "source/pykanidm";
 
   nativeBuildInputs = [
     poetry-core
@@ -39,6 +43,7 @@ buildPythonPackage {
 
   propagatedBuildInputs = [
     aiohttp
+    authlib
     pydantic
     toml
   ];

--- a/pkgs/development/python-modules/labelbox/default.nix
+++ b/pkgs/development/python-modules/labelbox/default.nix
@@ -99,5 +99,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/Labelbox/labelbox-python/blob/v.${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ rakesh4g ];
+    # https://github.com/Labelbox/labelbox-python/issues/1246
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/maison/default.nix
+++ b/pkgs/development/python-modules/maison/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/dbatten5/maison/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/napari-npe2/default.nix
+++ b/pkgs/development/python-modules/napari-npe2/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "napari-npe2";
-  version = "0.7.2";
+  version = "0.7.2-unstable-2023-10-20";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -25,11 +25,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "napari";
     repo = "npe2";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-PjoLocNTkcAnBNRbPi+MZqZtQ2bjWPIUVz0+k8nIn2A=";
+    rev = "9d29e4d6dbbec75c2d36273647efd9ddfb59ded0";
+    hash = "sha256-JLu/5pXijPdpKY2z2rREtSKPiP33Yy4viegbxUiQg7Y=";
   };
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  # fix this in the next release
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "0.7.2";
 
   nativeBuildInputs = [
     hatchling

--- a/pkgs/development/python-modules/pyaussiebb/default.nix
+++ b/pkgs/development/python-modules/pyaussiebb/default.nix
@@ -11,8 +11,8 @@
 
 buildPythonPackage rec {
   pname = "pyaussiebb";
-  version = "0.0.18";
-  format = "pyproject";
+  version = "0.1.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "yaleman";
     repo = "aussiebb";
     rev = "refs/tags/v${version}";
-    hash = "sha256-tEdddVsLFCHRvyLCctDakioiop2xWaJlfGE16P1ukHc=";
+    hash = "sha256-XNf9vYMlTLqhYIVNw9GjPcXpOm5EYCcC4aGukR8g3zc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pycfmodel/default.nix
+++ b/pkgs/development/python-modules/pycfmodel/default.nix
@@ -48,5 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Skyscanner/pycfmodel";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/pydantic-settings/default.nix
+++ b/pkgs/development/python-modules/pydantic-settings/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , hatchling
 , pydantic
 , python-dotenv
@@ -11,14 +12,16 @@
 
 buildPythonPackage rec {
   pname = "pydantic-settings";
-  version = "2.0.3";
-  format = "pyproject";
+  version = "2.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic-settings";
     rev = "v${version}";
-    hash = "sha256-3V6daCibvVr8RKo2o+vHC++QgIYKAOyRg11ATrCzM5Y=";
+    hash = "sha256-hU7u/AzaqCHKSUDHybsgXTW8IWi9hzBttPYDmMqdZbI=";
   };
 
   nativeBuildInputs = [
@@ -36,6 +39,11 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-examples
     pytest-mock
+  ];
+
+  disabledTests = [
+    # expected to fail
+    "test_docs_examples[docs/index.md:212-246]"
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/pydantic/1.nix
+++ b/pkgs/development/python-modules/pydantic/1.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, cython
+, email-validator
+, fetchFromGitHub
+, pytest-mock
+, pytestCheckHook
+, python-dotenv
+, pythonOlder
+, setuptools
+, typing-extensions
+, libxcrypt
+}:
+
+buildPythonPackage rec {
+  pname = "pydantic";
+  version = "1.10.13";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pydantic";
+    repo = "pydantic";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ruDVcCLPVuwIkHOjYVuKOoP3hHHr7ItIY55Y6hUgR74=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    cython
+  ];
+
+  buildInputs = lib.optionals (pythonOlder "3.9") [
+    libxcrypt
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  passthru.optional-dependencies = {
+    dotenv = [
+      python-dotenv
+    ];
+    email = [
+      email-validator
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+
+  pytestFlagsArray = [
+    # https://github.com/pydantic/pydantic/issues/4817
+    "-W" "ignore::pytest.PytestReturnNotNoneWarning"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  enableParallelBuilding = true;
+
+  pythonImportsCheck = [ "pydantic" ];
+
+  meta = with lib; {
+    description = "Data validation and settings management using Python type hinting";
+    homepage = "https://github.com/pydantic/pydantic";
+    changelog = "https://github.com/pydantic/pydantic/blob/v${version}/HISTORY.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -1,127 +1,77 @@
 { lib
-, stdenv
 , buildPythonPackage
-, autoflake
-, cython
-, devtools
-, email-validator
 , fetchFromGitHub
-, pytest-mock
-, pytestCheckHook
-, python-dotenv
-, pythonAtLeast
 , pythonOlder
-, pyupgrade
-, typing-extensions
-# dependencies for building documentation.
-# docs fail to build in Darwin sandbox: https://github.com/samuelcolvin/pydantic/issues/4245
-, withDocs ? (stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.isDarwin && pythonAtLeast "3.10")
-, ansi2html
-, markdown-include
-, mike
-, mkdocs
-, mkdocs-exclude
-, mkdocs-material
-, mdx-truly-sane-lists
-, sqlalchemy
-, ujson
-, orjson
-, hypothesis
+, hatchling
+, hatch-fancy-pypi-readme
 , libxcrypt
+, annotated-types
+, pydantic-core
+, typing-extensions
+, email-validator
+, dirty-equals
+, faker
+, pytestCheckHook
+, pytest-mock
 }:
 
 buildPythonPackage rec {
   pname = "pydantic";
-  version = "1.10.12";
-  format = "setuptools";
-
-  outputs = [
-    "out"
-  ] ++ lib.optionals withDocs [
-    "doc"
-  ];
+  version = "2.3.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pydantic";
-    repo = pname;
+    repo = "pydantic";
     rev = "refs/tags/v${version}";
-    hash = "sha256-3XnbPGU90wLCPEryFAOky6Iy73Dvgzzh+GbOKW8hZ4U=";
+    hash = "sha256-toqrWg8bYzc3UmvG/YmXawfmT8nqaA9fxy24k1cdj+M=";
   };
-
-  postPatch = ''
-    sed -i '/flake8/ d' Makefile
-
-    # Disable strict docs build due warnings being treated as errors
-    substituteInPlace mkdocs.yml \
-      --replace "strict: true" "strict: false"
-  '';
 
   buildInputs = lib.optionals (pythonOlder "3.9") [
     libxcrypt
   ];
 
   nativeBuildInputs = [
-    cython
-  ] ++ lib.optionals withDocs [
-    # dependencies for building documentation
-    autoflake
-    ansi2html
-    markdown-include
-    mdx-truly-sane-lists
-    mike
-    mkdocs
-    mkdocs-exclude
-    mkdocs-material
-    sqlalchemy
-    ujson
-    orjson
-    hypothesis
+    hatch-fancy-pypi-readme
+    hatchling
   ];
 
   propagatedBuildInputs = [
-    devtools
-    pyupgrade
+    annotated-types
+    pydantic-core
     typing-extensions
   ];
 
   passthru.optional-dependencies = {
-    dotenv = [
-      python-dotenv
-    ];
     email = [
       email-validator
     ];
   };
 
   nativeCheckInputs = [
+    dirty-equals
+    faker
     pytest-mock
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
 
-  pytestFlagsArray = [
-    # https://github.com/pydantic/pydantic/issues/4817
-    "-W" "ignore::pytest.PytestReturnNotNoneWarning"
-  ];
-
   preCheck = ''
     export HOME=$(mktemp -d)
+    substituteInPlace pyproject.toml \
+      --replace "'--benchmark-columns', 'min,mean,stddev,outliers,rounds,iterations'," "" \
+      --replace "'--benchmark-group-by', 'group'," "" \
+      --replace "'--benchmark-warmup', 'on'," "" \
+      --replace "'--benchmark-disable'," ""
   '';
 
-  # Must include current directory into PYTHONPATH, since documentation
-  # building process expects "import pydantic" to work.
-  preBuild = lib.optionalString withDocs ''
-    PYTHONPATH=$PWD:$PYTHONPATH make docs
-  '';
+  disabledTestPaths = [
+    "tests/benchmarks"
 
-  # Layout documentation in same way as "sphinxHook" does.
-  postInstall = lib.optionalString withDocs ''
-    mkdir -p $out/share/doc/$name
-    mv ./site $out/share/doc/$name/html
-  '';
-
-  enableParallelBuilding = true;
+    # avoid cyclic dependency
+    "tests/test_docs.py"
+  ];
 
   pythonImportsCheck = [ "pydantic" ];
 

--- a/pkgs/development/python-modules/pyngo/default.nix
+++ b/pkgs/development/python-modules/pyngo/default.nix
@@ -52,5 +52,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/yezz123/pyngo";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
+    # https://github.com/yezz123/pyngo/issues/70
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/pythonfinder/default.nix
+++ b/pkgs/development/python-modules/pythonfinder/default.nix
@@ -3,6 +3,7 @@
 , cached-property
 , click
 , fetchFromGitHub
+, fetchpatch
 , packaging
 , pydantic
 , pytest-timeout
@@ -13,8 +14,8 @@
 
 buildPythonPackage rec {
   pname = "pythonfinder";
-  version = "2.0.5";
-  format = "pyproject";
+  version = "2.0.6";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -22,11 +23,20 @@ buildPythonPackage rec {
     owner = "sarugaku";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-L/+6w5lLqHO5c9CThoUPOHXRPVxBlOWFDAmfoYxRw5g=";
+    hash = "sha256-C/Em8Vmv7q030hmH3jU/apBRSSC9QFK9mbBWjBjJHXg=";
   };
 
+  patches = [
+    # https://github.com/sarugaku/pythonfinder/issues/142
+    (fetchpatch {
+      name = "pydantic_2-compatibility.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/python-pythonfinder/-/raw/2.0.6-1/python-pythonfinder-2.0.6-pydantic2.patch";
+      hash = "sha256-mON1MeA+pj6VTB3zpBjF3LfB30wG0QH9nU4bD1djWwg=";
+    })
+  ];
+
   postPatch = ''
-    substituteInPlace setup.cfg \
+    substituteInPlace pyproject.toml \
       --replace " --cov" ""
   '';
 
@@ -35,9 +45,10 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    cached-property
     packaging
     pydantic
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    cached-property
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/pytradfri/default.nix
+++ b/pkgs/development/python-modules/pytradfri/default.nix
@@ -48,5 +48,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/home-assistant-libs/pytradfri/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
+    # https://github.com/home-assistant-libs/pytradfri/issues/720
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/rstcheck-core/default.nix
+++ b/pkgs/development/python-modules/rstcheck-core/default.nix
@@ -5,38 +5,46 @@
 , fetchFromGitHub
 , importlib-metadata
 , mock
-, poetry-core
 , pydantic
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
-, types-docutils
+, setuptools
+, setuptools-scm
 , typing-extensions
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "rstcheck-core";
-  version = "1.0.3";
-  format = "pyproject";
+  version = "1.2.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "rstcheck";
-    repo = pname;
+    repo = "rstcheck-core";
     rev = "refs/tags/v${version}";
-    hash = "sha256-9U+GhkwBr+f3yEe7McOxqPRUuTp9vP+3WT5wZ92n32w=";
+    hash = "sha256-cKJNktIB4vXt1MPRgYrJQ0aksmrVu7Y2uTyUjdx5YdA=";
   };
 
   nativeBuildInputs = [
-    poetry-core
+    setuptools
+    setuptools-scm
+    wheel
   ];
+
+  env = {
+    SETUPTOOLS_SCM_PRETEND_VERSION = version;
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-strict-prototypes";
+  };
 
   propagatedBuildInputs = [
     docutils
-    importlib-metadata
     pydantic
-    types-docutils
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-metadata
     typing-extensions
   ];
 
@@ -46,10 +54,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
-    # Disabled until https://github.com/rstcheck/rstcheck-core/issues/19 is resolved.
-    "test_error_without_config_file_macos"
-    "test_file_1_is_bad_without_config_macos"
+  disabledTests = [
+    # https://github.com/rstcheck/rstcheck-core/issues/84
+    "test_check_yaml_returns_error_on_bad_code_block"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -72,5 +72,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/dotX12/ShazamIO/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/steamship/default.nix
+++ b/pkgs/development/python-modules/steamship/default.nix
@@ -58,5 +58,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/steamship-core/python-client/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ natsukium ];
+    # https://github.com/steamship-core/python-client/issues/503
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -61,6 +61,12 @@ buildPythonPackage rec {
       url = "https://github.com/strawberry-graphql/strawberry/commit/710bb96f47c244e78fc54c921802bcdb48f5f421.patch";
       hash = "sha256-ekUZ2hDPCqwXp9n0YjBikwSkhCmVKUzQk7LrPECcD7Y=";
     })
+    (fetchpatch {
+      # https://github.com/strawberry-graphql/strawberry/pull/3255
+      name = "fix-tests-with-pydantic_2.patch";
+      url = "https://github.com/strawberry-graphql/strawberry/commit/0a0dc284ee6d31d4e82ac7ff1ed9fea4dff39fa6.patch";
+      hash = "sha256-LACWD7XA6YL/apJwhpx3LPCKxKUfa+XWyTLK+Zkxlaw=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -182,6 +182,8 @@ buildPythonPackage rec {
     "tests/websockets/test_graphql_transport_ws.py"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "A GraphQL library for Python that leverages type annotations";
     homepage = "https://strawberry.rocks";

--- a/pkgs/development/python-modules/versioningit/default.nix
+++ b/pkgs/development/python-modules/versioningit/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "versioningit";
-  version = "2.2.0";
+  version = "2.2.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-6xjnunJoqIC/HM/pLlNOlqs04Dl/KNy8s/wNpPaltr0=";
+    hash = "sha256-DlgkLXq9phrmNZalSUrp7WMayF2Ls8yOF24yU8pLy7U=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/withings-api/default.nix
+++ b/pkgs/development/python-modules/withings-api/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/vangorra/python_withings_api";
     license = licenses.mit;
     maintainers = with maintainers; [ kittywitch ];
+    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/xbox-webapi/default.nix
+++ b/pkgs/development/python-modules/xbox-webapi/default.nix
@@ -2,53 +2,52 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, aiohttp
+, setuptools
 , appdirs
 , ecdsa
+, httpx
 , ms-cv
 , pydantic
-, aresponses
 , pytest-asyncio
 , pytestCheckHook
+, respx
 }:
 
 buildPythonPackage rec {
   pname = "xbox-webapi";
-  version = "2.0.11";
+  version = "2.1.0";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8";
+
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OpenXbox";
     repo = "xbox-webapi-python";
     rev = "v${version}";
-    sha256 = "0li0bq914xizx9fj49s1iwfrv4bpzvl74bwsi5a34r9yizw02cvz";
+    hash = "sha256-9A3gdSlRjBCx5fBW+jkaSWsFuGieXQKvbEbZzGzLf94=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pytest-runner" ""
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
-    aiohttp
     appdirs
     ecdsa
+    httpx
     ms-cv
     pydantic
   ];
 
   nativeCheckInputs = [
-    aresponses
     pytest-asyncio
     pytestCheckHook
-  ];
-
-  pytestFlagsArray = [
-    "--asyncio-mode=auto"
+    respx
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/OpenXbox/xbox-webapi-python/blob/${src.rev}/CHANGELOG.md";
     description = "Library to authenticate with Windows Live/Xbox Live and use their API";
     homepage = "https://github.com/OpenXbox/xbox-webapi-python";
     license = licenses.mit;

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -258,6 +258,8 @@ let
         };
       });
 
+      pydantic = super.pydantic_1;
+
       pydexcom = super.pydexcom.overridePythonAttrs (oldAttrs: rec {
         version = "0.2.3";
         src = fetchFromGitHub {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -318,6 +318,15 @@ let
         };
       });
 
+      versioningit = super.versioningit.overridePythonAttrs (oldAttrs: rec {
+        version = "2.2.0";
+        src = fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          hash = "sha256-6xjnunJoqIC/HM/pLlNOlqs04Dl/KNy8s/wNpPaltr0=";
+        };
+      });
+
       # Pinned due to API changes ~1.0
       vultr = super.vultr.overridePythonAttrs (oldAttrs: rec {
         version = "0.1.2";

--- a/pkgs/servers/search/khoj/default.nix
+++ b/pkgs/servers/search/khoj/default.nix
@@ -2,74 +2,84 @@
 , stdenv
 , fetchFromGitHub
 , python3
-, qt6
+, postgresql
+, postgresqlTestHook
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "khoj";
-  version = "0.3.0";
-  format = "pyproject";
+  version = "1.0.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "debanjum";
     repo = "khoj";
     rev = "refs/tags/${version}";
-    hash = "sha256-9kKK0DXpLfPB2LMnYcC6BKgZaoRsNHBZVe4thI7b9tk=";
+    hash = "sha256-lvOeYTrvW5MfhuJ3lj9n9TRlvpRwVP2vFeaEeJdqIec=";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "dateparser == 1.1.1" "dateparser" \
-      --replace "defusedxml == 0.7.1" ""defusedxml"" \
-      --replace "fastapi == 0.77.1" "fastapi" \
-      --replace "jinja2 == 3.1.2" "jinja2" \
-      --replace "openai == 0.20.0" "openai" \
-      --replace "pillow == 9.3.0" "pillow" \
-      --replace "pydantic == 1.9.1" "pydantic" \
-      --replace "pyyaml == 6.0" "pyyaml" \
-      --replace "pyqt6 == 6.3.1" "pyqt6" \
-      --replace "rich >= 13.3.1" "rich" \
-      --replace "schedule == 1.1.0" "schedule" \
-      --replace "sentence-transformers == 2.2.2" "sentence-transformers" \
-      --replace "torch == 1.13.1" "torch" \
-      --replace "uvicorn == 0.17.6" "uvicorn"
-  '';
+  env = {
+    SETUPTOOLS_SCM_PRETEND_VERSION = version;
+    DJANGO_SETTINGS_MODULE = "khoj.app.settings";
+    postgresqlEnableTCP = 1;
+  };
 
   nativeBuildInputs = with python3.pkgs; [
     hatch-vcs
     hatchling
-  ] ++ (with qt6; [
-    wrapQtAppsHook
-  ]);
-
-  buildInputs = lib.optionals stdenv.isLinux [
-    qt6.qtwayland
-  ] ++ lib.optionals stdenv.isDarwin [
-    qt6.qtbase
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
+    aiohttp
+    anyio
+    authlib
+    beautifulsoup4
     dateparser
     defusedxml
+    django
     fastapi
+    google-auth
+    # gpt4all
+    gunicorn
+    httpx
+    itsdangerous
     jinja2
-    numpy
+    langchain
+    lxml
     openai
+    openai-whisper
+    pgvector
     pillow
+    psycopg2
     pydantic
-    pyqt6
+    pymupdf
+    python-multipart
     pyyaml
+    # rapidocr-onnxruntime
+    requests
     rich
     schedule
     sentence-transformers
+    stripe
+    tenacity
+    tiktoken
     torch
+    transformers
+    tzdata
     uvicorn
   ];
 
   nativeCheckInputs = with python3.pkgs; [
+    freezegun
+    factory-boy
+    pytest-xdist
+    trio
+    psutil
+    pytest-django
     pytestCheckHook
+  ] ++ [
+    (postgresql.withPackages (p: with p; [ pgvector ]))
+    postgresqlTestHook
   ];
 
   preCheck = ''
@@ -82,32 +92,51 @@ python3.pkgs.buildPythonApplication rec {
 
   disabledTests = [
     # Tests require network access
-    "test_search_with_valid_content_type"
-    "test_update_with_valid_content_type"
-    "test_regenerate_with_valid_content_type"
-    "test_image_search"
-    "test_notes_search"
-    "test_notes_search_with_only_filters"
-    "test_notes_search_with_include_filter"
-    "test_notes_search_with_exclude_filter"
+    "test_different_user_data_not_accessed"
+    "test_get_api_config_types"
+    "test_get_configured_types_via_api"
     "test_image_metadata"
     "test_image_search"
-    "test_image_search_query_truncated"
     "test_image_search_by_filepath"
-    "test_asymmetric_setup_with_missing_file_raises_error"
-    "test_asymmetric_setup_with_empty_file_raises_error"
-    "test_asymmetric_reload"
-    "test_asymmetric_setup"
-    "test_asymmetric_search"
-    "test_entry_chunking_by_max_tokens"
-    "test_incremental_update"
+    "test_image_search_query_truncated"
+    "test_index_update"
+    "test_index_update_with_no_auth_key"
+    "test_notes_search"
+    "test_notes_search_with_exclude_filter"
+    "test_notes_search_with_include_filter"
+    "test_parse_html_plaintext_file"
+    "test_regenerate_index_with_new_entry"
+    "test_regenerate_with_github_fails_without_pat"
+    "test_regenerate_with_invalid_content_type"
+    "test_regenerate_with_valid_content_type"
+    "test_search_for_user2_returns_empty"
+    "test_search_with_invalid_auth_key"
+    "test_search_with_invalid_content_type"
+    "test_search_with_no_auth_key"
+    "test_search_with_valid_content_type"
+    "test_text_index_same_if_content_unchanged"
+    "test_text_indexer_deletes_embedding_before_regenerate"
+    "test_text_search"
+    "test_text_search_setup_batch_processes"
+    "test_update_with_invalid_content_type"
+    "test_user_no_data_returns_empty"
+
+    # Tests require rapidocr-onnxruntime
+    "test_multi_page_pdf_to_jsonl"
+    "test_single_page_pdf_to_jsonl"
+    "test_ocr_page_pdf_to_jsonl"
+  ];
+
+  disabledTestPaths = [
+    # Tests require network access
+    "tests/test_conversation_utils.py"
   ];
 
   meta = with lib; {
     description = "Natural Language Search Assistant for your Org-Mode and Markdown notes, Beancount transactions and Photos";
     homepage = "https://github.com/debanjum/khoj";
     changelog = "https://github.com/debanjum/khoj/releases/tag/${version}";
-    license = licenses.gpl3Only;
+    license = licenses.agpl3Plus;
     maintainers = with maintainers; [ dit7ya ];
     # src/tcmalloc.cc:333] Attempt to free invalid pointer
     broken = stdenv.isDarwin;

--- a/pkgs/tools/misc/remote-exec/default.nix
+++ b/pkgs/tools/misc/remote-exec/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , buildPythonApplication
 , click
-, pydantic
+, pydantic_1
 , toml
 , watchdog
 , pytestCheckHook
@@ -29,7 +29,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     click
-    pydantic
+    pydantic_1
     toml
     watchdog
   ];

--- a/pkgs/tools/security/flare-floss/default.nix
+++ b/pkgs/tools/security/flare-floss/default.nix
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonPackage rec {
     halo
     networkx
     pefile
-    pydantic
+    pydantic_1
     rich
     tabulate
     tqdm

--- a/pkgs/tools/security/stacs/default.nix
+++ b/pkgs/tools/security/stacs/default.nix
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     click
-    pydantic
+    pydantic_1
     typing-extensions
     yara-python
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10038,6 +10038,8 @@ self: super: with self; {
 
   pydantic = callPackage ../development/python-modules/pydantic { };
 
+  pydantic_1 = callPackage ../development/python-modules/pydantic/1.nix { };
+
   pydantic-core = callPackage ../development/python-modules/pydantic-core { };
 
   pydantic-extra-types = callPackage ../development/python-modules/pydantic-extra-types { };


### PR DESCRIPTION
## Description of changes

- python311Packages.pydantic: 1.10.12 -> 2.3.0
Diff: https://github.com/pydantic/pydantic/compare/refs/tags/v1.10.12...v2.3.0
Changelog: https://github.com/pydantic/pydantic/blob/v2.3.0/HISTORY.md

- python311Packages.versioningit: 2.2.0 -> 2.2.1
Changelog: https://versioningit.readthedocs.io/en/latest/changelog.html

- python311Packages.pydantic-settings: 2.0.3 -> 2.1.0
Diff: https://github.com/pydantic/pydantic-settings/compare/v2.0.3...v2.1.0

- python311Packages.fastapi: add optional-dependencies for pydantic 2

- python311Packages.kanidm: 0.0.3 -> 0.0.3-unstable-2023-08-23

- python311Packages.django-ninja: 0.22.2 -> 1.0.1
Diff: https://github.com/vitalik/django-ninja/compare/v0.22.2...v1.0.1
Changelog: https://github.com/vitalik/django-ninja/releases/tag/v1.0.1

- python311Packages.pythonfinder: 2.0.5 -> 2.0.6
Diff: https://github.com/sarugaku/pythonfinder/compare/refs/tags/2.0.5...2.0.6
Changelog: https://github.com/sarugaku/pythonfinder/blob/v2.0.6/CHANGELOG.rst

- stacs: pin pydantic<2

- python311Packages.pyaussiebb: 0.0.18 -> 0.1.1
Diff: https://github.com/yaleman/pyaussiebb/compare/refs/tags/v0.0.18...v0.1.1
Changelog: https://github.com/yaleman/pyaussiebb/blob/v0.1.1/CHANGELOG.md

- python311Packages.demetriek: apply a pydantic>=2 compatible patch

- python311Packages.aiopurpleair: 2022.12.1 -> 2023.10.0
Diff: https://github.com/bachya/aiopurpleair/compare/refs/tags/2022.12.1...2023.10.0
Changelog: https://github.com/bachya/aiopurpleair/releases/tag/2023.10.0

- python311Packages.aionotion: 2023.05.5 -> 2023.08.0
Diff: https://github.com/bachya/aionotion/compare/2023.05.5...2023.08.0
Changelog: https://github.com/bachya/aionotion/releases/tag/2023.08.0

- python311Packages.fastapi-mail: 1.3.1 -> 1.4.1
Diff: https://github.com/sabuhish/fastapi-mail/compare/refs/tags/1.3.1...1.4.1
Changelog: https://github.com/sabuhish/fastapi-mail/releases/tag/1.4.1

- python311Packages.rstcheck-core: 1.0.3 -> 1.2.0
Diff: https://github.com/rstcheck/rstcheck-core/compare/refs/tags/v1.0.3...v1.2.0
Changelog: https://github.com/rstcheck/rstcheck-core/blob/v1.2.0/CHANGELOG.md

- python311Packages.strawberry-graphql: fix test with pydantic>=2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Eval reports
https://gist.github.com/natsukium/3d7429de0b016cf07492f3561331d002

## Known issue
- [x] cloudflare-dyndns.x86_64-linux
- [x] flare-floss.x86_64-linux
- [x] frigate.x86_64-linux
- [x] home-assistant-component-tests.lametric.x86_64-linux
- [x] home-assistant-component-tests.notion.x86_64-linux
- [x] home-assistant-component-tests.peco.x86_64-linux
- [x] home-assistant-component-tests.zwave_js.x86_64-linux
- [x] khoj.x86_64-linux
- [x] octoprint.x86_64-linux
- [x] python310Packages.qcs-api-client.x86_64-linux
- [x] python310Packages.sqlglot.x86_64-linux
- [ ] python311Packages.bentoml.x86_64-linux
- [ ] python311Packages.correctionlib.x86_64-linux
- [ ] python311Packages.dbt-semantic-interfaces https://github.com/dbt-labs/dbt-semantic-interfaces/issues/134
- [x] python311Packages.deepwave.x86_64-linux
- [ ] python311Packages.dependency-injector.x86_64-linux
- [ ] python311Packages.farm-haystack https://github.com/deepset-ai/haystack/issues/5304
- [ ] python311Packages.flask-security-too.x86_64-linux
- [ ] python311Packages.ha-mqtt-discoverable https://github.com/unixorn/ha-mqtt-discoverable/pull/141
- [ ] python311Packages.huum.x86_64-linux
- [ ] python311Packages.labelbox.x86_64-linux
- [x] python311Packages.linear_operator.x86_64-linux
- [ ] python311Packages.maison.x86_64-linux
- [x] python311Packages.pgmpy.x86_64-linux
- [ ] python311Packages.pycfmodel.x86_64-linux
- [x] python311Packages.pyngo https://github.com/yezz123/pyngo/issues/70
- [ ] python311Packages.pytraccar.x86_64-linux
- [ ] python311Packages.pytradfri https://github.com/home-assistant-libs/pytradfri/issues/720
- [x] python311Packages.radios.x86_64-linux https://github.com/NixOS/nixpkgs/pull/269821
- [ ] python311Packages.shazamio.x86_64-linux
- [ ] python311Packages.steamship https://github.com/steamship-core/python-client/issues/503
- [ ] python311Packages.withings-api.x86_64-linux
- [x] python311Packages.xbox-webapi.x86_64-linux