### PR TITLE
KGeoTag: init at 1.4.0

### DIFF
--- a/pkgs/by-name/kg/kgeotag/package.nix
+++ b/pkgs/by-name/kg/kgeotag/package.nix
@@ -1,0 +1,27 @@
+{ cmake, extra-cmake-modules, fetchFromGitLab, lib, libsForQt5 }:
+
+libsForQt5.mkDerivation rec {
+  pname = "kgeotag";
+  version = "1.4.0";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    repo = "kgeotag";
+    owner = "graphics";
+    rev = "v${version}";
+    hash = "sha256-az/kXEhD/RGfxOMiLEcb651WVPcyBSa8B2sWOF7bz8E=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [ libsForQt5.libkexiv2 libsForQt5.marble ];
+
+  meta = with lib; {
+    homepage = "https://kgeotag.kde.org/";
+    description = "A stand-alone photo geotagging program";
+    changelog = "https://invent.kde.org/graphics/kgeotag/-/blob/master/CHANGELOG.rst";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ cimm ];
+    mainProgram = "kgeotag";
+  };
+}


### PR DESCRIPTION
## Description of changes

KGeoTag is a KDE desktop application to geotag photos.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc