### PR TITLE
mapnik: disable test failing on aarch64

### DIFF
--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -86,6 +86,10 @@ stdenv.mkDerivation rec {
     "-DBUILD_DEMO_VIEWER=OFF"
   ];
 
+  disabledTests = lib.optionals stdenv.isAarch64 [
+    "test_passing_pycairo_context_svg"
+  ];
+
   # mapnik-config is currently not build with CMake. So we use the SCons for
   # this one. We can't add SCons to nativeBuildInputs though, as stdenv would
   # then try to build everything with scons.


### PR DESCRIPTION
## Description of changes

This PR is disabling `test_passing_pycairo_context_svg` test which fails on aarch64 with following error:

```
  ----------------------------- Captured stderr call -----------------------------
Mapnik LOG> 2023-11-23 23:52:00: SVG parse error: can't infer valid image dimensions from width:"100%" height:"100%"
2023-11-23 23:52:00.200 python3.10[49211:653605964] XType: Using static font registry.
___________________________ test_style_level_comp_op ___________________________

    def test_style_level_comp_op():
        m = mapnik.Map(256, 256)
        mapnik.load_map(m, '../data/good_maps/style_level_comp_op.xml')
        m.zoom_all()
        successes = []
        fails = []
        for name in mapnik.CompositeOp.names:
            # find_style returns a copy of the style object
            style_markers = m.find_style("markers")
            style_markers.comp_op = getattr(mapnik.CompositeOp, name)
            # replace the original style with the modified one
            replace_style(m, "markers", style_markers)
            im = mapnik.Image(m.width, m.height)
            mapnik.render(m, im)
            actual = '/private/tmp/nix-build-python3.10-python-mapnik-unstable-2020-09-08.drv-0/mapnik-style-comp-op-' + name + '.png'
            expected = 'images/style-comp-op/' + name + '.png'
            im.save(actual, 'png32')
            if not os.path.exists(expected) or os.environ.get('UPDATE'):
                print('generating expected test image: %s' % expected)
                im.save(expected, 'png32')
            expected_im = mapnik.Image.open(expected)
            # compare them
            if im.tostring('png32') == expected_im.tostring('png32'):
                successes.append(name)
            else:
                fails.append(
                    'failed comparing actual (%s) and expected(%s)' %
                    (actual, 'tests/python_tests/' + expected))
                fail_im = side_by_side_image(expected_im, im)
                fail_im.save(
                    '/private/tmp/nix-build-python3.10-python-mapnik-unstable-2020-09-08.drv-0/mapnik-style-comp-op-' +
                    name +
                    '.fail.png',
                    'png32')
>       eq_(len(fails), 0, '\n' + '\n'.join(fails))

/private/tmp/nix-build-python3.10-python-mapnik-unstable-2020-09-08.drv-0/source/test/python_tests/compositing_test.py:218: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = 1, b = 0
msg = '\nfailed comparing actual (/private/tmp/nix-build-python3.10-python-mapnik-unstable-2020-09-08.drv-0/mapnik-style-comp-op-color.png) and expected(tests/python_tests/images/style-comp-op/color.png)'

    def eq_(a, b, msg=None):
        """Shorthand for 'assert a == b, "%r != %r" % (a, b)
        """
        if not a == b:
>           raise AssertionError(msg or "%r != %r" % (a, b))
E           AssertionError: 
E           failed comparing actual (/private/tmp/nix-build-python3.10-python-mapnik-unstable-2020-09-08.drv-0/mapnik-style-comp-op-color.png) and expected(tests/python_tests/images/style-comp-op/color.png)

/nix/store/zy1497ijl9byi7g3vfsmzcbbmvqcdkvp-python3.10-nose-1.3.7/lib/python3.10/site-packages/nose/tools/trivial.py:29: AssertionError
```

I was trying to cross-compile mapnik on aarch64 to investigate what's wrong with `mapnik-style-comp-op-color.png` file, but hit cross-compiling failures with some dependencies and I gave up.

#ZurichZHF

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
