### PR TITLE
nixos-render-docs: take header and footer on CLI

### DIFF
--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
@@ -8,6 +8,7 @@ import xml.sax.saxutils as xml
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
 from markdown_it.token import Token
+from pathlib import Path
 from typing import Any, Generic, Optional
 from urllib.parse import quote
 
@@ -287,18 +288,27 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
     _links_in_last_description: Optional[list[str]] = None
 
     def __init__(self, revision: str,
+                 header: Path | None,
+                 footer: Path | None,
                  *,
                  # only for parallel rendering
                  _options_by_id: Optional[dict[str, str]] = None):
         super().__init__(revision)
         self._options_by_id = _options_by_id or {}
         self._renderer = OptionsManpageRenderer({}, self._options_by_id)
+        self._header = header
+        self._footer = footer
 
     def _parallel_render_prepare(self) -> Any:
-        return (self._revision, { '_options_by_id': self._options_by_id })
+        return (
+            self._revision,
+            self._header,
+            self._footer,
+            { '_options_by_id': self._options_by_id },
+        )
     @classmethod
     def _parallel_render_init_worker(cls, a: Any) -> ManpageConverter:
-        return cls(a[0], **a[1])
+        return cls(a[0], a[1], a[2], **a[3])
 
     def _render_option(self, name: str, option: dict[str, Any]) -> RenderedOption:
         links = self._renderer.link_footnotes = []
@@ -342,26 +352,30 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
     def finalize(self) -> str:
         result = []
 
-        result += [
-            r'''.TH "CONFIGURATION\&.NIX" "5" "01/01/1980" "NixOS" "NixOS Reference Pages"''',
-            r'''.\" disable hyphenation''',
-            r'''.nh''',
-            r'''.\" disable justification (adjust text to left margin only)''',
-            r'''.ad l''',
-            r'''.\" enable line breaks after slashes''',
-            r'''.cflags 4 /''',
-            r'''.SH "NAME"''',
-            self._render('{file}`configuration.nix` - NixOS system configuration specification'),
-            r'''.SH "DESCRIPTION"''',
-            r'''.PP''',
-            self._render('The file {file}`/etc/nixos/configuration.nix` contains the '
-                        'declarative specification of your NixOS system configuration. '
-                        'The command {command}`nixos-rebuild` takes this file and '
-                        'realises the system configuration specified therein.'),
-            r'''.SH "OPTIONS"''',
-            r'''.PP''',
-            self._render('You can use the following options in {file}`configuration.nix`.'),
-        ]
+        if self._header is not None:
+            with self._header.open() as f:
+                result += f.read().splitlines()
+        else:
+            result += [
+                r'''.TH "CONFIGURATION\&.NIX" "5" "01/01/1980" "NixOS" "NixOS Reference Pages"''',
+                r'''.\" disable hyphenation''',
+                r'''.nh''',
+                r'''.\" disable justification (adjust text to left margin only)''',
+                r'''.ad l''',
+                r'''.\" enable line breaks after slashes''',
+                r'''.cflags 4 /''',
+                r'''.SH "NAME"''',
+                self._render('{file}`configuration.nix` - NixOS system configuration specification'),
+                r'''.SH "DESCRIPTION"''',
+                r'''.PP''',
+                self._render('The file {file}`/etc/nixos/configuration.nix` contains the '
+                            'declarative specification of your NixOS system configuration. '
+                            'The command {command}`nixos-rebuild` takes this file and '
+                            'realises the system configuration specified therein.'),
+                r'''.SH "OPTIONS"''',
+                r'''.PP''',
+                self._render('You can use the following options in {file}`configuration.nix`.'),
+            ]
 
         for (name, opt) in self._sorted_options():
             result += [
@@ -383,11 +397,15 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
 
             result.append(".RE")
 
-        result += [
-            r'''.SH "AUTHORS"''',
-            r'''.PP''',
-            r'''Eelco Dolstra and the Nixpkgs/NixOS contributors''',
-        ]
+        if self._footer is not None:
+            with self._footer.open() as f:
+                result += f.read().splitlines()
+        else:
+            result += [
+                r'''.SH "AUTHORS"''',
+                r'''.PP''',
+                r'''Eelco Dolstra and the Nixpkgs/NixOS contributors''',
+            ]
 
         return "\n".join(result)
 
@@ -573,6 +591,8 @@ def _build_cli_db(p: argparse.ArgumentParser) -> None:
 
 def _build_cli_manpage(p: argparse.ArgumentParser) -> None:
     p.add_argument('--revision', required=True)
+    p.add_argument("--header", type=Path)
+    p.add_argument("--footer", type=Path)
     p.add_argument("infile")
     p.add_argument("outfile")
 
@@ -603,7 +623,11 @@ def _run_cli_db(args: argparse.Namespace) -> None:
             f.write(md.finalize())
 
 def _run_cli_manpage(args: argparse.Namespace) -> None:
-    md = ManpageConverter(revision = args.revision)
+    md = ManpageConverter(
+        revision = args.revision,
+        header = args.header,
+        footer = args.footer,
+    )
 
     with open(args.infile, 'r') as f:
         md.add_options(json.load(f))

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
@@ -288,8 +288,8 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
     _links_in_last_description: Optional[list[str]] = None
 
     def __init__(self, revision: str,
-                 header: Path | None,
-                 footer: Path | None,
+                 header: list[str] | None,
+                 footer: list[str] | None,
                  *,
                  # only for parallel rendering
                  _options_by_id: Optional[dict[str, str]] = None):
@@ -353,8 +353,7 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
         result = []
 
         if self._header is not None:
-            with self._header.open() as f:
-                result += f.read().splitlines()
+            result += self._header
         else:
             result += [
                 r'''.TH "CONFIGURATION\&.NIX" "5" "01/01/1980" "NixOS" "NixOS Reference Pages"''',
@@ -398,8 +397,7 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
             result.append(".RE")
 
         if self._footer is not None:
-            with self._footer.open() as f:
-                result += f.read().splitlines()
+            result += self._footer
         else:
             result += [
                 r'''.SH "AUTHORS"''',
@@ -623,10 +621,21 @@ def _run_cli_db(args: argparse.Namespace) -> None:
             f.write(md.finalize())
 
 def _run_cli_manpage(args: argparse.Namespace) -> None:
+    header = None
+    footer = None
+
+    if args.header is not None:
+        with args.header.open() as f:
+            header = f.read().splitlines()
+
+    if args.footer is not None:
+        with args.footer.open() as f:
+            footer = f.read().splitlines()
+
     md = ManpageConverter(
         revision = args.revision,
-        header = args.header,
-        footer = args.footer,
+        header = header,
+        footer = footer,
     )
 
     with open(args.infile, 'r') as f:


### PR DESCRIPTION

## Description of changes

This PR generalizes nixos-render-docs for manpage generation to take the header preamble and footer postscript as file paths as CLI flags --header and --footer.

The driving use-case for this is to support generation of the `home-manager` manpages https://github.com/nix-community/home-manager/pull/4673 using this package now that `optionsDocBook` has been deprecated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
