### PR TITLE
redis-plus-plus: 1.3.7 -> 1.3.10

### DIFF
--- a/pkgs/development/libraries/redis-plus-plus/0001-Fix-pkg-config-paths.patch
+++ b/pkgs/development/libraries/redis-plus-plus/0001-Fix-pkg-config-paths.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/redis++.pc.in b/cmake/redis++.pc.in
+index c98b990..46849b6 100644
+--- a/cmake/redis++.pc.in
++++ b/cmake/redis++.pc.in
+@@ -1,7 +1,5 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=${prefix}
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/include
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: redis++
+ Description: This is a Redis client, based on hiredis and written in C++11. It supports scritpting, pub/sub, pipeline, transaction, Redis Cluster, Redis Sentinel, connection pool, ACL, SSL and thread safety.

--- a/pkgs/development/libraries/redis-plus-plus/default.nix
+++ b/pkgs/development/libraries/redis-plus-plus/default.nix
@@ -8,14 +8,18 @@ assert enableShared || enableStatic;
 
 stdenv.mkDerivation rec {
   pname = "redis-plus-plus";
-  version = "1.3.7";
+  version = "1.3.10";
 
   src = fetchFromGitHub {
     owner = "sewenew";
     repo = "redis-plus-plus";
     rev = version;
-    sha256 = "sha256-QCNN85syxw2EGPdyTV3bL0txcHl7t2YhsKwK9lgnexY=";
+    sha256 = "sha256-lupS4WoJ4r0Vsh3sEGSuka0TtEBo2FPX2eks2blqRGk=";
   };
+
+  patches = [
+    ./0001-Fix-pkg-config-paths.patch
+  ];
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ hiredis ];


### PR DESCRIPTION
## Description of changes

https://github.com/sewenew/redis-plus-plus/releases/tag/1.3.8
https://github.com/sewenew/redis-plus-plus/releases/tag/1.3.9
https://github.com/sewenew/redis-plus-plus/releases/tag/1.3.10

Since these are patch releases, they probably qualify for backporting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
