### PR TITLE
qt6.wrapQtAppsHook: add qtbase and qtwayland to propagatedBuildInputs

### DIFF
--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -25,12 +25,14 @@ stdenv.mkDerivation {
 
 The same goes for Qt 5 where libraries and tools are under `libsForQt5`.
 
-Any Qt package should include `wrapQtAppsHook` in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
+Any Qt package should include `wrapQtAppsHook` (or `wrapQtClisHook`) in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
 
 ::: {.note}
-Qt 6 graphical applications should also include `qtwayland` in `buildInputs` on Linux (but not on platforms e.g. Darwin, where `qtwayland` is not available), to ensure the Wayland platform plugin is available.
 
-This may become default in the future, see [NixOS/nixpkgs#269674](https://github.com/NixOS/nixpkgs/pull/269674).
+`wrapQtAppsHook` will propagate `qtwayland` to ensure the Wayland platform plugin is available，it's useful for Graphical Linux applications. It should be noted that on platforms that do not support qtwaylnd (e.g. Darwin), only `qtbase` will be propagated.
+
+`wrapQtClisHook` will not propagate any qt components, it's suitable for pure command-line applications to reduce the closure size.
+
 :::
 
 ## Packages supporting multiple Qt versions {#qt-versions}

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -24,7 +24,10 @@ in
       #
       #   https://github.com/NixOS/nixpkgs/issues/272591
       #
-      [(import ../../pkgs/test/release {})]
+      [(import ../../pkgs/test/release {
+        inherit pkgs;
+        pkgs-path = pkgs.path;
+      })]
     ;
 
   }

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -25,8 +25,7 @@ in
       #   https://github.com/NixOS/nixpkgs/issues/272591
       #
       [(import ../../pkgs/test/release {
-        inherit pkgs;
-        pkgs-path = pkgs.path;
+        inherit pkgs lib nix;
       })]
     ;
 

--- a/pkgs/applications/graphics/pineapple-pictures/default.nix
+++ b/pkgs/applications/graphics/pineapple-pictures/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , qtsvg
-, qtwayland
 , qttools
 , exiv2
 , wrapQtAppsHook
@@ -28,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     qtsvg
-    qtwayland
     exiv2
   ];
 

--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "weston";
-  version = "13.0.2";
+  version = "13.0.3";
 
   src = fetchurl {
     url = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${version}/downloads/weston-${version}.tar.xz";
-    hash = "sha256-T+EUAfVe3Dp7Z1/RwJ8VmGAWL6p9PJegpNaCOzHu0Qw=";
+    hash = "sha256-J/aNluO5fZjare8TogI1ZSSST6OBQY+mcWuRNu8JkJM=";
   };
 
   postPatch = ''

--- a/pkgs/desktops/deepin/core/dde-application-manager/default.nix
+++ b/pkgs/desktops/deepin/core/dde-application-manager/default.nix
@@ -4,7 +4,7 @@
 , fetchpatch
 , cmake
 , pkg-config
-, wrapQtAppsHook
+, wrapQtClisHook
 , qtbase
 }:
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    wrapQtClisHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -182,7 +182,7 @@ let
           {
             name = "wrap-qt6-apps-hook";
             propagatedBuildInputs = [ qtbase.dev makeBinaryWrapper ]
-              ++ lib.optional stdenv.isLinux qtwayland.dev;
+              ++ lib.optional (lib.meta.availableOn stdenv.targetPlatform qtwayland) qtwayland.dev;
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -178,10 +178,11 @@ let
       };
 
       wrapQtAppsHook = callPackage
-        ({ makeBinaryWrapper }: makeSetupHook
+        ({ makeBinaryWrapper, qtbase, qtwayland }: makeSetupHook
           {
             name = "wrap-qt6-apps-hook";
-            propagatedBuildInputs = [ makeBinaryWrapper ];
+            propagatedBuildInputs = [ qtbase.dev makeBinaryWrapper ]
+              ++ lib.optional stdenv.isLinux qtwayland.dev;
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -182,7 +182,7 @@ let
           {
             name = "wrap-qt6-apps-hook";
             propagatedBuildInputs = [ qtbase.dev makeBinaryWrapper ]
-              ++ lib.optional (lib.meta.availableOn stdenv.targetPlatform qtwayland) qtwayland.dev;
+              ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform qtwayland) qtwayland.dev;
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -186,6 +186,14 @@ let
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 
+      wrapQtClisHook = callPackage
+        ({ makeBinaryWrapper }: makeSetupHook
+          {
+            name = "wrap-qt6-clis-hook";
+            propagatedBuildInputs = [ makeBinaryWrapper ];
+          } ./hooks/wrap-qt-apps-hook.sh)
+        { };
+
       qmake = callPackage
         ({ qtbase }: makeSetupHook
           {

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -75,9 +75,9 @@ else # Only set up Qt once.
     fi
 
     qtPreHook() {
-        # Check that wrapQtAppsHook is used, or it is explicitly disabled.
+        # Check that wrapQtAppsHook/wrapQtClisHook is used, or it is explicitly disabled.
         if [[ -z "$__nix_wrapQtAppsHook" && -z "$dontWrapQtApps" ]]; then
-            echo >&2 "Error: wrapQtAppsHook is not used, and dontWrapQtApps is not set."
+            echo >&2 "Error: wrapQtAppsHook or wrapQtClisHook is not used, and dontWrapQtApps is not set."
             exit 1
         fi
     }

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -1,4 +1,5 @@
-{ qtModule
+{ lib
+, qtModule
 , qtbase
 , qtdeclarative
 , wayland
@@ -11,4 +12,7 @@ qtModule {
   propagatedBuildInputs = [ qtbase qtdeclarative ];
   buildInputs = [ wayland libdrm ];
   nativeBuildInputs = [ pkg-config ];
+  meta = {
+    platforms = lib.subtractLists lib.platforms.darwin lib.platforms.unix;
+  };
 }

--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -15,13 +15,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "composer";
-  version = "2.7.6";
+  version = "2.7.7";
 
   # Hash used by ../../../build-support/php/pkgs/composer-phar.nix to
   # use together with the version from this package to keep the
   # bootstrap phar file up-to-date together with the end user composer
   # package.
-  passthru.pharHash = "sha256-KdyaGe8zU12wYbMRgLKoM6fPjSz0FFszovg1BId7ugg=";
+  passthru.pharHash = "sha256-qrlAzVPShaVMUEZYIKIID8txgqS6Hl95Wr+xBBSktL4=";
 
   composer = callPackage ../../../build-support/php/pkgs/composer-phar.nix {
     inherit (finalAttrs) version;
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "composer";
     repo = "composer";
     rev = finalAttrs.version;
-    hash = "sha256-LZwg3PR3zl07Nb6MS8oKkRfjLgqtT/c4sfUOzWE4S+U=";
+    hash = "sha256-N8el4oyz3ZGIXN2qmpf6Df0SIjuc1GjyuMuQCcR/xN4=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -86,7 +86,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-AyX57oV5Jf8U4B9tEl+b2Rnt/Igu7ockEap0wfN9b2Q=";
+    outputHash = "sha256-AsuiTDXJs7jN4N/dJr10BT2PH0f6K2CWDvI8zQW5L9c=";
   };
 
   installPhase = ''

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -9,7 +9,7 @@
 
 buildGoModule rec {
   pname = "telegraf";
-  version = "1.30.3";
+  version = "1.31.0";
 
   subPackages = [ "cmd/telegraf" ];
 
@@ -17,10 +17,10 @@ buildGoModule rec {
     owner = "influxdata";
     repo = "telegraf";
     rev = "v${version}";
-    hash = "sha256-B3Eeh3eOYg58NnMpV6f04HFzOtOn/enBqzCJRst6u2U=";
+    hash = "sha256-bnto39X/Mn8M5YbdM8JSoEPGCb5+UpHS6FPc5Q0kprE=";
   };
 
-  vendorHash = "sha256-Cudnc5ZyCQUqgao58ww69gfF6tPW6/oGP9zXbuPSTAE=";
+  vendorHash = "sha256-uyZZnEdAfkCYtgyjgPTLt463kcfdNczOruHaVmA+VIk=";
   proxyVendor = true;
 
   ldflags = [

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,4 +1,5 @@
 { supportedSystems
+, system ? builtins.currentSystem
 , packageSet ? (import ../..)
 , scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
@@ -33,7 +34,7 @@ let
     systems
     ;
 
-  pkgs = packageSet (recursiveUpdate { system = "x86_64-linux"; config.allowUnsupportedSystem = true; } nixpkgsArgs);
+  pkgs = packageSet (recursiveUpdate { inherit system; config.allowUnsupportedSystem = true; } nixpkgsArgs);
 
   hydraJob' = if scrubJobs then hydraJob else id;
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -9,6 +9,7 @@
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
+, system ? builtins.currentSystem
 , officialRelease ? false
   # The platform doubles for which we build Nixpkgs.
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
@@ -54,7 +55,7 @@
 
 let
   release-lib = import ./release-lib.nix {
-    inherit supportedSystems scrubJobs nixpkgsArgs;
+    inherit supportedSystems scrubJobs nixpkgsArgs system;
   };
 
   inherit (release-lib) mapTestOn pkgs;


### PR DESCRIPTION
qtwayland client side is the wayland platform plugin, provides a way to run Qt applications as Wayland clients 

without this, Qt applications only work on x11/xwayland

`wrap-qt5-apps-hook` has make qtwayland propaged
https://github.com/NixOS/nixpkgs/blob/b2063364e120e14ea5a120bd144ab75a1a3b83f5/pkgs/development/libraries/qt-5/5.15/default.nix#L354-L358
## Description of changes

cc @NixOS/qt-kde 



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
