### PR TITLE
xcwd: cleanup

### DIFF
--- a/pkgs/tools/X11/xcwd/default.nix
+++ b/pkgs/tools/X11/xcwd/default.nix
@@ -1,32 +1,32 @@
 { lib, stdenv, fetchFromGitHub, libX11 }:
 
-stdenv.mkDerivation rec {
-  version = "1.0";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xcwd";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner   = "schischi";
     repo    = "xcwd";
-    rev     = "v${version}";
-    sha256  = "sha256-M6/1H6hI50Cvx40RTKzZXoUui0FGZfwe1IwdaxMJIQo=";
+    rev     = "v${finalAttrs.version}";
+    hash    = "sha256-M6/1H6hI50Cvx40RTKzZXoUui0FGZfwe1IwdaxMJIQo=";
   };
 
   buildInputs = [ libX11 ];
 
   makeFlags = [ "prefix=$(out)" ];
 
-  installPhase = ''
-    install -D xcwd "$out/bin/xcwd"
+  preInstall = ''
+    mkdir -p $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = ''
-      A simple tool which print the current working directory of the currently focused window
+      A simple tool which prints the current working directory of the currently focused window
     '';
     homepage = "https://github.com/schischi/xcwd";
-    maintainers = [ maintainers.grburst ];
-    license = licenses.bsd3;
-    platforms = platforms.linux;
+    license = lib.licenses.bsd3;
     mainProgram = "xcwd";
+    maintainers = [ lib.maintainers.grburst ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

This PR does some general cleanup to the `xcwd`.

Changed things:
- remove `rec`
- remove `with lib;`
- change `sha256` to `hash`
- dont't override original `make install`, just create the install directory in `preInstall`
- fix typo in description
- change order of attributes (`meta` in alphabetical order)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
