### PR TITLE
mininet: 2.3.0 -> 2.3.1b4, make `mn` start again

### DIFF
--- a/nixos/modules/programs/mininet.nix
+++ b/nixos/modules/programs/mininet.nix
@@ -5,26 +5,39 @@
 with lib;
 
 let
-  cfg  = config.programs.mininet;
+  cfg = config.programs.mininet;
 
-  generatedPath = with pkgs; makeSearchPath "bin"  [
-    iperf ethtool iproute2 socat
+  telnet = pkgs.runCommand "inetutils-telnet"
+    { }
+    ''
+      mkdir -p $out/bin
+      ln -s ${pkgs.inetutils}/bin/telnet $out/bin
+    '';
+
+  generatedPath = with pkgs; makeSearchPath "bin" [
+    iperf
+    ethtool
+    iproute2
+    socat
+    # mn errors out without a telnet binary
+    # pkgs.inetutils brings an undesired ifconfig into PATH see #43105
+    nettools
+    telnet
   ];
 
-  pyEnv = pkgs.python.withPackages(ps: [ ps.mininet-python ]);
+  pyEnv = pkgs.python3.withPackages (ps: [ ps.mininet-python ]);
 
   mnexecWrapped = pkgs.runCommand "mnexec-wrapper"
-    { nativeBuildInputs = [ pkgs.makeWrapper pkgs.pythonPackages.wrapPython ]; }
+    { nativeBuildInputs = [ pkgs.makeWrapper pkgs.python3Packages.wrapPython ]; }
     ''
       makeWrapper ${pkgs.mininet}/bin/mnexec \
         $out/bin/mnexec \
         --prefix PATH : "${generatedPath}"
 
-      ln -s ${pyEnv}/bin/mn $out/bin/mn
-
-      # mn errors out without a telnet binary
-      # pkgs.inetutils brings an undesired ifconfig into PATH see #43105
-      ln -s ${pkgs.inetutils}/bin/telnet $out/bin/telnet
+      makeWrapper ${pyEnv}/bin/mn \
+        $out/bin/mn \
+        --prefix PYTHONPATH : "${pyEnv}/${pyEnv.sitePackages}" \
+        --prefix PATH : "${generatedPath}"
     '';
 in
 {

--- a/pkgs/tools/virtualization/mininet/default.nix
+++ b/pkgs/tools/virtualization/mininet/default.nix
@@ -9,7 +9,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mininet";
-  version = "2.3.0";
+  version = "2.3.1b4";
 
   outputs = [ "out" "py" ];
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "mininet";
     repo = "mininet";
     rev = version;
-    sha256 = "sha256-bCppmeB+zQMKTptnzhsXtl72XJXU3USo7cQgP1Z6SrY=";
+    hash = "sha256-Z7Vbfu0EJ4+rCpckXrt3hgxeB9N2nnyPIXgPBnpV4uw=";
   };
 
   buildFlags = [ "mnexec" ];
@@ -41,9 +41,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Emulator for rapid prototyping of Software Defined Networks";
-    license = {
-      fullName = "Mininet 2.3.0 License";
-    };
+    license = licenses.bsd3;
     platforms = platforms.linux;
     homepage = "https://github.com/mininet/mininet";
     maintainers = with maintainers; [ teto ];


### PR DESCRIPTION
## Description of changes

As mentioned in #214730, Mininet is currently broken: especially the binary `mn` cannot start. This PR bumps Mininet from 2.3.0 to 2.3.1b4, making `mn` start again, with these additional changes to the package & the module:
- Wrap `mn` so that it can find the `mininet` Python module upon launch.
- Switch to Python 3.
- Add `${pkgs.nettools}/bin` to `PATH` of the wrappers, forcing `mn` to use `ifconfig` from `nettools`. The `ifconfig` from `inetutils` does not work, as stated in #43105.
- Instead of adding a `telnet` symlink to output, create a separate derivation with symlink to `${pkgs.inetutils}/telnet` and add it to `PATH` of the wrappers instead.
- The license has been changed to BSD: https://github.com/mininet/mininet/commit/3f5503d7737a0f07eafce03594cf9ed5112e5ae8

The legacy `dpctl` issue mentioned in #214730 is not fixed.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
