### PR TITLE
sonic-server: fix build with clang 16

### DIFF
--- a/pkgs/servers/search/sonic-server/default.nix
+++ b/pkgs/servers/search/sonic-server/default.nix
@@ -1,6 +1,8 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , nixosTests
 , testers
@@ -18,7 +20,17 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-V97K4KS46DXje4qKA11O9NEm0s13aTUnM+XW8lGc6fo=";
   };
 
-  cargoHash = "sha256-vWAFWoscV0swwrBQoa3glKXMRgdGYa+QrPprlVCP1QM=";
+  cargoPatches = [
+    # Update rocksdb to 0.21 to fix compilation issues against clang 16, see:
+    # https://github.com/valeriansaliou/sonic/issues/315
+    # https://github.com/valeriansaliou/sonic/pull/316
+    (fetchpatch {
+      url = "https://github.com/valeriansaliou/sonic/commit/81d5f1efec21ef8b911ed3303fcbe9ca6335f562.patch";
+      hash = "sha256-nOvHThTc2L3UQRVusUsD/OzbSkhSleZc6n0WyZducHM=";
+    })
+  ];
+
+  cargoHash = "sha256-k+gPCkf8DCnuv/aLXcQwjmsDUu/eqSEqKXlUyj8bRq8=";
 
   # Found argument '--test-threads' which wasn't expected, or isn't valid in this context
   doCheck = false;


### PR DESCRIPTION
## Description of changes

Build of sonic-server is failing since a few weeks: https://hydra.nixos.org/build/239524816

This failing build has been caused by a clang 16 upgrade, because rocksdb depends on a old [rust-bindgen](https://github.com/rust-lang/rust-bindgen) version which is not compatible with this version of clang, see https://github.com/rust-lang/rust-bindgen/issues/2312

* Upstream fix: https://github.com/valeriansaliou/sonic/pull/316
* Upstream issue: https://github.com/valeriansaliou/sonic/issues/315

ZHF: https://github.com/NixOS/nixpkgs/issues/265948



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
