### PR TITLE
kapacitor: fix build of embedded `libflux` dependency with current rust

### DIFF
--- a/pkgs/servers/monitoring/kapacitor/default.nix
+++ b/pkgs/servers/monitoring/kapacitor/default.nix
@@ -20,6 +20,16 @@ let
       hash = "sha256-v9MUR+PcxAus91FiHYrMN9MbNOTWewh7MT6/t/QWQcM=";
     };
     patches = [
+      # This fixes a linting error due to an unneeded call to `.clone()`
+      # that gets enforced by a strict `deny(warnings)` build config.
+      # This is already fixed with newer versions of `libflux`, but it
+      # has been changed in a giant commit with a lot of autmated changes:
+      # https://github.com/influxdata/flux/commit/e7f7023848929e16ad5bd3b41d217847bd4fd72b#diff-96572e971d9e19b54290a434debbf7db054b21c9ce19035159542756ffb8ab87
+      #
+      # Can be removed as soon as kapacitor depends on a newer version of `libflux`, cf:
+      # https://github.com/influxdata/kapacitor/blob/v1.7.0/go.mod#L26
+      ./fix-linting-error-on-unneeded-clone.patch
+
       # https://github.com/influxdata/flux/pull/5273
       # fix compile error with Rust 1.64
       (fetchpatch {

--- a/pkgs/servers/monitoring/kapacitor/default.nix
+++ b/pkgs/servers/monitoring/kapacitor/default.nix
@@ -92,6 +92,12 @@ buildGoModule rec {
     rm server/server_test.go
   '';
 
+  # Tests start http servers which need to bind to local addresses,
+  # but that fails in the Darwin sandbox by default unless this option is turned on
+  # Error is: panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
+  # See also https://github.com/NixOS/nix/pull/1646
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Open source framework for processing, monitoring, and alerting on time series data";
     homepage = "https://influxdata.com/time-series-platform/kapacitor/";

--- a/pkgs/servers/monitoring/kapacitor/fix-linting-error-on-unneeded-clone.patch
+++ b/pkgs/servers/monitoring/kapacitor/fix-linting-error-on-unneeded-clone.patch
@@ -1,0 +1,13 @@
+diff --git a/flux-core/src/semantic/flatbuffers/types.rs b/flux-core/src/semantic/flatbuffers/types.rs
+index c3eecf06..9baf4070 100644
+--- a/flux-core/src/semantic/flatbuffers/types.rs
++++ b/flux-core/src/semantic/flatbuffers/types.rs
+@@ -715,7 +715,7 @@ mod tests {
+
+     fn test_serde(expr: &'static str) {
+         // let want = parser::parse(expr).unwrap();
+-        let mut p = parser::Parser::new(expr.clone());
++        let mut p = parser::Parser::new(expr);
+
+         let typ_expr = p.parse_type_expression();
+         if let Err(err) = ast::check::check(ast::walk::Node::TypeExpression(&typ_expr)) {


### PR DESCRIPTION
The embedded `libflux` dependency of `kapacitor` fails to build with more current rust tooling due to an unneeded `.clone()` call that is promoted into an error message by a strict linting build config.

This introduces a patch that removes the offending method call. The issue is already resolved upstream, but even the current `kapacitor` version still depends on this specific version of `libflux` [1], and the respective git commit contains a lot of other (automated) changes [2], so cherry-picking the patch via a GitHub URL seems even more brittle.

[1]: https://github.com/influxdata/kapacitor/blob/v1.7.1/go.mod#L26
[2]: https://github.com/influxdata/flux/commit/e7f7023848929e16ad5bd3b41d217847bd4fd72b#diff-96572e971d9e19b54290a434debbf7db054b21c9ce19035159542756ffb8ab87

## Description of changes

Adds a patch that removes the offending `.clone()` call.

Failing hydra build: https://hydra.nixos.org/build/241395053#tabs-summary
Hydra log: https://hydra.nixos.org/build/241395053/nixlog/3

Relevant log excerpt:

```
error: call to `.clone()` on a reference in this situation does nothing
   --> flux-core/src/semantic/flatbuffers/types.rs:718:45
    |
718 |         let mut p = parser::Parser::new(expr.clone());
    |                                             ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
note: the lint level is defined here
   --> flux-core/src/lib.rs:1:38
    |
1   | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
    |                                      ^^^^^^^^
    = note: `#[deny(noop_method_call)]` implied by `#[deny(warnings)]`

error: could not compile `flux-core` (lib test) due to previous error
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
