### PR TITLE
 python3.pkgs.pythonRuntimeDepsCheckHook: init 

### DIFF
--- a/pkgs/applications/misc/pysentation/default.nix
+++ b/pkgs/applications/misc/pysentation/default.nix
@@ -15,9 +15,14 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-TwHDXWgGWuQVgatBDc1iympnb6dy4xYThLR5MouEZHA=";
   };
 
-  nativeBuildInputs = [
-    python3.pkgs.setuptools
-    python3.pkgs.wheel
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "click"
+    "rich"
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/ai/airlift/package.nix
+++ b/pkgs/by-name/ai/airlift/package.nix
@@ -1,7 +1,6 @@
 { lib
 , python3
 , fetchPypi
-, argparse
 , kubernetes-helm
 , kind
 , docker
@@ -17,16 +16,22 @@ python3.pkgs.buildPythonApplication rec {
     inherit pname version;
     hash = "sha256-1LE3fpfX4NExJdUdSjt4BXvxQTLJ8zrRkGHkxo/6Pb8=";
   };
+
+  postPatch = ''
+    sed -i '/argparse/d' pyproject.toml
+  '';
+
+   nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
   buildInputs = [
     kubernetes-helm
     kind
     docker
   ];
-  nativeBuildInputs = [
-    python3.pkgs.poetry-core
-  ];
+
   propagatedBuildInputs = with python3.pkgs; [
-    argparse
     halo
     pyyaml
     hiyapyco

--- a/pkgs/by-name/ho/homeassistant-satellite/package.nix
+++ b/pkgs/by-name/ho/homeassistant-satellite/package.nix
@@ -16,8 +16,12 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = with python3.pkgs; [
+    pythonRelaxDepsHook
     setuptools
-    wheel
+  ];
+
+  pythonRelaxDeps = [
+    "aiohttp"
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/we/websecprobe/package.nix
+++ b/pkgs/by-name/we/websecprobe/package.nix
@@ -5,18 +5,17 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "websecprobe";
-  version = "0.0.10";
+  version = "0.0.11";
   pyproject = true;
 
   src = fetchPypi {
     pname = "WebSecProbe";
     inherit version;
-    hash = "sha256-QvXOyQUptMyim/bgvhihjgGs7vX0qX8MqK2ol8q9ePc=";
+    hash = "sha256-OKbKz3HSTtwyx/JNUtLJBTaHQcxkUWroMg9/msVWgk4=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools
-    wheel
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -172,6 +172,16 @@ in {
       };
     } ./python-remove-tests-dir-hook.sh) {};
 
+  pythonRuntimeDepsCheckHook = callPackage ({ makePythonHook, packaging }:
+    makePythonHook {
+      name = "python-runtime-deps-check-hook.sh";
+      propagatedBuildInputs = [ packaging ];
+      substitutions = {
+        inherit pythonInterpreter pythonSitePackages;
+        hook = ./python-runtime-deps-check-hook.py;
+      };
+    } ./python-runtime-deps-check-hook.sh) {};
+
   setuptoolsBuildHook = callPackage ({ makePythonHook, setuptools, wheel }:
     makePythonHook {
       name = "setuptools-setup-hook";

--- a/pkgs/development/interpreters/python/hooks/python-runtime-deps-check-hook.py
+++ b/pkgs/development/interpreters/python/hooks/python-runtime-deps-check-hook.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+The runtimeDependenciesHook validates, that all dependencies specified
+in wheel metadata are available in the local environment.
+
+In case that does not hold, it will print missing dependencies and
+violated version constraints.
+"""
+
+
+import importlib.metadata
+import re
+import sys
+import tempfile
+from argparse import ArgumentParser
+from zipfile import ZipFile
+
+from packaging.metadata import Metadata, parse_email
+from packaging.requirements import Requirement
+
+argparser = ArgumentParser()
+argparser.add_argument("wheel", help="Path to the .whl file to test")
+
+
+def error(msg: str) -> None:
+    print(f"  - {msg}", file=sys.stderr)
+
+
+def normalize_name(name: str) -> str:
+    """
+    Normalize package names according to PEP503
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def get_manifest_text_from_wheel(wheel: str) -> str:
+    """
+    Given a path to a wheel, this function will try to extract the
+    METADATA file in the wheels .dist-info directory.
+    """
+    with ZipFile(wheel) as zipfile:
+        for zipinfo in zipfile.infolist():
+            if zipinfo.filename.endswith(".dist-info/METADATA"):
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = zipfile.extract(zipinfo, path=tmp)
+                    with open(path, encoding="utf-8") as fd:
+                        return fd.read()
+
+    raise RuntimeError("No METADATA file found in wheel")
+
+
+def get_metadata(wheel: str) -> Metadata:
+    """
+    Given a path to a wheel, returns a parsed Metadata object.
+    """
+    text = get_manifest_text_from_wheel(wheel)
+    raw, _ = parse_email(text)
+    metadata = Metadata.from_raw(raw)
+
+    return metadata
+
+
+def test_requirement(requirement: Requirement) -> bool:
+    """
+    Given a requirement specification, tests whether the dependency can
+    be resolved in the local environment, and whether it satisfies the
+    specified version constraints.
+    """
+    if requirement.marker and not requirement.marker.evaluate():
+        # ignore requirements with incompatible markers
+        return True
+
+    package_name = normalize_name(requirement.name)
+
+    try:
+        package = importlib.metadata.distribution(requirement.name)
+    except importlib.metadata.PackageNotFoundError:
+        error(f"{package_name} not installed")
+        return False
+
+    if package.version not in requirement.specifier:
+        error(
+            f"{package_name}{requirement.specifier} not satisfied by version {package.version}"
+        )
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    args = argparser.parse_args()
+
+    metadata = get_metadata(args.wheel)
+    tests = [test_requirement(requirement) for requirement in metadata.requires_dist]
+
+    if not all(tests):
+        sys.exit(1)

--- a/pkgs/development/interpreters/python/hooks/python-runtime-deps-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-runtime-deps-check-hook.sh
@@ -1,0 +1,20 @@
+# Setup hook for PyPA installer.
+echo "Sourcing python-runtime-deps-check-hook"
+
+pythonRuntimeDepsCheckHook() {
+    echo "Executing pythonRuntimeDepsCheck"
+
+    export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
+
+    for wheel in dist/*.whl; do
+        echo "Checking runtime dependencies for $(basename $wheel)"
+        @pythonInterpreter@ @hook@ "$wheel"
+    done
+
+    echo "Finished executing pythonRuntimeDepsCheck"
+}
+
+if [ -z "${dontCheckRuntimeDeps-}" ]; then
+    echo "Using pythonRuntimeDepsCheckHook"
+    preInstallPhases+=" pythonRuntimeDepsCheckHook"
+fi

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -19,6 +19,7 @@
 , pythonOutputDistHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
+, pythonRuntimeDepsCheckHook
 , setuptoolsBuildHook
 , setuptoolsCheckHook
 , wheelUnpackHook
@@ -229,6 +230,13 @@ let
         }
       else
         pypaBuildHook
+    ) (
+      if isBootstrapPackage then
+        pythonRuntimeDepsCheckHook.override {
+          inherit (python.pythonOnBuildForHost.pkgs.bootstrap) packaging;
+        }
+      else
+        pythonRuntimeDepsCheckHook
     )] ++ lib.optionals (format' == "wheel") [
       wheelUnpackHook
     ] ++ lib.optionals (format' == "egg") [

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -29,7 +29,7 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.9.0";
+  version = "3.9.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "aio-libs";
     repo = "aiohttp";
     rev = "refs/tags/v${version}";
-    hash = "sha256-lCeB7uSXkcCCBv1UiwL4AmXpYNJCt4F7a3OKP88ALZU=";
+    hash = "sha256-uiqBUDbmROrhkanfBz4avvTSrnKxgVqw54k4jKhfRGY=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/aiohttp/unvendor-llhttp.patch
+++ b/pkgs/development/python-modules/aiohttp/unvendor-llhttp.patch
@@ -1,0 +1,60 @@
+diff --git a/Makefile b/Makefile
+index 5769d2a1..f505dd81 100644
+--- a/Makefile
++++ b/Makefile
+@@ -71,7 +71,7 @@ vendor/llhttp/node_modules: vendor/llhttp/package.json
+ generate-llhttp: .llhttp-gen
+ 
+ .PHONY: cythonize
+-cythonize: .install-cython $(PYXS:.pyx=.c)
++cythonize: $(PYXS:.pyx=.c)
+ 
+ .install-deps: .install-cython $(PYXS:.pyx=.c) $(call to-hash,$(CYS) $(REQS))
+ 	@python -m pip install -r requirements/dev.txt -c requirements/constraints.txt
+diff --git a/aiohttp/_cparser.pxd b/aiohttp/_cparser.pxd
+index 165dd61d..bc6bf86d 100644
+--- a/aiohttp/_cparser.pxd
++++ b/aiohttp/_cparser.pxd
+@@ -10,7 +10,7 @@ from libc.stdint cimport (
+ )
+ 
+ 
+-cdef extern from "../vendor/llhttp/build/llhttp.h":
++cdef extern from "@llhttpDev@/include/llhttp.h":
+ 
+     struct llhttp__internal_s:
+         int32_t _index
+diff --git a/setup.py b/setup.py
+index 4d59a022..d87d5b69 100644
+--- a/setup.py
++++ b/setup.py
+@@ -17,13 +17,6 @@ if sys.implementation.name != "cpython":
+     NO_EXTENSIONS = True
+ 
+ 
+-if IS_GIT_REPO and not (HERE / "vendor/llhttp/README.md").exists():
+-    print("Install submodules when building from git clone", file=sys.stderr)
+-    print("Hint:", file=sys.stderr)
+-    print("  git submodule update --init", file=sys.stderr)
+-    sys.exit(2)
+-
+-
+ # NOTE: makefile cythonizes all Cython modules
+ 
+ extensions = [
+@@ -33,12 +26,11 @@ extensions = [
+         [
+             "aiohttp/_http_parser.c",
+             "aiohttp/_find_header.c",
+-            "vendor/llhttp/build/c/llhttp.c",
+-            "vendor/llhttp/src/native/api.c",
+-            "vendor/llhttp/src/native/http.c",
+         ],
+         define_macros=[("LLHTTP_STRICT_MODE", 0)],
+-        include_dirs=["vendor/llhttp/build"],
++        include_dirs=["@llhttpDev@/include"],
++        library_dirs=["@llhttpLib@/lib"],
++        libraries=["llhttp"],
+     ),
+     Extension("aiohttp._helpers", ["aiohttp/_helpers.c"]),
+     Extension("aiohttp._http_writer", ["aiohttp/_http_writer.c"]),

--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -1,33 +1,43 @@
 { lib
-, aiohttp
 , buildPythonPackage
-, ddt
 , fetchPypi
-, pbr
-, pytestCheckHook
 , pythonOlder
+
+# build-system
+, pbr
 , setuptools
+
+# dependencies
+, aiohttp
+
+# tests
+, ddt
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "aioresponses";
-  version = "0.7.4";
-  format = "setuptools";
+  version = "0.7.6";
+  pyproject = true;
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-m4wQizY1TARjO60Op1K1XZVqdgL+PjI0uTn8RK+W8dg=";
+    hash = "sha256-95XZ29otYXdIQOfjL1Nm9FdS0a3Bt0yTYq/QFylsfuE=";
   };
 
   nativeBuildInputs = [
     pbr
+    setuptools
   ];
 
   propagatedBuildInputs = [
     aiohttp
-    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "aioresponses"
   ];
 
   nativeCheckInputs = [
@@ -39,10 +49,6 @@ buildPythonPackage rec {
     # Skip a test which makes requests to httpbin.org
     "test_address_as_instance_of_url_combined_with_pass_through"
     "test_pass_through_with_origin_params"
-  ];
-
-  pythonImportsCheck = [
-    "aioresponses"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/aiormq/default.nix
+++ b/pkgs/development/python-modules/aiormq/default.nix
@@ -6,9 +6,7 @@
 , pytestCheckHook
 , pamqp
 , yarl
-, setuptools
 , poetry-core
-, aiomisc
 }:
 
 buildPythonPackage rec {
@@ -20,13 +18,13 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mosquito";
-    repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-X5Uy1DGxvsyEFR1UgVYqxOX6mESLnNzQl7sVkvzjcw4=";
+    repo = "aiormq";
+    # https://github.com/mosquito/aiormq/issues/189
+    rev = "72c44f55313fc14e2a760a45a09831237b64c48d";
+    hash = "sha256-IIlna8aQY6bIA7OZHthfvMFFWnf3DDRBP1uiFCD7+Do=";
   };
 
   nativeBuildInputs = [
-    setuptools
     poetry-core
   ];
 

--- a/pkgs/development/python-modules/aiowatttime/default.nix
+++ b/pkgs/development/python-modules/aiowatttime/default.nix
@@ -2,42 +2,29 @@
 , aiohttp
 , aresponses
 , buildPythonPackage
+, certifi
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , pytest-aiohttp
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
+, yarl
 }:
 
 buildPythonPackage rec {
   pname = "aiowatttime";
-  version = "2023.08.0";
+  version = "2023.10.0";
   format = "pyproject";
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-/ulDImbLOTcoA4iH8e65A01aqqnCLn+01DWuM/4H4p4=";
+    hash = "sha256-3cVs/mIMkHx5jyfICL+I9pOr0uCV2uzasrEcAN4UFGg=";
   };
-
-  patches = [
-    # This patch removes references to setuptools and wheel that are no longer
-    # necessary and changes poetry to poetry-core, so that we don't need to add
-    # unnecessary nativeBuildInputs.
-    #
-    #   https://github.com/bachya/aiowatttime/pull/206
-    #
-    (fetchpatch {
-      name = "clean-up-build-dependencies.patch";
-      url = "https://github.com/bachya/aiowatttime/commit/c3cd53f794964c5435148caacd04f4e0ab8f550a.patch";
-      hash = "sha256-RLRbHmaR2A8MNc96WHx0L8ccyygoBUaOulAuRJkFuUM=";
-    })
-  ];
 
   nativeBuildInputs = [
     poetry-core
@@ -45,6 +32,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiohttp
+    certifi
+    yarl
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/apricot-select/default.nix
+++ b/pkgs/development/python-modules/apricot-select/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, nose
 , numba
 , numpy
 , pytestCheckHook
@@ -26,6 +27,10 @@ buildPythonPackage rec {
     hash = "sha256-v9BHFxmlbwXVipPze/nV35YijdFBuka3gAl85AlsffQ=";
   };
 
+  postPatch = ''
+    sed -i '/"nose"/d' setup.py
+  '';
+
   nativeBuildInputs = [
     setuptools
   ];
@@ -38,6 +43,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    nose
     pytestCheckHook
     torchvision
     scikit-learn

--- a/pkgs/development/python-modules/auth0-python/default.nix
+++ b/pkgs/development/python-modules/auth0-python/default.nix
@@ -3,19 +3,22 @@
 , aioresponses
 , buildPythonPackage
 , callee
+, cryptography
 , fetchFromGitHub
 , mock
 , poetry-core
 , poetry-dynamic-versioning
 , pyjwt
+, pyopenssl
 , pytestCheckHook
 , pythonOlder
 , requests
+, urllib3
 }:
 
 buildPythonPackage rec {
   pname = "auth0-python";
-  version = "4.6.0";
+  version = "4.6.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -24,7 +27,7 @@ buildPythonPackage rec {
     owner = "auth0";
     repo = "auth0-python";
     rev = "refs/tags/${version}";
-    hash = "sha256-KNhuonqFt+KrRYctQ426FcnzxISp5sBRs28hFL/Du0Q=";
+    hash = "sha256-weXEwrOP+TKVwhqCeFVqUw4x+q2Wplr0QWVUzpbNPSc=";
   };
 
   nativeBuildInputs = [
@@ -33,8 +36,12 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    requests
+    aiohttp
+    cryptography
     pyjwt
+    pyopenssl
+    requests
+    urllib3
   ] ++ pyjwt.optional-dependencies.crypto;
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/babel/default.nix
+++ b/pkgs/development/python-modules/babel/default.nix
@@ -4,26 +4,33 @@
 , isPyPy
 , pythonAtLeast
 , pythonOlder
-, tzdata
+
+# build-system
+, setuptools
 
 # tests
 , freezegun
 , pytestCheckHook
 , pytz
+, tzdata
 }:
 
 buildPythonPackage rec {
   pname = "babel";
-  version = "2.12.1";
-  format = "setuptools";
+  version = "2.13.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "Babel";
     inherit version;
-    hash = "sha256-zC2ZmZzQHURCCuclohyeNxGzqtx5dtYUf2IthYGWNFU=";
+    hash = "sha256-M+CVLX3WN0r42/Z2jMTd88z+/CRPmYbUB0cE8vvRiQA=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.9") [
     pytz

--- a/pkgs/development/python-modules/barectf/default.nix
+++ b/pkgs/development/python-modules/barectf/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , poetry-core
 , pytestCheckHook
+, pythonRelaxDepsHook
 , setuptools
 , jsonschema
 , pyyaml
@@ -22,8 +23,16 @@ buildPythonPackage rec {
     hash = "sha256-JelFfd3WS012dveNlIljhLdyPmgE9VEOXoZE3MBA/Gw=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "jsonschema"
+    "pyyaml"
+    "termcolor"
+  ];
 
   propagatedBuildInputs = [
     setuptools # needs pkg_resources at runtime
@@ -33,7 +42,13 @@ buildPythonPackage rec {
     termcolor
   ];
 
-  pythonImportsCheck = [ "barectf" ];
+  pythonImportsCheck = [
+    "barectf"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Generator of ANSI C tracers which output CTF data streams ";

--- a/pkgs/development/python-modules/bootstrap/packaging/default.nix
+++ b/pkgs/development/python-modules/bootstrap/packaging/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, python
+, flit-core
+, installer
+, packaging
+}:
+
+stdenv.mkDerivation {
+  pname = "${python.libPrefix}-bootstrap-${packaging.pname}";
+  inherit (packaging) version src meta;
+
+  buildPhase = ''
+    runHook preBuild
+
+    PYTHONPATH="${flit-core}/${python.sitePackages}" \
+      ${python.interpreter} -m flit_core.wheel
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    PYTHONPATH="${installer}/${python.sitePackages}" \
+      ${python.interpreter} -m installer \
+        --destdir "$out" --prefix "" dist/*.whl
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 
 , build
 , coloredlogs
@@ -25,6 +26,16 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-sHCPT6nTenE6mbTifNPtg0OMNIJCs7LRcF8Xuk+MwLs=";
   };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "packaging"
+    "twine"
+    "wheel"
+  ];
 
   propagatedBuildInputs = [
     build

--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -31,6 +31,11 @@ buildPythonPackage rec {
     hash = "sha256-SGWpm+AGIfqKMpDfmz2aMYmcs+XVREbHIXSuU4R7U/k=";
   };
 
+  postPatch = ''
+    # not strictly required, causes circular dependency cycle
+    sed -i '/importlib-metadata >= 4.6/d' pyproject.toml
+  '';
+
   nativeBuildInputs = [
     flit-core
   ];

--- a/pkgs/development/python-modules/cachetools/default.nix
+++ b/pkgs/development/python-modules/cachetools/default.nix
@@ -1,14 +1,19 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
 , pythonOlder
+
+# build-system
+, setuptools
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "cachetools";
-  version = "5.3.0";
-  format = "setuptools";
+  version = "5.3.2";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -16,8 +21,12 @@ buildPythonPackage rec {
     owner = "tkem";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-7MbP3jz17lGwjAeWo8QmS5v1vGqIQmYLbKVcK/q89Z4=";
+    hash = "sha256-CmyAW9uV63OV/zZsWwZkXOWbHfHAJdYFGJsRhpqQ1f4=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -3,12 +3,14 @@
 , cacert
 , pythonOlder
 , fetchFromGitHub
+, setuptools
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "certifi";
-  version = "2023.07.22";
+  version = "2023.11.17";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -16,7 +18,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = "python-certifi";
     rev = version;
-    hash = "sha256-V3bptJDNMGXlCMg6GHj792IrjfsG9+F/UpQKxeM0QOc=";
+    hash = "sha256-H3zsFJjWt2+tT7yqQOOZZwSL5y0AtfDz6Fqxwpm4Wl8=";
   };
 
   patches = [
@@ -29,6 +31,10 @@ buildPythonPackage rec {
     rm -v "certifi/cacert.pem"
     ln -snvf "${cacert}/etc/ssl/certs/ca-bundle.crt" "certifi/cacert.pem"
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedNativeBuildInputs = [
     # propagate cacerts setup-hook to set up `NIX_SSL_CERT_FILE`

--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -35,6 +35,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # test fails with filename normalization on zfs
+    "test_file_surrogates"
+  ];
+
   passthru.tests = {
     inherit black flask magic-wormhole mitmproxy typer;
   };

--- a/pkgs/development/python-modules/clickhouse-cli/default.nix
+++ b/pkgs/development/python-modules/clickhouse-cli/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonRelaxDepsHook
 , click
 , prompt-toolkit
 , pygments
@@ -17,6 +18,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-gkgLAedUtzGv/4P+D56M2Pb5YecyqyVYp06ST62sjdY=";
   };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "sqlparse"
+  ];
 
   propagatedBuildInputs = [
     click

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -29,20 +29,20 @@ let
 in
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "41.0.3"; # Also update the hash in vectors.nix
+  version = "41.0.7"; # Also update the hash in vectors.nix
   format = "pyproject";
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-bRknQRE+9eMNidy1uVbvThV48wRwhwG4tz044+FGHzQ=";
+    hash = "sha256-E/k86b6oAWwlOzSvxr1qdZk+XEBnLtVAWpyDLw1KALw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     name = "${pname}-${version}";
-    hash = "sha256-LQu7waympGUs+CZun2yDQd2gUUAgyisKBG5mddrfSo0=";
+    hash = "sha256-VeZhKisCPDRvmSjGNwCgJJeVj65BZ0Ge+yvXbZw86Rw=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "cryptography_vectors";
     inherit version;
-    hash = "sha256-gN4EUsSzT1b1UY6B69dba5BfVyiq7VIdQuQfTryKQ/s=";
+    hash = "sha256-ezb5drbljMGAExDhyTxYTGU503Haf4U47dj8Rj3IDVs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , isPy3k
 , pytestCheckHook
 , sphinx
@@ -17,6 +18,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-VipYbbICFrp9K+gmPeuesHnlYEj5uJBtEdX0WqgcUkc=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Add support for Python 3.12
+      # https://github.com/dabeaz/curio/pull/363
+      url = "https://github.com/dabeaz/curio/commit/a5590bb04de3f1f201fd1fd0ce9cfe5825db80ac.patch";
+      hash = "sha256-dwatxLOPAWLQSyNqJvkx6Cbl327tX9OpZXM5aaDX58I=";
+    })
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -10,6 +10,7 @@
 , packaging
 , psutil
 , pythonOlder
+, pythonRelaxDepsHook
 , pyyaml
 , setuptools
 , setuptools-scm
@@ -43,10 +44,15 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
+    pythonRelaxDepsHook
     setuptools
     setuptools-scm
     versioneer
   ] ++ versioneer.optional-dependencies.toml;
+
+  pythonRelaxDeps = [
+    "dask"
+  ];
 
   propagatedBuildInputs = [
     click

--- a/pkgs/development/python-modules/eventlet/default.nix
+++ b/pkgs/development/python-modules/eventlet/default.nix
@@ -11,6 +11,7 @@
 , nose3
 , iana-etc
 , pytestCheckHook
+, pythonAtLeast
 , libredirect
 }:
 
@@ -41,7 +42,8 @@ buildPythonPackage rec {
 
   # libredirect is not available on darwin
   # tests hang on pypy indefinitely
-  doCheck = !stdenv.isDarwin && !isPyPy;
+  # nose3 is incompatible with Python 3.12.
+  doCheck = !stdenv.isDarwin && !isPyPy && !(pythonAtLeast "3.12");
 
   preCheck = lib.optionalString doCheck ''
     echo "nameserver 127.0.0.1" > resolv.conf

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, pythonRelaxDepsHook
 
 # build-system
 , hatchling
@@ -35,7 +36,7 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.103.1";
+  version = "0.104.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -44,11 +45,18 @@ buildPythonPackage rec {
     owner = "tiangolo";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-2J8c3S4Ca+c5bI0tyjMJArJKux9qPmu+ohqve5PhSGI=";
+    hash = "sha256-xTTFBc+fswLYUhKRkWP/eiYSbG3j1E7CASkEtHVNTlk=";
   };
 
   nativeBuildInputs = [
     hatchling
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "anyio"
+    # https://github.com/tiangolo/fastapi/pull/9636
+    "starlette"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -1,18 +1,26 @@
 { lib
-, brotlicffi
 , buildPythonPackage
-, decorator
 , fetchPypi
-, flask
-, flask-limiter
-, flasgger
-, itsdangerous
-, markupsafe
-, raven
-, six
-, pytestCheckHook
+, pythonRelaxDepsHook
+
+# build-system
 , setuptools
+
+# dependencies
+, brotlicffi
+, decorator
+, flasgger
+, flask
+, greenlet
+, six
 , werkzeug
+
+# optional-dependencies
+, gunicorn
+, gevent
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -27,20 +35,29 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "greenlet"
   ];
 
   propagatedBuildInputs = [
     brotlicffi
     decorator
     flask
-    flask-limiter
     flasgger
-    itsdangerous
-    markupsafe
-    raven
+    greenlet
     six
     werkzeug
-  ] ++ raven.optional-dependencies.flask;
+  ];
+
+  passthru.optional-dependencies = {
+    mainapp = [
+      gunicorn
+      gevent
+    ];
+  };
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -13,8 +13,8 @@
 , pytest-trio
 , pytestCheckHook
 , pythonOlder
-, sniffio
 , socksio
+, trio
 # for passthru.tests
 , httpx
 , httpx-socks
@@ -22,16 +22,16 @@
 
 buildPythonPackage rec {
   pname = "httpcore";
-  version = "0.18.0";
+  version = "1.0.2";
   format = "pyproject";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "encode";
-    repo = pname;
+    repo = "httpcore";
     rev = "refs/tags/${version}";
-    hash = "sha256-UEpERsB7jZlMqRtyHxLYBisfDbTGaAiTtsgU1WUpvtA=";
+    hash = "sha256-gjAScRBzAuNiTSxspX6vzwTAdBIwVQbaSLEUFV1QP+E=";
   };
 
   nativeBuildInputs = [
@@ -40,18 +40,22 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    anyio
     certifi
     h11
-    sniffio
   ];
 
   passthru.optional-dependencies = {
+    asyncio = [
+      anyio
+    ];
     http2 = [
       h2
     ];
     socks = [
       socksio
+    ];
+    trio = [
+      trio
     ];
   };
 
@@ -61,19 +65,7 @@ buildPythonPackage rec {
     pytest-httpbin
     pytest-trio
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.http2
-    ++ passthru.optional-dependencies.socks;
-
-  disabledTests = [
-    # https://github.com/encode/httpcore/discussions/813
-    "test_connection_pool_timeout_during_request"
-    "test_connection_pool_timeout_during_response"
-    "test_h11_timeout_during_request"
-    "test_h11_timeout_during_response"
-    "test_h2_timeout_during_handshake"
-    "test_h2_timeout_during_request"
-    "test_h2_timeout_during_response"
-  ];
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   pythonImportsCheck = [
     "httpcore"
@@ -86,7 +78,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    changelog = "https://github.com/encode/httpcore/releases/tag/${version}";
+    changelog = "https://github.com/encode/httpcore/blob/${version}/CHANGELOG.md";
     description = "A minimal low-level HTTP client";
     homepage = "https://github.com/encode/httpcore";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, anyio
 , brotli
 , brotlicffi
 , buildPythonPackage
@@ -11,12 +12,12 @@
 , hatch-fancy-pypi-readme
 , hatchling
 , httpcore
+, idna
 , isPyPy
 , multipart
 , pygments
 , python
 , pythonOlder
-, rfc3986
 , rich
 , sniffio
 , socksio
@@ -29,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "httpx";
-  version = "0.25.0";
+  version = "0.25.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -38,7 +39,7 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-zQVavjU66ksO0FB1h32e0YUhOGiQ4jHPvjgLhtxjU6s=";
+    hash = "sha256-rGtIrs4dffs7Ndtjb400q7JrZh+HG9k0uwHw9pRlC5s=";
   };
 
   nativeBuildInputs = [
@@ -47,9 +48,10 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    anyio
     certifi
     httpcore
-    rfc3986
+    idna
     sniffio
   ];
 
@@ -83,14 +85,7 @@ buildPythonPackage rec {
     pytest-trio
     trustme
     uvicorn
-  ] ++ passthru.optional-dependencies.http2
-    ++ passthru.optional-dependencies.brotli
-    ++ passthru.optional-dependencies.socks;
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "rfc3986[idna2008]>=1.3,<2" "rfc3986>=1.3"
-  '';
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   # testsuite wants to find installed packages for testing entrypoint
   preCheck = ''

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "idna";
-  version = "3.4";
+  version = "3.6";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-gU9Sjo3q19MpgzuRxfqofWC/cYJM0Sp1MLVSYGPQLLQ=";
+    hash = "sha256-ns270IOwZ5iuHoaty/6KsUec+GTk7jD+TkagA9Ekkco=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/itsdangerous/default.nix
+++ b/pkgs/development/python-modules/itsdangerous/default.nix
@@ -21,6 +21,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [
+    "-W" "ignore::DeprecationWarning"
+  ];
+
   meta = with lib; {
     description = "Safely pass data to untrusted environments and back";
     homepage = "https://itsdangerous.palletsprojects.com";

--- a/pkgs/development/python-modules/jupyter-book/default.nix
+++ b/pkgs/development/python-modules/jupyter-book/default.nix
@@ -65,7 +65,10 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "docutils"
-    "sphinx-design"
+    "myst-nb"
+    "sphinx"
+    "sphinx-thebe"
+    "sphinxcontrib-bibtex"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/lsprotocol/default.nix
+++ b/pkgs/development/python-modules/lsprotocol/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "lsprotocol";
-  version = "2023.0.0b1";
+  version = "2023.0.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-Y/Mp/8MskRB6irNU3CBOKmo2Zt5S69h+GyMg71sQ9Uw=";
+    hash = "sha256-K5jocKVxMNoUYYUi9YO2+N7hHWj0MFLprqGOzsg1QRs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/miauth/default.nix
+++ b/pkgs/development/python-modules/miauth/default.nix
@@ -1,14 +1,21 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools
-, wheel
-, bluepy
 , pythonOlder
+, pythonRelaxDepsHook
+
+# build-system
+, setuptools
+
+# dependencies
+, bluepy
 , cryptography
+
+# tests
+, pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "miauth";
   version = "0.9.1";
   pyproject = true;
@@ -26,7 +33,11 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    wheel
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "cryptography"
   ];
 
   propagatedBuildInputs = [
@@ -37,6 +48,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "miauth"
   ];
+
+  doCheck = false; # no tests
 
   meta = with lib; {
     description = "Authenticate and interact with Xiaomi devices over BLE";

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -4,7 +4,7 @@
 , buildPythonPackage
 , pythonOlder
   # Mitmproxy requirements
-, aioquic
+, aioquic-mitmproxy
 , asgiref
 , blinker
 , brotli
@@ -29,7 +29,7 @@
 , setuptools
 , sortedcontainers
 , tornado
-, urwid
+, urwid-mitmproxy
 , wsproto
 , zstandard
   # Additional check requirements
@@ -57,7 +57,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    aioquic
+    aioquic-mitmproxy
     asgiref
     blinker
     brotli
@@ -81,7 +81,7 @@ buildPythonPackage rec {
     setuptools
     sortedcontainers
     tornado
-    urwid
+    urwid-mitmproxy
     wsproto
     zstandard
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/development/python-modules/mkdocs-material/default.nix
+++ b/pkgs/development/python-modules/mkdocs-material/default.nix
@@ -1,53 +1,85 @@
 { lib
-, callPackage
 , buildPythonPackage
 , fetchFromGitHub
-, colorama
+
+# build-system
 , hatch-requirements-txt
 , hatch-nodejs-version
 , hatchling
+, trove-classifiers
+
+# dependencies
+, babel
+, colorama
 , jinja2
 , markdown
 , mkdocs
 , mkdocs-material-extensions
+, paginate
 , pygments
 , pymdown-extensions
 , pythonOlder
 , regex
 , requests
+
+# optional-dependencies
+, mkdocs-minify-plugin
+, mkdocs-redirects
+, mkdocs-git-revision-date-localized-plugin
+, pillow
+, cairosvg
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs-material";
-  version = "9.3.1";
-  format = "pyproject";
+  version = "9.4.14";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "squidfunk";
-    repo = pname;
+    repo = "mkdocs-material";
     rev = "refs/tags/${version}";
-    hash = "sha256-2Z1U71agXxkYp1OFYd/xInAfN5SVI9FQf39b8DkX10o=";
+    hash = "sha256-oP0DeSRgoLx6boEOa3if5BitGXmJ11DoUVZK16Sjlwg=";
   };
 
   nativeBuildInputs = [
     hatch-requirements-txt
     hatch-nodejs-version
     hatchling
+    trove-classifiers
   ];
 
   propagatedBuildInputs = [
+    babel
     colorama
     jinja2
     markdown
     mkdocs
     mkdocs-material-extensions
+    paginate
     pygments
     pymdown-extensions
     regex
     requests
   ];
+
+  passthru.optional-dependencies = {
+    recommended = [
+      mkdocs-minify-plugin
+      mkdocs-redirects
+      # TODO: mkdocs-rss-plugin
+    ];
+    git = [
+      # TODO: gmkdocs-git-committers-plugin
+      mkdocs-git-revision-date-localized-plugin
+    ];
+    imaging = [
+      cairosvg
+      pillow
+    ];
+  };
 
   # No tests for python
   doCheck = false;
@@ -57,7 +89,9 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/squidfunk/mkdocs-material/blob/${src.rev}/CHANGELOG";
     description = "Material for mkdocs";
+    downloadPage = "https://github.com/squidfunk/mkdocs-material";
     homepage = "https://squidfunk.github.io/mkdocs-material/";
     license = licenses.mit;
     maintainers = with maintainers; [ dandellion ];

--- a/pkgs/development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
+++ b/pkgs/development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "mkdocs-material-extensions";
-  version = "1.1.1";
+  version = "1.3.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "facelessuser";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-FHI6WEQRd/Ff6pmU13f8f0zPSeFhhbmDdk4/0rdIl4I=";
+    hash = "sha256-/jU30Ol10/4haR3ZPJWZ3iWRfXG/RUOU1oclOYGjjAY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/mkdocs-minify-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-minify-plugin/default.nix
@@ -9,12 +9,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "mkdocs-minify";
+  pname = "mkdocs-minify-plugin";
   version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "byrnereese";
-    repo = "${pname}-plugin";
+    repo = "mkdocs-minify-plugin";
     rev = "refs/tags/${version}";
     hash = "sha256-LDCAWKVbFsa6Y/tmY2Zne4nOtxe4KvNplZuWxg4e4L8=";
   };

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -23,23 +23,26 @@
 , pyyaml-env-tag
 , watchdog
 
-# testing deps
+# optional-dependencies
 , babel
+
+# testing deps
 , mock
 , unittestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs";
-  version = "1.5.2";
-  format = "pyproject";
-  disabled = pythonOlder "3.6";
+  version = "1.5.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-9sV1bewsHVJEc2kTyGxDM6SjDTEKEc/HSY6gWBC5tvE=";
+    hash = "sha256-axH4AeL+osxoUIVJbW6YjiTfUr6TAXMB4raZ3oO0fyw=";
   };
 
   nativeBuildInputs = [
@@ -63,18 +66,25 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
+  passthru.optional-dependencies = {
+    i18n = [
+      babel
+    ];
+  };
+
   nativeCheckInputs = [
     unittestCheckHook
-    babel
     mock
-  ];
+  ] ++ passthru.optional-dependencies.i18n;
 
   unittestFlagsArray = [ "-v" "-p" "'*tests.py'" "mkdocs" ];
 
   pythonImportsCheck = [ "mkdocs" ];
 
   meta = with lib; {
+    changelog = "https://github.com/mkdocs/mkdocs/releases/tag/${version}";
     description = "Project documentation with Markdown / static website generator";
+    downloadPage = "https://github.com/mkdocs/mkdocs";
     longDescription = ''
       MkDocs is a fast, simple and downright gorgeous static site generator that's
       geared towards building project documentation. Documentation source files

--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -1,17 +1,21 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
+
+# build-system
 , flit-core
+
+# tests
 , pretend
 , pytestCheckHook
-, pythonOlder
 }:
 
 let
   packaging = buildPythonPackage rec {
     pname = "packaging";
     version = "23.2";
-    format = "pyproject";
+    pyproject = true;
 
     disabled = pythonOlder "3.7";
 
@@ -29,18 +33,27 @@ let
       pretend
     ];
 
+    pythonImportsCheck = [
+      "packaging"
+      "packaging.metadata"
+      "packaging.requirements"
+      "packaging.specifiers"
+      "packaging.tags"
+      "packaging.version"
+    ];
+
     # Prevent circular dependency with pytest
     doCheck = false;
-
-    pythonImportsCheck = [ "packaging" ];
 
     passthru.tests = packaging.overridePythonAttrs (_: { doCheck = true; });
 
     meta = with lib; {
+      changelog = "https://github.com/pypa/packaging/blob/${version}/CHANGELOG.rst";
       description = "Core utilities for Python packages";
-      homepage = "https://github.com/pypa/packaging";
+      downloadPage = "https://github.com/pypa/packaging";
+      homepage = "https://packaging.pypa.io/";
       license = with licenses; [ bsd2 asl20 ];
-      maintainers = with maintainers; [ bennofs ];
+      maintainers = teams.python.members ++ (with maintainers; [ bennofs ]);
     };
   };
 in

--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -10,14 +10,14 @@
 let
   packaging = buildPythonPackage rec {
     pname = "packaging";
-    version = "23.1";
+    version = "23.2";
     format = "pyproject";
 
     disabled = pythonOlder "3.7";
 
     src = fetchPypi {
       inherit pname version;
-      hash = "sha256-o5KYDSts/6ZEQxiYvlSwBFFRMZ0efsNPDP7Uh2fdM08=";
+      hash = "sha256-BI+w6UBQNlGOqvSKVZU8dQwR4aG2jg3RqdYu0MCSz8U=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/development/python-modules/paginate/default.nix
+++ b/pkgs/development/python-modules/paginate/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonAtLeast
 
 # build-system
 , setuptools
@@ -31,6 +32,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.12") [
+    # https://github.com/Pylons/paginate/issues/19
+    "test_wrong_collection"
+    "test_unsliceable_sequence3"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/paginate/default.nix
+++ b/pkgs/development/python-modules/paginate/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build-system
+, setuptools
+
+# tests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "paginate";
+  version = "0.5.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Pylons";
+    repo = "paginate";
+    rev = version;
+    hash = "sha256-HZWwOYOCk4mAmz8OnM9hhlf8HA+jC75dYVeo0l4a09o=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "paginate"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python pagination module";
+    homepage = "https://github.com/Pylons/paginate";
+    changelog = "https://github.com/Pylons/paginate/blob/${src.rev}/CHANGELOG.txt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -10,6 +10,7 @@
 , setuptools
 , setuptools-scm
 , playwright-driver
+, pythonRelaxDepsHook
 }:
 
 let
@@ -69,7 +70,17 @@ buildPythonPackage rec {
   '';
 
 
-  nativeBuildInputs = [ git setuptools-scm setuptools auditwheel ];
+  nativeBuildInputs = [
+    git
+    setuptools-scm
+    setuptools
+    auditwheel
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "pyee"
+  ];
 
   propagatedBuildInputs = [
     greenlet

--- a/pkgs/development/python-modules/plyfile/default.nix
+++ b/pkgs/development/python-modules/plyfile/default.nix
@@ -1,16 +1,40 @@
-{ lib, fetchPypi, buildPythonPackage, numpy
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+
+# build-system
+, pdm-pep517
+
+# dependencies
+, numpy
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "plyfile";
-  version = "1.0.1";
+  version = "1.0.2";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-TOrt8e2Ss6Jrdm/IxWzaG5sjkOwpmxbe3i5f1FCXJho=";
+  src = fetchFromGitHub {
+    owner = "dranjan";
+    repo = "python-plyfile";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HlyqljfjuaZoG5f2cfDQj+7KS0en7pW2PPEnpvH8U+E=";
   };
 
-  propagatedBuildInputs = [ numpy ];
+  nativeBuildInputs = [
+    pdm-pep517
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "NumPy-based text/binary PLY file reader/writer for Python";

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -2,14 +2,20 @@
 , lib
 , buildPythonPackage
 , fetchFromGitHub
-, numpy
-, scipy
-, cython
+
+# build-system
+, setuptools
+
+# dependencies
+, apricot-select
 , networkx
-, joblib
-, pandas
-, nose
-, pyyaml
+, numpy
+, scikit-learn
+, scipy
+, torch
+
+# tests
+, pytestCheckHook
 }:
 
 
@@ -26,9 +32,22 @@ buildPythonPackage rec {
     sha256 = "sha256-EnxKlRRfsOIDLAhYOq7bUSbI/NvPoSyYCZ9D5VCXFGQ=";
   };
 
-  propagatedBuildInputs = [ numpy scipy cython networkx joblib pyyaml ];
+  nativeBuildInputs = [
+    setuptools
+  ];
 
-  nativeCheckInputs = [ pandas nose ];  # as of 0.13.5, it depends explicitly on nose, rather than pytest.
+  propagatedBuildInputs = [
+    apricot-select
+    networkx
+    numpy
+    scikit-learn
+    scipy
+    torch
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     broken = stdenv.isDarwin;

--- a/pkgs/development/python-modules/pyarr/default.nix
+++ b/pkgs/development/python-modules/pyarr/default.nix
@@ -1,25 +1,52 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
-, types-requests
+, fetchpatch
+
+# build-system
+, poetry-core
+
+# dependencies
+, overrides
 , requests
+, types-requests
 }:
 
 buildPythonPackage rec {
   pname = "pyarr";
   version = "5.2.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-jlcc9Kj1MYSsnvJkKZXXWWJVDx3KIuojjbGtl8kDUpw=";
+  src = fetchFromGitHub {
+    owner = "totaldebug";
+    repo = "pyarr";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yvlDnAjmwDNdU1SWHGVrmoD3WHwrNt7hXoNNPo1hm1w=";
   };
 
+  patches = [
+    (fetchpatch {
+      # fix build hook specification
+      url = "https://github.com/totaldebug/pyarr/commit/e0aaf53fdb3ab2f60c27c1ec74ce361eca5278d6.patch";
+      hash = "sha256-vD7to465/tviY25D+FUjsg6mJ+N8ZP6qJbWCw9hx/84=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
   propagatedBuildInputs = [
+    overrides
     requests
     types-requests
   ];
 
-  pythonImportsCheck = [ "pyarr" ];
+  pythonImportsCheck = [
+    "pyarr"
+  ];
+
+  doCheck = false; # requires running *arr instances
 
   meta = with lib; {
     description = "Python client for Servarr API's (Sonarr, Radarr, Readarr, Lidarr)";

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -6,7 +6,6 @@
 , devtools
 , email-validator
 , fetchFromGitHub
-, fetchpatch
 , pytest-mock
 , pytestCheckHook
 , python-dotenv
@@ -53,6 +52,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i '/flake8/ d' Makefile
+
+    # Disable strict docs build due warnings being treated as errors
+    substituteInPlace mkdocs.yml \
+      --replace "strict: true" "strict: false"
   '';
 
   buildInputs = lib.optionals (pythonOlder "3.9") [

--- a/pkgs/development/python-modules/pyfaidx/default.nix
+++ b/pkgs/development/python-modules/pyfaidx/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, importlib-metadata
 , nose
 , numpy
 , setuptools
@@ -26,6 +27,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    importlib-metadata
     six
   ];
 

--- a/pkgs/development/python-modules/pyrfc3339/default.nix
+++ b/pkgs/development/python-modules/pyrfc3339/default.nix
@@ -1,21 +1,41 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
+
+# build-system
+, setuptools
+
+# dependencies
 , pytz
+
+# tests
 , nose
 }:
 
 buildPythonPackage rec {
   pname = "pyRFC3339";
   version = "1.1";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "06jv7ar7lpvvk0dixzwdr3wgm0g1lipxs429s2z7knwwa7hwpf41";
   };
 
-  propagatedBuildInputs = [ pytz ];
-  buildInputs = [ nose ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    pytz
+  ];
+
+  doCheck = pythonOlder "3.12";
+
+  nativeCheckInputs = [
+    nose
+  ];
 
   meta = with lib; {
     description = "Generate and parse RFC 3339 timestamps";

--- a/pkgs/development/python-modules/pysml/default.nix
+++ b/pkgs/development/python-modules/pysml/default.nix
@@ -1,4 +1,5 @@
 { lib
+, aiohttp
 , async-timeout
 , bitstring
 , buildPythonPackage
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    aiohttp
     async-timeout
     bitstring
     pyserial-asyncio

--- a/pkgs/development/python-modules/pysolcast/default.nix
+++ b/pkgs/development/python-modules/pysolcast/default.nix
@@ -1,4 +1,5 @@
 { lib
+, anyconfig
 , buildPythonPackage
 , fetchFromGitHub
 , isodate
@@ -29,6 +30,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    anyconfig
     isodate
     pyyaml
     requests

--- a/pkgs/development/python-modules/pysuez/default.nix
+++ b/pkgs/development/python-modules/pysuez/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , setuptools
+, regex
 , requests
 , pythonOlder
 }:
@@ -20,11 +21,17 @@ buildPythonPackage rec {
     hash = "sha256-Xgd0E/oFO2yyytBjuwr1vDJfKWC0Iw8P6GStCuCni/g=";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace ", 'datetime'" ""
+  '';
+
   nativeBuildInputs = [
     setuptools
   ];
 
   propagatedBuildInputs = [
+    regex
     requests
   ];
 

--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, trio, async-generator, hypothesis, outcome, pytest }:
+, trio, hypothesis, outcome, pytest }:
 
 buildPythonPackage rec {
   pname = "pytest-trio";
@@ -17,7 +17,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     trio
-    async-generator
     outcome
   ];
 

--- a/pkgs/development/python-modules/python-osc/default.nix
+++ b/pkgs/development/python-modules/python-osc/default.nix
@@ -1,18 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+
+# build-system
+, setuptools
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-osc";
   version = "1.8.3";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-pc4bpWyNgt9Ryz8pRrXdM6cFInkazEuFZOYtKyCtnKo=";
   };
 
-  pythonImportsCheck = [ "pythonosc" ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "pythonosc"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Open Sound Control server and client in pure python";

--- a/pkgs/development/python-modules/questionary/default.nix
+++ b/pkgs/development/python-modules/questionary/default.nix
@@ -6,6 +6,7 @@
 , prompt-toolkit
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -24,6 +25,11 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "prompt_toolkit"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/readchar/default.nix
+++ b/pkgs/development/python-modules/readchar/default.nix
@@ -2,6 +2,9 @@
 , buildPythonPackage
 , fetchFromGitHub
 
+# build-system
+, setuptools
+
 # tests
 , pytestCheckHook
 , pexpect
@@ -10,7 +13,7 @@
 buildPythonPackage rec {
   pname = "readchar";
   version = "4.0.5";
-  format = "setuptools";
+  pyproject = true;
 
   # Don't use wheels on PyPI
   src = fetchFromGitHub {
@@ -22,12 +25,17 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "--cov=readchar" ""
+      --replace "--cov=readchar" "" \
+      --replace "attr: readchar.__version__" "${version}"
     # run Linux tests on Darwin as well
     # see https://github.com/magmax/python-readchar/pull/99 for why this is not upstreamed
     substituteInPlace tests/linux/conftest.py \
       --replace 'sys.platform.startswith("linux")' 'sys.platform.startswith(("darwin", "linux"))'
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   pythonImportsCheck = [ "readchar" ];
 

--- a/pkgs/development/python-modules/requirements-detector/default.nix
+++ b/pkgs/development/python-modules/requirements-detector/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , packaging
 , poetry-core
-, poetry-semver
+, semver
 , pytestCheckHook
 , pythonOlder
 , toml
@@ -31,8 +31,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     astroid
     packaging
-    poetry-semver
     toml
+    semver
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/rnginline/default.nix
+++ b/pkgs/development/python-modules/rnginline/default.nix
@@ -2,6 +2,7 @@
 , fetchPypi
 , buildPythonPackage
 , poetry-core
+, pythonRelaxDepsHook
 , lxml
 , docopt-ng
 , typing-extensions
@@ -14,21 +15,20 @@
 buildPythonPackage rec {
   pname = "rnginline";
   version = "1.0.0";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-JWqzs+OqOynIAWYVgGrZiuiCqObAgGe6rBt0DcP3U6E=";
   };
 
-  format = "pyproject";
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'importlib-metadata = "^6.6.0"' 'importlib-metadata = "^6.0.0"'
-  '';
-
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "docopt-ng"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sphinx-mdinclude/default.nix
+++ b/pkgs/development/python-modules/sphinx-mdinclude/default.nix
@@ -1,11 +1,17 @@
 { lib
 , buildPythonPackage
-, fetchpatch
 , fetchPypi
+
+# build-system
 , flit-core
+
+# dependencies
 , docutils
 , mistune
 , pygments
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,13 +25,24 @@ buildPythonPackage rec {
     hash = "sha256-KZjj0YswIsmYPRtyGR/jfiX/zNVBZcvjrLIszu3ZGvQ=";
   };
 
-  nativeBuildInputs = [ flit-core ];
-  propagatedBuildInputs = [ mistune docutils ];
+  nativeBuildInputs = [
+    flit-core
+  ];
 
-  nativeCheckInputs = [ pygments ];
+  propagatedBuildInputs = [
+    docutils
+    mistune
+    pygments
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/miyakogi/m2r";
+    broken = true; # https://github.com/omnilib/sphinx-mdinclude/issues/22
+    homepage = "https://github.com/omnilib/sphinx-mdinclude";
+    changelog = "https://github.com/omnilib/sphinx-mdinclude/blob/v${version}/CHANGELOG.md";
     description = "Sphinx extension for including or writing pages in Markdown format.";
     longDescription = ''
       A simple Sphinx extension that enables including Markdown documents from within

--- a/pkgs/development/python-modules/sphinx-prompt/default.nix
+++ b/pkgs/development/python-modules/sphinx-prompt/default.nix
@@ -1,9 +1,19 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonRelaxDepsHook
+
+# build-system
 , poetry-core
 , poetry-dynamic-versioning
+
+# dependencies
+, docutils
+, pygments
 , sphinx
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -26,9 +36,24 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry-core
     poetry-dynamic-versioning
+    pythonRelaxDepsHook
   ];
 
-  propagatedBuildInputs = [ sphinx ];
+  pythonRelaxDeps = [
+    "docutils"
+    "pygments"
+    "Sphinx"
+  ];
+
+  propagatedBuildInputs = [
+    docutils
+    pygments
+    sphinx
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "A sphinx extension for creating unselectable prompt";

--- a/pkgs/development/python-modules/sphinxcontrib-applehelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-applehelp/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   ];
 
   # Check is disabled due to circular dependency of sphinx
+  dontCheckRuntimeDeps = true;
   doCheck = false;
 
   pythonNamespaces = [ "sphinxcontrib" ];

--- a/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   ];
 
   # Check is disabled due to circular dependency of sphinx
+  dontCheckRuntimeDeps = true;
   doCheck = false;
 
   pythonNamespaces = [ "sphinxcontrib" ];

--- a/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   ];
 
   # Check is disabled due to circular dependency of sphinx
+  dontCheckRuntimeDeps = true;
   doCheck = false;
 
   pythonNamespaces = [ "sphinxcontrib" ];

--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   ];
 
   # Check is disabled due to circular dependency of sphinx
+  dontCheckRuntimeDeps = true;
   doCheck = false;
 
   pythonNamespaces = [ "sphinxcontrib" ];

--- a/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   ];
 
   # Check is disabled due to circular dependency of sphinx
+  dontCheckRuntimeDeps = true;
   doCheck = false;
 
   pythonNamespaces = [ "sphinxcontrib" ];

--- a/pkgs/development/python-modules/sphinxcontrib-websupport/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-websupport/default.nix
@@ -26,6 +26,8 @@ buildPythonPackage rec {
     sphinxcontrib-serializinghtml
   ];
 
+  # circular dependency on sphinx
+  dontCheckRuntimeDeps = true;
   doCheck = false;
 
   pythonNamespaces = [ "sphinxcontrib" ];

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -52,6 +52,10 @@ buildPythonPackage rec {
     hash = "sha256-ldBn+pdZfqnBKdYkOcG47ScH/hBgeJBeIvn1hCIBw/A=";
   };
 
+  postPatch = ''
+    sed -i '/tag_build = dev/d' setup.cfg
+  '';
+
   nativeBuildInputs =[
     setuptools
   ] ++ lib.optionals (!isPyPy) [

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -1,32 +1,43 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonAtLeast
 , pythonRelaxDepsHook
-, pbr
-, python-mimeparse
-, extras
-, traceback2
-, testscenarios
+
+# build-system
+, hatchling
+, hatch-vcs
+
+# dependencies
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "testtools";
-  version = "2.6.0";
+  version = "2.7.1";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-KLZeFMDy0+y7+19VydzeXk+qgKwWo3qCOQmh/jy8swo=";
+    sha256 = "sha256-323pYBDinuIfY3oUfqvzDVCyXjhB3R1o+T7onOd+Nmw=";
   };
 
-  propagatedBuildInputs = [ pbr python-mimeparse extras ];
-  buildInputs = [ traceback2 ];
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  nativeBuildInputs = [
+    hatchling
+    hatch-vcs
+    pythonRelaxDepsHook
+  ];
+
+  pythonRemoveDeps = [
+    "fixtures"
+  ];
+
+  propagatedBuildInputs = lib.optionals (pythonAtLeast "3.12") [
+    setuptools
+  ];
 
   # testscenarios has a circular dependency on testtools
   doCheck = false;
-  nativeCheckInputs = [ testscenarios ];
-
-  pythonRemoveDeps = [ "fixtures" ];
 
   meta = {
     description = "A set of extensions to the Python standard library's unit testing framework";

--- a/pkgs/development/python-modules/thelogrus/default.nix
+++ b/pkgs/development/python-modules/thelogrus/default.nix
@@ -5,6 +5,7 @@
 , poetry-core
 , pyaml
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -23,6 +24,11 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "pyaml"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/time-machine/default.nix
+++ b/pkgs/development/python-modules/time-machine/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pythonAtLeast
 , pythonOlder
+, setuptools
 , backports-zoneinfo
 , python-dateutil
 , pytestCheckHook
@@ -10,17 +11,21 @@
 
 buildPythonPackage rec {
   pname = "time-machine";
-  version = "2.12.0";
-  format = "setuptools";
+  version = "2.13.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "adamchainz";
     repo = pname;
     rev = version;
-    hash = "sha256-vBww78/3vC3IA4Nh9Ne+rBo/CO9FggjP+TUUV2/ih9c=";
+    hash = "sha256-SjenPLLr4JoWK5HAokwgW+bw3mfAZiuDb1N7Za5wtrw=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     python-dateutil
@@ -33,6 +38,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.9") [
+    # https://github.com/adamchainz/time-machine/issues/405
+    "test_destination_string_naive"
     # Assertion Errors related to Africa/Addis_Ababa
     "test_destination_datetime_tzinfo_zoneinfo_nested"
     "test_destination_datetime_tzinfo_zoneinfo_no_orig_tz"
@@ -45,6 +52,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/adamchainz/time-machine/blob/${src.rev}/CHANGELOG.rst";
     description = "Travel through time in your tests";
     homepage = "https://github.com/adamchainz/time-machine";
     license = licenses.mit;

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -1,7 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, pythonOlder
 , attrs
 , sortedcontainers
-, async-generator
 , exceptiongroup
 , idna
 , outcome
@@ -40,7 +39,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     attrs
     sortedcontainers
-    async-generator
     idna
     outcome
     sniffio

--- a/pkgs/development/python-modules/trove-classifiers/default.nix
+++ b/pkgs/development/python-modules/trove-classifiers/default.nix
@@ -9,14 +9,14 @@
 let
   self = buildPythonPackage rec {
     pname = "trove-classifiers";
-    version = "2023.8.7";
+    version = "2023.11.29";
     format = "setuptools";
 
     disabled = pythonOlder "3.7";
 
     src = fetchPypi {
       inherit pname version;
-      hash = "sha256-yfKgqF1UXlNi6Wfk8Gn1b939kSFeIv+kjGb7KDUhMZo=";
+      hash = "sha256-/49/2Cx5MhE7RufvZ0LHAJHMY2QMjGXbANkfLpQLlRQ=";
     };
 
     postPatch = ''

--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -2,21 +2,20 @@
 , buildPythonPackage
 , fetchPypi
 , flit-core
-, python
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "typing-extensions";
-  version = "4.7.1";
-  format = "pyproject";
+  version = "4.8.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "typing_extensions";
     inherit version;
-    hash = "sha256-t13cJk8LpWFdt7ohfa65lwGtKVNTxF+elZYzN87u/7I=";
+    hash = "sha256-345DOenLdzV1WMvbzsozwwNxTPhh0e7xXhBwBVrot+8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/uqbar/default.nix
+++ b/pkgs/development/python-modules/uqbar/default.nix
@@ -21,6 +21,10 @@ buildPythonPackage rec {
     hash = "sha256-cEhWXGtMSXVjT5QigDedjT/lwYQnVqPCE5vbctXWznk=";
   };
 
+  postPatch = ''
+    sed -i '/"black"/d' pyproject.toml
+  '';
+
   propagatedBuildInputs = [
     unidecode
     sphinx

--- a/pkgs/development/python-modules/yarl/default.nix
+++ b/pkgs/development/python-modules/yarl/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
-, pythonAtLeast
 , pythonOlder
+, cython_3
+, expandvars
+, setuptools
 , idna
 , multidict
 , typing-extensions
@@ -12,28 +13,26 @@
 
 buildPythonPackage rec {
   pname = "yarl";
-  version = "1.9.2";
+  version = "1.9.3";
 
   disabled = pythonOlder "3.7";
 
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-BKudS59YfAbYAcKr/pMXt3zfmWxlqQ1ehOzEUBCCNXE=";
+    hash = "sha256-ShSQe1l+xVdA9j5S1/7g6e4J1bnVek85mnQjJo5Fe1c=";
   };
-
-  patches = [
-    # https://github.com/aio-libs/yarl/issues/876
-    (fetchpatch {
-      url = "https://github.com/aio-libs/yarl/commit/0a94c6e4948e00fff072c0cf367afbf4ac36f906.patch";
-      hash = "sha256-bqT46OLZLkBef8FQ1L95ITD70mC3+WIkr3+h2ekKrvE=";
-    })
-  ];
 
   postPatch = ''
     sed -i '/^addopts/d' setup.cfg
   '';
+
+  nativeBuildInputs = [
+    cython_3
+    expandvars
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     idna

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -386,8 +386,10 @@ in python.pkgs.buildPythonApplication rec {
   pythonRelaxDeps = [
     "ciso8601"
     "cryptography"
+    "httpx"
     "lru-dict"
     "orjson"
+    "yarl"
   ];
 
   # copy tests early, so patches apply as they would to the git repo

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -332,7 +332,7 @@ in python.pkgs.buildPythonApplication rec {
   format = "pyproject";
 
   # check REQUIRED_PYTHON_VER in homeassistant/const.py
-  disabled = python.pythonOlder "3.10";
+  disabled = python.pythonOlder "3.11";
 
   # don't try and fail to strip 6600+ python files, it takes minutes!
   dontStrip = true;
@@ -354,28 +354,13 @@ in python.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python.pkgs; [
     pythonRelaxDepsHook
     setuptools
-    wheel
   ];
 
   pythonRelaxDeps = [
-    "aiohttp"
-    "attrs"
-    "awesomeversion"
-    "bcrypt"
     "ciso8601"
     "cryptography"
-    "home-assistant-bluetooth"
-    "httpx"
-    "ifaddr"
+    "lru-dict"
     "orjson"
-    "pip"
-    "PyJWT"
-    "pyOpenSSL"
-    "PyYAML"
-    "requests"
-    "typing-extensions"
-    "voluptuous-serialize"
-    "yarl"
   ];
 
   # copy tests early, so patches apply as they would to the git repo
@@ -481,6 +466,8 @@ in python.pkgs.buildPythonApplication rec {
     "--deselect tests/test_config.py::test_merge"
     # AssertionError: assert 'WARNING' not in '2023-11-10 ...nt abc[L]>\n'"
     "--deselect=tests/helpers/test_script.py::test_multiple_runs_repeat_choose"
+    # SystemError: PyThreadState_SetAsyncExc failed
+    "--deselect=tests/helpers/test_template.py::test_template_timeout"
     # tests are located in tests/
     "tests"
   ];

--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -18,12 +18,13 @@ with python3.pkgs; buildPythonApplication rec {
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
   ];
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'sqlalchemy = "^1.4"' 'sqlalchemy = "*"'
-  '';
+  pythonRelaxDeps = [
+    "docutils"
+    "sqlalchemy"
+  ];
 
   propagatedBuildInputs = [
     click

--- a/pkgs/tools/audio/wyoming/piper.nix
+++ b/pkgs/tools/audio/wyoming/piper.nix
@@ -27,6 +27,11 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     setuptools
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "wyoming"
   ];
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/misc/ntfy-sh/default.nix
+++ b/pkgs/tools/misc/ntfy-sh/default.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
     mkdocs
     python3
     python3Packages.mkdocs-material
-    python3Packages.mkdocs-minify
+    python3Packages.mkdocs-minify-plugin
     python3Packages.mkdocs-simple-hooks
   ];
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -244,6 +244,7 @@ mapAliases ({
   memory_profiler = memory-profiler; # added 2023-10-09
   mistune_0_8 = throw "mistune_0_8 was removed because it was outdated and insecure"; # added 2022-08-12
   mistune_2_0 = mistune; # added 2022-08-12
+  mkdocs-minify = mkdocs-minify-plugin; # added 2023-11-28
   mox = throw "mox was removed because it is unmaintained"; # added 2023-02-21
   mrkd = throw "mrkd has been promoted to a top-level attribute"; # added 2023-08-01
   multi_key_dict = multi-key-dict; # added 2023-11-05

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16,6 +16,9 @@ self: super: with self; {
     build = toPythonModule (callPackage ../development/python-modules/bootstrap/build {
       inherit (bootstrap) flit-core installer;
     });
+    packaging = toPythonModule (callPackage ../development/python-modules/bootstrap/packaging {
+      inherit (bootstrap) flit-core installer;
+    });
   };
 
   setuptools = callPackage ../development/python-modules/setuptools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6960,7 +6960,7 @@ self: super: with self; {
   mkdocs-macros = callPackage ../development/python-modules/mkdocs-macros { };
   mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
   mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };
-  mkdocs-minify = callPackage ../development/python-modules/mkdocs-minify { };
+  mkdocs-minify-plugin = callPackage ../development/python-modules/mkdocs-minify-plugin { };
   mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };
   mkdocs-simple-hooks = callPackage ../development/python-modules/mkdocs-simple-hooks { };
   mkdocs-swagger-ui-tag = callPackage ../development/python-modules/mkdocs-swagger-ui-tag { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8742,6 +8742,8 @@ self: super: with self; {
 
   pagelabels = callPackage ../development/python-modules/pagelabels { };
 
+  paginate = callPackage ../development/python-modules/paginate { };
+
   paho-mqtt = callPackage ../development/python-modules/paho-mqtt { };
 
   palace = callPackage ../development/python-modules/palace { };


### PR DESCRIPTION
## Description of changes

Implements a hook, that checks whether all dependencies, as specified by
the wheel manifest, are present in the current environment.

Complains about missing packages, as well as version specifier
mismatches.

Requires at least `packaging>=23.2` and creates a bootstrap version of it.
Not sure if this is necessary, or if we should just not check on bootstrap packages.

Breaks the build for some packages, e.g., when we prevent infinite
recursion, like on sphinxcontrib packages, which have a dependency on `sphinx`. 
What do we want to do here? Will set `dontCheckRuntimeDeps` for now.

Fixes: #250865

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
