### PR TITLE
mmdebstrap: init at 1.4.0

### DIFF
--- a/nixos/modules/programs/apt.nix
+++ b/nixos/modules/programs/apt.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.apt;
+in
+
+{
+  meta.maintainers = [ maintainers.MakiseKurisu ];
+
+  ###### interface
+  options.programs.apt = {
+    enable = mkEnableOption (mdDoc ''
+      Whether to enable {command}`apt`, the package manager for Debian-based systems.
+
+      Please be aware that this option **DOES NOT** enable {command}`apt` as a
+      package manager on NixOS. It is mainly to allow programs to use {command}`apt`
+      to work on Debian-based root file systems.
+    '');
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.apt;
+      defaultText = literalExpression "pkgs.apt";
+      description = mdDoc ''
+        {command}`apt` package to use.
+      '';
+    };
+
+    keyringPackages = mkOption {
+      type = with types; listOf package;
+      default = with pkgs; [
+          debian-archive-keyring
+      ];
+      defaultText = literalExpression ''
+        with pkgs; [
+          debian-archive-keyring
+        ];
+      '';
+      description = mdDoc ''
+        Archive keyring packages for {command}`apt`.
+
+        Packages specified here will have its `/etc/apt/trusted.gpg.d` content symbolic
+        linked in the rootfs, so {command}`apt` could use them to verify the archive
+        content.
+      '';
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    users.users._apt = {
+      isSystemUser = true;
+      group = "nogroup";
+    };
+    environment.etc =
+      let
+        trusted = pkgs: map (p: "${getBin p}/etc/apt/trusted.gpg.d") pkgs;
+        buildEtc = p: attrsets.concatMapAttrs (n: v: {
+          "apt/trusted.gpg.d/${n}" = {
+            source = "${p}/${n}";
+          };
+        }) (builtins.readDir p);
+        buildEtcForEach = t: map buildEtc t;
+        keyrings = pkgs: attrsets.mergeAttrsList (buildEtcForEach (trusted pkgs));
+      in
+      keyrings cfg.keyringPackages;
+  };
+}

--- a/pkgs/by-name/ap/apt/dont-install-outside.patch
+++ b/pkgs/by-name/ap/apt/dont-install-outside.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 62182cddf..024a0e0bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -262,16 +262,3 @@ if(TARGET update-po AND TARGET update-po4a)
+ add_dependencies(update-po update-po4a)
+ endif()
+ 
+-# Create our directories.
+-install_empty_directories(
+-  ${CONF_DIR}/apt.conf.d
+-  ${CONF_DIR}/auth.conf.d
+-  ${CONF_DIR}/preferences.d
+-  ${CONF_DIR}/sources.list.d
+-  ${CONF_DIR}/trusted.gpg.d
+-  ${CACHE_DIR}/archives/partial
+-  ${STATE_DIR}/lists/partial
+-  ${STATE_DIR}/mirrors/partial
+-  ${STATE_DIR}/periodic
+-  ${LOG_DIR}
+-)

--- a/pkgs/by-name/ap/apt/package.nix
+++ b/pkgs/by-name/ap/apt/package.nix
@@ -77,7 +77,17 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
   ];
 
+  patches = [
+    # We must specify the config and state dir outside of Nix store to be
+    # writable by apt. However, this has the side effect of CMake trying to create
+    # folder structure during install phase in those places.
+    ./dont-install-outside.patch
+  ];
+
   cmakeFlags = [
+    # apt cannot work when those 2 are set to Nix's readonly store
+    (lib.cmakeOptionType "filepath" "CMAKE_INSTALL_SYSCONFDIR" "/etc")
+    (lib.cmakeOptionType "filepath" "CMAKE_INSTALL_LOCALSTATEDIR" "/var")
     (lib.cmakeOptionType "filepath" "BERKELEY_INCLUDE_DIRS" "${lib.getDev db}/include")
     (lib.cmakeOptionType "filepath" "DOCBOOK_XSL""${docbook_xsl}/share/xml/docbook-xsl")
     (lib.cmakeOptionType "filepath" "GNUTLS_INCLUDE_DIR" "${lib.getDev gnutls}/include")

--- a/pkgs/by-name/ap/apt/package.nix
+++ b/pkgs/by-name/ap/apt/package.nix
@@ -1,4 +1,5 @@
 { lib
+, config
 , stdenv
 , fetchurl
 , bzip2
@@ -30,6 +31,7 @@
 , zstd
 , withDocs ? true
 , withNLS ? true
+, nixStoreDir ? config.nix.storeDir or builtins.storeDir
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -88,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # apt-key is a shell script, as such, we need to specify its dependencies,
     # since $PATH could be controlled by other packages
-    patsh -f $out/bin/apt-key -s ${builtins.storeDir}
+    patsh -f $out/bin/apt-key -s ${nixStoreDir}
   '';
 
   patches = [

--- a/pkgs/by-name/ap/apt/package.nix
+++ b/pkgs/by-name/ap/apt/package.nix
@@ -19,6 +19,7 @@
 , libxslt
 , lz4
 , p11-kit
+, patsh
 , perlPackages
 , pkg-config
 , triehash
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     gtest
     (lib.getBin libxslt)
+    patsh
     pkg-config
     triehash
   ];
@@ -83,6 +85,10 @@ stdenv.mkDerivation (finalAttrs: {
     # the following error:
     # E: Unable to determine a suitable packaging system type
     ln -s ${lib.getBin dpkg}/bin/dpkg $out/bin/dpkg
+
+    # apt-key is a shell script, as such, we need to specify its dependencies,
+    # since $PATH could be controlled by other packages
+    patsh -f $out/bin/apt-key -s ${builtins.storeDir}
   '';
 
   patches = [

--- a/pkgs/by-name/ap/apt/package.nix
+++ b/pkgs/by-name/ap/apt/package.nix
@@ -77,6 +77,14 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
   ];
 
+  postInstall = ''
+    # apt assumes dpkg is installed under the same $BIN_DIR folder on a Debian
+    # system (among a few other things), otherwise it will refuse to run with
+    # the following error:
+    # E: Unable to determine a suitable packaging system type
+    ln -s ${lib.getBin dpkg}/bin/dpkg $out/bin/dpkg
+  '';
+
   patches = [
     # We must specify the config and state dir outside of Nix store to be
     # writable by apt. However, this has the side effect of CMake trying to create

--- a/pkgs/by-name/de/debian-archive-keyring/package.nix
+++ b/pkgs/by-name/de/debian-archive-keyring/package.nix
@@ -1,12 +1,12 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitLab
 , gnupg
 , jetring
 , debian-archive-keyring
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "debian-archive-keyring";
   version = "2023.4";
 

--- a/pkgs/by-name/de/debian-archive-keyring/package.nix
+++ b/pkgs/by-name/de/debian-archive-keyring/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, gnupg
+, jetring
+, debian-archive-keyring
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "debian-archive-keyring";
+  version = "2023.4";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "release-team";
+    repo = "${finalAttrs.pname}";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-RjHC4AJ0xyVmELVjX/WBmZYsKWFqcg8F5j+9+18jwj4=";
+  };
+
+  nativeBuildInputs = [
+    gnupg
+    jetring
+  ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  meta = {
+    homepage = "https://packages.debian.org/sid/debian-archive-keyring";
+    description = "GnuPG archive keys of the Debian archive";
+    license = with lib.licenses; [ publicDomain ];
+    maintainers = with lib.maintainers; [ MakiseKurisu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/de/debian-archive-keyring/package.nix
+++ b/pkgs/by-name/de/debian-archive-keyring/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "release-team";
-    repo = "${finalAttrs.pname}";
+    repo = "debian-archive-keyring";
     rev = "${finalAttrs.version}";
     hash = "sha256-RjHC4AJ0xyVmELVjX/WBmZYsKWFqcg8F5j+9+18jwj4=";
   };

--- a/pkgs/by-name/je/jetring/package.nix
+++ b/pkgs/by-name/je/jetring/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "debian";
-    repo = "${finalAttrs.pname}";
+    repo = "jetring";
     rev = "debian/${finalAttrs.version}";
     hash = "sha256-IXm0N5HAzm+o5ipULYQQo+VmQ9MbIrwZ+xRD9O6q43A=";
   };

--- a/pkgs/by-name/je/jetring/package.nix
+++ b/pkgs/by-name/je/jetring/package.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitLab
+, installShellFiles
 , gnupg
 , perl
 , jetring
@@ -17,6 +18,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     rev = "debian/${finalAttrs.version}";
     hash = "sha256-IXm0N5HAzm+o5ipULYQQo+VmQ9MbIrwZ+xRD9O6q43A=";
   };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   buildInputs = [
     gnupg
@@ -35,9 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mkdir -p $out/bin/
     mv "''${PROGS[@]}" $out/bin/
 
-    mkdir -p $out/man/man{1,7}
-    mv *.1 $out/man/man1
-    mv *.7 $out/man/man7
+    installManPage *.1 *.7
 
     runHook postInstall
   '';

--- a/pkgs/by-name/je/jetring/package.nix
+++ b/pkgs/by-name/je/jetring/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, gnupg
+, perl
+, jetring
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jetring";
+  version = "0.31";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "${finalAttrs.pname}";
+    rev = "debian/${finalAttrs.version}";
+    hash = "sha256-IXm0N5HAzm+o5ipULYQQo+VmQ9MbIrwZ+xRD9O6q43A=";
+  };
+
+  buildInputs = [
+    gnupg
+    perl
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PROGS=(jetring-accept jetring-apply jetring-build jetring-diff
+      jetring-explode jetring-gen jetring-review jetring-signindex
+      jetring-checksum)
+
+    mkdir -p $out/bin/
+    mv "''${PROGS[@]}" $out/bin/
+
+    mkdir -p $out/man/man{1,7}
+    mv *.1 $out/man/man1
+    mv *.7 $out/man/man7
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://packages.debian.org/sid/jetring";
+    description = "gpg keyring maintenance using changesets";
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ MakiseKurisu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/je/jetring/package.nix
+++ b/pkgs/by-name/je/jetring/package.nix
@@ -1,12 +1,12 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitLab
 , gnupg
 , perl
 , jetring
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jetring";
   version = "0.31";
 

--- a/pkgs/by-name/mm/mmdebstrap/package.nix
+++ b/pkgs/by-name/mm/mmdebstrap/package.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitea
 
 , glibc
@@ -23,7 +23,7 @@
 , mmdebstrap
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mmdebstrap";
   version = "1.4.0";
 

--- a/pkgs/by-name/mm/mmdebstrap/package.nix
+++ b/pkgs/by-name/mm/mmdebstrap/package.nix
@@ -1,0 +1,126 @@
+{ lib
+, stdenv
+, fetchFromGitea
+
+, glibc
+, help2man
+, makeWrapper
+, patsh
+
+, apt
+, coreutils
+, dpkg
+, fakechroot
+, fakeroot
+, findutils
+, gnupg
+, gnutar
+, perl
+, python3
+, shadow
+, util-linux
+
+, mmdebstrap
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mmdebstrap";
+  version = "1.4.0";
+
+  src = fetchFromGitea {
+    domain = "gitlab.mister-muffin.de";
+    owner = "josch";
+    repo = "mmdebstrap";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-ulW+zCYVMqi6wzqPYYlTsKZqgW9DmClTFJdEMRY4yiI=";
+  };
+
+  nativeBuildInputs = [
+    glibc
+    help2man
+    makeWrapper
+    patsh
+  ];
+
+  buildInputs = [
+    perl
+    python3
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    patchShebangs ./tarfilter
+    patsh -f ./mmdebstrap-autopkgtest-build-qemu -s ${builtins.storeDir}
+
+    pod2man ./mmdebstrap > ./mmdebstrap.1
+    pod2man ./mmdebstrap-autopkgtest-build-qemu > ./mmdebstrap-autopkgtest-build-qemu.1
+    help2man --no-info --name "filter a tarball like dpkg does" --version-string="${finalAttrs.version}" ./tarfilter > ./tarfilter.1
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin/
+    mv mmdebstrap $out/bin/
+    mv mmdebstrap-autopkgtest-build-qemu $out/bin/
+    mv tarfilter $out/bin/mmtarfilter
+
+    mkdir -p $out/man/man1/
+    mv mmdebstrap.1 $out/man/man1/
+    mv mmdebstrap-autopkgtest-build-qemu.1 $out/man/man1/
+    mv tarfilter.1 $out/man/man1/mmtarfilter.1
+
+    mkdir -p $out/lib/apt/solvers/
+    mv proxysolver $out/lib/apt/solvers/mmdebstrap-dump-solution
+
+    mkdir -p $out/share/mmdebstrap
+    mv hooks/ $out/share/mmdebstrap/
+
+    mkdir -p $out/share/doc/mmdebstrap/
+    mv examples/ $out/share/doc/mmdebstrap/
+
+    mkdir -p $out/share/libexec/mmdebstrap/
+    mv gpgvnoexpkeysig $out/share/libexec/mmdebstrap/
+    mv ldconfig.fakechroot $out/share/libexec/mmdebstrap/
+
+    wrapProgram $out/bin/mmdebstrap \
+      --suffix PERL5LIB : $out/include \
+      --set PATH ${lib.makeBinPath [
+        "$out" apt coreutils dpkg fakechroot fakeroot
+               findutils gnupg gnutar shadow util-linux
+      ]}
+
+    headers=(
+      syscall.h sys/syscall.h asm/unistd.h asm/unistd_32.h asm/unistd_64.h bits/wordsize.h bits/syscall.h
+      sys/ioctl.h features.h features-time64.h bits/timesize.h stdc-predef.h sys/cdefs.h bits/long-double.h
+      gnu/stubs.h gnu/stubs-64.h bits/ioctls.h asm/ioctls.h asm-generic/ioctls.h linux/ioctl.h asm/ioctl.h
+      asm-generic/ioctl.h bits/ioctl-types.h sys/ttydefaults.h
+    )
+    for h in "''${headers[@]}"
+    do
+      h2ph -d $out ${glibc.dev}/include/$h
+      mkdir -p $out/include/$(dirname $h)
+      mv $out${glibc.dev}/include/''${h%.h}.ph $out/include/$(dirname $h)
+    done
+    mv $out/_h2ph_pre.ph $out/include/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    changelog = "https://gitlab.mister-muffin.de/josch/mmdebstrap/src/tag/${finalAttrs.version}/CHANGELOG.md";
+    description = "An alternative to debootstrap which uses apt internally";
+    homepage = "https://gitlab.mister-muffin.de/josch/mmdebstrap";
+    # The source repo does not contain a LICENSE file.
+    # However, the author is part of the Debian team, and the MIT license is
+    # included in the Debian packaging repo for all source files:
+    # https://salsa.debian.org/debian/mmdebstrap/-/blob/master/debian/copyright
+    license = licenses.mit;
+    maintainers = with maintainers; [ MakiseKurisu ];
+    mainProgram = "mmdebstrap";
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/by-name/mm/mmdebstrap/package.nix
+++ b/pkgs/by-name/mm/mmdebstrap/package.nix
@@ -114,11 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.mister-muffin.de/josch/mmdebstrap/src/tag/${finalAttrs.version}/CHANGELOG.md";
     description = "An alternative to debootstrap which uses apt internally";
     homepage = "https://gitlab.mister-muffin.de/josch/mmdebstrap";
-    # The source repo does not contain a LICENSE file.
-    # However, the author is part of the Debian team, and the MIT license is
-    # included in the Debian packaging repo for all source files:
-    # https://salsa.debian.org/debian/mmdebstrap/-/blob/master/debian/copyright
-    license = licenses.mit;
+    license = with lib.licenses; [ mit publicDomain ];
     maintainers = with maintainers; [ MakiseKurisu ];
     mainProgram = "mmdebstrap";
     platforms = platforms.linux;

--- a/pkgs/by-name/mm/mmdebstrap/package.nix
+++ b/pkgs/by-name/mm/mmdebstrap/package.nix
@@ -4,6 +4,7 @@
 
 , glibc
 , help2man
+, installShellFiles
 , makeWrapper
 , patsh
 
@@ -38,6 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     glibc
     help2man
+    installShellFiles
     makeWrapper
     patsh
   ];
@@ -68,10 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mv mmdebstrap-autopkgtest-build-qemu $out/bin/
     mv tarfilter $out/bin/mmtarfilter
 
-    mkdir -p $out/man/man1/
-    mv mmdebstrap.1 $out/man/man1/
-    mv mmdebstrap-autopkgtest-build-qemu.1 $out/man/man1/
-    mv tarfilter.1 $out/man/man1/mmtarfilter.1
+    installManPage *.1
 
     mkdir -p $out/lib/apt/solvers/
     mv proxysolver $out/lib/apt/solvers/mmdebstrap-dump-solution

--- a/pkgs/by-name/mm/mmdebstrap/package.nix
+++ b/pkgs/by-name/mm/mmdebstrap/package.nix
@@ -103,9 +103,10 @@ stdenv.mkDerivation (finalAttrs: {
     do
       h2ph -d $out ${glibc.dev}/include/$h
       mkdir -p $out/include/$(dirname $h)
-      mv $out${glibc.dev}/include/''${h%.h}.ph $out/include/$(dirname $h)
+      mv $out/${glibc.dev}/include/''${h%.h}.ph $out/include/$(dirname $h)
     done
     mv $out/_h2ph_pre.ph $out/include/
+    rm -rf $out/${glibc.dev}
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

This PR adds `mmdebstrap`, an alternative to `debootstrap`, well, not quite.

Turned out, nobody actually uses `apt` on NixOS! How do you guys install packages then🤔 As a result, it is utterly broken in the current state, which is unfortunately, since `mmdebstrap` use it to resolve dependencies. Today is the time to give our legacy distro some love.

---

The first 3 commits fix existing implementation of `apt` package, so the key executables (`apt-get` and `apt-key`) can be properly used by other packages as `buildInputs`.

However, to actually use apt archives, you need to have the correct keyring that signed its content. The next 2 commits introduce a new package `debian-archive-keyring` and its build dependency `jetring`.

The end user's system still needs some additional configuration to make the keyring discoverable by `apt`. It also expects some default config folders to exist, otherwise it will generate some noise. Since those lives in `/etc`, a NixOS module is introduced in the next commit. The module allows us to support future keyring package easily, for example, one for Ubuntu.

Finally, the last commit introduces `mmdebstrap`.

---

Below are recording of me testing `apt` and `mmdebstrap`:

- `apt`: https://asciinema.org/a/78fzbseZx8McWTNkJ5pqO6Fi0
- `mmdebstrap`: https://asciinema.org/a/O7lwnKPeGxroHzCT2HKWKy4vK

Note: in the above recording, the rootless mode of `mmdebstrap` failed due to mismatched glibc version. I think this is due to my running system is (mostly) based on 23.05 but the master is on a different glibc. I could retest this when 23.11 is released. The root mode run fine, so I am not too worried about the rootless mode for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
