### PR TITLE
cudaPackages: bump the default 11 -> 12

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -96,7 +96,7 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=23.11, `pkgs.nextcloud27` will be installed by default.
   - Please note that an upgrade from v26 (or older) to v28 directly is not possible. Please upgrade to `nextcloud27` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud27;`](options.html#opt-services.nextcloud.package).
 
-- The vendored third party libraries have been mostly removed from `cudaPackages.nsight_systems`, which we now only ship for `cudaPackages_11_8` and later due to outdated dependencies. Users comfortable with the vendored dependencies may use `overrideAttrs` to amend the `postPatch` phase and the `meta.broken` correspondingly.
+- The vendored third party libraries have been mostly removed from `cudaPackages.nsight_systems`, which we now only ship for `cudaPackages_11_8` and later due to outdated dependencies. Users comfortable with the vendored dependencies may use `overrideAttrs` to amend the `postPatch` phase and the `meta.broken` correspondingly. Alternatively, one could package the deprecated `boost170` locally, as required for `cudaPackages_11_4.nsight_systems`.
 
 - The `cudaPackages` package scope has been updated to `cudaPackages_12`.
 

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -96,6 +96,10 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=23.11, `pkgs.nextcloud27` will be installed by default.
   - Please note that an upgrade from v26 (or older) to v28 directly is not possible. Please upgrade to `nextcloud27` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud27;`](options.html#opt-services.nextcloud.package).
 
+- The vendored third party libraries have been mostly removed from `cudaPackages.nsight_systems`, which we now only ship for `cudaPackages_11_8` and later due to outdated dependencies. Users comfortable with the vendored dependencies may use `overrideAttrs` to amend the `postPatch` phase and the `meta.broken` correspondingly.
+
+- The `cudaPackages` package scope has been updated to `cudaPackages_12`.
+
 - `services.resolved.fallbackDns` can now be used to disable the upstream fallback servers entirely by setting it to an empty list. To get the previous behaviour of the upstream defaults set it to null, the new default, instead.
 
 - `services.avahi.nssmdns` got split into `services.avahi.nssmdns4` and `services.avahi.nssmdns6` which enable the mDNS NSS switch for IPv4 and IPv6 respectively.

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -245,7 +245,6 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
       buildInputs = prevAttrs.buildInputs ++ [
         final.cuda_cudart.stubs
         final.pkgs.alsa-lib
-        # final.pkgs.boost170 # cudaPackages_11_4
         final.pkgs.boost178
         final.pkgs.e2fsprogs
         final.pkgs.gst_all_1.gst-plugins-base
@@ -266,7 +265,7 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
         qtWaylandPlugins
       ];
 
-      # Require boost 1.70 deprecated in Nixpkgs
+      # Older releases require boost 1.70 deprecated in Nixpkgs
       meta.broken = prevAttrs.meta.broken or false || lib.versionOlder final.cudaVersion "11.8";
     }
   );

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -210,20 +210,64 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
   );
 
   nsight_systems = prev.nsight_systems.overrideAttrs (
-    prevAttrs: {
-      nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [final.pkgs.qt5.wrapQtAppsHook];
+    prevAttrs:
+    let
+      qt = if lib.versionOlder prevAttrs.version "2022.4.2.1" then final.pkgs.qt5 else final.pkgs.qt6;
+      qtwayland =
+        if lib.versions.major qt.qtbase.version == "5" then
+          lib.getBin qt.qtwayland
+        else
+          lib.getLib qt.qtwayland;
+      qtWaylandPlugins = "${qtwayland}/${qt.qtbase.qtPluginPrefix}";
+    in
+    {
+      # An ad hoc replacement for
+      # https://github.com/ConnorBaker/cuda-redist-find-features/issues/11
+      env.rmPatterns = toString [
+        "nsight-systems/*/*/libQt*"
+        "nsight-systems/*/*/libstdc*"
+        "nsight-systems/*/*/libboost*"
+        "nsight-systems/*/*/lib{ssl,ssh,crypto}*"
+        "nsight-systems/*/*/lib{arrow,jpeg}*"
+        "nsight-systems/*/*/Mesa"
+        "nsight-systems/*/*/python/bin/python"
+        "nsight-systems/*/*/libexec"
+        "nsight-systems/*/*/Plugins"
+      ];
+      postPatch =
+        prevAttrs.postPatch or ""
+        + ''
+          for path in $rmPatterns ; do
+            rm -r "$path"
+          done
+        '';
+      nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ qt.wrapQtAppsHook ];
       buildInputs = prevAttrs.buildInputs ++ [
+        final.cuda_cudart.stubs
         final.pkgs.alsa-lib
+        # final.pkgs.boost170 # cudaPackages_11_4
+        final.pkgs.boost178
         final.pkgs.e2fsprogs
+        final.pkgs.gst_all_1.gst-plugins-base
+        final.pkgs.gst_all_1.gstreamer
         final.pkgs.nss
         final.pkgs.numactl
         final.pkgs.pulseaudio
+        final.pkgs.rdma-core
+        final.pkgs.ucx
         final.pkgs.wayland
         final.pkgs.xorg.libXcursor
         final.pkgs.xorg.libXdamage
         final.pkgs.xorg.libXrandr
         final.pkgs.xorg.libXtst
+        qt.qtbase
+        (qt.qtdeclarative or qt.full)
+        (qt.qtsvg or qt.full)
+        qtWaylandPlugins
       ];
+
+      # Require boost 1.70 deprecated in Nixpkgs
+      meta.broken = prevAttrs.meta.broken or false || lib.versionOlder final.cudaVersion "11.8";
     }
   );
 

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableCuda [
     cudaPackages.cuda_cudart.dev
     cudaPackages.cuda_cudart.lib
+    cudaPackages.cuda_cccl.dev
     cudaPackages.libcublas.dev
     cudaPackages.libcublas.lib
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7318,7 +7318,7 @@ with pkgs;
   cudaPackages_12_1 = callPackage ./cuda-packages.nix { cudaVersion = "12.1"; };
   cudaPackages_12_2 = callPackage ./cuda-packages.nix { cudaVersion = "12.2"; };
   cudaPackages_12_3 = callPackage ./cuda-packages.nix { cudaVersion = "12.3"; };
-  cudaPackages_12 = recurseIntoAttrs cudaPackages_12_0;
+  cudaPackages_12 = cudaPackages_12_2; # Latest supported by cudnn
 
   # Use the older cudaPackages for tensorflow and jax, as determined by cudnn
   # compatibility: https://www.tensorflow.org/install/source#gpu

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7324,9 +7324,7 @@ with pkgs;
   # compatibility: https://www.tensorflow.org/install/source#gpu
   cudaPackagesGoogle = cudaPackages_11;
 
-  # TODO: try upgrading once there is a cuDNN release supporting CUDA 12. No
-  # such cuDNN release as of 2023-01-10.
-  cudaPackages = cudaPackages_11;
+  cudaPackages = recurseIntoAttrs cudaPackages_12;
 
   # TODO: move to alias
   cudatoolkit = cudaPackages.cudatoolkit;


### PR DESCRIPTION
## Description of changes

WIP. Addresses https://github.com/NixOS/nixpkgs/issues/222778

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Check cudnn compatibility
- [ ] Check eval
- [ ] `nixpkgs-review --extra-nixpkgs-config '{ cudaSupport = true; }'`
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
- [ ] Backport everything except the major version bump itself

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@NixOS/cuda-maintainers 

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
