### PR TITLE
Hdhomerun 20231109

### DIFF
--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.silicondust.com/support/linux";
     license = licenses.lgpl21Only;
     platforms = platforms.unix;
-    maintainers = [ maintainers.titanous ];
+    maintainers = [ maintainers.titanous maintainers.sielicki ];
   };
 }

--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitHub }:
 
 # libhdhomerun requires UDP port 65001 to be open in order to detect and communicate with tuners.
 # If your firewall is enabled, make sure to have something like:
@@ -6,21 +6,19 @@
 
 stdenv.mkDerivation rec {
   pname = "libhdhomerun";
-  version = "20220303";
+  version = "20231109";
 
-  src = fetchurl {
-    url = "https://download.silicondust.com/hdhomerun/libhdhomerun_${version}.tgz";
-    sha256 = "sha256-HlT/78LUiTkRUB2jHmYrnQY+bBiv4stcZlMyUnelSpc=";
+  src = fetchFromGitHub {
+    owner = "Silicondust";
+    repo = "${pname}";
+    rev = "e8f29fd4e071580ffb583cbeb9cf720c96a4e75f"; # 20231109
+    sha256 = "sha256-ni6bhvTXbFzNnKr6cgG0m7o3JEIDY7jouT88rfSf66A=";
   };
-
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace Makefile \
-      --replace "-arch x86_64" "-arch ${stdenv.hostPlatform.darwinArch}"
-  '';
 
   makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
   ];
+  patches = [ ./nixos-darwin-no-fat-dylib.patch ];
 
   installPhase = ''
     mkdir -p $out/{bin,lib,include/hdhomerun}

--- a/pkgs/development/libraries/libhdhomerun/nixos-darwin-no-fat-dylib.patch
+++ b/pkgs/development/libraries/libhdhomerun/nixos-darwin-no-fat-dylib.patch
@@ -1,0 +1,52 @@
+From 6b9ed19d7874b88b7db5b740dac3dcd7dcda6c8c Mon Sep 17 00:00:00 2001
+From: Nicholas Sielicki <git@opensource.nslick.com>
+Date: Sat, 25 Nov 2023 13:54:39 -0600
+Subject: [PATCH] nixos-darwin-no-fat-dylib
+
+Signed-off-by: Nicholas Sielicki <git@opensource.nslick.com>
+---
+ Makefile | 24 ++++--------------------
+ 1 file changed, 4 insertions(+), 20 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 1d8fb9f..35c7d15 100644
+--- a/Makefile
++++ b/Makefile
+@@ -42,30 +42,14 @@ LIBSRCS += hdhomerun_video.c
+ 
+ ifeq ($(OS),Darwin)
+ 
+-TARGET_X64 := -target x86_64-apple-macos10.11
+-TARGET_ARM64 := -target arm64-apple-macos11
+-
+ all : hdhomerun_config libhdhomerun.dylib
+ 
+-hdhomerun_config_x64 : hdhomerun_config.c $(LIBSRCS)
+-	$(CC) $(TARGET_X64) $(CFLAGS) $+ $(LDFLAGS) -o $@
+-	$(STRIP) $@
+-
+-hdhomerun_config_arm64 : hdhomerun_config.c $(LIBSRCS)
+-	$(CC) $(TARGET_ARM64) $(CFLAGS) $+ $(LDFLAGS) -o $@
++hdhomerun_config: hdhomerun_config.c $(LIBSRCS)
++	$(CC) $(CFLAGS) $+ $(LDFLAGS) -o $@
+ 	$(STRIP) $@
+ 
+-hdhomerun_config : hdhomerun_config_x64 hdhomerun_config_arm64
+-	lipo -create -output hdhomerun_config hdhomerun_config_x64 hdhomerun_config_arm64
+-
+-libhdhomerun_x64.dylib : $(LIBSRCS)
+-	$(CC) $(TARGET_X64) $(CFLAGS) -DDLL_EXPORT -fPIC -dynamiclib $+ $(LDFLAGS) -o $@
+-
+-libhdhomerun_arm64.dylib : $(LIBSRCS)
+-	$(CC) $(TARGET_ARM64) $(CFLAGS) -DDLL_EXPORT -fPIC -dynamiclib $+ $(LDFLAGS) -o $@
+-
+-libhdhomerun.dylib : libhdhomerun_x64.dylib libhdhomerun_arm64.dylib
+-	lipo -create -output libhdhomerun.dylib libhdhomerun_x64.dylib libhdhomerun_arm64.dylib
++libhdhomerun.dylib : $(LIBSRCS)
++	$(CC) $(CFLAGS) -DDLL_EXPORT -fPIC -dynamiclib $+ $(LDFLAGS) -o $@
+ 
+ else
+ 
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

bump libhdhomerun, fix darwin build with upstream changes

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
