### PR TITLE
snippetexpander: init at 1.0.1

### DIFF
--- a/pkgs/by-name/sn/snippetexpander/package.nix
+++ b/pkgs/by-name/sn/snippetexpander/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+, scdoc
+, installShellFiles
+, snippetexpanderd
+}:
+
+buildGoModule rec {
+  inherit (snippetexpanderd) src version;
+
+  pname = "snippetexpander";
+
+  vendorHash = "sha256-wSAho59yxcXTu1zQ5x783HT4gtfSM4GdsOEeC1wfHhE=";
+
+  proxyVendor = true;
+
+  modRoot = "cmd/snippetexpander";
+
+  nativeBuildInputs = [
+    scdoc
+    installShellFiles
+  ];
+
+  buildInputs = [
+    snippetexpanderd
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    make man
+    installManPage snippetexpander.1
+  '';
+
+  meta = with lib; {
+    description = "Your little expandable text snippet helper CLI";
+    homepage = "https://snippetexpander.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ianmjones ];
+    platforms = platforms.linux;
+    mainProgram = "snippetexpander";
+  };
+}

--- a/pkgs/by-name/sn/snippetexpanderd/package.nix
+++ b/pkgs/by-name/sn/snippetexpanderd/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromSourcehut
+, pkg-config
+, makeWrapper
+, scdoc
+, installShellFiles
+, xorg
+, gtk3
+}:
+
+buildGoModule rec {
+  pname = "snippetexpanderd";
+  version = "1.0.1";
+
+  src = fetchFromSourcehut {
+    owner = "~ianmjones";
+    repo = "snippetexpander";
+    rev = "v${version}";
+    hash = "sha256-y3TJ+L3kXYfZFzAD1vmhvP6Yarctu5LHq/74005h8sI=";
+  };
+
+  vendorHash = "sha256-QX8HI8I1ZJI6HJ1sl86OiJ4nxwFAjHH8h1zB9ASJaQs=";
+
+  modRoot = "cmd/snippetexpanderd";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    scdoc
+    installShellFiles
+  ];
+
+  buildInputs = [
+    xorg.libX11
+    gtk3
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    make man
+    installManPage snippetexpanderd.1 snippetexpander-placeholders.5
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/snippetexpanderd \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ xorg.libX11 ]}
+  '';
+
+  meta = with lib; {
+    description = "Your little expandable text snippet helper daemon";
+    homepage = "https://snippetexpander.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ianmjones ];
+    platforms = platforms.linux;
+    mainProgram = "snippetexpanderd";
+  };
+}

--- a/pkgs/by-name/sn/snippetexpandergui/package.nix
+++ b/pkgs/by-name/sn/snippetexpandergui/package.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+, makeWrapper
+, wails
+, scdoc
+, installShellFiles
+, xorg
+, gtk3
+, webkitgtk
+, gsettings-desktop-schemas
+, snippetexpanderd
+}:
+
+buildGoModule rec {
+  inherit (snippetexpanderd) src version;
+
+  pname = "snippetexpandergui";
+
+  vendorHash = "sha256-iZfZdT8KlfZMVLQcYmo6EooIdsSGrpO/ojwT9Ft1GQI=";
+
+  proxyVendor = true;
+
+  modRoot = "cmd/snippetexpandergui";
+
+  nativeBuildInputs = [
+    makeWrapper
+    wails
+    scdoc
+    installShellFiles
+  ];
+
+  buildInputs = [
+    xorg.libX11
+    gtk3
+    webkitgtk
+    gsettings-desktop-schemas
+    snippetexpanderd
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  tags = [
+    "desktop"
+    "production"
+  ];
+
+  postInstall = ''
+    mv build/linux/share $out/share
+    make man
+    installManPage snippetexpandergui.1
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/snippetexpandergui \
+      --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}
+  '';
+
+  meta = with lib; {
+    description = "Your little expandable text snippet helper GUI";
+    homepage = "https://snippetexpander.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ianmjones ];
+    platforms = platforms.linux;
+    mainProgram = "snippetexpandergui";
+  };
+}

--- a/pkgs/by-name/sn/snippetexpanderx/package.nix
+++ b/pkgs/by-name/sn/snippetexpanderx/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, pkg-config
+, vala
+, wrapGAppsHook
+, installShellFiles
+, scdoc
+, at-spi2-atk
+, at-spi2-core
+, dbus
+, gtk3
+, ibus
+, libgee
+, xorg
+, snippetexpanderd
+}:
+
+stdenv.mkDerivation rec {
+  inherit (snippetexpanderd) src version;
+
+  pname = "snippetexpanderx";
+
+  sourceRoot = "source/cmd/snippetexpanderx";
+
+  nativeBuildInputs = [
+    pkg-config
+    vala
+    wrapGAppsHook
+    installShellFiles
+    scdoc
+  ];
+
+  buildInputs = [
+    at-spi2-atk
+    at-spi2-core
+    dbus
+    gtk3
+    ibus
+    libgee
+    xorg.libX11
+    snippetexpanderd
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m555 snippetexpanderx $out/bin/
+    installManPage snippetexpanderx.1
+    runHook postInstall
+  '';
+
+  # There are no tests.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Your little expandable text snippet helper auto expander daemon";
+    homepage = "https://snippetexpander.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ianmjones ];
+    platforms = platforms.linux;
+    mainProgram = "snippetexpanderx";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add Snippet Expander daemon, auto expander daemon, GUI, and CLI.

Website: https://snippetexpander.org
Source: https://git.sr.ht/~ianmjones/snippetexpander/

The daemon is a required dependency of the auto expander daemon, GUI and CLI, hence why they are all being submitted in this initial PR together.

It will then be possible for people to choose whether they want to use the GUI, CLI, or auto expander daemon packages in any combination, with the daemon always being included.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
