### PR TITLE
gnomeExtensions.gsconnect: 55 -> 56

### DIFF
--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-gsconnect";
-  version = "55";
+  version = "56";
 
   outputs = [ "out" "installedTests" ];
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "GSConnect";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    hash = "sha256-n6NbNgl+2FOhly/BeR7I6BvPOYe7leAdeAegaqhcGJU=";
+    hash = "sha256-V2L65Fz1WcJE2ENE8uNgIuVSXLDHokcgM4Caz1sOdZM=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
@@ -11,29 +11,37 @@ index 3fb887c3..e8cbe1bd 100644
  Terminal=false
  NoDisplay=true
  Icon=org.gnome.Shell.Extensions.GSConnect
+diff --git a/src/__nix-prepend-search-paths.js b/src/__nix-prepend-search-paths.js
+new file mode 100644
+index 00000000..d009dfd9
+--- /dev/null
++++ b/src/__nix-prepend-search-paths.js
+@@ -0,0 +1,2 @@
++import GIRepository from 'gi://GIRepository';
++'@typelibPath@'.split(':').forEach(path => GIRepository.Repository.prepend_search_path(path));
 diff --git a/src/extension.js b/src/extension.js
-index 3fae443a..7aa19842 100644
+index 53ecd5fc..78782357 100644
 --- a/src/extension.js
 +++ b/src/extension.js
-@@ -4,6 +4,8 @@
+@@ -2,6 +2,8 @@
+ //
+ // SPDX-License-Identifier: GPL-2.0-or-later
  
- 'use strict';
- 
-+'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
++import './__nix-prepend-search-paths.js';
 +
- const Gio = imports.gi.Gio;
- const GObject = imports.gi.GObject;
- const Gtk = imports.gi.Gtk;
+ import Gio from 'gi://Gio';
+ import GObject from 'gi://GObject';
+ 
 diff --git a/src/prefs.js b/src/prefs.js
-index b8860c82..d6292606 100644
+index dd20fd20..5f82c53a 100644
 --- a/src/prefs.js
 +++ b/src/prefs.js
-@@ -4,6 +4,8 @@
+@@ -2,6 +2,8 @@
+ //
+ // SPDX-License-Identifier: GPL-2.0-or-later
  
- 'use strict';
- 
-+'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
++import './__nix-prepend-search-paths.js';
 +
- const {Gio, GLib, Adw} = imports.gi;
- 
- // Bootstrap
+ import Gio from 'gi://Gio';
+ import GLib from 'gi://GLib';
+ import Adw from 'gi://Adw';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update of gnomeExtensions.gsconnect to v56 which works with Gnome 45 (unlike v55). See https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v56.

I must admit I did not know what pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch does, so I have just tried to adapt it to the new style of imports.

Fixes: https://github.com/NixOS/nixpkgs/issues/269566

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
