### PR TITLE
invidtui: init at 0.3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15232,6 +15232,12 @@
     githubId = 3302;
     name = "Renzo Carbonara";
   };
+  rettetdemdativ = {
+    email = "michael@koeppl.dev";
+    github = "rettetdemdativ";
+    githubId = 5265630;
+    name = "Michael Köppl";
+  };
   revol-xut = {
     email = "revol-xut@protonmail.com";
     name = "Tassilo Tanneberger";

--- a/pkgs/by-name/in/invidtui/package.nix
+++ b/pkgs/by-name/in/invidtui/package.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub, yt-dlp, ffmpeg, mpv }:
+
+buildGoModule rec {
+  pname = "invidtui";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "darkhz";
+    repo = "invidtui";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-zUr0zrIJPpqhHvL7PFFN7cgcgBXV+WHO/eRes7+HzxM=";
+  };
+
+  vendorHash = "sha256-cKvY3/3N3SESBVol7Af3M3mJaPwxLzd/rKN8P+qh7sY=";
+
+  doCheck = true;
+
+  postPatch = ''
+        substituteInPlace cmd/flags.go \
+          --replace "\"ffmpeg\"" "\"${lib.getBin ffmpeg}/bin/ffmpeg\"" \
+          --replace "\"mpv\"" "\"${lib.getBin mpv}/bin/mpv\"" \
+          --replace "\"yt-dlp\"" "\"${lib.getBin yt-dlp}/bin/yt-dlp\""
+  '';
+
+  meta = with lib; {
+    homepage = "https://darkhz.github.io/invidtui/";
+    description = "An invidious TUI client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rettetdemdativ ];
+    mainProgram = "invidtui";
+  };
+}


### PR DESCRIPTION
## Description of changes

[https://darkhz.github.io/invidtui/](https://darkhz.github.io/invidtui/)
InvidTUI is an invidious client, which fetches data from invidious instances and displays a user interface in the terminal, and allows for selecting and playing Youtube audio and video.

Currently, it is tested on Linux and Windows, and it should work on MacOS.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
