### PR TITLE
lib/attrsets: add `genAttrs'`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -651,6 +651,20 @@ rec {
     f:
     listToAttrs (map (n: nameValuePair n (f n)) names);
 
+  /* Generate an attribute set by mapping over a list of items
+     Taking two functions, one to apply for the name and one to
+     apply for the value of the attribute set.
+
+    Example:
+       genAttrs' [ {a = 2; b.c = "a" } {a = 1; b.c = "b"} ]
+          (i: i.b.c) (i: i.a)
+       => { a = 2; b = 1; }
+
+    Type:
+      genAttrs' :: [ a ] -> (a -> String) -> (a -> Any) -> AttrSet
+  */
+  genAttrs' = items: f: g:
+    listToAttrs (map (i: nameValuePair (f i) (g i)) items);
 
   /* Check whether the argument is a derivation. Any set with
      `{ type = "derivation"; }` counts as a derivation.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -785,6 +785,10 @@ runTests {
     };
   };
 
+  testGenAttrs = {
+    expr = attrsets.genAttrs [ "foo" "bar" ] (name: "${name}123");
+    expected = { foo = "foo123"; bar = "bar123"; };
+  };
 
   testMergeAttrsListExample1 = {
     expr = attrsets.mergeAttrsList [ { a = 0; b = 1; } { c = 2; d = 3; } ];

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -789,6 +789,13 @@ runTests {
     expr = attrsets.genAttrs [ "foo" "bar" ] (name: "${name}123");
     expected = { foo = "foo123"; bar = "bar123"; };
   };
+  testGenAttrsPrime = {
+    expr = attrsets.genAttrs' [ { foo = "a"; bar = "b"; } { foo = "c"; bar = "d"; } ] (x: x.foo) (x: "${toString x.foo}${toString x.bar}");
+    expected = {
+      a = "ab";
+      c = "cd";
+    };
+  };
 
   testMergeAttrsListExample1 = {
     expr = attrsets.mergeAttrsList [ { a = 0; b = 1; } { c = 2; d = 3; } ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As wished by @infinisil in #197004 I'm splitting each function into other PRs to merge incrementally.

Main changes from #197004 is that I'm no longer including them in `lib/default.nix` ref: #266103
And I've added types and tests.

I've also added a test for genAttrs, which seemed missing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
