### PR TITLE
mathematica: 13.3.0 -> 13.3.1

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -77,7 +77,7 @@ callPackage real-drv {
     homepage = "http://www.wolfram.com/mathematica/";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ herberteuler ];
+    maintainers = with maintainers; [ herberteuler rafaelrc ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/science/math/mathematica/generic.nix
+++ b/pkgs/applications/science/math/mathematica/generic.nix
@@ -158,9 +158,10 @@ in stdenv.mkDerivation {
 
     # Remove PATH restriction, root and avahi daemon checks, and hostname call
     sed -i '
-      s/^PATH=/# &/
+      s/^\s*PATH=/# &/
       s/isRoot="false"/# &/
-      s/^checkAvahiDaemon$/# &/
+      s/^\s*checkAvahiDaemon$/:/
+      s/^\s*installBundledInstall$/:/
       s/`hostname`/""/
     ' MathInstaller
 

--- a/pkgs/applications/science/math/mathematica/versions.nix
+++ b/pkgs/applications/science/math/mathematica/versions.nix
@@ -8,6 +8,20 @@
 
 let versions = [
   {
+    version = "13.3.1";
+    lang = "en";
+    language = "English";
+    sha256 = "sha256-0+mYVGiF4Qn3eiLIoINSHVIqT8GtlBPFRYIOF+nHyQo=";
+    installer = "Mathematica_13.3.1_LINUX.sh";
+  }
+  {
+    version = "13.3.1";
+    lang = "en";
+    language = "English";
+    sha256 = "sha256-03R4s05fmTcZnlZIMSI6xlLER58MIoccoCr27F8BXOk=";
+    installer = "Mathematica_13.3.1_BNDL_LINUX.sh";
+  }
+  {
     version = "13.3.0";
     lang = "en";
     language = "English";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39306,7 +39306,16 @@ with pkgs;
 
   mathematica = callPackage ../applications/science/math/mathematica { };
 
+  mathematica-webdoc = callPackage ../applications/science/math/mathematica {
+    webdoc = true;
+  };
+
   mathematica-cuda = callPackage ../applications/science/math/mathematica {
+    cudaSupport = true;
+  };
+
+  mathematica-webdoc-cuda = callPackage ../applications/science/math/mathematica {
+    webdoc = true;
     cudaSupport = true;
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

### Official changelog
https://www.wolfram.com/mathematica/quick-revision-history/

### [mathematica: 13.3.0 -> 13.3.1](https://github.com/NixOS/nixpkgs/commit/cc1b0c4091c36e59956797e94fa9bc872af9f3d7)
This version of Mathematica was not able to be built by simply adding the new version number to the list as previous updates. Some changes were made to the linux installation script that broke with the previous nix code.

Before building, the official installation script is modified using sed by the derivation. Some of this changes used to comment out lines calling some functions such as `checkAvahiDaemon`. However, some of those function calls were the sole body of if statements that in bash, if empty, caused the script to crash. Thus, those `sed` commands were modified to change the function call into a no-op (`:`). Also a check for whitespace  was added to the regexes as those function calls are indented inside the if bodies.

This new version also added a call to a new function `installBundledInstall` that caused the installation script to exit with a 127 error code causing the build process to fail. This function was not present in previous versions and I found no similar code. I tried just removing the call, as done with other functions (such as the case mentioned in the previous paragraph). The issue with this function seems to be the fact that it tries to execute the installer again. However the path used it not valid. I don't understand why this function is necessary, as the installer is already running, and the installation seems to be successful anyway.

### [mathematica: add webdoc versions to all-packages](https://github.com/NixOS/nixpkgs/commit/459104f841356362bfb9ce1c788c1d42846b2454)

Mathematica can be both installed with offline documentation or web documentation. This is reflected by the derivation's `webdoc` flag. The webdoc installer is much more smaller with 2GB compared to the offline documentation version with 5.7GB. The default package "mathematica" installs the offline documentation version, requiring the bigger installer and generating a much larger package. Thus, I also added aliases to install the webdoc version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
