### PR TITLE
qt6.qtbase: derive plugin load path from PATH

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -59,6 +59,7 @@ let
           ./patches/0009-qtbase-allow-translations-outside-prefix.patch
           ./patches/0010-qtbase-find-qmlimportscanner-in-macdeployqt-via-envi.patch
           ./patches/0011-qtbase-check-in-the-QML-folder-of-this-library-does-.patch
+          ./patches/0012-qtbase-derive-plugin-load-path-from-PATH.patch
         ];
       };
       env = callPackage ./qt-env.nix { };

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -11,11 +11,9 @@
 , lndir
 , perl
 , pkg-config
-, python3
 , which
 , cmake
 , ninja
-, ccache
 , xmlstarlet
 , libproxy
 , xorg
@@ -236,10 +234,13 @@ stdenv.mkDerivation rec {
     "-DQT_FEATURE_cxx17_filesystem=OFF"
   ] ++ lib.optional (qttranslations != null) "-DINSTALL_TRANSLATIONSDIR=${qttranslations}/translations";
 
-  NIX_LDFLAGS = toString (lib.optionals stdenv.isDarwin [
-    # Undefined symbols for architecture arm64: "___gss_c_nt_hostbased_service_oid_desc"
-    "-framework GSS"
-  ]);
+  env = {
+    NIX_CFLAGS_COMPILE = "-DNIXPKGS_QT_PLUGIN_PREFIX=\"${qtPluginPrefix}\"";
+    NIX_LDFLAGS = toString (lib.optionals stdenv.isDarwin [
+      # Undefined symbols for architecture arm64: "___gss_c_nt_hostbased_service_oid_desc"
+      "-framework GSS"
+    ]);
+  };
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/qt-6/patches/0012-qtbase-derive-plugin-load-path-from-PATH.patch
+++ b/pkgs/development/libraries/qt-6/patches/0012-qtbase-derive-plugin-load-path-from-PATH.patch
@@ -1,0 +1,33 @@
+From 989697dc8cdcefca1abecfec1316fdce7dc3bf10 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <me@pbb.lc>
+Date: Sun, 10 May 2020 12:47:28 +0200
+Subject: [PATCH 12/12] qtbase: derive plugin load path from PATH
+
+---
+ src/corelib/kernel/qcoreapplication.cpp | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index cf773a2328e..44f539390fb 100644
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
+@@ -2988,6 +2988,16 @@ QStringList QCoreApplication::libraryPathsLocked()
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+ 
++        // Add library paths derived from PATH
++        const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(QStringLiteral(":"));
++        const QString plugindir = QStringLiteral("../" NIXPKGS_QT_PLUGIN_PREFIX);
++        for (const QString &path: paths) {
++            if (!path.isEmpty()) {
++                app_libpaths->append(QDir::cleanPath(path + QDir::separator() + plugindir));
++            }
++        }
++
++
+         auto setPathsFromEnv = [&](QString libPathEnv) {
+             if (!libPathEnv.isEmpty()) {
+                 QStringList paths = libPathEnv.split(QDir::listSeparator(), Qt::SkipEmptyParts);
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/270028
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
