### PR TITLE
wofi-pass: init at 23.1.2

### DIFF
--- a/pkgs/tools/security/pass/wofi-pass.nix
+++ b/pkgs/tools/security/pass/wofi-pass.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pass-wayland
+, coreutils
+, gnugrep
+, libnotify
+, pwgen
+, findutils
+, makeWrapper
+, wl-clipboard
+, wtype
+, wofi
+, extensions ? exts: []
+}:
+
+let
+  wrapperPath = lib.makeBinPath [
+    coreutils
+    findutils
+    gnugrep
+    libnotify
+    pwgen
+    wofi
+    wl-clipboard
+    wtype
+    (pass-wayland.withExtensions extensions)
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "wofi-pass";
+  version = "23.1.2";
+
+  src = fetchFromGitHub {
+    owner = "schmidtandreas";
+    repo = "wofi-pass";
+    rev = "v${version}";
+    sha256 = "sha256-Z1a+nfnL6NXhufpCU7VIkwuifoS88Pf9qI8GCuP/Zqc=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 wofi-pass -t $out/bin
+    install -Dm755 wofi-pass.conf -t $out/share/doc/wofi-pass/wofi-pass.conf
+  '';
+
+  fixupPhase = ''
+    patchShebangs $out/bin
+
+    wrapProgram $out/bin/wofi-pass \
+      --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = {
+    description = "A script to make wofi work with password-store";
+    homepage = "https://github.com/schmidtandreas/wofi-pass";
+    maintainers = with lib.maintainers; [ akechishiro ];
+    license = lib.licenses.gpl2Plus;
+    platforms = with lib.platforms; linux;
+    mainProgram = "wofi-pass";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36512,6 +36512,8 @@ with pkgs;
 
   wofi = callPackage ../applications/misc/wofi { };
 
+  wofi-pass = callPackage ../../pkgs/tools/security/pass/wofi-pass.nix { };
+
   wofi-emoji = callPackage ../applications/misc/wofi-emoji { };
 
   cl-wordle = callPackage ../games/cl-wordle { };


### PR DESCRIPTION
## Description of changes

Init for the fork of `wofi-pass` that is still actively maintained : https://github.com/schmidtandreas/wofi-pass 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
