### PR TITLE
kodiPackages.libretro-mupen64plus-nx: init

### DIFF
--- a/pkgs/applications/video/kodi/addons/libretro-mupen64plus-nx/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-mupen64plus-nx/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildKodiBinaryAddon, fetchFromGitHub, libretro, mupen64plus }:
+
+buildKodiBinaryAddon rec {
+  pname = "kodi-libretro-mupen64plus-nx";
+  namespace = "game.libretro.mupen64plus-nx";
+  version = "2.5.0.41";
+
+  src = fetchFromGitHub {
+    owner = "kodi-game";
+    repo = "game.libretro.mupen64plus-nx";
+    rev = "${version}-Nexus";
+    sha256 = "sha256-LKTf2i6nsQVJ/Id3jstxIiIQxGobiWhfSwjBgQ+zRnQ=";
+  };
+
+  extraCMakeFlags = [
+    "-DMUPEN64PLUS-NX_LIB=${mupen64plus}/lib/retroarch/cores/mupen64plus_next_libretro.so"
+  ];
+
+  extraBuildInputs = [ mupen64plus ];
+  propagatedBuildInputs = [
+    libretro
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-game/game.libretro.mupen64plus-nx";
+    description = "Mupen64plus GameClient for Kodi";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  inherit (libretro) fuse genesis-plus-gx mgba nestopia snes9x twenty-fortyeight;
+  inherit (libretro) fuse genesis-plus-gx mgba nestopia snes9x twenty-fortyeight mupen64plus;
 in
 
 let self = rec {
@@ -71,6 +71,8 @@ let self = rec {
   libretro-mgba = callPackage ../applications/video/kodi/addons/libretro-mgba { inherit mgba; };
 
   libretro-nestopia = callPackage ../applications/video/kodi/addons/libretro-nestopia { inherit nestopia; };
+
+  libretro-mupen64plus-nx = callPackage ../applications/video/kodi/addons/libretro-mupen64plus-nx { inherit mupen64plus; };
 
   libretro-snes9x = callPackage ../applications/video/kodi/addons/libretro-snes9x { inherit snes9x; };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
