### PR TITLE
pangomm: fix build for v 2.42.2

### DIFF
--- a/pkgs/development/libraries/pangomm/2.42.2-add-missing-include-attrlist.cc.patch
+++ b/pkgs/development/libraries/pangomm/2.42.2-add-missing-include-attrlist.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/untracked/pango/pangomm/attrlist.cc b/untracked/pango/pangomm/attrlist.cc
+index 76c3341..0c6d68d 100755
+--- a/untracked/pango/pangomm/attrlist.cc
++++ b/untracked/pango/pangomm/attrlist.cc
+@@ -3,6 +3,7 @@
+ 
+ #include <glibmm.h>
+ 
++#include <pango-1.0/pango/pango-markup.h>
+ #include <pangomm/attrlist.h>
+ #include <pangomm/private/attrlist_p.h>
+ 

--- a/pkgs/development/libraries/pangomm/2.42.nix
+++ b/pkgs/development/libraries/pangomm/2.42.nix
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-GyTJJiSuEnXMtXdYF10198Oa0zQtjAtLpg8NmEnS0Io=";
   };
 
+  patches = [
+    # Fixes a missing include leading to build failures while compiling `attrlist.cc` (as outlined by @dslm4515 [1])
+    # Note that the files in that directory are generated and not tracked in Git [2], which is why we can't simply
+    # try to cherry-pick an upstream patch from future versions.
+    # [1]: https://github.com/dslm4515/BMLFS/issues/16#issuecomment-914624797
+    # [2]: https://github.com/GNOME/pangomm/tree/master/untracked
+    ./2.42.2-add-missing-include-attrlist.cc.patch
+  ];
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkg-config meson ninja python3 ] ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
The build of `pangomm` 2.42 is broken due to a missing include statement in `attrlist.cc` (a generated source file). This also breaks the builds of other packaged libraries that still rely on this older version (like `gigedit`).

Others have already run into this issue and @dslm4515 has outlined a patch in a respective issue on their BMLFS project [1]. I didn't find any simple way to cherry pick such a patch through `fetchpatch` though, as the respective source code is generated and not checked into Git [2].

[1]: https://github.com/dslm4515/BMLFS/issues/16#issuecomment-914624797
[2]: https://github.com/GNOME/pangomm/tree/master/untracked

## Description of changes

Add the missing include statement to `untracked/pango/pangomm/attrlist.cc` through a dedicated patch.

Affected Hydra build: https://hydra.nixos.org/build/241863925
Hydra log: https://hydra.nixos.org/build/241863925/nixlog/2

Relevant log excerpt:

```
FAILED: pango/pangomm/libpangomm-1.4.so.1.0.30.p/_build_pangomm-2.42.2_untracked_pango_pangomm_attrlist.cc.o 
g++ -Ipango/pangomm/libpangomm-1.4.so.1.0.30.p -Ipango/pangomm -I../pango/pangomm -Ipango -I../pango -I../untracked/pango -I/nix/store/ybmdzvab1s6hfkfj4hm848pgdxzlc36g-glib-2.78.1-dev/include -I/nix/store/ybmdzvab1s6hfkfj4hm848pgdxzlc36g-glib-2.78.1-dev/include/glib-2.0 -I/nix/store/5qxy21wbd1n391y8wrf2djyjkiz1bs16-glib-2.78.1/lib/glib-2.0/include -I/nix/store/6v4bdqfjznacxmqb8wvxqvk74diw5q9l-glibmm-2.66.6-dev/include/glibmm-2.4 -I/nix/store/lzbbssdyg9q0rw8prf64xj9af1a4djcq-glibmm-2.66.6/lib/glibmm-2.4/include -I/nix/store/m2p3ahf8j79dskhz9iydd141jhlqcigw-libsigc++-2.12.1/include/sigc++-2.0 -I/nix/store/m2p3ahf8j79dskhz9iydd141jhlqcigw-libsigc++-2.12.1/lib/sigc++-2.0/include -I/nix/store/qm4w9jdpw01p9sim0lin2lfhnqlnhx6a-cairo-1.18.0-dev/include/cairo -I/nix/store/4q1b6baa364dx88s3h5dz4np2a0zsnrl-freetype-2.13.2-dev/include/freetype2 -I/nix/store/4q1b6baa364dx88s3h5dz4np2a0zsnrl-freetype-2.13.2-dev/include -I/nix/store/s68pjnas6flk2vcyxvl2xyp8sb9das9q-cairomm-1.14.5-dev/include/cairomm-1.0 -I/nix/store/668k6szxb81zrzmsxhzjidd12hqmlgsz-cairomm-1.14.5/lib/cairomm-1.0/include -I/nix/store/2jm5k3i1zrvl1j48pnpj8gycjm90c6qy-pango-1.51.0-dev/include/pango-1.0 -I/nix/store/5qlry8s28q321mgak217l655byddnwqh-harfbuzz-7.3.0-dev/include/harfbuzz -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++11 -Wall -fPIC -DPANGOMM_BUILD=1 -MD -MQ pango/pangomm/libpangomm-1.4.so.1.0.30.p/_build_pangomm-2.42.2_untracked_pango_pangomm_attrlist.cc.o -MF pango/pangomm/libpangomm-1.4.so.1.0.30.p/_build_pangomm-2.42.2_untracked_pango_pangomm_attrlist.cc.o.d -o pango/pangomm/libpangomm-1.4.so.1.0.30.p/_build_pangomm-2.42.2_untracked_pango_pangomm_attrlist.cc.o -c /build/pangomm-2.42.2/untracked/pango/pangomm/attrlist.cc
/build/pangomm-2.42.2/untracked/pango/pangomm/attrlist.cc: In constructor 'Pango::AttrList::AttrList(const Glib::ustring&, gunichar)':
/build/pangomm-2.42.2/untracked/pango/pangomm/attrlist.cc:38:20: error: 'pango_parse_markup' was not declared in this scope
   38 |   gboolean bTest = pango_parse_markup(markup_text.c_str(), -1 /* means null-terminated */, accel_marker,
      |                    ^~~~~~~~~~~~~~~~~~
/build/pangomm-2.42.2/untracked/pango/pangomm/attrlist.cc: In constructor 'Pango::AttrList::AttrList(const Glib::ustring&, gunichar, Glib::ustring&, gunichar&)':
/build/pangomm-2.42.2/untracked/pango/pangomm/attrlist.cc:65:20: error: 'pango_parse_markup' was not declared in this scope
   65 |   gboolean bTest = pango_parse_markup(markup_text.c_str(), -1 /* means null-terminated */, accel_marker,
      |                    ^~~~~~~~~~~~~~~~~~
[7/30] Compiling C++ object pango/pangomm/libpangomm-1.4.so.1.0.30.p/_build_pangomm-2.42.2_untracked_pango_pangomm_cairofontmap.cc.o
ninja: build stopped: subcommand failed.
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
