### PR TITLE
osquery: Apply unreleased upstream patch to build using Clang 16

### DIFF
--- a/pkgs/tools/system/osquery/Use-locale.h-instead-of-removed-xlocale.h-header.patch
+++ b/pkgs/tools/system/osquery/Use-locale.h-instead-of-removed-xlocale.h-header.patch
@@ -1,15 +1,21 @@
-From: Jack Baldry <jack.baldry@grafana.com>
-Date: Tue, 15 Nov 2022 14:34:33 -0400
-Subject: [PATCH] Use locale.h instead of removed xlocale.h header
-
-https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27
-
-Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
----
- libraries/cmake/source/augeas/gnulib/generated/linux/x86_64/lib/locale.h  | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
+diff --git a/libraries/cmake/source/augeas/gnulib/generated/linux/aarch64/lib/locale.h b/libraries/cmake/source/augeas/gnulib/generated/linux/aarch64/lib/locale.h
+index 4f9baece2..afe947956 100644
+--- a/libraries/cmake/source/augeas/gnulib/generated/linux/aarch64/lib/locale.h
++++ b/libraries/cmake/source/augeas/gnulib/generated/linux/aarch64/lib/locale.h
+@@ -48,9 +48,9 @@
+ /* NetBSD 5.0 mis-defines NULL.  */
+ #include <stddef.h>
+ 
+-/* Mac OS X 10.5 defines the locale_t type in <xlocale.h>.  */
++/* Mac OS X 10.5 defines the locale_t type in <locale.h>.  */
+ #if 1
+-# include <xlocale.h>
++# include <locale.h>
+ #endif
+ 
+ /* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
 diff --git a/libraries/cmake/source/augeas/gnulib/generated/linux/x86_64/lib/locale.h b/libraries/cmake/source/augeas/gnulib/generated/linux/x86_64/lib/locale.h
+index 4f9baece2..afe947956 100644
 --- a/libraries/cmake/source/augeas/gnulib/generated/linux/x86_64/lib/locale.h
 +++ b/libraries/cmake/source/augeas/gnulib/generated/linux/x86_64/lib/locale.h
 @@ -48,9 +48,9 @@
@@ -24,6 +30,3 @@ diff --git a/libraries/cmake/source/augeas/gnulib/generated/linux/x86_64/lib/loc
  #endif
  
  /* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
--- 
-2.38.1
-

--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -1,6 +1,7 @@
 { lib
 , cmake
 , fetchFromGitHub
+, fetchpatch
 , git
 , llvmPackages
 , nixosTests
@@ -32,6 +33,15 @@ buildStdenv.mkDerivation rec {
     ./Remove-circular-definition-of-AUDIT_FILTER_EXCLUDE.patch
     # For current state of compilation against glibc in the clangWithLLVM toolchain, refer to the upstream issue in https://github.com/osquery/osquery/issues/7823.
     ./Remove-system-controls-table.patch
+
+    # osquery uses a vendored boost library that still relies on old standard types (e.g. `std::unary_function`)
+    # which have been removed as of C++17. The patch is already checked in upstream, but there have been no
+    # releases yet. Can likely be removed with versions > 5.10.2.
+    (fetchpatch {
+      name = "fix-build-on-clang-16.patch";
+      url  = "https://github.com/osquery/osquery/commit/222991a15b4ae0a0fb919e4965603616536e1b0a.patch";
+      hash = "sha256-PdzEoeR1LXVri1Cd+7KMhKmDC8yZhAx3f1+9tjLJKyo=";
+    })
   ];
 
 


### PR DESCRIPTION
osquery uses vendored boost libraries that still rely on old standard types like `std::unary_function` (deprecated since C++11, removed in C++17) which breaks the build with current Clang.

There already is an upstream patch for this  [1], but it hasn't been released yet.
[1]: https://github.com/osquery/osquery/commit/222991a15b4ae0a0fb919e4965603616536e1b0a

## Description of changes

<details>
  <summary>Fetch and apply the unreleased upstream patch during nix builds.</summary>


Fetch and apply the unreleased upstream patch during nix builds. This should be revertible as soon as upstream releases the patch and the new version is packaged.

Hydra build: https://hydra.nixos.org/build/241362794#tabs-details
Hydra log: https://hydra.nixos.org/build/241362794/nixlog/3

Relevant log excerpt:

```
In file included from /build/source/libraries/cmake/source/boost/src/libs/thread/src/pthread/thread.cpp:11:
In file included from /build/source/libraries/cmake/source/boost/src/libs/thread/include/boost/thread/thread_only.hpp:22:
In file included from /build/source/libraries/cmake/source/boost/src/libs/thread/include/boost/thread/detail/thread.hpp:41:
In file included from /build/source/libraries/cmake/source/boost/src/libs/container_hash/include/boost/functional/hash.hpp:6:
/build/source/libraries/cmake/source/boost/src/libs/container_hash/include/boost/container_hash/hash.hpp:131:33: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
        struct hash_base : std::unary_function<T, std::size_t> {};
                           ~~~~~^
/nix/store/wh3jv0niw62xfngky1lhi4sfnjrgyqg6-libcxx-16.0.6-dev/include/c++/v1/__functional/unary_function.h:46:1: note: '__unary_function' declared here
using __unary_function = __unary_function_keep_layout_base<_Arg, _Result>;
^
```
  
</details>

<details>
  <summary>Changed locale.h header patch to also apply to aarch64</summary>

The package already includes a [patch for x86_64](https://github.com/NixOS/nixpkgs/blob/a0393ca30c4a4595ef3afa2bd3cd3e9ce49d182a/pkgs/tools/system/osquery/Use-locale.h-instead-of-removed-xlocale.h-header.patch) that fixes broken builds due to a broken include in a vendored library. The same error also broke the build on aarch64, so I extended the patch to extend to that architecture, too.

Hydra build: https://hydra.nixos.org/build/241365529
Hydra log: https://hydra.nixos.org/build/241365529/nixlog/3

Relevant log excerpt:

```
In file included from /build/source/libraries/cmake/source/augeas/gnulib/src/lib/hard-locale.c:23:
/build/source/libraries/cmake/source/augeas/gnulib/generated/linux/aarch64/lib/locale.h:53:11: fatal error: 'xlocale.h' file not found
# include <xlocale.h>
          ^~~~~~~~~~~
1 error generated.
```
  
</details>

#ZurichZHF

ZHF: https://github.com/NixOS/nixpkgs/issues/265948

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
