### PR TITLE
pianotrans: add missing resampy dependency

### DIFF
--- a/pkgs/by-name/pi/pianotrans/package.nix
+++ b/pkgs/by-name/pi/pianotrans/package.nix
@@ -18,8 +18,9 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     piano-transcription-inference
-    torch
+    resampy
     tkinter
+    torch
   ];
 
   # Project has no tests

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34713,8 +34713,6 @@ with pkgs;
 
   pianoteq = callPackage ../applications/audio/pianoteq { };
 
-  pianotrans = callPackage ../applications/audio/pianotrans { };
-
   picard = callPackage ../applications/audio/picard { };
 
   picocom = callPackage ../tools/misc/picocom {


### PR DESCRIPTION
## Description of changes

librosa 0.10 makes `resampy` optional, from https://librosa.org/doc/0.10.0/generated/librosa.resample.html:

> samplerate and resampy are not installed with librosa. To use samplerate or resampy, they should be installed manually

Fix error:

```
$ nix run nixpkgs#pianotrans -- pianotrans/test/cut_liszt.opus 
Queue: pianotrans/test/cut_liszt.opus
--------------------------------------------------------------------------------
Checkpoint path: /nix/store/s98wff9nmi99kjlsqs6llvl6dkx09qmv-python3.11-piano-transcription-inference-0.0.5/share/checkpoint.pth
Using cpu for inference.
Using CPU.
--------------------------------------------------------------------------------
Transcribe: pianotrans/test/cut_liszt.opus
Traceback (most recent call last):
  File "/nix/store/qm6g6d6i35gm7l1b9l74bang7zzgpy0f-pianotrans-1.0.1/lib/python3.11/site-packages/PianoTrans.py", line 35, in worker
    self.inference(file)
  File "/nix/store/qm6g6d6i35gm7l1b9l74bang7zzgpy0f-pianotrans-1.0.1/lib/python3.11/site-packages/PianoTrans.py", line 56, in inference
    (audio, _) = load_audio(audio_path, sr=sample_rate, mono=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/s98wff9nmi99kjlsqs6llvl6dkx09qmv-python3.11-piano-transcription-inference-0.0.5/lib/python3.11/site-packages/piano_transcription_inference/utilities.py", line 556, in load_audio
    y = audio.resample(y, orig_sr=sr_native, target_sr=sr, res_type=res_type)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/yvlzrvpcfag7v4k7dhmrmwxqpqd2jfn9-python3.11-librosa-0.10.1/lib/python3.11/site-packages/librosa/core/audio.py", line 677, in resample
    y_hat = resampy.resample(y, orig_sr, target_sr, filter=res_type, axis=axis)
            ^^^^^^^^^^^^^^^^
  File "/nix/store/4x1hkz5kff9nkvzarjb2mf7ipaym4lpy-python3.11-lazy-loader-0.3/lib/python3.11/site-packages/lazy_loader/__init__.py", line 111, in __getattr__
    raise ModuleNotFoundError(
ModuleNotFoundError: No module named 'resampy'

This error is lazily reported, having originally occured in
  File /nix/store/yvlzrvpcfag7v4k7dhmrmwxqpqd2jfn9-python3.11-librosa-0.10.1/lib/python3.11/site-packages/librosa/core/audio.py, line 32, in <module>

----> resampy = lazy.load("resampy")
--------------------------------------------------------------------------------
Queue finished.
--------------------------------------------------------------------------------
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
