### PR TITLE
python311Packages.botocore: 1.31.57 -> 1.32.7

### DIFF
--- a/pkgs/development/python-modules/aiobotocore/default.nix
+++ b/pkgs/development/python-modules/aiobotocore/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   version = "2.8.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
@@ -81,6 +81,8 @@ buildPythonPackage rec {
     "test_sso_cred_fetcher_raises_helpful_message_on_unauthorized_exception"
     "test_sso_credential_fetcher_can_fetch_credentials"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Python client for amazon services";

--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -77,6 +77,8 @@ buildPythonPackage rec {
     "test_unexpected_sar_error_stops_processing"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Python library to transform SAM templates into AWS CloudFormation templates";
     homepage = "https://github.com/aws/serverless-application-model";

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.28.57"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.33.6"; # N.B: if you change this, change botocore and awscli to a matching version
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "boto";
     repo = pname;
     rev = version;
-    hash = "sha256-+kuILCUK10tvpfTEAHZGvKKmpw6Pgn+v2kQkwCkPMKg=";
+    hash = "sha256-oOrUVBh1sbaOibU8A+bGZ4z7IEiE4gjHwZ+8889Hv60=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +42,10 @@ buildPythonPackage rec {
     # Integration tests require networking
     "tests/integration"
   ];
+
+  passthru.optional-dependencies = {
+    crt = [ botocore.optional-dependencies.crt ];
+  };
 
   meta = with lib; {
     homepage = "https://github.com/boto/boto3";

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -6,6 +6,7 @@
 , urllib3
 , pytestCheckHook
 , jsonschema
+, awscrt
 }:
 
 buildPythonPackage rec {
@@ -40,6 +41,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "botocore"
   ];
+
+  passthru.optional-dependencies = {
+    crt = [ awscrt ];
+  };
 
   meta = with lib; {
     homepage = "https://github.com/boto/botocore";

--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "aws-cloudformation";
-    repo = "cfn-python-lint";
+    repo = "cfn-lint";
     rev = "refs/tags/v${version}";
     hash = "sha256-0NHD8P+lKsrsEX/ypUS5dIwHOLudQcqkH8zG5RxANxE=";
   };
@@ -76,7 +76,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Checks cloudformation for practices and behaviour that could potentially be improved";
-    homepage = "https://github.com/aws-cloudformation/cfn-python-lint";
+    homepage = "https://github.com/aws-cloudformation/cfn-lint";
     changelog = "https://github.com/aws-cloudformation/cfn-lint/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ ];

--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -57,12 +57,6 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # These tests depend on the current date, for example because of issues like this.
-    # This makes it possible for them to succeed on hydra and then begin to fail without
-    # any code changes.
-    # https://github.com/aws-cloudformation/cfn-python-lint/issues/1705
-    # See also: https://github.com/NixOS/nixpkgs/issues/108076
-    "TestQuickStartTemplates"
     # Requires git directory
     "test_update_docs"
     # Tests depend on network access (fails in getaddrinfo)

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -151,7 +151,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Allows your tests to easily mock out AWS Services";
-    homepage = "https://github.com/spulec/moto";
+    homepage = "https://github.com/getmoto/moto";
     changelog = "https://github.com/getmoto/moto/blob/${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = [ ];

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "s3transfer";
-  version = "0.7.0";
+  version = "0.8.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "boto";
     repo = pname;
     rev = version;
-    hash = "sha256-EvLqRvm9E1Taf+JvbhQbfJqIlbu2a+rB2MX0IO90x98=";
+    hash = "sha256-sdoPjkZHN5wVCK9V6V+fkGvQvEQo2ABy2lqefEKfg6o=";
   };
 
   propagatedBuildInputs = [ botocore ];
@@ -35,6 +35,10 @@ buildPythonPackage rec {
   lib.optionals stdenv.isDarwin [ "tests/unit/test_compat.py" ];
 
   pythonImportsCheck = [ "s3transfer" ];
+
+  passthru.optional-dependencies = {
+    crt = [ botocore.optional-dependencies.crt ];
+  };
 
   meta = with lib; {
     description = "Library for managing Amazon S3 transfers";

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -10,13 +10,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.30.2"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.31.6"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-XbYsPbYUIJPCS+nhcE3A5K7yxHcGUkulT5vHPT5T9kM=";
+    hash = "sha256-PINiNkP2vopPgc9bH0x7mifeUt7gdXi3/i2Ye96RANg=";
   };
-
 
   propagatedBuildInputs = with python3.pkgs; [
     botocore


### PR DESCRIPTION
## Description of changes

Update the awscli stack:

* python311Packages.botocore: 1.31.57 -> 1.32.7
* python311Packages.boto3: 1.28.57 -> 1.29.7
* python311Packages.s3transfer: 0.7.0 -> 0.8.0
* awscli: 1.30.2 -> 1.30.7
* python311Packages.moto: 4.2.6 -> 4.2.10
* python311Packages.cfn-lint: 0.79.11 -> 0.83.3
* python311Packages.aws-sam-translator: 1.78.0 -> 1.81.0
* python311Packages.aiobotocore: 2.6.0 -> 2.7.0

Also fixes the broken build of aws-encryption-sdk-cli.
botocore =>1.32 supports urllib3 v2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
