### PR TITLE
ravedude: ensure avrdude is in the PATH

### DIFF
--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://crates.io/crates/ravedude";
     license = with licenses; [ mit /* or */ asl20 ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ rvarago ];
+    maintainers = with maintainers; [ rvarago liff ];
     mainProgram = "ravedude";
   };
 }

--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -3,6 +3,8 @@
 , fetchCrate
 , pkg-config
 , udev
+, avrdude
+, makeBinaryWrapper
 , nix-update-script
 , testers
 , ravedude
@@ -19,9 +21,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-HeFmQsgr6uHrWi6s5sMQ6n63a44Msarb5p0+wUzKFkE=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config makeBinaryWrapper ];
 
   buildInputs = [ udev ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ravedude --suffix PATH : ${lib.makeBinPath [ avrdude ]}
+  '';
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
## Description of changes

ravedude attempts to execute `avrdude` from the current `PATH` and unless the user has separately installed `avrdude`, that will fail.

This means, for example, that `nix run nixpkgs#ravedude -- uno` won’t work by default.

Wrapping the binary with `avrdude` in `PATH` fixes the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc