### PR TITLE
bisq-desktop: 1.9.12 -> 1.9.14

### DIFF
--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -13,6 +13,7 @@
 , tor
 , zip
 , xz
+, findutils
 }:
 
 let
@@ -24,7 +25,9 @@ let
     # whereas Nix only scans for hashes in uncompressed text.
     # ${bisq-tor}
 
-    JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:+UseStringDeduplication ${args}" bisq-desktop-wrapped "$@"
+    classpath=@out@/lib/desktop.jar:@out@/lib/*
+
+    exec "${openjdk11}/bin/java" -Djpackage.app-version=@version@ -XX:MaxRAM=8g -Xss1280k -XX:+UseG1GC -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:+UseStringDeduplication -Djava.net.preferIPv4Stack=true -classpath $classpath ${args} bisq.desktop.app.BisqAppMain "$@"
   '';
 
   bisq-tor = writeScript "bisq-tor" ''
@@ -35,11 +38,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bisq-desktop";
-  version = "1.9.12";
+  version = "1.9.14";
 
   src = fetchurl {
     url = "https://github.com/bisq-network/bisq/releases/download/v${version}/Bisq-64bit-${version}.deb";
-    sha256 = "0zzrl7dmd3m7pymwvl68gnjspbpzf1w17bcwr0ipgsszmr35k9rs";
+    sha256 = "0xbq94qbp59523xjp80bly38aisfwkfi0y9hmyhf8xlw084b82kz";
   };
 
   nativeBuildInputs = [
@@ -50,6 +53,7 @@ stdenv.mkDerivation rec {
     strip-nondeterminism
     xz
     zip
+    findutils
   ];
 
   desktopItems = [
@@ -83,24 +87,22 @@ stdenv.mkDerivation rec {
     mkdir -p native/linux/x64/
     cp ${bisq-tor} ./tor
     tar --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cJf native/linux/x64/tor.tar.xz tor
-    zip -r opt/bisq/lib/app/desktop-${version}-all.jar native
-    strip-nondeterminism opt/bisq/lib/app/desktop-${version}-all.jar
+    tor_jar_file=$(find ./opt/bisq/lib/app -name "tor-binary-linux64-*.jar")
+    zip -r $tor_jar_file native
+    strip-nondeterminism ./opt/bisq/lib/app/*.jar
   '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib $out/bin
-    cp opt/bisq/lib/app/desktop-${version}-all.jar $out/lib
+    mkdir -p $out $out/bin
+    cp -r opt/bisq/lib/app $out/lib
 
-    makeWrapper ${openjdk11}/bin/java $out/bin/bisq-desktop-wrapped \
-      --add-flags "-jar $out/lib/desktop-${version}-all.jar bisq.desktop.app.BisqAppMain"
+    install -D -m 777 ${bisq-launcher ""} $out/bin/bisq-desktop
+    substituteAllInPlace $out/bin/bisq-desktop
 
-    makeWrapper ${bisq-launcher ""} $out/bin/bisq-desktop \
-      --prefix PATH : $out/bin
-
-    makeWrapper ${bisq-launcher "-Dglass.gtk.uiScale=2.0"} $out/bin/bisq-desktop-hidpi \
-      --prefix PATH : $out/bin
+    install -D -m 777 ${bisq-launcher "-Dglass.gtk.uiScale=2.0"} $out/bin/bisq-desktop-hidpi
+    substituteAllInPlace $out/bin/bisq-desktop-hidpi
 
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Replaces #260499

- Version bump from 1.9.12 to 1.9.14. See the changelog https://github.com/bisq-network/bisq/releases/tag/v1.9.14
- Refactor the package to account for upstream providing a directory of JAR files instead of a single "fat JAR."
  - The Tor binary is now in a different JAR file, and the file name contains what looks like a Git commit; This makes the file name inconsistent. The `buildPhase` uses `find` to discover the file name.
  - I found additional java flags which upstream uses, so I added them.
Since there's no longer a single JAR, I had to add the `-classpath` argument when calling `java`.
  - I removed an unnecessary wrapper, to make my life easier in the future.

NOTE: Needs to be "backported" to 23.11; Sometimes the Bisq network sets a minimum required version, and currently it's 1.9.14.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
