### PR TITLE
mmctl: 7.10.5 -> 9.2.2

### DIFF
--- a/pkgs/tools/misc/mmctl/0001-module-replace-public.patch
+++ b/pkgs/tools/misc/mmctl/0001-module-replace-public.patch
@@ -1,0 +1,8 @@
+--- a/go.mod
++++ b/go.mod
+@@ -218,3 +218,5 @@ exclude (
+ 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
+ 	github.com/willf/bitset v1.2.0
+ )
++
++replace github.com/mattermost/mattermost/server/public => ./public

--- a/pkgs/tools/misc/mmctl/default.nix
+++ b/pkgs/tools/misc/mmctl/default.nix
@@ -5,30 +5,41 @@
 
 buildGoModule rec {
   pname = "mmctl";
-  version = "7.10.5";
+  version = "9.2.2";
 
   src = fetchFromGitHub {
     owner = "mattermost";
-    repo = "mmctl";
+    repo = "mattermost";
     rev = "v${version}";
-    sha256 = "sha256-FQdxFvYJ+YrOc1p3/Ju3ZOGFH32WeZjHXtsIYG+O0U0=";
-  };
+    hash = "sha256-53L2F20vaLLxtQS3DP/u0ZxLtnXHmjfcOMbXd4i+A6Y=";
+  } + "/server";
 
-  vendorHash = null;
+  vendorHash = "sha256-v8aKZyb4emrwuIgSBDgla5wzwyt6PVGakbXjB9JVaCk=";
 
-  checkPhase = "make test";
+  patches = [ ./0001-module-replace-public.patch ];
+
+  subPackages = [ "cmd/mmctl" ];
+
+  checkPhase = "go test -tags unit -timeout 30m ./cmd/mmctl/...";
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/mattermost/mmctl/v6/commands.Version=${version}"
+    "-X github.com/mattermost/mattermost/server/public/model.Version=${version}"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildNumber=${version}-nixpkgs"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=1970-01-01"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=n/a"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildHash=v${version}"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=v${version}"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=none"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=false"
   ];
 
   meta = with lib; {
     description = "A remote CLI tool for Mattermost";
     homepage = "https://github.com/mattermost/mmctl";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ppom ];
+    maintainers = with maintainers; [ ppom mgdelacroix ];
     mainProgram = "mmctl";
   };
 }

--- a/pkgs/tools/misc/mmctl/default.nix
+++ b/pkgs/tools/misc/mmctl/default.nix
@@ -28,9 +28,7 @@ buildGoModule rec {
     "-X github.com/mattermost/mattermost/server/public/model.Version=${version}"
     "-X github.com/mattermost/mattermost/server/public/model.BuildNumber=${version}-nixpkgs"
     "-X github.com/mattermost/mattermost/server/public/model.BuildDate=1970-01-01"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=n/a"
     "-X github.com/mattermost/mattermost/server/public/model.BuildHash=v${version}"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=v${version}"
     "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=none"
     "-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=false"
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6012,7 +6012,11 @@ with pkgs;
 
   mlarchive2maildir = callPackage ../applications/networking/mailreaders/mlarchive2maildir { };
 
-  mmctl = callPackage ../tools/misc/mmctl { };
+  mmctl = callPackage ../tools/misc/mmctl {
+    # mmctl tests currently fail with go1.21. See
+    # https://mattermost.atlassian.net/browse/MM-55465
+    buildGoModule = buildGo120Module;
+  };
 
   moar = callPackage ../tools/misc/moar { };
 


### PR DESCRIPTION
## Description of changes

This PR updates `mmctl` version to `v9.2.2`, which is the latest release

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).