### PR TITLE
python311Packages.tldextract: 5.1.0 -> 5.1.1

### DIFF
--- a/pkgs/development/python-modules/tldextract/default.nix
+++ b/pkgs/development/python-modules/tldextract/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "tldextract";
-  version = "5.1.0";
+  version = "5.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "john-kurkowski";
     repo = "tldextract";
     rev = "refs/tags/${version}";
-    hash = "sha256-x5SJcbTUrqG7mMUPXIhR1rEu3PZ+VA00dFYeoGnX5l0=";
+    hash = "sha256-/VBbU8FuB8MEuX6MgGO44+gfqVjl1aHHDHncHY2Jo38=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/warcio/default.nix
+++ b/pkgs/development/python-modules/warcio/default.nix
@@ -50,6 +50,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Streaming WARC/ARC library for fast web archive IO";
     homepage = "https://github.com/webrecorder/warcio";
+    changelog = "https://github.com/webrecorder/warcio/blob/master/CHANGELIST.rst";
     license = licenses.asl20;
     maintainers = with maintainers; [ Luflosi ];
   };

--- a/pkgs/development/python-modules/warcio/default.nix
+++ b/pkgs/development/python-modules/warcio/default.nix
@@ -9,11 +9,15 @@
 , requests
 , wsgiprox
 , multidict
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "warcio";
   version = "1.7.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "webrecorder";

--- a/pkgs/development/python-modules/warcio/default.nix
+++ b/pkgs/development/python-modules/warcio/default.nix
@@ -2,14 +2,14 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
-, six
-, setuptools
-, pytestCheckHook
 , httpbin
-, requests
-, wsgiprox
 , multidict
+, pytestCheckHook
 , pythonOlder
+, requests
+, setuptools
+, six
+, wsgiprox
 }:
 
 buildPythonPackage rec {
@@ -40,16 +40,20 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     httpbin
+    multidict # Optional. Without this, one test in test/test_utils.py is skipped.
+    pytestCheckHook
     requests
     wsgiprox
-    multidict # Optional. Without this, one test in test/test_utils.py is skipped.
   ];
 
-  pytestFlagsArray = [ "--offline" ];
+  pytestFlagsArray = [
+    "--offline"
+  ];
 
-  pythonImportsCheck = [ "warcio" ];
+  pythonImportsCheck = [
+    "warcio"
+  ];
 
   meta = with lib; {
     description = "Streaming WARC/ARC library for fast web archive IO";

--- a/pkgs/development/python-modules/warcio/default.nix
+++ b/pkgs/development/python-modules/warcio/default.nix
@@ -28,6 +28,7 @@ buildPythonPackage rec {
 
   patches = [
     (fetchpatch {
+      # Add offline mode to skip tests that require an internet connection, https://github.com/webrecorder/warcio/pull/135
       name = "add-offline-option.patch";
       url = "https://github.com/webrecorder/warcio/pull/135/commits/2546fe457c57ab0b391764a4ce419656458d9d07.patch";
       hash = "sha256-3izm9LvAeOFixiIUUqmd5flZIxH92+NxL7jeu35aObQ=";
@@ -49,6 +50,11 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "--offline"
+  ];
+
+  disabledTests = [
+    # Tests require network access, see above
+    "test_get_cache_to_file"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
Diff: https://github.com/john-kurkowski/tldextract/compare/refs/tags/5.1.0...5.1.1

Changelog: https://github.com/john-kurkowski/tldextract/blob/5.1.1/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
