### PR TITLE
codeberg-pages: 4.6.2 -> 5.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "codeberg-pages";
-  version = "4.6.2";
+  version = "5.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "Codeberg";
     repo = "pages-server";
-    rev = "ce241fa40adee2b12f8e225db98e09a45bc2acbb";
-    sha256 = "sha256-mL2Xs7eyldoZK4zrX6WFlFtwdLN0iVyl1Qh8X6b2u9c=";
+    rev = "ea68a82cd22a8a8c1f265260af22b9406f13e3a9";
+    hash = "sha256-TSXRB0oq1CtHC9ooO+Y3ICS5YE+q+ivZAcYBSd1oWi0=";
   };
 
-  vendorHash = "sha256-R/LuZkA2xHmu7SO3BVyK1C6n9U+pYn50kNkyLltn2ng=";
+  vendorHash = "sha256-vTYB3ka34VooN2Wh/Rcj+2S1qAsA2a/VtXlILn1W7oU=";
 
   patches = [ ./disable_httptest.patch ];
 

--- a/pkgs/development/tools/continuous-integration/codeberg-pages/disable_httptest.patch
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/disable_httptest.patch
@@ -1,12 +1,13 @@
 diff --git a/server/handler/handler_test.go b/server/handler/handler_test.go
 deleted file mode 100644
-index 626564a..0000000
+index 6521633..0000000
 --- a/server/handler/handler_test.go
 +++ /dev/null
-@@ -1,49 +0,0 @@
+@@ -1,52 +0,0 @@
 -package handler
 -
 -import (
+-	"net/http"
 -	"net/http/httptest"
 -	"testing"
 -	"time"
@@ -24,13 +25,15 @@ index 626564a..0000000
 -		"https://docs.codeberg.org/pages/raw-content/",
 -		[]string{"/.well-known/acme-challenge/"},
 -		[]string{"raw.codeberg.org", "fonts.codeberg.org", "design.codeberg.org"},
+-		[]string{"pages"},
+-		cache.NewKeyValueCache(),
 -		cache.NewKeyValueCache(),
 -		cache.NewKeyValueCache(),
 -	)
 -
 -	testCase := func(uri string, status int) {
 -		t.Run(uri, func(t *testing.T) {
--			req := httptest.NewRequest("GET", uri, nil)
+-			req := httptest.NewRequest("GET", uri, http.NoBody)
 -			w := httptest.NewRecorder()
 -
 -			log.Printf("Start: %v\n", time.Now())


### PR DESCRIPTION
## Things done

#ZurichZHF

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes]( ) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
