### PR TITLE
{db48,libffi,pam,sharutils}: fix `pkgsLLVM` builds

### DIFF
--- a/pkgs/development/libraries/db/db-4.8.nix
+++ b/pkgs/development/libraries/db/db-4.8.nix
@@ -11,4 +11,7 @@ import ./generic.nix (args // {
 
   drvArgs.hardeningDisable = [ "format" ];
   drvArgs.doCheck = false;
+  drvArgs.env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
 })

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -3,7 +3,7 @@
 
   # test suite depends on dejagnu which cannot be used during bootstrapping
   # dejagnu also requires tcl which can't be built statically at the moment
-, doCheck ? !(stdenv.hostPlatform.isStatic)
+, doCheck ? (!(stdenv.hostPlatform.isStatic) && stdenv.hostPlatform == stdenv.buildPlatform)
 , dejagnu
 , nix-update-script
 }:
@@ -50,6 +50,10 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = nix-update-script { };
+  };
+
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
   };
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -57,6 +57,10 @@ stdenv.mkDerivation rec {
     "SCONFIGDIR=${placeholder "out"}/etc/security"
   ];
 
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
   doCheck = false; # fails
 
   passthru.tests = {

--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -58,6 +58,10 @@ stdenv.mkDerivation rec {
       substituteInPlace intl/Makefile.in --replace "AR = ar" ""
     '';
 
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
   doCheck = true;
 
   meta = with lib; {


### PR DESCRIPTION
TODO check for upstream patches

These fail with

`ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]`

To test, add a `lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform)` so there will be less rebuilds

`libffi` tests disabled on canExecute cross because

```
UNRESOLVED: libffi.bhaible/test-call.c -W -Wall -DDGTEST=1 -Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized -O0 compilation failed to produce executable
Executing on host: x86_64-unknown-linux-musl-clang  ../../testsuite/libffi.bhaible/test-call.c   -W -Wall -DDGTEST=1 -Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized -O2  -I/build/libffi-3.4.4/x86_64-unknown-linux-musl/testsuite/../include -I../../testsuite/../include  -I/build/libffi-3.4.4/x86_64-unknown-linux-musl/testsuite/../include/.. -L/build/libffi-3.4.4/x86_64-unknown-linux-musl/testsuite/../.libs  -lffi -lm  -o ./test-call.exe    (timeout = 300)
spawn -ignore SIGHUP x86_64-unknown-linux-musl-clang ../../testsuite/libffi.bhaible/test-call.c -W -Wall -DDGTEST=1 -Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized -O2 -I/build/libffi-3.4.4/x86_64-unknown-linux-musl/testsuite/../include -I../../testsuite/../include-I/build/libffi-3.4.4/x86_64-unknown-linux-musl/testsuite/../include/.. -L/build/libffi-3.4.4/x86_64-unknown-linux-musl/testsuite/../.libs -lffi -lm -o ./test-call.exe
/nix/store/clang-16.0.6/bin/clang: Relink `/nix/store/libunwind-x86_64-unknown-linux-musl-16.0.6/lib/libunwind.so.1' with `/nix/store/glibc-2.38-27/lib/libc.so.6' for IFUNC symbol `memset'
/nix/store/musl-clang-wrapper-16.0.6/bin/x86_64-unknown-linux-musl-clang: line 261:  4349 Segmentation fault      (core dumped) /nix/store/clang-16.0.6/bin/clang "@$responseFile"
compiler exited with status 1
FAIL: libffi.bhaible/test-call.c -W -Wall -DDGTEST=1 -Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized -O2 (test for excess errors)
Excess errors:
/nix/store/clang-16.0.6/bin/clang: Relink `/nix/storelibunwind-x86_64-unknown-linux-musl-16.0.6/lib/libunwind.so.1' with `/nix/store/glibc-2.38-27/lib/libc.so.6' for IFUNC symbol `memset'
/nix/store/x86_64-unknown-linux-musl-clang-wrapper-16.0.6/bin/x86_64-unknown-linux-musl-clang: line 261:  4349 Segmentation fault      (core dumped) /nix/store/clang-16.0.6/bin/clang "@$responseFile"
```


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
