### PR TITLE
python3Packages.yamlpath: mark as broken

### DIFF
--- a/pkgs/development/tools/yamlpath/default.nix
+++ b/pkgs/development/tools/yamlpath/default.nix
@@ -46,5 +46,6 @@ python3.pkgs.buildPythonApplication rec {
      '';
     license = licenses.isc;
     maintainers = with maintainers; [ Flakebi ];
+    broken = true;
   };
 }

--- a/pkgs/development/tools/yamlpath/default.nix
+++ b/pkgs/development/tools/yamlpath/default.nix
@@ -46,6 +46,9 @@ python3.pkgs.buildPythonApplication rec {
      '';
     license = licenses.isc;
     maintainers = with maintainers; [ Flakebi ];
+
+   # No support for ruamel.yaml > 0.17.21
+   # https://github.com/wwkimball/yamlpath/issues/217
     broken = true;
   };
 }


### PR DESCRIPTION
`yamlpath` depends on `ruamel.yaml` <= 0.17.21 [1], but the packaged version in Nixpkgs is on version 0.17.32 by now. This breaks a lot of the libraries own unit tests.

As I don't see anything in Nixpkgs depending on `yamlpath`, this simply marks the package as broken.

[1]: https://github.com/wwkimball/yamlpath/blob/9bbddea5205147d49e612abb26cf1671a3861256/setup.py#L48

## Description of changes

Mark the package as broken.

#ZurichZHF

ZHF: https://github.com/NixOS/nixpkgs/issues/265948

Hydra build: https://hydra.nixos.org/build/241253815#tabs-summary
Hydra logs: https://hydra.nixos.org/build/241253815/nixlog/1

Various tests fail like this:

```
>           assert result.success, result.stderr
E           AssertionError: Traceback (most recent call last):
E               File "/nix/store/8wmyl8bxwridjxvzy7r7ygn77skm6wrc-python3.11-pytest-console-scripts-1.4.1/lib/python3.11/site-packages/pytest_console_scripts/__init__.py", line 310, in console_script
E                 return s()
E                        ^^^
E               File "/build/source/yamlpath/commands/yaml_merge.py", line 548, in main
E                 exit_state = merge_condense_all(log, mergers, [])
E                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               File "/build/source/yamlpath/commands/yaml_merge.py", line 394, in merge_condense_all
E                 lhs_prime.merge_with(lhs_doc.data)
E               File "/build/source/yamlpath/merger/merger.py", line 865, in merge_with
E                 merge_performed = self._insert_dict(
E                                   ^^^^^^^^^^^^^^^^^^
E               File "/build/source/yamlpath/merger/merger.py", line 657, in _insert_dict
E                 merged_data = self._merge_dicts(lhs, rhs, insert_at)
E                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               File "/build/source/yamlpath/merger/merger.py", line 225, in _merge_dicts
E                 lhs[key].yaml_set_tag(val.tag.value)
E                 ^^^^^^^^^^^^^^^^^^^^^
E             AttributeError: 'CommentedSeq' object has no attribute 'yaml_set_tag'
``` 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
