### PR TITLE
{tor,mullvad}-browser: add missing libGL required for wayland

### DIFF
--- a/pkgs/applications/networking/browsers/mullvad-browser/default.nix
+++ b/pkgs/applications/networking/browsers/mullvad-browser/default.nix
@@ -35,6 +35,7 @@
 , waylandSupport ? stdenv.isLinux
 , libxkbcommon
 , libdrm
+, libGL
 
 , mediaSupport ? true
 , ffmpeg
@@ -82,7 +83,7 @@ let
       stdenv.cc.libc
       zlib
     ] ++ lib.optionals libnotifySupport [ libnotify ]
-      ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
+      ++ lib.optionals waylandSupport [ libxkbcommon libdrm libGL ]
       ++ lib.optionals pipewireSupport [ pipewire ]
       ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
       ++ lib.optionals libvaSupport [ libva ]

--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -31,6 +31,7 @@
 , waylandSupport ? stdenv.isLinux
 , libxkbcommon
 , libdrm
+, libGL
 
 , audioSupport ? mediaSupport
 
@@ -98,7 +99,7 @@ lib.warnIf (useHardenedMalloc != null)
       stdenv.cc.libc
       zlib
     ] ++ lib.optionals libnotifySupport [ libnotify ]
-      ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
+      ++ lib.optionals waylandSupport [ libxkbcommon libdrm libGL ]
       ++ lib.optionals pipewireSupport [ pipewire ]
       ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
       ++ lib.optionals libvaSupport [ libva ]


### PR DESCRIPTION
## Description of changes
On unstable & 23.11 branches on a Wayland system, glxtest started to fail during startup which disabled GPU acceleration (`WebRender (Software)` instead of `WebRender` in `about:support`):
```console
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libEGL missing (t=0.252773) [GFX1-]: glxt
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libEGL missing (t=0.252773) |[1][GFX1-]: 
```

The issue only affects Wayland, X11 is fine (at least on my GNOME setup tested with Wayland & XWayland).
Adding `libGL` to wayland dependencies fixes the issue.

Interestingly 23.05 is unaffected and this issue didn't exist when GPU acceleration was initially added in #267085.

Issue was first reported in https://github.com/NixOS/nixpkgs/pull/269764#issuecomment-1826305479.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
