### PR TITLE
aldente: 1.22.3 -> 1.24

### DIFF
--- a/pkgs/os-specific/darwin/aldente/default.nix
+++ b/pkgs/os-specific/darwin/aldente/default.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "aldente";
-  version = "1.22.3";
+  version = "1.24";
 
   src = fetchurl {
     url = "https://github.com/davidwernhart/aldente-charge-limiter/releases/download/${finalAttrs.version}/AlDente.dmg";
-    hash = "sha256-pSqBDDumCbORLQ+B3skSqKmgG2KybR5Zb4ojiNQcAaM=";
+    hash = "sha256-5byGKtVgKiE8m0+GXDtUpTwQpuUj4lv0hPOl4jhH9wk=";
   };
 
   dontBuild = true;
@@ -47,13 +47,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "macOS tool to limit maximum charging percentage";
     homepage = "https://apphousekitchen.com";
     changelog = "https://github.com/davidwernhart/aldente-charge-limiter/releases/tag/${finalAttrs.version}";
-    license = with licenses; [ unfree ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ stepbrobd ];
+    license = with lib.licenses; [ unfree ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ stepbrobd ];
     platforms = [ "aarch64-darwin" "x86_64-darwin" ];
   };
 })


### PR DESCRIPTION
## Description of changes

update from 1.22.3 to 1.24
remove `with lib;`

```diff
diff --git a/pkgs/os-specific/darwin/aldente/default.nix b/pkgs/os-specific/darwin/aldente/default.nix
index 7ca454609ae..245ba81e291 100644
--- a/pkgs/os-specific/darwin/aldente/default.nix
+++ b/pkgs/os-specific/darwin/aldente/default.nix
@@ -6,11 +6,11 @@

 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "aldente";
-  version = "1.22.3";
+  version = "1.24";

   src = fetchurl {
     url = "https://github.com/davidwernhart/aldente-charge-limiter/releases/download/${finalAttrs.version}/AlDente.dmg";
-    hash = "sha256-pSqBDDumCbORLQ+B3skSqKmgG2KybR5Zb4ojiNQcAaM=";
+    hash = "sha256-5byGKtVgKiE8m0+GXDtUpTwQpuUj4lv0hPOl4jhH9wk=";
   };

   dontBuild = true;
@@ -47,13 +47,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';

-  meta = with lib; {
+  meta = {
     description = "macOS tool to limit maximum charging percentage";
     homepage = "https://apphousekitchen.com";
     changelog = "https://github.com/davidwernhart/aldente-charge-limiter/releases/tag/${finalAttrs.version}";
-    license = with licenses; [ unfree ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ stepbrobd ];
+    license = with lib.licenses; [ unfree ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ stepbrobd ];
     platforms = [ "aarch64-darwin" "x86_64-darwin" ];
   };
 })
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
