### PR TITLE
nixos/clamav: ensure freshclam starts first

### DIFF
--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -145,7 +145,8 @@ in
 
     systemd.services.clamav-daemon = mkIf cfg.daemon.enable {
       description = "ClamAV daemon (clamd)";
-      after = optional cfg.updater.enable "clamav-freshclam.service";
+      after = optionals cfg.updater.enable [ "clamav-freshclam.service" ];
+      wants = optionals cfg.updater.enable [ "clamav-freshclam.service" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ clamdConfigFile ];
 


### PR DESCRIPTION
## Description of changes

If one enables `clamav.daemon` without `clamav.updater` and `/var/lib/clamav` hasn't been intialized before, the new `preStart` prints a hopefully understandable error message:

```
❯ nixos-rebuild switch --use-remote-sudo -L
...
× clamav-daemon.service - ClamAV daemon (clamd)
     Loaded: loaded (/etc/systemd/system/clamav-daemon.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Sun 2023-11-26 22:40:33 UTC; 2s ago
...
Nov 26 22:40:33 ss-xps13 systemd[1]: Starting ClamAV daemon (clamd)...
Nov 26 22:40:33 ss-xps13 clamav-daemon-pre-start[532805]: The state directory, /var/lib/clamav, doesn't exist.
Nov 26 22:40:33 ss-xps13 clamav-daemon-pre-start[532805]: You need to run `freshclam` or set `services.clamav.updater.enable` first.
Nov 26 22:40:33 ss-xps13 systemd[1]: clamav-daemon.service: Control process exited, code=exited, status=1/FAILURE
...
```

It also turned out that `systemd.services.clamav-daemon.after = optional ... [ "clamav-freshclam.service" ]` wasn't sufficient for freshclam to get started before `clamav-daemon` during the system activation (i.e. on nixos-rebuild switch), so I added a `wants = ...` statement

Examples of an error prior to this change:
- https://discourse.nixos.org/t/how-to-use-clamav-in-nixos/19782/3
- https://github.com/NixOS/nixpkgs/issues/187992

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

CC `pkgs.clamav` maintainers: @robberer @qknight @globin
CC recent contributors to the module: @happysalada

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Switched into an equivalent nixos configuration locally
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
