### PR TITLE
prometheus-restic-exporter: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12170,6 +12170,12 @@
     githubId = 92937;
     name = "Breland Miley";
   };
+  minersebas = {
+    email = "scherthan_sebastian@web.de";
+    github = "MinerSebas";
+    githubId = 66798382;
+    name = "Sebastian Maximilian Scherthan";
+  };
   minijackson = {
     email = "minijackson@riseup.net";
     github = "minijackson";

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -71,6 +71,7 @@ let
     "pve"
     "py-air-control"
     "redis"
+    "restic"
     "rspamd"
     "rtl_433"
     "sabnzbd"

--- a/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
@@ -1,0 +1,131 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.restic;
+in
+{
+  port = 9753;
+  extraOpts = {
+    repository = mkOption {
+      type = types.str;
+      description = lib.mdDoc ''
+        URI pointing to the repository to monitor.
+      '';
+      example = "sftp:backup@192.168.1.100:/backups/example";
+    };
+
+    passwordFile = mkOption {
+      type = types.path;
+      description = lib.mdDoc ''
+        File containing the password to the repository.
+      '';
+      example = "/etc/nixos/restic-password";
+    };
+
+    environmentFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = lib.mdDoc ''
+        File containing the credentials to access the repository, in the
+        format of an EnvironmentFile as described by systemd.exec(5)
+      '';
+    };
+
+    refreshInterval = mkOption {
+      type = types.ints.unsigned;
+      default = 60;
+      description = lib.mdDoc ''
+        Refresh interval for the metrics in seconds.
+        Computing the metrics is an expensive task, keep this value as high as possible.
+      '';
+    };
+
+    rcloneOptions = mkOption {
+      type = with types; attrsOf (oneOf [ str bool ]);
+      default = { };
+      description = lib.mdDoc ''
+        Options to pass to rclone to control its behavior.
+        See <https://rclone.org/docs/#options> for
+        available options. When specifying option names, strip the
+        leading `--`. To set a flag such as
+        `--drive-use-trash`, which does not take a value,
+        set the value to the Boolean `true`.
+      '';
+    };
+
+    rcloneConfig = mkOption {
+      type = with types; attrsOf (oneOf [ str bool ]);
+      default = { };
+      description = lib.mdDoc ''
+        Configuration for the rclone remote being used for backup.
+        See the remote's specific options under rclone's docs at
+        <https://rclone.org/docs/>. When specifying
+        option names, use the "config" name specified in the docs.
+        For example, to set `--b2-hard-delete` for a B2
+        remote, use `hard_delete = true` in the
+        attribute set.
+
+        ::: {.warning}
+        Secrets set in here will be world-readable in the Nix
+        store! Consider using the {option}`rcloneConfigFile`
+        option instead to specify secret values separately. Note that
+        options set here will override those set in the config file.
+        :::
+      '';
+    };
+
+    rcloneConfigFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = lib.mdDoc ''
+        Path to the file containing rclone configuration. This file
+        must contain configuration for the remote specified in this backup
+        set and also must be readable by root.
+
+        ::: {.caution}
+        Options set in `rcloneConfig` will override those set in this
+        file.
+        :::
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-restic-exporter}/bin/restic-exporter.py \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+      EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
+    };
+    environment =
+      let
+        rcloneRemoteName = builtins.elemAt (splitString ":" cfg.repository) 1;
+        rcloneAttrToOpt = v: "RCLONE_" + toUpper (builtins.replaceStrings [ "-" ] [ "_" ] v);
+        rcloneAttrToConf = v: "RCLONE_CONFIG_" + toUpper (rcloneRemoteName + "_" + v);
+        toRcloneVal = v: if lib.isBool v then lib.boolToString v else v;
+      in
+      {
+        RESTIC_REPO_URL = cfg.repository;
+        RESTIC_REPO_PASSWORD_FILE = cfg.passwordFile;
+        LISTEN_ADDRESS = cfg.listenAddress;
+        LISTEN_PORT = toString cfg.port;
+        REFRESH_INTERVAL = toString cfg.refreshInterval;
+      }
+      // (mapAttrs'
+        (name: value:
+          nameValuePair (rcloneAttrToOpt name) (toRcloneVal value)
+        )
+        cfg.rcloneOptions)
+      // optionalAttrs (cfg.rcloneConfigFile != null) {
+        RCLONE_CONFIG = cfg.rcloneConfigFile;
+      }
+      // (mapAttrs'
+        (name: value:
+          nameValuePair (rcloneAttrToConf name) (toRcloneVal value)
+        )
+        cfg.rcloneConfig);
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1217,6 +1217,39 @@ let
       '';
     };
 
+    restic =
+      let
+        repository = "rest:http://127.0.0.1:8000";
+        passwordFile = pkgs.writeText "restic-test-password" "test-password";
+      in
+      {
+        exporterConfig = {
+          enable = true;
+          inherit repository passwordFile;
+        };
+        metricProvider = {
+          services.restic.server = {
+            enable = true;
+            extraFlags = [ "--no-auth" ];
+          };
+          environment.systemPackages = [ pkgs.restic ];
+        };
+        exporterTest = ''
+          # prometheus-restic-exporter.service fails without initialised repository
+          systemctl("stop prometheus-restic-exporter.service")
+
+          # Initialise the repository
+          wait_for_unit("restic-rest-server.service")
+          wait_for_open_port(8000)
+          succeed("restic init --repo ${repository} --password-file ${passwordFile}")
+
+          systemctl("start prometheus-restic-exporter.service")
+          wait_for_unit("prometheus-restic-exporter.service")
+          wait_for_open_port(9753)
+          wait_until_succeeds("curl -sSf localhost:9753/metrics | grep 'restic_check_success 1.0'")
+        '';
+      };
+
     rspamd = {
       exporterConfig = {
         enable = true;
@@ -1722,7 +1755,12 @@ mapAttrs
       testScript = ''
         ${nodeName}.start()
         ${concatStringsSep "\n" (map (line:
-          if (builtins.substring 0 1 line == " " || builtins.substring 0 1 line == ")")
+          if builtins.any (b: b) [
+            (builtins.match "^[[:space:]]*$" line != null)
+            (builtins.substring 0 1 line == "#")
+            (builtins.substring 0 1 line == " ")
+            (builtins.substring 0 1 line == ")")
+          ]
           then line
           else "${nodeName}.${line}"
         ) (splitString "\n" (removeSuffix "\n" testConfig.exporterTest)))}

--- a/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, python3
+, restic
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "prometheus-restic-exporter";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ngosang";
+    repo = "restic-exporter";
+    rev = version;
+    hash = "sha256-Qwhlecginl5+V+iddN/vIHfJA1kQOZtscECsoD4LJPE=";
+  };
+
+  buildInputs = [
+    (python3.withPackages (ps: [ ps.prometheus-client ]))
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m0755 restic-exporter.py $out/bin/restic-exporter.py
+
+    substituteInPlace $out/bin/restic-exporter.py --replace \"restic\" \"${lib.makeBinPath [ restic ]}/restic\"
+
+    patchShebangs $out/bin/restic-exporter.py
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Prometheus exporter for the Restic backup system";
+    homepage = "https://github.com/ngosang/restic-exporter";
+    changelog = "https://github.com/ngosang/restic-exporter/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ minersebas ];
+    mainProgram = "restic-exporter.py";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , python3
 , restic
+, nixosTests
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -31,6 +32,10 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    restic-exporter = nixosTests.prometheus-exporters.restic;
+  };
 
   meta = with lib; {
     description = "Prometheus exporter for the Restic backup system";


### PR DESCRIPTION
## Description of changes

This adds [restic-exporter](https://github.com/ngosang/restic-exporter/tree/main) and Module that uses it to nixpkgs.

Name: I prefixed `prometheus-` as this seems to be the convention in nixpkgs (See [sql_exporter](https://github.com/justwatchcom/sql_exporter) that is packaged as `prometheus-sql-exporter`).
Location: I added the new Package to the `by-name` Folder, but I can instead move instead to `servers/monitoring/prometheus/` next to the preexisting exporters.

For the module options, I leaned on the preexisting `services.restic.backup` Options, but I don't know what appropriate examples would be for the rclone options.
For the default Port I picked a random Number and a quick grep accros the repo didn't show any preexisting use.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
