### PR TITLE
importlab: 0.7 → 0.8.1

### DIFF
--- a/pkgs/development/python-modules/importlab/default.nix
+++ b/pkgs/development/python-modules/importlab/default.nix
@@ -1,20 +1,18 @@
 { stdenv
 , lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , networkx
 , pytestCheckHook
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "importlab";
-  version = "0.7";
+  version = "0.8.1";
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "importlab";
-    rev = "676d17cd41ac68de6ebb48fb71780ad6110c4ae3";
-    hash = "sha256-O8y1c65NQ+19BnGnUnWrA0jYUqF+726CFAcWzHFOiHE=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-s4k4U7H26wJ9pQnDtA5nh+ld1mtLZvGzYTqtd1VuFGU=";
   };
 
   propagatedBuildInputs = [ networkx ];


### PR DESCRIPTION
## Description of changes

In `python3Packages.importlab`:
- switch from `fetchFromGitHub` with a pinned git commit hash to `fetchPypi`:
  upstream does not tag their releases in git;
- update from 0.7 to 0.8.1.

cc @sei40kr


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
