### PR TITLE
owncast: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/servers/owncast/default.nix
+++ b/pkgs/servers/owncast/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "0.1.1";
+  version = "0.1.2";
 in buildGoModule {
   pname = "owncast";
   inherit version;
@@ -17,9 +17,9 @@ in buildGoModule {
     owner = "owncast";
     repo = "owncast";
     rev = "v${version}";
-    hash = "sha256-nBTuvVVnFlC75p8bRCN+lNl9fExBZrsLEesvXWwNlAQ=";
+    hash = "sha256-pPBY2PcXe3k9G6kjj/vF5VB6DEmiwKDUrK4VGR4xNzU=";
   };
-  vendorHash = "sha256-yjy5bDJjWk7UotBVqvVFiGx8mpfhpqMTxoQm/eWHcw4=";
+  vendorHash = "sha256-7HxiZh5X5AZVMiZT6B8DfOy6stJ3+dFEixwJYv5X0dY=";
 
   propagatedBuildInputs = [ ffmpeg ];
 


### PR DESCRIPTION
## Description of changes

Update owncast version to `v0.1.2`.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).