### PR TITLE
Skip `sqlite3_bind_bug68849.phpt` php unit test on i686 linux

### DIFF
--- a/pkgs/development/interpreters/php/skip-sqlite3_bind_bug68849.phpt.patch
+++ b/pkgs/development/interpreters/php/skip-sqlite3_bind_bug68849.phpt.patch
@@ -1,0 +1,75 @@
+diff --git a/ext/sqlite3/tests/sqlite3_bind_bug68849.phpt b/ext/sqlite3/tests/sqlite3_bind_bug68849.phpt
+deleted file mode 100644
+index 6324d079..00000000
+--- a/ext/sqlite3/tests/sqlite3_bind_bug68849.phpt
++++ /dev/null
+@@ -1,69 +0,0 @@
+---TEST--
+-Bug #68849 bindValue is not using the right data type
+---EXTENSIONS--
+-sqlite3
+---FILE--
+-<?php
+-
+-$db = new SQLite3(':memory:');
+-
+-$db->exec("CREATE TABLE test (a INTEGER, b TEXT, c REAL);" .
+-        "INSERT INTO test VALUES (1, 'hello', 3.14);" .
+-        "INSERT INTO test VALUES (3, 'world', 3.15);" .
+-        "INSERT INTO test VALUES (0, '42', 0.42);"
+-);
+-
+-$s = $db->prepare('SELECT * FROM test WHERE (a+2) = ?;');
+-$s->bindValue(1, 3);
+-$r = $s->execute();
+-var_dump($r->fetchArray(SQLITE3_ASSOC));
+-
+-$s = $db->prepare('SELECT * FROM test WHERE a = ?;');
+-$s->bindValue(1, true);
+-$r = $s->execute();
+-var_dump($r->fetchArray(SQLITE3_ASSOC));
+-
+-$s = $db->prepare('SELECT * FROM test WHERE a = ?;');
+-$s->bindValue(1, false);
+-$r = $s->execute();
+-var_dump($r->fetchArray(SQLITE3_ASSOC));
+-
+-$s = $db->prepare('SELECT * FROM test WHERE c = ?;');
+-$s->bindValue(1, 3.15);
+-$r = $s->execute();
+-var_dump($r->fetchArray(SQLITE3_ASSOC));
+-
+-?>
+---EXPECT--
+-array(3) {
+-  ["a"]=>
+-  int(1)
+-  ["b"]=>
+-  string(5) "hello"
+-  ["c"]=>
+-  float(3.14)
+-}
+-array(3) {
+-  ["a"]=>
+-  int(1)
+-  ["b"]=>
+-  string(5) "hello"
+-  ["c"]=>
+-  float(3.14)
+-}
+-array(3) {
+-  ["a"]=>
+-  int(0)
+-  ["b"]=>
+-  string(2) "42"
+-  ["c"]=>
+-  float(0.42)
+-}
+-array(3) {
+-  ["a"]=>
+-  int(3)
+-  ["b"]=>
+-  string(5) "world"
+-  ["c"]=>
+-  float(3.15)
+-}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -600,7 +600,15 @@ lib.makeScope pkgs.newScope (self: with self; {
           doCheck = false;
         }
         { name = "sodium"; buildInputs = [ libsodium ]; }
-        { name = "sqlite3"; buildInputs = [ sqlite ]; }
+        {
+          name = "sqlite3";
+          buildInputs = [ sqlite ];
+
+          # The `sqlite3_bind_bug68849.phpt` test is currently broken for i686 Linux systems since sqlite 3.43, cf.:
+          # - https://github.com/php/php-src/issues/12076
+          # - https://www.sqlite.org/forum/forumpost/abbb95376ec6cd5f
+          patches = lib.optional (stdenv.isi686 && stdenv.isLinux) ../development/interpreters/php/skip-sqlite3_bind_bug68849.phpt.patch;
+        }
         { name = "sysvmsg"; }
         { name = "sysvsem"; }
         { name = "sysvshm"; }


### PR DESCRIPTION
## Description of changes

Skip the `sqlite3_bind_bug68849.phpt` which is currently broken on  i686 Linux (since SQLite >= 3.43 [1]). This test is seemingly supposed to be testing data types [2] while binding query parameters but relies on very specific floating point precision/behavior. See also the SQLite forum discussion on the matter [3].

This patch deactivates the test in question in a way that should fail to build if the test gets modified upstream.

[1]: https://github.com/php/php-src/issues/12076
[2]: https://bugs.php.net/bug.php?id=68849
[3]: https://www.sqlite.org/forum/forumpost/abbb95376ec6cd5f

Resources:
- Example of a broken test derivation because of this:  https://hydra.nixos.org/build/242134990
- Log: https://hydra.nixos.org/build/242134990/nixlog/4
- From the log, you can see that the cause of the failure is  `sqlite3_bind_bug68849.phpt` :

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   13
---------------------------------------------------------------------

Number of tests :   82                78
Tests skipped   :    4 (  4.9%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    1 (  1.2%) (  1.3%)
Tests passed    :   77 ( 93.9%) ( 98.7%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Bug #68849 bindValue is not using the right data type [tests/sqlite3_bind_bug68849.phpt]
=====================================================================
```

#ZurichZHF

ZHF: https://github.com/NixOS/nixpkgs/issues/265948

## Things done

- [x] Run as a dependency of `nixos.tests.allDrivers.php.httpd.i686-linux` (which were broken before, now working)

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
