### PR TITLE
nix-doc: broken

### DIFF
--- a/pkgs/tools/package-management/nix-doc/default.nix
+++ b/pkgs/tools/package-management/nix-doc/default.nix
@@ -39,5 +39,9 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ maintainers.lf- ];
     platforms = platforms.unix;
     mainProgram = "nix-doc";
+
+    # `nix-doc` currently contains a broken unit test, which causes the check phase to fail.
+    # https://github.com/lf-/nix-doc/issues/24
+    broken = true;
   };
 }


### PR DESCRIPTION
`nix-doc` contains a unit test that breaks on current Nixpkgs builds. As I'm not sure what the test is supposed to check for exactly and whether the breakage might have been caused by a recent update of `nix` (the project depends on `nix-expr`), I propose simply marking it as such for now.

I also opened a corresponding GitHub issue upstream: https://github.com/lf-/nix-doc/issues/24

@lf-: I thought I'd simply open this in case you'd need to invest time investigating where this breakage actually comes from. If it's an easy fix, feel free to simply close this PR :)

## Description of changes

Mark the project as broken, referring to the upstream ticket.

Failing Hydra build: https://hydra.nixos.org/build/242152066
Hydra log: https://hydra.nixos.org/build/242152066/nixlog/1

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
