### PR TITLE
 python3.pkgs.govee-led-wez: init at 0.0.15,  home-assistant.custom-components.govee-lan: init at unstable-2023-06-10 

### DIFF
--- a/pkgs/development/python-modules/govee-led-wez/default.nix
+++ b/pkgs/development/python-modules/govee-led-wez/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, aiohttp
+, bleak
+, bleak-retry-connector
+, buildPythonPackage
+, certifi
+, fetchFromGitHub
+, hatchling
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage {
+  pname = "govee-led-wez";
+  version = "0.0.15";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "wez";
+    repo = "govee-py";
+    # https://github.com/wez/govee-py/issues/2
+    rev = "931273e3689838613d63bc1bcc65ee744fa999f4";
+    hash = "sha256-VMH7sot9e2SYMyBNutyW6oCCjp2N+EKukxn1Dla3AlY=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    bleak
+    bleak-retry-connector
+    certifi
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "govee_led_wez"
+  ];
+
+  meta = with lib; {
+    description = "Control Govee Lights from Python";
+    homepage = "https://github.com/wez/govee-py";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -3,6 +3,10 @@
 
 {
   adaptive_lighting = callPackage ./adaptive_lighting {};
+
+  govee-lan = callPackage ./govee-lan {};
+
   miele = callPackage ./miele {};
+
   prometheus_sensor = callPackage ./prometheus_sensor {};
 }

--- a/pkgs/servers/home-assistant/custom-components/govee-lan/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/govee-lan/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, govee-led-wez
+}:
+
+buildHomeAssistantComponent {
+  owner = "wez";
+  domain = "govee_lan";
+  version = "unstable-2023-06-10";
+
+  src = fetchFromGitHub {
+    owner = "wez";
+    repo = "govee-lan-hass";
+    rev = "18d8455510d158496f7e5d4f0286f58bd61042bb";
+    hash = "sha256-ZhrxEPBEi+Z+2ZOAQ1amhO0tqvhM6tyFQgoRIVNDtXY=";
+  };
+
+  dontBuild = true;
+
+  propagatedBuildInputs = [
+    govee-led-wez
+  ];
+
+  # enable when pytest-homeassistant-custom-component is packaged
+  doCheck = false;
+
+  # nativeCheckInputs = [
+  #   pytest-homeassistant-custom-component
+  #   pytestCheckHook
+  # ];
+
+  meta = with lib; {
+    description = "Control Govee lights via the LAN API from Home Assistant";
+    homepage = "https://github.com/wez/govee-lan-hass";
+    maintainers = with maintainers; [ SuperSandro2000 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4741,6 +4741,8 @@ self: super: with self; {
 
   govee-ble = callPackage ../development/python-modules/govee-ble { };
 
+  govee-led-wez = callPackage ../development/python-modules/govee-led-wez { };
+
   goveelights = callPackage ../development/python-modules/goveelights { };
 
   gpapi = callPackage ../development/python-modules/gpapi { };


### PR DESCRIPTION
## Description of changes

Tested with a govee led strip. Works as upstream described it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
