### PR TITLE
nile: fix passthru.updateScript

### DIFF
--- a/pkgs/games/nile/default.nix
+++ b/pkgs/games/nile/default.nix
@@ -1,5 +1,5 @@
 { lib
-, writeScript
+, unstableGitUpdater
 , buildPythonApplication
 , fetchFromGitHub
 , pythonOlder
@@ -15,7 +15,7 @@
 
 buildPythonApplication rec {
   pname = "nile";
-  version = "unstable-2023-10-03";
+  version = "unstable-2023-10-02";
   format = "pyproject";
 
   src = fetchFromGitHub {
@@ -55,30 +55,5 @@ buildPythonApplication rec {
     maintainers = with maintainers; [ aidalgol ];
   };
 
-  # Upstream does not create git tags when bumping the version, so we have to
-  # extract it from the source code on the main branch.
-  passthru.updateScript = writeScript "gogdl-update-script" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl gnused jq common-updater-scripts
-    set -eou pipefail;
-
-    owner=imLinguin
-    repo=nile
-    path='nile/__init__.py'
-
-    version=$(
-      curl --cacert "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      https://raw.githubusercontent.com/$owner/$repo/main/$path |
-      sed -n 's/^\s*version\s*=\s*"\([0-9]\.[0-9]\.[0-9]\)"\s*$/\1/p')
-
-    commit=$(curl --cacert "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      https://api.github.com/repos/$owner/$repo/commits?path=$path |
-      jq -r '.[0].sha')
-
-    update-source-version \
-      ${pname} \
-      "$version" \
-      --file=./pkgs/games/nile/default.nix \
-      --rev=$commit
-  '';
+  passthru.updateScript = unstableGitUpdater { };
 }


### PR DESCRIPTION
## Description of changes
The update script was erroneously carried over from the `gogdl` derivation code, upon which this derivation was based initially.  It should be using `unstableGitUpdater` instead.

Date in current "unstable" version string corrected to UTC.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
