### PR TITLE
swayfx: wrap like sway

### DIFF
--- a/pkgs/applications/window-managers/sway/fx.nix
+++ b/pkgs/applications/window-managers/sway/fx.nix
@@ -27,9 +27,10 @@ sway-unwrapped.overrideAttrs (oldAttrs: rec {
   meta = with lib; {
     description = "Sway, but with eye candy!";
     homepage = "https://github.com/WillPower3309/swayfx";
-    maintainers = with maintainers; [ ricarch97 ];
     license = licenses.mit;
+    maintainers = with maintainers; [ ricarch97 ];
     platforms = platforms.linux;
+    mainProgram = "swayfx";
 
     longDescription = ''
       Fork of Sway, an incredible and one of the most well established Wayland

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -1,5 +1,4 @@
 { lib
-, sway-unwrapped
 , makeWrapper, symlinkJoin, writeShellScriptBin
 , withBaseWrapper ? true, extraSessionCommands ? "", dbus
 , withGtkWrapper ? false, wrapGAppsHook, gdk-pixbuf, glib, gtk3
@@ -10,6 +9,8 @@
 , enableXWayland ? true
 , dbusSupport ? true
 }:
+
+sway-unwrapped:
 
 assert extraSessionCommands != "" -> withBaseWrapper;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32647,10 +32647,11 @@ with pkgs;
     wlroots_0_16
     wlroots;
 
+  wrapSway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   sway-unwrapped = callPackage ../applications/window-managers/sway {
     wlroots = wlroots_0_16;
   };
-  sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
+  sway = wrapSway sway-unwrapped;
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
@@ -32661,7 +32662,8 @@ with pkgs;
 
   swaycons = callPackage ../applications/window-managers/sway/swaycons.nix { };
 
-  swayfx = callPackage ../applications/window-managers/sway/fx.nix { };
+  swayfx-unwrapped = callPackage ../applications/window-managers/sway/fx.nix { };
+  swayfx = wrapSway swayfx-unwrapped;
 
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };
 


### PR DESCRIPTION
## Description of changes
The current implementation of swayfx is unwrapped, we should wrap it like we wrap swayfx for consistency.

Simpler alternative to:
- #234243
Has fallen out of date. Arguments don't need to be added to the `fx.nix` derivation since https://github.com/NixOS/nixpkgs/pull/237044/commits/898559e730be1fc6a10d0e720b88a13fa940ea60 and it's missing `meta.mainProgram` which is now required by the wrapper.

Fixes WillPower3309/swayfx#161

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@name-snrl @rafaelsgirao