### PR TITLE
nixos: postpone optionsDocBook deprecation one release cycle

### DIFF
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -157,19 +157,24 @@ in rec {
       echo "file json-br $dst/options.json.br" >> $out/nix-support/hydra-build-products
     '';
 
-  optionsDocBook = lib.warn "optionsDocBook is deprecated since 23.11 and will be removed in 24.05"
-    (pkgs.runCommand "options-docbook.xml" {
-      nativeBuildInputs = [
-        pkgs.nixos-render-docs
-      ];
-    } ''
-      nixos-render-docs -j $NIX_BUILD_CORES options docbook \
-        --manpage-urls ${pkgs.path + "/doc/manpage-urls.json"} \
-        --revision ${lib.escapeShellArg revision} \
-        --document-type ${lib.escapeShellArg documentType} \
-        --varlist-id ${lib.escapeShellArg variablelistId} \
-        --id-prefix ${lib.escapeShellArg optionIdPrefix} \
-        ${optionsJSON}/share/doc/nixos/options.json \
-        "$out"
-    '');
+  optionsDocBook =
+    let
+      odxml = (pkgs.runCommand "options-docbook.xml" {
+        nativeBuildInputs = [
+          pkgs.nixos-render-docs
+        ];
+      } ''
+        nixos-render-docs -j $NIX_BUILD_CORES options docbook \
+          --manpage-urls ${pkgs.path + "/doc/manpage-urls.json"} \
+          --revision ${lib.escapeShellArg revision} \
+          --document-type ${lib.escapeShellArg documentType} \
+          --varlist-id ${lib.escapeShellArg variablelistId} \
+          --id-prefix ${lib.escapeShellArg optionIdPrefix} \
+          ${optionsJSON}/share/doc/nixos/options.json \
+          "$out"
+      '');
+    in
+      if lib.versionAtLeast lib.trivial.release "24.05"
+      then lib.warn "optionsDocBook is deprecated since 24.05 and will be removed in 24.11" odxml
+      else odxml;
 }


### PR DESCRIPTION
## Description of changes

* home-manager still depends on it, see
  https://github.com/nix-community/home-manager/issues/4273.
* The deprecation warning should (ideally) be targeting developers, but
  currently all home-manager users get it. (It's not nice to show
  warnings to users that aren't in a position to do something about it.)
* With this patch, the warning keeps beeing emitted on nixpkgs-unstable,
  but silenced for NixOS 24.11.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
