### PR TITLE
nix-ld: mark as broken on 32 bit targets

### DIFF
--- a/pkgs/os-specific/linux/nix-ld/default.nix
+++ b/pkgs/os-specific/linux/nix-ld/default.nix
@@ -52,5 +52,9 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ mic92 ];
     platforms = platforms.linux;
+
+    # 32 bit builds are broken due to a missing #define value:
+    # https://github.com/Mic92/nix-ld/issues/64
+    broken = stdenv.is32bit;
   };
 }


### PR DESCRIPTION
`nix-ld`'s source code doesn't build on 32 bit targets due to a missing `#define` value since the tool [switched from musl to nolibc ](https://github.com/Mic92/nix-ld/blame/6ac25c22be4ca118e2a94f626671a52612642a9e/src/nix-ld.c#L21C9-L21C20) in 2021.

See https://github.com/Mic92/nix-ld/issues/64

Hydra job: https://hydra.nixos.org/build/241835411#tabs-summary
Log: https://hydra.nixos.org/build/241835411/nixlog/2

Relevant log excerpt:
```
[3/8] Compiling C object nix-ld.p/src_nix-ld.c.o
FAILED: nix-ld.p/src_nix-ld.c.o 
gcc -Inix-ld.p -I. -I.. -I../vendor/nolibc -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -ffast-math -fno-common -fdiagnostics-show-option -fno-strict-aliasing -fvisibility=hidden -fcf-protection --param=ssp-buffer-size=4 -fPIE -fno-asynchronous-unwind-tables -fno-ident -ffreestanding -static-pie -DPTR_SIZE=4 -MD -MQ nix-ld.p/src_nix-ld.c.o -MF nix-ld.p/src_nix-ld.c.o.d -o nix-ld.p/src_nix-ld.c.o -c ../src/nix-ld.c
../src/nix-ld.c: In function 'total_mapping_size':
../src/nix-ld.c:127:32: error: expected expression before ';' token
  127 |   size_t addr_min = UINTPTR_MAX;
      |                                ^
[4/8] Generating symbol file test/libexample-lib.so.p/libexample-lib.so.symbols
ninja: build stopped: subcommand failed.
```

## Description of changes

Marks `nix-ld` as broken for 32 bit targets.

#ZurichZHF

ZHF: https://github.com/NixOS/nixpkgs/issues/265948

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
