### PR TITLE
zfs: default disable zfs_dmu_offset_next_sync to avoid data corruption

### DIFF
--- a/pkgs/os-specific/linux/zfs/patches/disable-zfs-dmu-offset-next-sync-by-default-v2-2.patch
+++ b/pkgs/os-specific/linux/zfs/patches/disable-zfs-dmu-offset-next-sync-by-default-v2-2.patch
@@ -1,0 +1,44 @@
+From 3ba4ff328ab001d88d7714087d8a89687bc68312 Mon Sep 17 00:00:00 2001
+From: Andrew Marshall <andrew@johnandrewmarshall.com>
+Date: Sun, 26 Nov 2023 12:46:18 -0500
+Subject: [PATCH] Disable zfs_dmu_offset_next_sync tunable by default
+
+This helps mitigate a data corruption bug. This was previously defaulted
+to zero, so doing so seems safe.
+
+See https://github.com/openzfs/zfs/issues/11900
+See https://github.com/openzfs/zfs/issues/15526
+---
+ man/man4/zfs.4   | 2 +-
+ module/zfs/dmu.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/man/man4/zfs.4 b/man/man4/zfs.4
+index 4ec52a2fb..2a69a8f54 100644
+--- a/man/man4/zfs.4
++++ b/man/man4/zfs.4
+@@ -1660,7 +1660,7 @@ Allow no-operation writes.
+ The occurrence of nopwrites will further depend on other pool properties
+ .Pq i.a. the checksumming and compression algorithms .
+ .
+-.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 1 Ns | Ns 0 Pq int
++.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 0 Ns | Ns 1 Pq int
+ Enable forcing TXG sync to find holes.
+ When enabled forces ZFS to sync data when
+ .Sy SEEK_HOLE No or Sy SEEK_DATA
+diff --git a/module/zfs/dmu.c b/module/zfs/dmu.c
+index ddb29020b..5d37b6f92 100644
+--- a/module/zfs/dmu.c
++++ b/module/zfs/dmu.c
+@@ -82,7 +82,7 @@ static uint_t zfs_per_txg_dirty_frees_percent = 30;
+  * Disabling this option will result in holes never being reported in dirty
+  * files which is always safe.
+  */
+-static int zfs_dmu_offset_next_sync = 1;
++static int zfs_dmu_offset_next_sync = 0;
+ 
+ /*
+  * Limit the amount we can prefetch with one call to this amount.  This
+-- 
+2.42.0
+

--- a/pkgs/os-specific/linux/zfs/stable.nix
+++ b/pkgs/os-specific/linux/zfs/stable.nix
@@ -28,6 +28,10 @@ callPackage ./generic.nix args {
   # this package should point to the latest release.
   version = "2.2.0";
 
+  extraPatches = [
+    ./patches/disable-zfs-dmu-offset-next-sync-by-default-v2-2.patch
+  ];
+
   tests = [
     nixosTests.zfs.installer
     nixosTests.zfs.stable

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -36,4 +36,8 @@ callPackage ./generic.nix args {
   tests = [
     nixosTests.zfs.unstable
   ];
+
+  extraPatches = [
+    ./patches/disable-zfs-dmu-offset-next-sync-by-default-v2-2.patch
+  ];
 }


### PR DESCRIPTION
This helps mitigate a data corruption bug. This was previously defaulted to zero prior to upstream commit
05b3eb6d232009db247882a39d518e7282630753, and it is already a tunable, so doing this seems safe. Initially data corruption was thought to be introduced with v2.2, but further upstream investigation currently believes that changes in v2.2 only exacerbated the issue that already existed.

A longer-term fix is likely to be
https://github.com/openzfs/zfs/pull/15571, though that is not yet merged. The zfs_2_1 package has already backported that, so do not apply the tunable default change there.

Positioning of `extraPatches` is to avoid merge conflicts with https://github.com/NixOS/nixpkgs/pull/269097.

Patch is nearly identical to the [Gentoo][1] patch, but better patch formatting.

See https://github.com/openzfs/zfs/issues/11900
See https://github.com/openzfs/zfs/issues/15526

[1]: https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-fs/zfs-kmod/files/zfs-kmod-2.2.1-Disable-zfs_dmu_offset_next_sync-tunable-by-default.patch

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
