### PR TITLE
Home Assistant Custom Component Errata

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -43,7 +43,7 @@ in {
 
       # test loading custom components
       customComponents = with pkgs.home-assistant-custom-components; [
-        prometheus-sensor
+        prometheus_sensor
       ];
 
       # test loading lovelace modules

--- a/pkgs/servers/home-assistant/build-custom-component/check_manifest.py
+++ b/pkgs/servers/home-assistant/build-custom-component/check_manifest.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 
 import json
-import importlib_metadata
+import os
 import sys
 
+import importlib_metadata
 from packaging.requirements import Requirement
+
+
+def error(msg: str) -> None:
+    print(f"  - {msg}", file=sys.stderr)
+    return False
 
 
 def check_requirement(req: str):
@@ -13,16 +19,13 @@ def check_requirement(req: str):
     try:
         version = importlib_metadata.distribution(requirement.name).version
     except importlib_metadata.PackageNotFoundError:
-        print(f"  - Dependency {requirement.name} is missing", file=sys.stderr)
-        return False
+        return error(f"{requirement.name}{requirement.specifier} not present")
 
     # https://packaging.pypa.io/en/stable/specifiers.html
-    if not version in requirement.specifier:
-        print(
-            f"  - {requirement.name}{requirement.specifier} expected, but got {version}",
-            file=sys.stderr,
+    if version not in requirement.specifier:
+        return error(
+            f"{requirement.name}{requirement.specifier} expected, but got {version}"
         )
-        return False
 
     return True
 
@@ -30,13 +33,24 @@ def check_requirement(req: str):
 def check_manifest(manifest_file: str):
     with open(manifest_file) as fd:
         manifest = json.load(fd)
+
+    ok = True
+
+    derivation_domain = os.environ.get("domain")
+    manifest_domain = manifest["domain"]
+    if derivation_domain != manifest_domain:
+        ok = False
+        error(
+            f"Derivation attribute domain ({derivation_domain}) must match manifest domain ({manifest_domain})"
+        )
+
     if "requirements" in manifest:
-        ok = True
         for requirement in manifest["requirements"]:
             ok &= check_requirement(requirement)
-        if not ok:
-            print("Manifest requirements are not met", file=sys.stderr)
-            sys.exit(1)
+
+    if not ok:
+        error("Manifest check failed.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/pkgs/servers/home-assistant/build-custom-component/default.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/default.nix
@@ -23,7 +23,7 @@ home-assistant.python.pkgs.buildPythonPackage (
       runHook preInstall
 
       mkdir $out
-      cp -r $src/custom_components/ $out/
+      cp -r ./custom_components/ $out/
 
       runHook postInstall
     '';

--- a/pkgs/servers/home-assistant/build-custom-component/default.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/default.nix
@@ -3,7 +3,8 @@
 , makeSetupHook
 }:
 
-{ pname
+{ owner
+, domain
 , version
 , format ? "other"
 , ...
@@ -17,6 +18,7 @@ let
 in
 home-assistant.python.pkgs.buildPythonPackage (
   {
+    pname = "${owner}/${domain}";
     inherit format;
 
     installPhase = ''

--- a/pkgs/servers/home-assistant/custom-components/README.md
+++ b/pkgs/servers/home-assistant/custom-components/README.md
@@ -25,7 +25,7 @@ versions into the Python environment.
 }:
 
 buildHomeAssistantComponent {
-  # pname, version
+  # owner, domain, version
 
   src = fetchFromGithub {
     # owner, repo, rev, hash
@@ -40,18 +40,34 @@ buildHomeAssistantComponent {
   }
 }
 
-## Package name normalization
+## Package attribute
 
-Apply the same normalization rules as defined for python packages in
-[PEP503](https://peps.python.org/pep-0503/#normalized-names).
-The name should be lowercased and dots, underlines or multiple
-dashes should all be replaced by a single dash.
+The attribute name must reflect the domain as seen in the
+`manifest.json`, which in turn will match the python module name below
+in the `custom_components/` directory.
+
+**Example:**
+
+The project [mweinelt/ha-prometheus-sensor](https://github.com/mweinelt/ha-prometheus-sensor/blob/1.0.0/custom_components/prometheus_sensor/manifest.json#L2)
+would receive the attribute name `"prometheus_sensor"`, because both
+domain in the `manifest.json` as well as the module name are
+`prometheus_sensor`.
+
+## Package name
+
+The `pname` attribute is a composition of both `owner` and `domain`.
+
+Don't set `pname`, set `owner and `domain` instead.
+
+Exposing the `domain` attribute separately allows checking for
+conflicting components at eval time.
 
 ## Manifest check
 
 The `buildHomeAssistantComponent` builder uses a hook to check whether
 the dependencies specified in the `manifest.json` are present and
-inside the specified version range.
+inside the specified version range. It also makes sure derivation
+and manifest agree about the domain name.
 
 There shouldn't be a need to disable this hook, but you can set
 `dontCheckManifest` to `true` in the derivation to achieve that.

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -2,5 +2,5 @@
 }:
 
 {
-  prometheus-sensor = callPackage ./prometheus-sensor {};
+  prometheus_sensor = callPackage ./prometheus_sensor {};
 }

--- a/pkgs/servers/home-assistant/custom-components/prometheus_sensor/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/prometheus_sensor/default.nix
@@ -4,7 +4,8 @@
 }:
 
 buildHomeAssistantComponent rec {
-  pname = "prometheus-sensor";
+  owner = "mweinelt";
+  domain = "prometheus_sensor";
   version = "1.0.0";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
## Description of changes

Correcting some things that were quickly noticeable when users submitted new component packages.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
