### PR TITLE
linuxPackages.systemtap: fix cross-build by depending on host Python

### DIFF
--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -17,7 +17,7 @@ let
     inherit version;
     src = fetchgit { inherit url rev sha256; };
     nativeBuildInputs = [ pkg-config cpio python3 python3.pkgs.setuptools ];
-    buildInputs = [ elfutils gettext ];
+    buildInputs = [ elfutils gettext python3 ];
     enableParallelBuilding = true;
     env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ]; # Needed with GCC 12
   };


### PR DESCRIPTION
## Description of changes

`linuxPackages.systemtap` requires host Python libraries to build against:

```
aarch64-unknown-linux-gnu-gcc -I./../includes -I/build/systemtap/python/../includes/sys -fPIC -I/nix/store/3vd81cp5vqy3apdzrdhk23k5n62wl845-python3-aarch64-unknown-linux-gnu-3.11.6/include/python3.11 -c HelperSDT/_HelperSDT.c -o /build/systemtap/python/py3build/temp.linux-aarch64-cpython-311/HelperSDT/_HelperSDT.o
HelperSDT/_HelperSDT.c:152:10: fatal error: python3.11/Python.h: No such file or directory
  152 | #include <python3.11/Python.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
error: command '/nix/store/gwvk9jj6ygnq8b0xnysrd18rb8kc25jj-aarch64-unknown-linux-gnu-gcc-wrapper-12.3.0/bin/aarch64-unknown-linux-gnu-gcc' failed with exit code 1
```

#ZurichZHF (even though this isn't really ZHF-related :p)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
