### PR TITLE
gnome.gpaste: Fix typelib path modification

### DIFF
--- a/pkgs/desktops/gnome/misc/gpaste/fix-paths.patch
+++ b/pkgs/desktops/gnome/misc/gpaste/fix-paths.patch
@@ -1,40 +1,53 @@
+diff --git a/src/gnome-shell/__nix-prepend-search-paths.js b/src/gnome-shell/__nix-prepend-search-paths.js
+new file mode 100644
+index 00000000..e8e20c67
+--- /dev/null
++++ b/src/gnome-shell/__nix-prepend-search-paths.js
+@@ -0,0 +1,3 @@
++import GIRepository from 'gi://GIRepository';
++
++GIRepository.Repository.prepend_search_path('@typelibDir@');
 diff --git a/src/gnome-shell/extension.js b/src/gnome-shell/extension.js
-index cb862a30..2bd41363 100644
+index cb862a30..980767c9 100644
 --- a/src/gnome-shell/extension.js
 +++ b/src/gnome-shell/extension.js
-@@ -10,6 +10,10 @@ import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/ex
- import checkerBypass from './checkerBypass.js';
- import { GPasteIndicator } from './indicator.js';
- 
-+import GIRepository from 'gi://GIRepository';
-+
-+GIRepository.Repository.prepend_search_path('@typelibDir@');
-+
- export default class GPasteExtension extends Extension {
-     enable() {
-         checkerBypass();
-diff --git a/src/gnome-shell/prefs.js b/src/gnome-shell/prefs.js
-index 4c0d9bde..5740d8f6 100644
---- a/src/gnome-shell/prefs.js
-+++ b/src/gnome-shell/prefs.js
-@@ -5,8 +5,11 @@
+@@ -4,6 +4,8 @@
+  * Copyright (c) 2010-2023, Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
   */
  
- import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
-+import GIRepository from 'gi://GIRepository';
- 
--import GPasteGtk from 'gi://GPasteGtk?version=4';
-+GIRepository.Repository.prepend_search_path('@typelibDir@');
++import './__nix-prepend-search-paths.js';
 +
-+const {default: GPasteGtk} = await import('gi://GPasteGtk?version=4');
+ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+ import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
  
- export default class GPastePreferences extends ExtensionPreferences {
-     getPreferencesWidget() {
+diff --git a/src/gnome-shell/meson.build b/src/gnome-shell/meson.build
+index 86cbb0b2..80fc4d67 100644
+--- a/src/gnome-shell/meson.build
++++ b/src/gnome-shell/meson.build
+@@ -1,4 +1,5 @@
+ shell_extension_files = [
++  '__nix-prepend-search-paths.js',
+   'aboutItem.js',
+   'actionButton.js',
+   'actionButtonActor.js',
+diff --git a/src/gnome-shell/prefs.js b/src/gnome-shell/prefs.js
+index 4c0d9bde..58f54f9a 100644
+--- a/src/gnome-shell/prefs.js
++++ b/src/gnome-shell/prefs.js
+@@ -4,6 +4,8 @@
+  * Copyright (c) 2010-2023, Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
+  */
+ 
++import './__nix-prepend-search-paths.js';
++
+ import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+ 
+ import GPasteGtk from 'gi://GPasteGtk?version=4';
 diff --git a/src/libgpaste/gpaste/gpaste-settings.c b/src/libgpaste/gpaste/gpaste-settings.c
-index 7e53eb64..ee620070 100644
+index 830f5e0b..c8df0e11 100644
 --- a/src/libgpaste/gpaste/gpaste-settings.c
 +++ b/src/libgpaste/gpaste/gpaste-settings.c
-@@ -1013,7 +1013,10 @@ create_g_settings (void)
+@@ -1039,7 +1039,10 @@ create_g_settings (void)
      }
      else
      {


### PR DESCRIPTION
## Description of changes
- GPaste 45 switched to ES6 modules.
- Imports in an ES6 module are resolved before the statements in the module body are evaluated.
- If we want our typelib path modification to take effect, we need to do it before the typelibs are imported.

One option is delaying further imports with a top-level await of dynamic import.
I did that in 33cb22179266ae5d6c6b63e3bcb2606a5a9acc7d
But forgot to do it in `extension.js`, causing the extensions to sometimes fail to start:

    JS ERROR: Extension GPaste@gnome-shell-extensions.gnome.org: Error: Requiring GPaste, version 2: Typelib file for namespace 'GPaste', version '2' not found
        require@resource:///org/gnome/gjs/modules/esm/gi.js:16:28
        @gi://GPaste?version=2:3:25
        @resource:///org/gnome/shell/ui/init.js:21:20

Not sure how it can sometimes work.

I could apply the transformation to `extension.js` as well
but there are multiple imports in the file so it would be pretty annoying
since any import that transitively imports typelibs would need to be converted.

Since gjs currently appears to load imports synchronously
and module bodies are executed when all imports are resolved (post-order),
we can instead just create a separate module and import it first.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
