### PR TITLE
rl-2311: Link to blog post on the file set library

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -663,7 +663,8 @@ The module update takes care of the new config syntax and the data itself (user 
   designed to be easy and safe to use.
 
   This aims to be a replacement for `lib.sources`-based filtering.
-  To learn more about it, see [the tutorial](https://nix.dev/tutorials/file-sets).
+  To learn more about it, see [the blog post](https://www.tweag.io/blog/2023-11-28-file-sets/)
+  or [the tutorial](https://nix.dev/tutorials/file-sets).
 
 - [`lib.gvariant`](https://nixos.org/manual/nixpkgs/unstable#sec-functions-library-gvariant):
   A partial and basic implementation of GVariant formatted strings.


### PR DESCRIPTION
## Description of changes

Now that https://www.tweag.io/blog/2023-11-28-file-sets/ is published we can link to it from the release notes.

The release managers @RaitoBezarius and @figsoda already confirmed this would be okay to have [^1] [^2], but @figsoda wanted to give the final say to the release editors, so I requested them for a review here.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

[^1]: https://matrix.to/#/!aGqRytqbCECitOFhbt:nixos.org/$KJY-rzpMurM2VQbgk449nA_P1KgeqZZJEWWhjC-JWuw
[^2]: https://matrix.to/#/!aGqRytqbCECitOFhbt:nixos.org/$94sRBiLb2zirG1ZiRyi7PeYn3UBXhhtYWp1oD7gN8S0

## Things done

- [x] Rendered the manual and checks it looks correct.

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
