### PR TITLE
valent: unstable-2023-08-26 -> unstable-2023-11-11

### DIFF
--- a/pkgs/applications/misc/valent/default.nix
+++ b/pkgs/applications/misc/valent/default.nix
@@ -5,7 +5,6 @@
 , meson
 , ninja
 , pkg-config
-, vala
 , wrapGAppsHook4
 , evolution-data-server-gtk4
 , glib
@@ -14,7 +13,7 @@
 , gst_all_1
 , json-glib
 , libadwaita
-, libpeas
+, libpeas2
 , libportal-gtk4
 , pulseaudio
 , sqlite
@@ -22,14 +21,14 @@
 
 stdenv.mkDerivation rec {
   pname = "valent";
-  version = "unstable-2023-08-26";
+  version = "unstable-2023-11-11";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "valent";
-    rev = "89d1e5a0312a0371bfcd9a95486805917c3729c0";
+    rev = "51bca834b1c52a1cc49b79fe79d45dfcd9113c02";
     fetchSubmodules = true;
-    hash = "sha256-28l+SkjVQkOA/5f5nT5BbqIV2BrMLmSK/YtDGYl1xjQ=";
+    hash = "sha256-jmhio/vS+w37IW81XgV4xfb/6ralMgAlwi3zigr4t20=";
   };
 
   nativeBuildInputs = [
@@ -37,7 +36,6 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    vala
     wrapGAppsHook4
   ];
 
@@ -50,7 +48,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-base
     json-glib
     libadwaita
-    libpeas
+    libpeas2
     libportal-gtk4
     pulseaudio
     sqlite
@@ -58,6 +56,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dplugin_bluez=true"
+    # FIXME: libpeas2 (and libpeas) not compiled with -Dvapi=true
+    "-Dvapi=false"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Note that valent is reported to fail in current nixos-unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
