### PR TITLE
uptime-kuma: 1.23.6 -> 1.23.7

### DIFF
--- a/pkgs/servers/monitoring/uptime-kuma/default.nix
+++ b/pkgs/servers/monitoring/uptime-kuma/default.nix
@@ -2,16 +2,16 @@
 
 buildNpmPackage rec {
   pname = "uptime-kuma";
-  version = "1.23.6";
+  version = "1.23.7";
 
   src = fetchFromGitHub {
     owner = "louislam";
     repo = "uptime-kuma";
     rev = version;
-    hash = "sha256-E/iyusAZnEnfXQ63LZA+9dgE0MvhFOKmrIXCEZ+LGi8=";
+    hash = "sha256-XAtXfrsm9nWWOFJSbL/wWRgzmr2as9J/Y0SwPC0f65o=";
   };
 
-  npmDepsHash = "sha256-AeN6+0DKd+Q2g3I960PeL3IBla5S7X0od9J244HiwLU=";
+  npmDepsHash = "sha256-ZAAHvpUBIj2TDGvzkfAEonQrX3AkEbaAL/pap5Q9j7c=";
 
   patches = [
     # Fixes the permissions of the database being not set correctly


### PR DESCRIPTION
## Description of changes

This PR updates uptime-kuma to `1.23.7`. Here is the [github release](https://github.com/louislam/uptime-kuma/releases/tag/1.23.7) with a list of the changes

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).