### PR TITLE
cups-brother-hl1210w: fix ppd symlink path

### DIFF
--- a/pkgs/misc/cups/drivers/hl1210w/default.nix
+++ b/pkgs/misc/cups/drivers/hl1210w/default.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation {
 
     substituteInPlace $out/opt/brother/Printers/HL1210W/cupswrapper/brother_lpdwrapper_HL1210W --replace /opt "$out/opt"
 
-    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/lib/cups/filter $out/share/cups/model
     ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brother_lpdwrapper_HL1210W $out/lib/cups/filter/brother_lpdwrapper_HL1210W
-    ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brother-HL1210W-cups-en.ppd $out/lib/cups/filter/brother-HL1210W-cups-en.ppd
+    ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brother-HL1210W-cups-en.ppd $out/share/cups/model/
     # cp brcupsconfig4 $out/opt/brother/Printers/HL1110/cupswrapper/
     ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brcupsconfig4 $out/lib/cups/filter/brcupsconfig4
 


### PR DESCRIPTION
## Description of changes

Move the symlink of the PPD file to the CUPS model directory.

Fixes #269142.