### PR TITLE
goredo: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/by-name/go/goredo/fix-tests.diff
+++ b/pkgs/by-name/go/goredo/fix-tests.diff
@@ -32,8 +32,8 @@ diff '--color=auto' -ru goredo-2.0.0/t/goredo-double-consideration.t goredo-2.0.
  redo-stamp <"\$3"
  EOF
 diff '--color=auto' -ru goredo-2.0.0/t/redo-sh.tests/clean.do goredo-2.0.0.new/t/redo-sh.tests/clean.do
---- goredo-2.0.0/t/redo-sh.tests/clean.do	2023-10-08 18:50:45.000000000 +0200
-+++ goredo-2.0.0.new/t/redo-sh.tests/clean.do	2023-10-08 20:19:29.213465244 +0200
+--- goredo-2.0.0/t/redo-sh.tests/clean	2023-10-08 18:50:45.000000000 +0200
++++ goredo-2.0.0.new/t/redo-sh.tests/clean	2023-10-08 20:19:29.213465244 +0200
 @@ -1,4 +1,4 @@
  for f in * ; do
      [ -d $f ] || continue

--- a/pkgs/by-name/go/goredo/package.nix
+++ b/pkgs/by-name/go/goredo/package.nix
@@ -9,14 +9,17 @@
 
 buildGoModule rec {
   pname = "goredo";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchurl {
     url = "http://www.goredo.cypherpunks.ru/download/${pname}-${version}.tar.zst";
-    hash = "sha256-oUC/N6NLEVBrFC3tSEsWEXUBl5oyZNmqRTFWFbgL+zg=";
+    hash = "sha256-kVxCHXQ9PjaLYviB8sf8oHiFniyNrHMO6C/qSZhjK7k=";
   };
 
-  patches = [ ./fix-tests.diff ];
+  patches = [
+    # Adapt tests to Linux/nix-build requirements:
+    ./fix-tests.diff
+  ];
 
   nativeBuildInputs = [ zstd ];
 


### PR DESCRIPTION
## Description of changes

Fixes a rare race condition triggered by targets modified outside of redo.

[Changelog](http://www.goredo.cypherpunks.ru/News.html#Release-2_002e5_002e0)



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
