### PR TITLE
libsForQt5.bismuth: Fix generated JS

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/0001-esbuild-config.patch
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/0001-esbuild-config.patch
@@ -1,0 +1,13 @@
+diff --git a/src/kwinscript/CMakeLists.txt b/src/kwinscript/CMakeLists.txt
+index 9e2f7054..ed607027 100644
+--- a/src/kwinscript/CMakeLists.txt
++++ b/src/kwinscript/CMakeLists.txt
+@@ -39,7 +39,7 @@ endif()
+ set(ESBUILD_COMMAND
+     "esbuild" "--bundle" "${CMAKE_CURRENT_SOURCE_DIR}/index.ts"
+     "--outfile=${CMAKE_CURRENT_BINARY_DIR}/bismuth/contents/code/index.mjs"
+-    "--format=esm" "--platform=neutral")
++    "--format=esm" "--platform=neutral" "--target=es6")
+ if(USE_NPM)
+   list(PREPEND ESBUILD_COMMAND "npx")
+ endif()

--- a/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/default.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/default.nix
@@ -21,6 +21,10 @@ mkDerivation rec {
     sha256 = "sha256-c13OFEw6E/I8j/mqeLnuc9Chi6pc3+AgwAMPpCzh974=";
   };
 
+  patches = [
+    ./0001-esbuild-config.patch
+  ];
+
   cmakeFlags = [
     "-DUSE_TSC=OFF"
     "-DUSE_NPM=OFF"


### PR DESCRIPTION
## Description of changes

After upgrading to release-23.11 nixpkgs branch, I found that the kwin addin "Bismuth" was failing to be loaded by kwin and would result in this error:
```
kwin_scripting: Component failed to load:  (file:///run/current-system/sw/share/kwin/scripts/bismuth/contents/ui/main.qml:5:1: Script file:///run/current-system/sw/share/kwin/scripts/bismuth/contents/code/index.mjs unavailable
    import "../code/index.mjs" as Bismuth
    ^, file:///run/current-system/sw/share/kwin/scripts/bismuth/contents/code/index.mjs:795:10: Unexpected token `{'
      static {
             ^, file:///run/current-system/sw/share/kwin/scripts/bismuth/contents/code/index.mjs:796:9: Expected token `('
        this.id = "MonocleLayout";
            ^)
```

Bismuth itself wasn't changed (still 3.1.4), so I bisect'd nixpkgs and found that this regressed in https://github.com/NixOS/nixpkgs/pull/238674.  esbuild added "Static fields with assign semantics now use static blocks if possible" in 0.18.5 (https://github.com/evanw/esbuild/blob/v0.18.5/CHANGELOG.md), which causes generation of JavaScript code that is incompatible with KWin's JavaScript engine (QtScript).  A non-nixpkgs build of Bismuth wouldn't be affected by this because it is pinned to esbuild 0.14.1 (https://github.com/Bismuth-Forge/bismuth/blob/ef69afe69f615149ab347e4402862ee900452a65/package.json#L9), but nixpkgs configures Bismuth with "-DUSE_NPM=OFF" (https://github.com/NixOS/nixpkgs/blob/3820cc90caa77cb888e6f1b0f62eb7a788de644a/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/default.nix#L26) and uses its native esbuild instead.

This change patches the build of Bismuth to use esbuild's `--target` option to generate code compatible with KWin, retaining the esbuild upgrade and the use of native nixpkgs built tooling, but targeting a lower JavaScript level that is compatible with KWin.

Please backport to 23.11 to fix this functional regression.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
