### PR TITLE
ravedude: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -10,14 +10,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ravedude";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-wcY9fvfIn1pWMAh5FI/QFl18CV2xjmRGSwwoRfGvujo=";
+    hash = "sha256-LhPRz3DUMDoe50Hq3yO+2BHpyh5fQ4sMNGLttjkdSZw=";
   };
 
-  cargoHash = "sha256-AOIrB0FRagbA2+JEURF41d+th0AbR++U5WKCcZmh4Os=";
+  cargoHash = "sha256-Uo8wlTAHBkn/WeGPhPP+BU80wjSyNHsWQj8QvA7mHrk=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -4,6 +4,8 @@
 , pkg-config
 , udev
 , nix-update-script
+, testers
+, ravedude
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -21,7 +23,13 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ udev ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = ravedude;
+      version = "v${version}";
+    };
+  };
 
   meta = with lib; {
     description = "Tool to easily flash code onto an AVR microcontroller with avrdude";

--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -3,6 +3,7 @@
 , fetchCrate
 , pkg-config
 , udev
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,6 +20,8 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ udev ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Tool to easily flash code onto an AVR microcontroller with avrdude";

--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -29,5 +29,6 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ mit /* or */ asl20 ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ rvarago ];
+    mainProgram = "ravedude";
   };
 }


### PR DESCRIPTION
## Description of changes

[New release of ravedude](https://github.com/Rahix/avr-hal/releases/tag/ravedude-0.1.6).

Added an update script and a test for update automation.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
