### PR TITLE
ugrep-indexer: init at 0.9.6

### DIFF
--- a/pkgs/by-name/ug/ugrep-indexer/package.nix
+++ b/pkgs/by-name/ug/ugrep-indexer/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, brotli
+, bzip2
+, lz4
+, xz
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ugrep-indexer";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "Genivia";
+    repo = "ugrep-indexer";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ZXZF9ZSdfQ2gxi5JkDJCUzMbkTs9KLzZBsyYxR/v4tI=";
+  };
+
+  buildInputs = [
+    brotli
+    bzip2
+    lz4
+    zlib
+    zstd
+    xz
+  ];
+
+  meta = with lib; {
+    description = "Utility that recursively indexes files to speed up recursive grepping";
+    homepage = "https://github.com/Genivia/ugrep-indexer";
+    changelog = "https://github.com/Genivia/ugrep-indexer/releases/tag/v${finalAttrs.version}";
+    maintainers = with maintainers; [ mikaelfangel ];
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds `ugrep-indexer`
 > The ugrep-indexer utility recursively indexes files to speed up recursive grepping.

Thought it would be a nice addition to the already package `ugrep` package.

[https://github.com/Genivia/ugrep-indexer](https://github.com/Genivia/ugrep-indexer)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
