### PR TITLE
gnomeExtensions.unite: 72 -> 77

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -23,7 +23,6 @@
 , vte
 , wrapGAppsHook
 , xdg-utils
-, xprop
 }:
 let
   # Helper method to reduce redundancy
@@ -135,12 +134,6 @@ super: lib.trivial.pipe super [
         gtop_path = "${libgtop}/lib/girepository-1.0";
       })
     ];
-  }))
-
-  (patchExtension "unite@hardpixel.eu" (old: {
-    buildInputs = [ xprop ];
-
-    meta.maintainers = with lib.maintainers; [ rhoriguchi ];
   }))
 
   (patchExtension "x11gestures@joseexposito.github.io" (old: {

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -16,6 +16,8 @@
   "taskwhisperer-extension@infinicode.de" = callPackage ./taskwhisperer { };
   "tilingnome@rliang.github.com" = callPackage ./tilingnome { };
   "TopIcons@phocean.net" = callPackage ./topicons-plus { };
+  # Can be removed when https://github.com/hardpixel/unite-shell/issues/353 resolved
+  "unite@hardpixel.eu" = callPackage ./unite { };
   "valent@andyholmes.ca" = callPackage ./valent { };
   "window-corner-preview@fabiomereu.it" = callPackage ./window-corner-preview { };
 }

--- a/pkgs/desktops/gnome/extensions/unite/default.nix
+++ b/pkgs/desktops/gnome/extensions/unite/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, gnome, fetchFromGitHub, xprop, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-unite";
+  version = "77";
+
+  src = fetchFromGitHub {
+    owner = "hardpixel";
+    repo = "unite-shell";
+    rev = "v${version}";
+    hash = "sha256-5PClGWOxqwTVaqBySu5I+qavaV1vcKHUvoYJ3Qgcq2o=";
+  };
+
+  passthru = {
+    extensionUuid = "unite@hardpixel.eu";
+    extensionPortalSlug = "unite";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  buildInputs = [ xprop ];
+
+  buildPhase = ''
+    runHook preBuild
+    glib-compile-schemas --strict --targetdir="unite@hardpixel.eu/schemas/" "unite@hardpixel.eu/schemas"
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r "unite@hardpixel.eu" $out/share/gnome-shell/extensions
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Unite is a GNOME Shell extension which makes a few layout tweaks to the top panel and removes window decorations to make it look like Ubuntu Unity Shell";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ rhoriguchi ];
+    homepage = "https://github.com/hardpixel/unite-shell";
+    broken = versionOlder gnome.gnome-shell.version "3.32";
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes #269765.

Haven't had time to test. Strangely `unite` does not release the latest version on <https://extensions.gnome.org/extension/1287/unite/>.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
