### PR TITLE
nikto: 2.2.0 -> 2.5.0

### DIFF
--- a/pkgs/tools/networking/nikto/default.nix
+++ b/pkgs/tools/networking/nikto/default.nix
@@ -6,20 +6,23 @@
 , installShellFiles
 }:
 
+let
+  version = "2.5.0";
+in
 stdenv.mkDerivation rec {
   pname = "nikto";
-  version = "2.2.0";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "sullo";
     repo = "nikto";
-    rev = "c83d0461edd75c02677dea53da2896644f35ecab";
-    sha256 = "0vwq2zdxir67cn78ls11qf1smd54nppy266v7ajm5rqdc47q7fy2";
+    rev = version;
+    sha256 = "sha256-lWiDbWc2BWAUgyaIm0tvZytja02WogYRoc7na4sHiNM=";
   };
 
   # Nikto searches its configuration file based on its current path
   # This fixes the current path regex for the wrapped executable.
-  patches = [ ./NIKTODIR-nix-wrapper-fix.patch ];
+  patches = [ ./nix-wrapper-fix.patch ];
 
   postPatch = ''
     # EXECDIR needs to be changed to the path where we copy the programs stuff
@@ -31,10 +34,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
-  propagatedBuildInputs = [ perlPackages.NetSSLeay ];
-
   buildInputs = [
     perlPackages.perl
+    perlPackages.NetSSLeay
   ];
 
   installPhase = ''
@@ -44,7 +46,6 @@ stdenv.mkDerivation rec {
     install -Dm 755 "program/nikto.pl" "$out/bin/nikto"
     install -Dm 644 program/nikto.conf.default "$out/etc/nikto.conf"
     installManPage documentation/nikto.1
-    install -Dm 644 program/docs/nikto_manual.html "$out/share/doc/${pname}/manual.html"
     install -Dm 644 README.md "$out/share/doc/${pname}/README"
     runHook postInstall
   '';
@@ -58,6 +59,7 @@ stdenv.mkDerivation rec {
     description = "Web server scanner";
     license = licenses.gpl2Plus;
     homepage = "https://cirt.net/Nikto2";
+    changelog = "https://github.com/sullo/nikto/releases/tag/${version}";
     maintainers = with maintainers; [ shamilton ];
     platforms = platforms.unix;
   };

--- a/pkgs/tools/networking/nikto/nix-wrapper-fix.patch
+++ b/pkgs/tools/networking/nikto/nix-wrapper-fix.patch
@@ -1,26 +1,26 @@
-diff --color -ur a/program/nikto.pl b/program/nikto.pl
---- a/program/nikto.pl	2021-01-30 12:05:54.915072538 +0100
-+++ b/program/nikto.pl	2021-01-30 12:36:42.877729231 +0100
-@@ -223,7 +223,8 @@
+diff --git a/program/nikto.pl b/program/nikto.pl
+index 2cb07f9..323e666 100755
+--- a/program/nikto.pl
++++ b/program/nikto.pl
+@@ -243,7 +243,7 @@ sub config_init {
      # Guess Nikto current directory
      my $NIKTODIR = abs_path($0);
      chomp($NIKTODIR);
 -    $NIKTODIR =~ s#[\\/]nikto.pl$##;
 +    $NIKTODIR =~ s#[\\/]bin[\\/]\.nikto-wrapped$##;
-+
  
      # Guess user's home directory -- to support Windows
      foreach my $var (split(/ /, "HOME USERPROFILE")) {
-@@ -231,10 +232,10 @@
+@@ -251,10 +251,10 @@ sub config_init {
      }
  
      # Read the conf files in order (previous values are over-written with each, if multiple found)
--    push(@CF,"$NIKTODIR/nikto.conf.default");
+-    push(@CF, "$NIKTODIR/nikto.conf.default");
 +    push(@CF,"$NIKTODIR/etc/nikto.conf.default");
-     push(@CF,"/etc/nikto.conf");
-     push(@CF,"$home/nikto.conf");
--    push(@CF,"$NIKTODIR/nikto.conf");
+     push(@CF, "/etc/nikto.conf");
+     push(@CF, "$home/nikto.conf");
+-    push(@CF, "$NIKTODIR/nikto.conf");
 +    push(@CF,"$NIKTODIR/etc/nikto.conf");
-     push(@CF,"nikto.conf");
-     push(@CF,"$VARIABLES{'configfile'}");
+     push(@CF, "nikto.conf");
+     push(@CF, "$VARIABLES{'configfile'}");
  


### PR DESCRIPTION
## Description of changes

I'm going to need a bit of help to get this over the finish line.

here is what I did
- took the latest commit from nikto 2.5.0 branch https://github.com/sullo/nikto/tree/nikto-2.5.0/program
- fixed the patch, and removed the line that installs removed documentation.

however I still get this error
```
ERROR: Can't locate Net/SSLeay.pm in @INC (you may need to install the Net::SSLeay module) (@INC entries checked: /nix/store/khyv1jr3g7246bs87dqfy8ba0ica4fbm-perl-5.38.0/lib/perl5/site_perl/5.38.0/darwin-thread-multi-2level /nix/store/khyv1jr3g7246bs87dqfy8ba0ica4fbm-perl-5.38.0/lib/perl5/site_perl/5.38.0 /nix/store/khyv1jr3g7246bs87dqfy8ba0ica4fbm-perl-5.38.0/lib/perl5/5.38.0/darwin-thread-multi-2level /nix/store/khyv1jr3g7246bs87dqfy8ba0ica4fbm-perl-5.38.0/lib/perl5/5.38.0) at (eval 21) line 1.
BEGIN failed--compilation aborted at (eval 21) line 1.
```

I tried moving propagatedBuildInputs (which sounds like correct) to buildinputs to try to match other packages using ssleay.pm, but this didn't fix the problem.

any pointers would be appreciated!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
