### PR TITLE
nv-codec-headers-12: 12.0.16.0 -> 12.1.14.0; ffmpeg: 6.0 -> 6.1; jellyfin-ffmpeg: 6.0-7 -> 6.0.1-1

### DIFF
--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "4.4.4";
-  sha256 = "sha256-Q8bkuF/1uJfqttJJoObnnLX3BEduv+qxsvOrVhMvRjA=";
+  hash = "sha256-Q8bkuF/1uJfqttJJoObnnLX3BEduv+qxsvOrVhMvRjA=";
   extraPatches = [
     {
       name = "libsvtav1-1.5.0-compat-compressed_ten_bit_format.patch";

--- a/pkgs/development/libraries/ffmpeg/5.nix
+++ b/pkgs/development/libraries/ffmpeg/5.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "5.1.3";
-  sha256 = "sha256-twfJvANLQGO7TiyHPMPqApfHLFUlOGZTTIIGEnjyvuE=";
+  hash = "sha256-twfJvANLQGO7TiyHPMPqApfHLFUlOGZTTIIGEnjyvuE=";
   extraPatches = [
     {
       name = "libsvtav1-1.5.0-compat-compressed_ten_bit_format.patch";

--- a/pkgs/development/libraries/ffmpeg/6.nix
+++ b/pkgs/development/libraries/ffmpeg/6.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "6.0";
-  sha256 = "sha256-RVbgsafIbeUUNXmUbDQ03ZN42oaUo0njqROo7KOQgv0=";
+  version = "6.1";
+  hash = "sha256-NzhD2D16bCVCyCXo0TRwZYp3Ta5eFSfoQPa+iRkeNZg=";
 }

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -698,7 +698,7 @@ stdenv.mkDerivation (finalAttrs: {
       ++ optional withUnfree unfreeRedistributable;
     pkgConfigModules = [ "libavutil" ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ atemu ];
+    maintainers = with maintainers; [ atemu arthsmn ];
     mainProgram = "ffmpeg";
   };
 })

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -179,8 +179,8 @@
  */
 , alsa-lib
 , bzip2
-, clang
 , celt
+, clang
 , dav1d
 , fdk_aac
 , fontconfig
@@ -188,27 +188,31 @@
 , frei0r
 , fribidi
 , game-music-emu
+, glslang
 , gnutls
 , gsm
-, libjack2
+, intel-media-sdk
 , ladspaH
 , lame
-, libass
 , libaom
+, libass
 , libbluray
 , libbs2b
 , libcaca
 , libdc1394
-, libraw1394
 , libdrm
+, libGL
+, libGLU
 , libiconv
-, intel-media-sdk
+, libjack2
 , libmodplug
 , libmysofa
 , libogg
 , libopenmpt
 , libopus
 , libplacebo
+, libpulseaudio
+, libraw1394
 , librsvg
 , libssh
 , libtensorflow
@@ -223,41 +227,37 @@
 , libwebp
 , libX11
 , libxcb
-, libXv
 , libXext
 , libxml2
-, xz
+, libXv
 , nv-codec-headers
 , nv-codec-headers-11
-, openal
 , ocl-icd # OpenCL ICD
+, openal
 , opencl-headers  # OpenCL headers
 , opencore-amr
-, libGL
-, libGLU
 , openh264
 , openjpeg
-, libpulseaudio
 , rav1e
-, svt-av1
 , rtmpdump
 , samba
 , SDL2
 , soxr
 , speex
 , srt
+, svt-av1
 , vid-stab
 , vo-amrwbenc
+, vulkan-headers
+, vulkan-loader
 , x264
 , x265
 , xavs
 , xvidcore
+, xz
 , zeromq4
 , zimg
 , zlib
-, vulkan-headers
-, vulkan-loader
-, glslang
 /*
  *  Darwin frameworks
  */

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -1,4 +1,4 @@
-{ version, sha256, extraPatches ? [] }:
+{ version, hash, extraPatches ? [] }:
 
 { lib, stdenv, buildPackages, removeReferencesTo, addOpenGLRunpath, pkg-config, perl, texinfo, yasm
 
@@ -27,6 +27,7 @@
   # Feature flags
 , withAlsa ? withHeadlessDeps && stdenv.isLinux # Alsa in/output supporT
 , withAom ? withFullDeps # AV1 reference encoder
+, withAribcaption ? withFullDeps && lib.versionAtLeast version "6.1" # ARIB STD-B24 Caption Decoder/Renderer
 , withAss ? withHeadlessDeps && stdenv.hostPlatform == stdenv.buildPlatform # (Advanced) SubStation Alpha subtitle rendering
 , withBluray ? withFullDeps # BluRay reading
 , withBs2b ? withFullDeps # bs2b DSP library
@@ -195,6 +196,7 @@
 , ladspaH
 , lame
 , libaom
+, libaribcaption
 , libass
 , libbluray
 , libbs2b
@@ -231,7 +233,7 @@
 , libxml2
 , libXv
 , nv-codec-headers
-, nv-codec-headers-11
+, nv-codec-headers-12
 , ocl-icd # OpenCL ICD
 , openal
 , opencl-headers  # OpenCL headers
@@ -334,7 +336,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchgit {
     url = "https://git.ffmpeg.org/ffmpeg.git";
     rev = "n${finalAttrs.version}";
-    inherit sha256;
+    inherit hash;
   };
 
   postPatch = ''
@@ -344,10 +346,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
     substituteInPlace doc/filters.texi \
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
-  '' + lib.optionalString withVulkan ''
-    # FIXME: horrible hack, remove for next release
-    substituteInPlace libavutil/hwcontext_vulkan.c \
-      --replace VK_EXT_VIDEO_DECODE VK_KHR_VIDEO_DECODE
   '';
 
   patches = map (patch: fetchpatch patch) (extraPatches
@@ -441,6 +439,7 @@ stdenv.mkDerivation (finalAttrs: {
      *  External libraries
      */
     (enableFeature withAlsa "alsa")
+    (optionalString withAribcaption "--enable-libaribcaption")
     (enableFeature withBzlib "bzlib")
     (enableFeature withCelt "libcelt")
     (enableFeature withCuda "cuda")
@@ -553,9 +552,10 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO This was always in buildInputs before, why?
   buildInputs = optionals withFullDeps [ libdc1394 ]
   ++ optionals (withFullDeps && !stdenv.isDarwin) [ libraw1394 ] # TODO where does this belong to
-  ++ optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast version "6") then nv-codec-headers-11 else nv-codec-headers) ]
+  ++ optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast version "6") then nv-codec-headers-12 else nv-codec-headers) ]
   ++ optionals withAlsa [ alsa-lib ]
   ++ optionals withAom [ libaom ]
+  ++ optionals withAribcaption [ libaribcaption ]
   ++ optionals withAss [ libass ]
   ++ optionals withBluray [ libbluray ]
   ++ optionals withBs2b [ libbs2b ]

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,21 +1,18 @@
 { ffmpeg_6-full
-, nv-codec-headers-12
 , chromaprint
 , fetchFromGitHub
 , lib
 }:
 
-(ffmpeg_6-full.override {
-  nv-codec-headers-11 = nv-codec-headers-12;
-}).overrideAttrs (old: rec {
+ffmpeg_6-full.overrideAttrs (old: rec {
   pname = "jellyfin-ffmpeg";
-  version = "6.0-7";
+  version = "6.0.1-1";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-ffmpeg";
     rev = "v${version}";
-    sha256 = "sha256-Z4getn/mVYIRANkIOyt7jMpcqHBvq5GXLK/ST5zV1r4=";
+    hash = "sha256-LMwGxx++z6TpZLnpeRGraid4653Mp8T4pY5EP4Z7GXY=";
   };
 
   buildInputs = old.buildInputs ++ [ chromaprint ];

--- a/pkgs/development/libraries/nv-codec-headers/12_x.nix
+++ b/pkgs/development/libraries/nv-codec-headers/12_x.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   pname = "nv-codec-headers";
-  version = "12.0.16.0";
+  version = "12.1.14.0";
 
   src = fetchgit {
     url = "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git";
     rev = "n${version}";
-    sha256 = "sha256-8YZU9pb0kzat0JBVEotaZUkNicQvLNIrIyPU9KTTjwg=";
+    sha256 = "sha256-WJYuFmMGSW+B32LwE7oXv/IeTln6TNEeXSkquHh85Go=";
   };
 
   makeFlags = [

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -148,6 +148,9 @@ let
 
       depsBuildBuild = [ buildPackages.stdenv.cc ];
 
+      # FIXME: remove on next release
+      patches = [ ./ffmpeg-6.1.patch ];
+
       postPatch = lib.optionalString (stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "12.0") ''
         substituteInPlace src/output/plugins/OSXOutputPlugin.cxx \
           --replace kAudioObjectPropertyElement{Main,Master} \

--- a/pkgs/servers/mpd/ffmpeg-6.1.patch
+++ b/pkgs/servers/mpd/ffmpeg-6.1.patch
@@ -1,0 +1,10 @@
+--- a/src/decoder/plugins/FfmpegIo.cxx
++++ b/src/decoder/plugins/FfmpegIo.cxx
+@@ -26,6 +26,7 @@
+ 
+ extern "C" {
+ #include <libavutil/mem.h>
++#include <libavutil/error.h>
+ }
+ 
+ AvioStream::~AvioStream()

--- a/pkgs/tools/graphics/gifski/default.nix
+++ b/pkgs/tools/graphics/gifski/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, ffmpeg
+, ffmpeg_5
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    ffmpeg
+    ffmpeg_5
   ];
 
   buildFeatures = [ "video" ];

--- a/pkgs/tools/wayland/wl-screenrec/default.nix
+++ b/pkgs/tools/wayland/wl-screenrec/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , pkg-config
 , libdrm
-, ffmpeg
+, ffmpeg_5
 , wayland
 }:
 
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     wayland
     libdrm
-    ffmpeg
+    ffmpeg_5
   ];
 
   doCheck = false; # tests use host compositor, etc


### PR DESCRIPTION
## Description of changes
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
