### PR TITLE
instawow: init at 3.1.0

### DIFF
--- a/pkgs/games/instawow/default.nix
+++ b/pkgs/games/instawow/default.nix
@@ -1,0 +1,48 @@
+{ lib, python3, fetchFromGitHub, plugins ? [ ] }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "instawow";
+  version = "v3.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "layday";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-xJw/tgHBfOlv5JYsWWdEJ8vpel348YtXCQsaLqgp3Z0=";
+  };
+
+  extras = [ ];  # Disable GUI, most dependencies are not packaged.
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+  propagatedBuildInputs = with python3.pkgs; [
+    aiohttp
+    aiohttp-client-cache
+    alembic
+    attrs
+    cattrs
+    click
+    iso8601
+    loguru
+    mako
+    packaging
+    pluggy
+    prompt-toolkit
+    questionary
+    rapidfuzz
+    sqlalchemy
+    truststore
+    typing-extensions
+    yarl
+  ] ++ plugins;
+
+  meta = with lib; {
+    homepage = "https://github.com/layday/instawow";
+    description = "World of Warcraft add-on manager CLI and GUI";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ seirl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16395,6 +16395,8 @@ with pkgs;
     indradb-server
     indradb-client;
 
+  instawow = callPackage ../games/instawow/default.nix { };
+
   intel-graphics-compiler = callPackage ../development/compilers/intel-graphics-compiler { };
 
   intercal = callPackage ../development/compilers/intercal { };


### PR DESCRIPTION
## Description of changes

Adds instawow, a World of Warcraft add-on manager.

https://github.com/layday/instawow (138 stars).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
