### PR TITLE
ruby-modules: improve cross-compilation support

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, runCommand, ruby, lib, rsync
+{ stdenv
+, lib
+, buildPackages
+, runCommand
+, ruby
 , defaultGemConfig, buildRubyGem, buildEnv
 , makeBinaryWrapper
 , bundler
@@ -190,7 +194,7 @@ let
       runCommand name' basicEnvArgs ''
         mkdir -p $out
         for i in $paths; do
-          ${rsync}/bin/rsync -a $i/lib $out/
+          ${buildPackages.rsync}/bin/rsync -a $i/lib $out/
         done
         eval "$postBuild"
       ''

--- a/pkgs/development/ruby-modules/bundled-common/functions.nix
+++ b/pkgs/development/ruby-modules/bundled-common/functions.nix
@@ -59,8 +59,21 @@ in rec {
     then attrs // gemConfig.${attrs.gemName} attrs
     else attrs);
 
-  genStubsScript = { lib, ruby, confFiles, bundler, groups, binPaths, ... }: ''
-      ${ruby}/bin/ruby ${./gen-bin-stubs.rb} \
+  genStubsScript = { lib, runCommand, ruby, confFiles, bundler, groups, binPaths, ... }:
+    let
+      genStubsScript = runCommand "gen-bin-stubs"
+        {
+          strictDeps = true;
+          nativeBuildInputs = [ ruby ];
+        }
+        ''
+          cp ${./gen-bin-stubs.rb} $out
+          chmod +x $out
+          patchShebangs --build $out
+        '';
+    in
+    ''
+      ${genStubsScript} \
         "${ruby}/bin/ruby" \
         "${confFiles}/Gemfile" \
         "$out/${ruby.gemPath}" \

--- a/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+++ b/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require 'rbconfig'
 require 'rubygems'
 require 'rubygems/specification'

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -258,7 +258,9 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
   # store.
   fixupPhase = attrs.fixupPhase or ''
     runHook preFixup
-    patchShebangs --update --host $out/${ruby.gemPath}/bin
+    if [[ -d $out/${ruby.gemPath}/bin ]]; then
+      patchShebangs --update --host $out/${ruby.gemPath}/bin
+    fi
     runHook postFixup
   '';
 

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -252,6 +252,16 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     runHook postInstall
   '';
 
+  # For Ruby-generated binstubs, shebang paths are already in Nix store but for
+  # ruby used to build the package. Update them to match the host system. Note
+  # that patchShebangsAuto ignores scripts where shebang line is already in Nix
+  # store.
+  fixupPhase = attrs.fixupPhase or ''
+    runHook preFixup
+    patchShebangs --update --host $out/${ruby.gemPath}/bin
+    runHook postFixup
+  '';
+
   propagatedBuildInputs = gemPath ++ propagatedBuildInputs;
   propagatedUserEnvPkgs = gemPath ++ propagatedUserEnvPkgs;
 


### PR DESCRIPTION
## Description of changes

This PR contains fixes for cross-compilation in Ruby infrastructure. In particular,
- `bundler{App,Env}` were using host ruby to execute gen-bin-stubs.rb, same for rsync if `copyGemFiles` was set.
- `buildRubyGem` output contained Ruby-generated binstubs that referenced `ruby` from nativeBuildInputs.

For example,
```
nix build --impure --expr 'let
  pkgs = import ./. {
    localSystem.system = "aarch64-linux";
    crossSystem.config = "x86_64-unknown-linux-gnu";
  };
in
pkgs.doing'
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
