### PR TITLE
nimPackages.wcwidth: init at 0.1.3

### DIFF
--- a/pkgs/development/nim-packages/wcwidth/default.nix
+++ b/pkgs/development/nim-packages/wcwidth/default.nix
@@ -1,0 +1,20 @@
+{ lib, pkgs, buildNimPackage, fetchFromGitHub }:
+
+buildNimPackage (finalAttrs: {
+  pname = "wcwidth";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "shoyu777";
+    repo = "wcwidth-nim";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-VuLaocfWV4/96+xiNr1US6f8UFySfidrqq8zuTD1aRk=";
+  };
+
+  meta = finalAttrs.src.meta // (with lib; {
+    description = "Implementation of wcwidth with Nim";
+    homepage = "https://github.com/shoyu777/wcwidth-nim";
+    license = licenses.mit;
+    maintainers = [ maintainers.joachimschmidt557 ];
+  });
+})

--- a/pkgs/top-level/nim-packages.nix
+++ b/pkgs/top-level/nim-packages.nix
@@ -143,6 +143,8 @@ lib.makeScope newScope (self:
 
     vmath = callPackage ../development/nim-packages/vmath { };
 
+    wcwidth = callPackage ../development/nim-packages/wcwidth { };
+
     ws = callPackage ../development/nim-packages/ws { };
 
     x11 = callPackage ../development/nim-packages/x11 { };


### PR DESCRIPTION
## Description of changes

This PR adds the `wcwidth` nim package. It is a dependency for the [new version](https://github.com/joachimschmidt557/nimmm/releases/tag/v0.3.0) of [nimmm](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/file-managers/nimmm/default.nix).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
