### PR TITLE
edk2/OVMF: various fixes (cross), features (RISC-V), security updates (2023-11)

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -7,7 +7,9 @@
 , tpmSupport ? false
 , tlsSupport ? false
 , debug ? false
-, sourceDebug ? debug
+# Usually, this option is broken, do not use it except if you know what you are
+# doing.
+, sourceDebug ? false
 }:
 
 assert csmSupport -> seabios != null;

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -118,5 +118,6 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     license = lib.licenses.bsd2;
     inherit (edk2.meta) platforms;
     maintainers = with lib.maintainers; [ adamcstephens raitobezarius ];
+    broken = stdenv.isDarwin;
   };
 })

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -22,6 +22,8 @@ let
     "OvmfPkg/OvmfPkgX64.dsc"
   else if stdenv.hostPlatform.isAarch then
     "ArmVirtPkg/ArmVirtQemu.dsc"
+  else if stdenv.hostPlatform.isRiscV then
+    "OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc"
   else
     throw "Unsupported architecture";
 
@@ -69,7 +71,8 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     cp ${seabios}/Csm16.bin OvmfPkg/Csm/Csm16/Csm16.bin
   '';
 
-  postFixup = if stdenv.hostPlatform.isAarch then ''
+  postFixup = (
+    if stdenv.hostPlatform.isAarch then ''
     mkdir -vp $fd/FV
     mkdir -vp $fd/AAVMF
     mv -v $out/FV/QEMU_{EFI,VARS}.fd $fd/FV
@@ -82,10 +85,18 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     # Also add symlinks for Fedora dir layout: https://src.fedoraproject.org/cgit/rpms/edk2.git/tree/edk2.spec
     ln -s $fd/FV/AAVMF_CODE.fd $fd/AAVMF/QEMU_EFI-pflash.raw
     ln -s $fd/FV/AAVMF_VARS.fd $fd/AAVMF/vars-template-pflash.raw
-  '' else ''
+  ''
+  else if stdenv.hostPlatform.isRiscV then ''
+    mkdir -vp $fd/FV
+
+    mv -v $out/FV/RISCV_VIRT_{CODE,VARS}.fd $fd/FV/
+    truncate -s 32M $fd/FV/RISCV_VIRT_CODE.fd
+    truncate -s 32M $fd/FV/RISCV_VIRT_VARS.fd
+  ''
+  else ''
     mkdir -vp $fd/FV
     mv -v $out/FV/OVMF{,_CODE,_VARS}.fd $fd/FV
-  '';
+  '');
 
   dontPatchELF = true;
 

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -21,6 +21,8 @@ else if stdenv.isAarch32 then
   "ARM"
 else if stdenv.isAarch64 then
   "AARCH64"
+else if stdenv.hostPlatform.isRiscV64 then
+  "RISCV64"
 else
   throw "Unsupported architecture";
 
@@ -92,7 +94,7 @@ edk2 = stdenv.mkDerivation rec {
     description = "Intel EFI development kit";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
     license = licenses.bsd2;
-    platforms = with platforms; aarch64 ++ arm ++ i686 ++ x86_64;
+    platforms = with platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ riscv64;
   };
 
   passthru = {

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -31,7 +31,7 @@ buildType = if stdenv.isDarwin then
 
 edk2 = stdenv.mkDerivation rec {
   pname = "edk2";
-  version = "202308";
+  version = "202311";
 
   patches = [
     # pass targetPrefix as an env var
@@ -46,7 +46,7 @@ edk2 = stdenv.mkDerivation rec {
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    hash = "sha256-Eoi1xf/hw/Knr7n0f0rgVof7wTgrHkmvV4eJjJV1NhM=";
+    hash = "sha256-gC/If8U9qo70rGvNl3ld/mmZszwY0w/5Ge/K21mhzYw=";
   };
 
   # We don't want EDK2 to keep track of OpenSSL,

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -60,11 +60,12 @@ edk2 = stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pythonEnv ];
-  depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.util-linux buildPackages.bash ];
+  depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.bash ];
+  depsHostHost = [ libuuid ];
   strictDeps = true;
 
   # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
-  ${"GCC5_${targetArch}_PREFIX"}=stdenv.cc.targetPrefix;
+  ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
 
   makeFlags = [ "-C BaseTools" ];
 


### PR DESCRIPTION
## Description of changes

This introduces:

- RISC-V support for OVMF/EDK2 (I should have done it before)
- Fixes https://github.com/NixOS/nixpkgs/issues/245188 properly.
- Performs a security update from 2023-08 → 2023-11 because of:

- https://bugzilla.tianocore.org/show_bug.cgi?id=4555
- https://bugzilla.tianocore.org/show_bug.cgi?id=2541
- https://bugzilla.tianocore.org/show_bug.cgi?id=4151

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (via cross compilation)
  - [x] riscv64-linux (via cross compilation)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
