### PR TITLE
teeworlds: fix meta.license

### DIFF
--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -99,7 +99,18 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://teeworlds.com/";
-    license = "BSD-style, see `license.txt'";
+    license = with lib.licenses; [
+      # See https://github.com/teeworlds/teeworlds/blob/master/license.txt
+      lib.licenses.zlib # Main license
+      cc-by-sa-30 # All content under 'datasrc' except the fonts
+      ofl  # datasrc/fonts/SourceHanSans.ttc
+      free # datasrc/fonts/DejaVuSans.ttf
+      bsd2 # src/engine/external/json-parser/
+      bsd3 # src/engine/external/wavpack
+      # zlib src/engine/external/md5/
+      # zlib src/engine/external/pnglite/
+      # zlib src/engine/external/zlib/
+    ];
     maintainers = with lib.maintainers; [ astsmtl Luflosi ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
## Description of changes
Replace stringy license with a list of all used licenses.

The original meta.license said that the license was BSD-style but this information has been outdated for a long time.
The license was changed in 2008: https://github.com/teeworlds/teeworlds/commit/bc108df382b5ac4ca637bf97ba9b2d8b2d83e58f#diff-7bb54d15ef4c4e0f20bb24add68a12fccced9925b304eaa696023143d278ea26.
The current license is clearly the zlib license and below that some notes about the licenses of `datasrc` (and `data`, which has not existed in the tree for many years), the fonts in `datasrc` and the libraries in `src/engine/external`.
See https://github.com/teeworlds/teeworlds/blob/master/license.txt for the current version of the license.
The meta.license string has been unchanged since the commit adding teeworlds in 2009: e71dbdbb8334152dbf3083801d194b2f88cee9b4.

See issue #269788.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc