### PR TITLE
paraview: fix strlcat symbol provided by glibc 2.38

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -86,6 +86,10 @@ in stdenv.mkDerivation rec {
     qtsvg
   ];
 
+  patches = [
+    ./dont-redefine-strlcat.patch
+  ];
+
   postInstall = let docDir = "$out/share/paraview-${lib.versions.majorMinor version}/doc"; in
     lib.optionalString withDocs ''
       mkdir -p ${docDir};

--- a/pkgs/applications/graphics/paraview/dont-redefine-strlcat.patch
+++ b/pkgs/applications/graphics/paraview/dont-redefine-strlcat.patch
@@ -1,0 +1,28 @@
+--- a/VTK/ThirdParty/netcdf/vtknetcdf/include/vtk_netcdf_mangle.h	2023-11-27 21:11:33.562949964 +0100
++++ b/VTK/ThirdParty/netcdf/vtknetcdf/include/vtk_netcdf_mangle.h	2023-11-27 21:11:33.562949964 +0100
+@@ -1246,7 +1246,7 @@
+ #define write_numrecs vtknetcdf_write_numrecs
+ 
+ /* Only define strlcat conditionally, as it's provided by system headers on the BSDs. */
+-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(_BSD_SOURCE)
++#ifndef HAVE_STRLCAT
+ #define strlcat vtknetcdf_strlcat
+ #endif
+ 
+--- a/VTK/ThirdParty/netcdf/vtknetcdf/config.h.in	2023-11-27 21:10:35.113525241 +0100
++++ b/VTK/ThirdParty/netcdf/vtknetcdf/config.h.in	2023-11-27 21:10:55.241982399 +0100
+@@ -1,7 +1,5 @@
+ /* config.h.in.  Generated from configure.ac by autoheader.  */
+ 
+-#include "vtk_netcdf_mangle.h"
+-
+ /* Define if building universal (internal helper macro) */
+ #cmakedefine AC_APPLE_UNIVERSAL_BUILD
+ 
+@@ -621,4 +619,6 @@
+ #endif
+ #endif
+ 
++#include "vtk_netcdf_mangle.h"
++
+ #include "ncconfigure.h"


### PR DESCRIPTION
Glibc introduces strlcat in commit [1].
The logic of vtknetcdf was to only define strlcat conditionally on not BSD systems, but starting with glibc 2.38, strlcat is also defined on Linux.

The CMakelist checks for the symbol existence, the redefinition of the symbol can be conditional on the boolean HAVE_STRLCAT instead of if not BSD systems.

This commit fixes #268961.

[1] https://sourceware.org/git/?p=glibc.git;a=commit;h=454a20c8756c9c1d55419153255fc7692b3d2199

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
