### PR TITLE
libedit: manually define __STDC_ISO_10646__ to fix the build issue against musl

### DIFF
--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -14,6 +14,17 @@ stdenv.mkDerivation rec {
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
   # NROFF = "${groff}/bin/nroff";
 
+  # GCC automatically include `stdc-predefs.h` while Clang does not do
+  # this by default. While Musl is ISO 10646 compliant, doesn't define
+  # __STDC_ISO_10646__. This definition is in `stdc-predefs.h` that's
+  # why libedit builds just fine with GCC and Musl.
+  # There is a DR to fix this issue with Clang which is not merged
+  # yet.
+  # https://reviews.llvm.org/D137043
+  NIX_CFLAGS_COMPILE = lib.optional
+    (stdenv.targetPlatform.isMusl && stdenv.cc.isClang)
+    "-D__STDC_ISO_10646__=201103L";
+
   patches = [ ./01-cygwin.patch ];
 
   propagatedBuildInputs = [ ncurses ];


### PR DESCRIPTION
## Description of changes
Musl is ISO 10646 compliant but doesn't define __STDC_ISO_10646__ we need to do it ourselves. Without this change, the following build will fail.

```nix
pkgsCross.musl64.libedit.override({ stdenv = pkgs.pkgsCross.musl64.llvmPackages_16.libcxxStdenv; })
```
## Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested the following snippet with and without this patch:

```nix
let
    tmpPkgs = import /path/to/nixpkgs {};
    pkgs = import /path/to/nixpkgs {
        crossSystem = tmpPkgs.lib.systems.examples.musl64; 
in tmpPkgs.pkgsCross.musl64.libedit.override({ stdenv = pkgs.pkgsCross.musl64.llvmPackages_16.libcxxStdenv; })
```
