### PR TITLE
makeFontsConf: add impureFontDirectories argument

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -1,16 +1,29 @@
-{ runCommand, stdenv, lib, libxslt, fontconfig, dejavu_fonts, fontDirectories }:
+{ runCommand, stdenv, lib, libxslt, fontconfig, dejavu_fonts, fontDirectories
+, impureFontDirectories ? [
+    # nix user profile
+    "~/.nix-profile/lib/X11/fonts" "~/.nix-profile/share/fonts"
+  ]
+  ++ lib.optional stdenv.isDarwin "~/Library/Fonts"
+  ++ [
+    # FHS paths for non-NixOS platforms
+    "/usr/share/fonts" "/usr/local/share/fonts"
+  ]
+  # darwin paths
+  ++ lib.optionals stdenv.isDarwin [ "/Library/Fonts" "/System/Library/Fonts" ]
+  # nix default profile
+  ++ [ "/nix/var/nix/profiles/default/lib/X11/fonts" "/nix/var/nix/profiles/default/share/fonts" ] }:
 
 runCommand "fonts.conf"
   {
     nativeBuildInputs = [ libxslt ];
     buildInputs = [ fontconfig ];
+    inherit fontDirectories;
     # Add a default font for non-nixos systems, <1MB and in nixos defaults.
-    fontDirectories = fontDirectories ++ [ dejavu_fonts.minimal ]
-      # further non-nixos fonts on darwin
-      ++ lib.optionals stdenv.isDarwin [ "/System/Library/Fonts" "/Library/Fonts" "~/Library/Fonts" ];
+    impureFontDirectories = impureFontDirectories ++ [ dejavu_fonts.minimal ];
   }
   ''
     xsltproc --stringparam fontDirectories "$fontDirectories" \
+      --stringparam impureFontDirectories "$impureFontDirectories" \
       --path ${fontconfig.out}/share/xml/fontconfig \
       ${./make-fonts-conf.xsl} ${fontconfig.out}/etc/fonts/fonts.conf \
       > $out

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -15,6 +15,7 @@
   <xsl:output method='xml' encoding="UTF-8" doctype-system="urn:fontconfig:fonts.dtd" />
 
   <xsl:param name="fontDirectories" />
+  <xsl:param name="impureFontDirectories" />
 
   <xsl:template match="/fontconfig">
 
@@ -23,29 +24,26 @@
 
       <!-- the first cachedir will be used to store the cache -->
       <cachedir prefix="xdg">fontconfig</cachedir>
+      <xsl:text>&#0010;</xsl:text>
       <!-- /var/cache/fontconfig is useful for non-nixos systems -->
       <cachedir>/var/cache/fontconfig</cachedir>
+      <xsl:text>&#0010;</xsl:text>
 
       <!-- system-wide config -->
       <include ignore_missing="yes">/etc/fonts/conf.d</include>
+      <xsl:text>&#0010;</xsl:text>
 
       <dir prefix="xdg">fonts</dir>
+      <xsl:text>&#0010;</xsl:text>
       <xsl:for-each select="str:tokenize($fontDirectories)">
         <dir><xsl:value-of select="." /></dir>
         <xsl:text>&#0010;</xsl:text>
       </xsl:for-each>
 
-      <!-- nix user profile -->
-      <dir>~/.nix-profile/lib/X11/fonts</dir>
-      <dir>~/.nix-profile/share/fonts</dir>
-
-      <!-- FHS paths for non-NixOS platforms -->
-      <dir>/usr/share/fonts</dir>
-      <dir>/usr/local/share/fonts</dir>
-
-      <!-- nix default profile -->
-      <dir>/nix/var/nix/profiles/default/lib/X11/fonts</dir>
-      <dir>/nix/var/nix/profiles/default/share/fonts</dir>
+      <xsl:for-each select="str:tokenize($impureFontDirectories)">
+        <dir><xsl:value-of select="." /></dir>
+        <xsl:text>&#0010;</xsl:text>
+      </xsl:for-each>
 
     </fontconfig>
 


### PR DESCRIPTION
## Description of changes
Idea to fix #269082: this add a parameter `impureFontDirectories` to `makeFontsConf`, which by default reproduces the current behaviour (with a minimal tweak on the order of the darwin folders) but can be modified easily.

This is a partial solution: there are other impure settings in `makeFontsConf` that should be made configurable (say `impureCacheDirectories` and `impureConfigDirectories`; `<dir prefix="xdg">fonts</dir>` is hardcoded at the top and should rather be part of `impureFontDirectories`, etc.).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
