### PR TITLE
workflows/check-by-name: Limited and exponential retries

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -16,6 +16,9 @@ jobs:
     # This is x86_64-linux, for which the tool is always prebuilt on the nixos-* channels,
     # as specified in nixos/release-combined.nix
     runs-on: ubuntu-latest
+    # This should take 1 minute at most, but let's be generous.
+    # The default of 6 hours is definitely too long
+    timeout-minutes: 10
     steps:
       - name: Resolving the merge commit
         env:

--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           # This checks for mergeability of a pull request as recommended in
           # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
+
+          # Retry the API query this many times
+          retryCount=3
+          # Start with 5 seconds, but double every retry
+          retryInterval=5
           while true; do
             echo "Checking whether the pull request can be merged"
             prInfo=$(gh api \
@@ -33,10 +38,19 @@ jobs:
             mergedSha=$(jq -r .merge_commit_sha <<< "$prInfo")
 
             if [[ "$mergeable" == "null" ]]; then
-              # null indicates that GitHub is still computing whether it's mergeable
-              # Wait a couple seconds before trying again
-              echo "GitHub is still computing whether this PR can be merged, waiting 5 seconds before trying again"
-              sleep 5
+              if (( retryCount == 0 )); then
+                echo "Not retrying anymore, probably GitHub is having internal issues"
+                exit 1
+              else
+                (( retryCount -= 1 )) || true
+
+                # null indicates that GitHub is still computing whether it's mergeable
+                # Wait a couple seconds before trying again
+                echo "GitHub is still computing whether this PR can be merged, waiting $retryInterval seconds before trying again ($retryCount retries left)"
+                sleep "$retryInterval"
+
+                (( retryInterval *= 2 )) || true
+              fi
             else
               break
             fi


### PR DESCRIPTION
## Description of changes

We've had a recent PR CI mass failure event, ultimately caused by the mergeability check GitHub API not returning a result, which could be related to a [recent GitHub incident](https://www.githubstatus.com/incidents/66vhjmd266r9).

But due to the `pkgs/by-name` check workflow not backing off appropriately between retries, it pummeled the API, resulting in exceeding the API rate limit:

https://github.com/NixOS/nixpkgs/actions/runs/6986875738/job/19012809808

This commit improves that for the future by implementing a retry strategy limited to three retries, with exponential backoff. This means that the failure of one PR shouldn't affect others (they all use the same GITHUB_TOKEN with a shared rate limit).

## Things done
- [x] Tested that the workflow still runs and doesn't have a syntax error: https://github.com/tweag/nixpkgs/pull/78
- [x] Tested that the added code path works locally