### PR TITLE
linux-rt_latest: remove patch that doesn't apply

### DIFF
--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -166,7 +166,6 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
-        kernelPatches.dell_xps_regression
       ];
     };
 


### PR DESCRIPTION
## Description of changes
```
linux-config> Hunk #1 succeeded at 50 with fuzz 2 (offset 11 lines).
linux-config> applying patch /nix/store/mbz5gln1q4swlzmqs2399br98qjif9kn-request-key-helper.patch
linux-config> patching file security/keys/request_key.c
linux-config> Hunk #1 succeeded at 117 (offset 3 lines).
linux-config> applying patch /nix/store/6nns7vkb92g73ry8pkppf65xg7vl160k-export-rt-sched-migrate.patch
linux-config> patching file kernel/sched/core.c
linux-config> Hunk #1 succeeded at 2270 (offset 458 lines).
linux-config> Hunk #2 succeeded at 2302 (offset 459 lines).
linux-config> applying patch /nix/store/370gjy25pg6qyw1nr7ds2ljyaj14b32c-Revert-101bd907b424-misc-rtsx-judge-ASPM-Mode-to-set.patch
linux-config> patching file drivers/misc/cardreader/rts5227.c
linux-config> Reversed (or previously applied) patch detected!  Assume -R? [n]
linux-config> Apply anyway? [n]
linux-config> Skipping patch.
linux-config> 1 out of 1 hunk ignored -- saving rejects to file drivers/misc/cardreader/rts5227.c.rej
linux-config> patching file drivers/misc/cardreader/rts5228.c
linux-config> Hunk #1 FAILED at 435.
linux-config> Hunk #2 succeeded at 446 with fuzz 2 (offset -23 lines).
linux-config> 1 out of 2 hunks FAILED -- saving rejects to file drivers/misc/cardreader/rts5228.c.rej
linux-config> patching file drivers/misc/cardreader/rts5249.c
linux-config> Reversed (or previously applied) patch detected!  Assume -R? [n]
linux-config> Apply anyway? [n]
linux-config> Skipping patch.
linux-config> 1 out of 1 hunk ignored -- saving rejects to file drivers/misc/cardreader/rts5249.c.rej
linux-config> patching file drivers/misc/cardreader/rts5260.c
linux-config> Hunk #1 FAILED at 517.
linux-config> Hunk #2 succeeded at 522 with fuzz 2 (offset -17 lines).
linux-config> 1 out of 2 hunks FAILED -- saving rejects to file drivers/misc/cardreader/rts5260.c.rej
linux-config> patching file drivers/misc/cardreader/rts5261.c
linux-config> Hunk #1 FAILED at 498.
linux-config> Hunk #2 succeeded at 521 with fuzz 2 (offset -26 lines).
linux-config> 1 out of 2 hunks FAILED -- saving rejects to file drivers/misc/cardreader/rts5261.c.rej
linux-config> patching file drivers/misc/cardreader/rtsx_pcr.c
linux-config> Reversed (or previously applied) patch detected!  Assume -R? [n]
linux-config> Apply anyway? [n]
linux-config> Skipping patch.
linux-config> 1 out of 1 hunk ignored -- saving rejects to file drivers/misc/cardreader/rtsx_pcr.c.rej
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
