### PR TITLE
python311Packages.approvaltests: 10.0.0 -> 10.1.0

### DIFF
--- a/pkgs/development/python-modules/approval-utilities/default.nix
+++ b/pkgs/development/python-modules/approval-utilities/default.nix
@@ -2,17 +2,28 @@
 , buildPythonPackage
 , approvaltests
 , pythonOlder
+, setuptools
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "approval-utilities";
   inherit (approvaltests) version src;
   disabled = pythonOlder "3.7";
-  format = "setuptools";
+  pyproject = true;
 
   postPatch = ''
     mv setup.approval_utilities.py setup.py
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    # used in approval_utilities/utilities/time_utilities.py
+    typing-extensions
+  ];
 
   pythonImportsCheck = [ "approval_utilities" ];
 

--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -5,21 +5,21 @@
 , buildPythonPackage
 , empty-files
 , fetchFromGitHub
-, mock
 , mrjob
 , numpy
 , pyperclip
 , pytest
+, pytest-asyncio
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , testfixtures
-, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "approvaltests";
-  version = "10.0.0";
-  format = "setuptools";
+  version = "10.1.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -27,8 +27,12 @@ buildPythonPackage rec {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-3KorHpJUeWSJKVN/4IN0AqKOIL0sT5MaxkvQqpeilhw=";
+    hash = "sha256-t+Vxo6Pn3b2H3yAg5LGsGTjrZr4MXeGOY2BF9eFFAdE=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     allpairspy
@@ -39,16 +43,16 @@ buildPythonPackage rec {
     pyperclip
     pytest
     testfixtures
-    typing-extensions
   ];
 
   nativeCheckInputs = [
-    mock
     numpy
+    pytest-asyncio
     pytestCheckHook
   ];
 
   disabledTests = [
+    "test_docstrings"
     # Tests expects paths below ApprovalTests.Python directory
     "test_received_filename"
     "test_pytest_namer"


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/approvals/ApprovalTests.Python/compare/refs/tags/v10.0.0...v10.1.0

Changelog: https://github.com/approvals/ApprovalTests.Python/releases/tag/v10.1.0



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
