### PR TITLE
get-google-fonts: init at unstable-2020-06-30

### DIFF
--- a/pkgs/by-name/ge/get-google-fonts/package.nix
+++ b/pkgs/by-name/ge/get-google-fonts/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, fetchpatch
+}:
+
+buildNpmPackage {
+  pname = "get-google-fonts";
+  version = "1.2.2-unstable-2020-06-30";
+
+  src = fetchFromGitHub {
+    owner = "MrMaxie";
+    repo = "get-google-fonts";
+    rev = "2f8b15f6d7072533ca2ad5e0b74ccf28a313e8c8";
+    hash = "sha256-LD+ur0GB2uefggQsdQRkKMwWB39HGiYYiJIrTLudcLc=";
+  };
+
+  patches = [
+    # update lock file to contain all necessary information
+    # https://github.com/MrMaxie/get-google-fonts/pull/27
+    (fetchpatch {
+      url = "https://github.com/MrMaxie/get-google-fonts/commit/f2c818fc7c9ee228db020305f432fd08eda7dc5f.patch";
+      hash = "sha256-BszZdAZWpnkNETKYvSElg0lCjgcP7BNeXfMvePKAio4=";
+    })
+  ];
+
+  npmDepsHash = "sha256-VUphB0Qq94rlcGrrsO2Nat/bD2IZTtdevGKsXFu/YdQ=";
+
+  dontBuild = true;
+
+  meta = with lib; {
+    description = "Downloads and adapts Google fonts to working offline";
+    homepage = "https://github.com/MrMaxie/get-google-fonts";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
