### PR TITLE
Cinnamon updates 2023-11-27

### DIFF
--- a/pkgs/desktops/cinnamon/mint-artwork/default.nix
+++ b/pkgs/desktops/cinnamon/mint-artwork/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-artwork";
-  version = "1.7.6";
+  version = "1.7.7";
 
   src = fetchurl {
     urls = [
       "http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
-      "https://web.archive.org/web/20231010134817/http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
+      "https://web.archive.org/web/20231123132622/http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
     ];
-    hash = "sha256-u1hD0q67bKYKv/xMqqgxA6660v03xjVL4X7zxnNwGf8=";
+    hash = "sha256-FwhZmquT+tByqBIhsoLQOtqsbkp+v4eWIoFenVlgCGc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-l-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-l-icons/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-l-icons";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-x6rM4e8o3uoMPE+0NpZ7BgUZOCkj0XZEtepeNXsmyfU=";
+    hash = "sha256-3bLMuygijkDZ6sIqDzh6Ypwlmz+hpKgdITqrz7Jg3zY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-l-theme/default.nix
+++ b/pkgs/desktops/cinnamon/mint-l-theme/default.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-l-theme";
-  version = "1.9.5";
+  version = "1.9.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     # They don't really do tags, this is just a named commit.
-    rev = "078219f4f947245b3b7bf271c7311f67bf744bfb";
-    hash = "sha256-GK1bwKeyYTXZUNnOdOnqu2C0ZwJHheRVRYL2SLwOnd0=";
+    rev = "1444bacf3ff470db05b663b9c5c3a3419decba60";
+    hash = "sha256-n+5PMfNUNJrVSvCXiFdiRQrq6A6WPINcT110J8OV6FQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-themes/default.nix
+++ b/pkgs/desktops/cinnamon/mint-themes/default.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.1.5";
+  version = "2.1.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-l/ePlvdrHUhRz/KBaBgUSA9KF/pufqeCgSAFRR03IKE=";
+    hash = "sha256-Acf9cwTKDUF1WwIqT3BR8wFpfUNRyZ+8anOIIg3O3CQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-y-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-y-icons/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.6.7";
+  version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-wA+geSx1DpMIth1DWkbp6FtaOMg5wgdshQpeK86S3vs=";
+    hash = "sha256-rVcYt7lnQGS8Bs0aneMFu580K0XTUh4P0kcVwps4l6Q=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/cinnamon/xreader/default.nix
+++ b/pkgs/desktops/cinnamon/xreader/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , glib
 , gobject-introspection
 , intltool
@@ -27,23 +26,14 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "3.8.2";
+  version = "3.8.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-2zqlfoN4L+V237cQ3PVh49YaZfNKGiLqh2JIiGJE340=";
+    sha256 = "sha256-fLnpBJJzrsQSyN+Ok1u/+CwHzBg+bzFR2Jwkc5mpMPA=";
   };
-
-  patches = [
-    # Fix build with meson 1.2, can be dropped on next bump
-    # https://github.com/linuxmint/xreader/issues/612
-    (fetchpatch {
-      url = "https://github.com/linuxmint/xreader/commit/06b18a884c8cf3257ea1f053a82784da078999ed.patch";
-      sha256 = "sha256-+LXEW3OkfhkIcbxtvfQYjdaC18O8imOx22t91ad/XZw=";
-    })
-  ];
 
   nativeBuildInputs = [
     shared-mime-info


### PR DESCRIPTION
## Description of changes

Since branch-off has happened, it should be fine to land some of the updates early.

Patch version bumps only for now (note that not all commits here are picked from https://github.com/NixOS/nixpkgs/pull/268515)

<!--

cinnamon.mint-l-theme: 1.9.5 -> 1.9.6
cinnamon.mint-l-icons: 1.6.5 -> 1.6.6
cinnamon.mint-y-icons: 1.6.7 -> 1.6.9
cinnamon.mint-themes: 2.1.5 -> 2.1.6
cinnamon.xreader: 3.8.2 -> 3.8.3
cinnamon.mint-artwork: 1.7.6 -> 1.7.7

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
