### PR TITLE
[Backport 23.11] apptainer, singularity: use self-contained LOCALSTATEDIR by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -445,6 +445,10 @@
 
 - A new option was added to the virtualisation module that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.
 
+- Apptainer/Singularity now defaults to using `"$out/var/lib"` for the `LOCALSTATEDIR` configuration option instead of the top-level `"/var/lib"`. This change impacts the `SESSIONDIR` (container-run-time mount point) configuration, which is set to `$LOCALSTATEDIR/<apptainer or singularity>/mnt/session`. This detaches the packages from the top-level directory, rendering the NixOS module optional.
+
+  The default behavior of the NixOS module `programs.singularity` stays unchanged. We add a new option `programs.singularity.enableExternalSysConfDir` (default to `true`) to specify whether to set the top-level `"/var/lib"` as `LOCALSTATEDIR` or not.
+
 - DocBook option documentation is no longer supported, all module documentation now uses markdown.
 
 - `services.outline` can now be configured to use local filesystem storage instead of S3 storage using [services.outline.storage.storageType](#opt-services.outline.storage.storageType).

--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -82,10 +82,6 @@ in
     };
     systemd.tmpfiles.rules = [
       "d /var/lib/${cfg.packageOverriden.projectName}/mnt/session 0770 root root -"
-      "d /var/lib/${cfg.packageOverriden.projectName}/mnt/final 0770 root root -"
-      "d /var/lib/${cfg.packageOverriden.projectName}/mnt/overlay 0770 root root -"
-      "d /var/lib/${cfg.packageOverriden.projectName}/mnt/container 0770 root root -"
-      "d /var/lib/${cfg.packageOverriden.projectName}/mnt/source 0770 root root -"
     ];
   };
 

--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -45,6 +45,18 @@ in
         Use `lib.mkForce` to forcefully specify the overridden package.
       '';
     };
+    enableExternalLocalStateDir = mkOption {
+      type = types.bool;
+      default = true;
+      example = false;
+      description = mdDoc ''
+        Whether to use top-level directories as LOCALSTATEDIR
+        instead of the store path ones.
+        This affects the SESSIONDIR of Apptainer/Singularity.
+        If set to true, the SESSIONDIR will become
+        `/var/lib/''${projectName}/mnt/session`.
+      '';
+    };
     enableFakeroot = mkOption {
       type = types.bool;
       default = true;
@@ -65,7 +77,9 @@ in
 
   config = mkIf cfg.enable {
     programs.singularity.packageOverriden = (cfg.package.override (
-      optionalAttrs cfg.enableFakeroot {
+      optionalAttrs cfg.enableExternalLocalStateDir {
+        externalLocalStateDir = "/var/lib";
+      } // optionalAttrs cfg.enableFakeroot {
         newuidmapPath = "/run/wrappers/bin/newuidmap";
         newgidmapPath = "/run/wrappers/bin/newgidmap";
       } // optionalAttrs cfg.enableSuid {
@@ -80,7 +94,7 @@ in
       group = "root";
       source = "${cfg.packageOverriden}/libexec/${cfg.packageOverriden.projectName}/bin/starter-suid.orig";
     };
-    systemd.tmpfiles.rules = [
+    systemd.tmpfiles.rules = mkIf cfg.enableExternalLocalStateDir [
       "d /var/lib/${cfg.packageOverriden.projectName}/mnt/session 0770 root root -"
     ];
   };

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -71,6 +71,8 @@ in
 , newuidmapPath ? null
   # Path to SUID-ed newgidmap executable
 , newgidmapPath ? null
+  # External LOCALSTATEDIR
+, externalLocalStateDir ? null
   # Remove the symlinks to `singularity*` when projectName != "singularity"
 , removeCompat ? false
   # Workaround #86349
@@ -106,6 +108,7 @@ in
     inherit
       enableSeccomp
       enableSuid
+      externalLocalStateDir
       projectName
       removeCompat
       starterSuidPath
@@ -141,7 +144,7 @@ in
   configureScript = "./mconfig";
 
   configureFlags = [
-    "--localstatedir=/var/lib"
+    "--localstatedir=${if externalLocalStateDir != null then externalLocalStateDir else "${placeholder "out"}/var/lib"}"
     "--runstatedir=/var/run"
   ]
   ++ lib.optional (!enableSeccomp) "--without-seccomp"

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -111,7 +111,7 @@ rec {
             touch .${projectName}.d/env/94-appsbase.sh
 
             cd ..
-            mkdir -p /var/lib/${projectName}/mnt/{container,final,overlay,session,source}
+            mkdir -p /var/lib/${projectName}/mnt/session
             echo "root:x:0:0:System administrator:/root:/bin/sh" > /etc/passwd
             echo > /etc/resolv.conf
             TMPDIR=$(pwd -P) ${projectName} build $out ./img


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This backports #250949.

This PR fixes the #250581 on branch release-23.11. It contains no breaking changes, and the release note entry in the original commit is already inside the 23.11 release note.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
