### PR TITLE
nixos/dnsdist: add options for dnscrypt

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -235,6 +235,9 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `stdenv`: The `--replace` flag in `substitute`, `substituteInPlace`, `substituteAll`, `substituteAllStream`, and `substituteStream` is now deprecated if favor of the new `--replace-fail`, `--replace-warn` and `--replace-quiet`. The deprecated `--replace` equates to `--replace-warn`.
 
+- New options were added to the dnsdist module to enable and configure a DNSCrypt endpoint (see `services.dnsdist.dnscrypt.enable`, etc.).
+  The module can generate the DNSCrypt provider key pair, certificates and also performs their rotation automatically with no downtime.
+
 - The Yama LSM is now enabled by default in the kernel, which prevents ptracing
   non-child processes. This means you will not be able to attach gdb to an
   existing process, but will need to start that process from gdb (so it is a

--- a/nixos/modules/services/networking/dnsdist.nix
+++ b/nixos/modules/services/networking/dnsdist.nix
@@ -4,10 +4,79 @@ with lib;
 
 let
   cfg = config.services.dnsdist;
+
+  toLua = lib.generators.toLua {};
+
+  mkBind = cfg: toLua "${cfg.listenAddress}:${toString cfg.listenPort}";
+
   configFile = pkgs.writeText "dnsdist.conf" ''
-    setLocal('${cfg.listenAddress}:${toString cfg.listenPort}')
+    setLocal(${mkBind cfg})
+    ${lib.optionalString cfg.dnscrypt.enable dnscryptSetup}
     ${cfg.extraConfig}
   '';
+
+  dnscryptSetup = ''
+    last_rotation = 0
+    cert_serial = 0
+    provider_key = ${toLua cfg.dnscrypt.providerKey}
+    cert_lifetime = ${toLua cfg.dnscrypt.certLifetime} * 60
+
+    function file_exists(name)
+       local f = io.open(name, "r")
+       return f ~= nil and io.close(f)
+    end
+
+    function dnscrypt_setup()
+      -- generate provider keys on first run
+      if provider_key == nil then
+        provider_key = "/var/lib/dnsdist/private.key"
+        if not file_exists(provider_key) then
+          generateDNSCryptProviderKeys("/var/lib/dnsdist/public.key",
+                                       "/var/lib/dnsdist/private.key")
+          print("DNSCrypt: generated provider keypair")
+        end
+      end
+
+      -- generate resolver certificate
+      local now = os.time()
+      generateDNSCryptCertificate(
+        provider_key, "/run/dnsdist/resolver.cert", "/run/dnsdist/resolver.key",
+        cert_serial, now - 60, now + cert_lifetime)
+      addDNSCryptBind(
+        ${mkBind cfg.dnscrypt}, ${toLua cfg.dnscrypt.providerName},
+        "/run/dnsdist/resolver.cert", "/run/dnsdist/resolver.key")
+    end
+
+    function maintenance()
+      -- certificate rotation
+      local now = os.time()
+      local dnscrypt = getDNSCryptBind(0)
+
+      if ((now - last_rotation) > 0.9 * cert_lifetime) then
+        -- generate and start using a new certificate
+        dnscrypt:generateAndLoadInMemoryCertificate(
+          provider_key, cert_serial + 1,
+          now - 60, now + cert_lifetime)
+
+        -- stop advertising the last certificate
+        dnscrypt:markInactive(cert_serial)
+
+        -- remove the second to last certificate
+        if (cert_serial > 1)  then
+          dnscrypt:removeInactiveCertificate(cert_serial - 1)
+        end
+
+        print("DNSCrypt: rotated certificate")
+
+        -- increment serial number
+        cert_serial = cert_serial + 1
+        last_rotation = now
+      end
+    end
+
+    dnscrypt_setup()
+  '';
+
 in {
   options = {
     services.dnsdist = {
@@ -15,13 +84,67 @@ in {
 
       listenAddress = mkOption {
         type = types.str;
-        description = lib.mdDoc "Listen IP Address";
+        description = lib.mdDoc "Listen IP address";
         default = "0.0.0.0";
       };
       listenPort = mkOption {
-        type = types.int;
+        type = types.port;
         description = lib.mdDoc "Listen port";
         default = 53;
+      };
+
+      dnscrypt = {
+        enable = mkEnableOption (lib.mdDoc "a DNSCrypt endpoint to dnsdist");
+
+        listenAddress = mkOption {
+          type = types.str;
+          description = lib.mdDoc "Listen IP address of the endpoint";
+          default = "0.0.0.0";
+        };
+
+        listenPort = mkOption {
+          type = types.port;
+          description = lib.mdDoc "Listen port of the endpoint";
+          default = 443;
+        };
+
+        providerName = mkOption {
+          type = types.str;
+          default = "2.dnscrypt-cert.${config.networking.hostName}";
+          defaultText = literalExpression "2.dnscrypt-cert.\${config.networking.hostName}";
+          example = "2.dnscrypt-cert.myresolver";
+          description = lib.mdDoc ''
+            The name that will be given to this DNSCrypt resolver.
+
+            ::: {.note}
+            The provider name must start with `2.dnscrypt-cert.`.
+            :::
+          '';
+        };
+
+        providerKey = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = lib.mdDoc ''
+            The filepath to the provider secret key.
+            If not given a new provider key pair will be generated in
+            /var/lib/dnsdist on the first run.
+
+            ::: {.note}
+            The file must be readable by the dnsdist user/group.
+            :::
+          '';
+        };
+
+        certLifetime = mkOption {
+          type = types.ints.positive;
+          default = 15;
+          description = lib.mdDoc ''
+            The lifetime (in minutes) of the resolver certificate.
+            This will be automatically rotated before expiration.
+          '';
+        };
+
       };
 
       extraConfig = mkOption {
@@ -35,6 +158,14 @@ in {
   };
 
   config = mkIf cfg.enable {
+    users.users.dnsdist = {
+      description = "dnsdist daemons user";
+      isSystemUser = true;
+      group = "dnsdist";
+    };
+
+    users.groups.dnsdist = {};
+
     systemd.packages = [ pkgs.dnsdist ];
 
     systemd.services.dnsdist = {
@@ -42,8 +173,10 @@ in {
 
       startLimitIntervalSec = 0;
       serviceConfig = {
-        DynamicUser = true;
-
+        User = "dnsdist";
+        Group = "dnsdist";
+        RuntimeDirectory = "dnsdist";
+        StateDirectory = "dnsdist";
         # upstream overrides for better nixos compatibility
         ExecStartPre = [ "" "${pkgs.dnsdist}/bin/dnsdist --check-config --config ${configFile}" ];
         ExecStart = [ "" "${pkgs.dnsdist}/bin/dnsdist --supervised --disable-syslog --config ${configFile}" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -242,7 +242,7 @@ in {
   discourse = handleTest ./discourse.nix {};
   dnscrypt-proxy2 = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy2.nix {};
   dnscrypt-wrapper = runTestOn ["x86_64-linux"] ./dnscrypt-wrapper;
-  dnsdist = runTest ./dnsdist.nix {};
+  dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = handleTest ./doas.nix {};
   docker = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker.nix {};
   docker-rootless = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker-rootless.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -242,7 +242,7 @@ in {
   discourse = handleTest ./discourse.nix {};
   dnscrypt-proxy2 = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy2.nix {};
   dnscrypt-wrapper = runTestOn ["x86_64-linux"] ./dnscrypt-wrapper;
-  dnsdist = handleTest ./dnsdist.nix {};
+  dnsdist = runTest ./dnsdist.nix {};
   doas = handleTest ./doas.nix {};
   docker = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker.nix {};
   docker-rootless = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker-rootless.nix {};

--- a/nixos/tests/dnsdist.nix
+++ b/nixos/tests/dnsdist.nix
@@ -1,48 +1,48 @@
-import ./make-test-python.nix (
-  { pkgs, ... }: {
-    name = "dnsdist";
-    meta = with pkgs.lib; {
-      maintainers = with maintainers; [ jojosch ];
-    };
+{ pkgs, lib, ... }:
 
-    nodes.machine = { pkgs, lib, ... }: {
-      services.bind = {
-        enable = true;
-        extraOptions = "empty-zones-enable no;";
-        zones = lib.singleton {
-          name = ".";
-          master = true;
-          file = pkgs.writeText "root.zone" ''
-            $TTL 3600
-            . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
-            . IN NS ns.example.org.
+{
+  name = "dnsdist";
+  meta = with lib; {
+    maintainers = with maintainers; [ jojosch ];
+  };
 
-            ns.example.org. IN A    192.168.0.1
-            ns.example.org. IN AAAA abcd::1
+  nodes.machine = { pkgs, lib, ... }: {
+    services.bind = {
+      enable = true;
+      extraOptions = "empty-zones-enable no;";
+      zones = lib.singleton {
+        name = ".";
+        master = true;
+        file = pkgs.writeText "root.zone" ''
+          $TTL 3600
+          . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+          . IN NS ns.example.org.
 
-            1.0.168.192.in-addr.arpa IN PTR ns.example.org.
-          '';
-        };
-      };
-      services.dnsdist = {
-        enable = true;
-        listenPort = 5353;
-        extraConfig = ''
-          newServer({address="127.0.0.1:53", name="local-bind"})
+          ns.example.org. IN A    192.168.0.1
+          ns.example.org. IN AAAA abcd::1
+
+          1.0.168.192.in-addr.arpa IN PTR ns.example.org.
         '';
       };
-
-      environment.systemPackages = with pkgs; [ dig ];
+    };
+    services.dnsdist = {
+      enable = true;
+      listenPort = 5353;
+      extraConfig = ''
+        newServer({address="127.0.0.1:53", name="local-bind"})
+      '';
     };
 
-    testScript = ''
-      machine.wait_for_unit("bind.service")
-      machine.wait_for_open_port(53)
-      machine.succeed("dig @127.0.0.1 +short -x 192.168.0.1 | grep -qF ns.example.org")
+    environment.systemPackages = with pkgs; [ dig ];
+  };
 
-      machine.wait_for_unit("dnsdist.service")
-      machine.wait_for_open_port(5353)
-      machine.succeed("dig @127.0.0.1 -p 5353 +short -x 192.168.0.1 | grep -qF ns.example.org")
-    '';
-  }
-)
+  testScript = ''
+    machine.wait_for_unit("bind.service")
+    machine.wait_for_open_port(53)
+    machine.succeed("dig @127.0.0.1 +short -x 192.168.0.1 | grep -qF ns.example.org")
+
+    machine.wait_for_unit("dnsdist.service")
+    machine.wait_for_open_port(5353)
+    machine.succeed("dig @127.0.0.1 -p 5353 +short -x 192.168.0.1 | grep -qF ns.example.org")
+  '';
+}


### PR DESCRIPTION
## Description of changes

Options for declaratively setting up DNSCrypt in dnsdist.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested 
  - [x] nixosTests.dnsdist.base
  - [x] nixosTests.dnsdist.dnscrypt
  - [x] automatic generation of provider keypar
  - [x] the provider keypar is not overwritten on restart
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
