### PR TITLE
monitoring-plugins: fix path to ping in check_ping

### DIFF
--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -34,7 +34,6 @@ let
     lm_sensors
     net-snmp
     procps
-    unixtools.ping
   ];
 
   mailq = runCommand "mailq-wrapper" { preferLocalBuild = true; } ''
@@ -76,8 +75,8 @@ stdenv.mkDerivation rec {
       -e 's|^DEFAULT_PATH=.*|DEFAULT_PATH=\"${binPath}\"|'
 
     configureFlagsArray+=(
-      --with-ping-command='ping -4 -n -U -w %d -c %d %s'
-      --with-ping6-command='ping -6 -n -U -w %d -c %d %s'
+      --with-ping-command='${lib.getBin unixtools.ping}/bin/ping -4 -n -U -w %d -c %d %s'
+      --with-ping6-command='${lib.getBin unixtools.ping}/bin/ping -6 -n -U -w %d -c %d %s'
     )
 
     install -Dm555 ${share} $out/share


### PR DESCRIPTION
The path to ping was configured to use the wrapper prior to its removal [1]. This change removed the absolute path to ping/ping6 and added them to the binPath. Only the perl scripts use binPath, and now the C program `check_ping` fails to find the ping command.

[1] See 759ec1113d0a1d6315b38bd83ec3562dacc08238

## Description of changes

Configure the path to ping via absolute path.

I noticed this on 23.11 beta, so this needs a backport.

Before:

```
❯ ./result/bin/check_ping -H google.com -w 100,10% -c 200,20% -p 2
ping -6 -n -U -w 10 -c 2 google.com
CRITICAL - Could not interpret output from ping command

❯ strace -f ./result/bin/check_ping -H google.com -w 100,10% -c 200,20% -p 2
[...]
[pid 2578908] execve("ping", ["ping", "-6", "-n", "-U", "-w", "10", "-c", "2", "google.com"], 0x7ffedcf9ff70 /* 1 var */) = -1 ENOENT (No such file or directory)
[...]
```

After:
```
❯ ./result/bin/check_ping -H google.com -w 100,10% -c 200,20% -p 2
PING OK - Packet loss = 0%, RTA = 8.06 ms|rta=8.060000ms;100.000000;200.000000;0.000000 pl=0%;10;20;0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
