### PR TITLE
nix-output-monitor: 2.0.0.7 -> 2.1.1

### DIFF
--- a/pkgs/tools/nix/nix-output-monitor/generated-package.nix
+++ b/pkgs/tools/nix/nix-output-monitor/generated-package.nix
@@ -1,147 +1,44 @@
 # This file has been autogenerate with cabal2nix.
 # Update via ./update.sh"
-{
-  mkDerivation,
-  ansi-terminal,
-  async,
-  attoparsec,
-  base,
-  bytestring,
-  cassava,
-  containers,
-  data-default,
-  directory,
-  extra,
-  fetchzip,
-  filepath,
-  hermes-json,
-  HUnit,
-  lib,
-  lock-file,
-  MemoTrie,
-  mtl,
-  nix-derivation,
-  optics,
-  random,
-  relude,
-  safe,
-  stm,
-  streamly-core,
-  strict,
-  strict-types,
-  terminal-size,
-  text,
-  time,
-  typed-process,
-  wcwidth,
-  word8,
+{ mkDerivation, ansi-terminal, async, attoparsec, base, bytestring
+, cassava, containers, data-default, directory, extra, fetchzip
+, filepath, hermes-json, HUnit, lib, lock-file, MemoTrie
+, nix-derivation, optics, random, relude, safe, stm, streamly-core
+, strict, strict-types, terminal-size, text, time, transformers
+, typed-process, unix, word8
 }:
 mkDerivation {
   pname = "nix-output-monitor";
-  version = "2.0.0.7";
+  version = "2.1.1";
   src = fetchzip {
-    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v2.0.0.7.tar.gz";
-    sha256 = "1b2c9kfz80rv2r1s7h6iikyq3bn32h1fv2yq65wkhg3in7qg49jp";
+    url = "https://code.maralorn.de/maralorn/nix-output-monitor/archive/v2.1.1.tar.gz";
+    sha256 = "1k1gdx7yczz7xm096i8lk09zq6yw1yj8izx6czymfd4qqwj2y49l";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal
-    async
-    attoparsec
-    base
-    bytestring
-    cassava
-    containers
-    data-default
-    directory
-    extra
-    filepath
-    hermes-json
-    lock-file
-    MemoTrie
-    mtl
-    nix-derivation
-    optics
-    relude
-    safe
-    stm
-    streamly-core
-    strict
-    strict-types
-    terminal-size
-    text
-    time
-    wcwidth
-    word8
+    ansi-terminal async attoparsec base bytestring cassava containers
+    data-default directory extra filepath hermes-json lock-file
+    MemoTrie nix-derivation optics relude safe stm streamly-core strict
+    strict-types terminal-size text time transformers word8
   ];
   executableHaskellDepends = [
-    ansi-terminal
-    async
-    attoparsec
-    base
-    bytestring
-    cassava
-    containers
-    data-default
-    directory
-    extra
-    filepath
-    hermes-json
-    lock-file
-    MemoTrie
-    mtl
-    nix-derivation
-    optics
-    relude
-    safe
-    stm
-    streamly-core
-    strict
-    strict-types
-    terminal-size
-    text
-    time
-    typed-process
-    wcwidth
-    word8
+    ansi-terminal async attoparsec base bytestring cassava containers
+    data-default directory extra filepath hermes-json lock-file
+    MemoTrie nix-derivation optics relude safe stm streamly-core strict
+    strict-types terminal-size text time transformers typed-process
+    unix word8
   ];
   testHaskellDepends = [
-    ansi-terminal
-    async
-    attoparsec
-    base
-    bytestring
-    cassava
-    containers
-    data-default
-    directory
-    extra
-    filepath
-    hermes-json
-    HUnit
-    lock-file
-    MemoTrie
-    mtl
-    nix-derivation
-    optics
-    random
-    relude
-    safe
-    stm
-    streamly-core
-    strict
-    strict-types
-    terminal-size
-    text
-    time
-    typed-process
-    wcwidth
-    word8
+    ansi-terminal async attoparsec base bytestring cassava containers
+    data-default directory extra filepath hermes-json HUnit lock-file
+    MemoTrie nix-derivation optics random relude safe stm streamly-core
+    strict strict-types terminal-size text time transformers
+    typed-process word8
   ];
   homepage = "https://github.com/maralorn/nix-output-monitor";
-  description = "Parses output of nix-build to show additional information";
+  description = "Processes output of Nix commands to show helpful and pretty information";
   license = lib.licenses.agpl3Plus;
   mainProgram = "nom";
-  maintainers = [lib.maintainers.maralorn];
+  maintainers = [ lib.maintainers.maralorn ];
 }

--- a/pkgs/tools/nix/nix-output-monitor/update.sh
+++ b/pkgs/tools/nix/nix-output-monitor/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq alejandra
+#!nix-shell -i bash -p cabal2nix curl jq
 #
 # This script will update the nix-output-monitor derivation to the latest version using
 # cabal2nix.
@@ -12,7 +12,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 derivation_file="${script_dir}/generated-package.nix"
 
 # This is the latest released version of nix-output-monitor on GitHub.
-new_version=$(curl --silent "https://api.github.com/repos/maralorn/nix-output-monitor/releases" | jq '.[0].tag_name' --raw-output)
+new_version=$(curl --silent "https://code.maralorn.de/api/v1/repos/maralorn/nix-output-monitor/releases" | jq '.[0].tag_name' --raw-output)
 
 echo "Updating nix-output-monitor to version $new_version."
 echo "Running cabal2nix and outputting to ${derivation_file}..."
@@ -24,9 +24,7 @@ EOF
 
 cabal2nix \
   --maintainer maralorn \
-  "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/${new_version}.tar.gz" \
+  "https://code.maralorn.de/maralorn/nix-output-monitor/archive/${new_version}.tar.gz" \
   >> "$derivation_file"
-
-alejandra "${derivation_file}" | cat
 
 echo "Finished."


### PR DESCRIPTION
## Description of changes

https://code.maralorn.de/maralorn/nix-output-monitor/releases/tag/v2.1.0

* More consistent table alignment calculation (thanks to @9999years)
  * Alignment issues on WSL, macOS or kitty should be gone now, please report any issues you encounter
  * This changes the icon for waiting builds and downloads to use the pause symbol
* Correct SIGINT/SIGTERM handling (thanks to @picnoir)
* Use bold font in status line
* Significant performance fixes

2.1.1 disables -Werror for release

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
