### PR TITLE
nixos/mastodon; Releasenotes and (possibly) better error messages for `streamingProcesses`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -71,7 +71,9 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
 - `services.mastodon` doesn't support providing a TCP port to its `streaming`
   component anymore, as upstream implemented parallelization by running
   multiple instances instead of running multiple processes in one instance.
-  Please create a PR if you are interested in this feature.
+  Please create a PR if you are interested in this feature.\
+  Due to this, the desired number of such instances
+  {option}`services.mastodon.streamingProcesses` now needs to be declared explicitly.
 
 - The `services.hostapd` module was rewritten to support `passwordFile` like
   options, WPA3-SAE, and management of multiple interfaces. This breaks

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -229,7 +229,7 @@ in {
       streamingProcesses = lib.mkOption {
         description = lib.mdDoc ''
           Number of processes used by the mastodon-streaming service.
-          Recommended is the amount of your CPU cores minus one.
+          Please define this explicitly, recommended is the amount of your CPU cores minus one.
         '';
         type = lib.types.ints.positive;
         example = 3;


### PR DESCRIPTION
## Description of changes

/cc @erictapen We briefly discussed this in chat.
Explicitly declaring `services.mastodon.streamingProcesses` is now necessary, but wasn't in the module shipped with 23.05. This PR contains 2 things:

- commit number one: That breaking change IMHO should be mentioned in the release notes, this adds the corresponding info.
- commit number two, this is a currently still broken proposal I'd like to get feedback on:  
  IMHO the current error message when forgetting to declare the new necessary option is rather obscure and not immediately obvious, you at least need to resort to `--show-trace` to discover what's actually going on or explicitly look up that option. 
  I manually modified `nixos/tests/web-apps/mastodon/standard.nix` by undeclaring the option in there, this is how the error looks like right now:
    ```
    $ nix-build . -A pkgs.mastodon.passthru.tests.mastodon.standard 
  error: The option `nodes.server.services.mastodon.streamingProcesses' is used but not defined.
  (use '--show-trace' to show detailed location information)
  ```
  My idea is to cover this case with assertions that can provide a better error message. Unfortunately, I currently still struggle with typing:
  ```
  $ nix-build . -A pkgs.mastodon.passthru.tests.mastodon.standard
  error: cannot compare null with an integer
  (use '--show-trace' to show detailed location information)
  ```
  Before investing more time into the assertions thing, I'd like to gather feedback whether we actually want something like that. Otherwise, I am totally fine with just merging the release notes commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built and visually inspected manual on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
