### PR TITLE
texlive: create outputsToInstall outputs in main derivation

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -203,14 +203,9 @@ let
     withPackages = reqs: self (args // { requiredTeXPackages = ps: requiredTeXPackages ps ++ reqs ps; __fromCombineWrapper = false; });
   };
 
-  out = (if (! __combine)
-    # meta.outputsToInstall = [ "out" "man" ] is invalid within buildEnv:
-    # checkMeta will notice that there is no actual "man" output, and fail
-    # so we set outputsToInstall from the outside, where it is safe
-    then lib.addMetaAttrs { inherit (pkgList) outputsToInstall; }
-    else x: x) # texlive.combine: man pages used to be part of out
+  out =
 # no indent for git diff purposes
-((buildEnv {
+(buildEnv {
 
   inherit name;
 
@@ -240,6 +235,14 @@ let
   inherit meta passthru;
 
   postBuild =
+    # create outputs
+  lib.optionalString (! __combine) ''
+    for otherOutputName in $outputs ; do
+      if [[ "$otherOutputName" == 'out' ]] ; then continue ; fi
+      otherOutput="otherOutput_$otherOutputName"
+      ln -s "''${!otherOutput}" "''${!otherOutputName}"
+    done
+  '' +
     # environment variables (note: only export the ones that are used in the wrappers)
   ''
     TEXMFROOT="${texmfroot}"
@@ -431,5 +434,16 @@ let
     ln -s "$TEXMFDIST" "$out"/share/texmf
   ''
   ;
-}).overrideAttrs (_: { allowSubstitutes = true; }));
+}).overrideAttrs (prev:
+  { allowSubstitutes = true; }
+  # the outputsToInstall must be built by the main derivation for nix-profile-install to work
+  // lib.optionalAttrs (! __combine) ({
+    outputs = pkgList.outputsToInstall;
+    meta = prev.meta // { inherit (pkgList) outputsToInstall; };
+  } // (lib.mapAttrs'
+    (out: drv: { name = "otherOutput_" + out; value = drv; })
+    (lib.getAttrs (builtins.tail pkgList.outputsToInstall) splitOutputs)
+    )
+  )
+);
 in out)


### PR DESCRIPTION
## Description of changes
Fix https://github.com/NixOS/nixos-org-configurations/issues/309 and further issue reported at https://github.com/NixOS/nixos-org-configurations/issues/309#issuecomment-1826744938

In short: my hacky use of `passthru.outputs` and `meta.outputsToInstall` to make `texlive` pretend to be a multi-output derivation is flawed. `nix-env` and `nix profile` expect everything in `meta.outputsToInstall` to be an actual output of the derivation – putting them in `passthru` is not enough!

I wish `outputsToInstall` and `outputs` were not so tightly coupled... but here we are.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
