### PR TITLE
quantum-espresso: 6.6 -> 7.2

### DIFF
--- a/pkgs/applications/science/chemistry/quantum-espresso/default.nix
+++ b/pkgs/applications/science/chemistry/quantum-espresso/default.nix
@@ -1,41 +1,119 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchFromGitHub
+, fetchurl
+, git
+, cmake
+, gnum4
 , gfortran
+, pkg-config
 , fftw
 , blas
 , lapack
-, useMpi ? false
+, scalapack
+, wannier90
+, hdf5
+, libmbd
+, libxc
+, enableMpi ? true
 , mpi
 }:
 
+assert ! blas.isILP64;
+assert ! lapack.isILP64;
+
+let
+  # "rev"s must exactly match the git submodule commits in the QE repo
+  gitSubmodules = {
+    devxlib = fetchFromGitLab {
+      group = "max-centre";
+      owner = "components";
+      repo = "devicexlib";
+      rev = "a6b89ef77b1ceda48e967921f1f5488d2df9226d";
+      hash = "sha256-p3fRplVG4YSN6ILNlOwf+aSEhpTJPXqiS1+wnzWVA2U=";
+    };
+
+    pw2qmcpack = fetchFromGitHub {
+      owner = "QMCPACK";
+      repo = "pw2qmcpack";
+      rev = "f72ab25fa4ea755c1b4b230ae8074b47d5509c70";
+      hash = "sha256-K1Z90xexsUvk4SdEb8FGryRal0GAFoLz3j1h/RT2nYw=";
+    };
+  };
+
+in
 stdenv.mkDerivation rec {
-  version = "6.6";
+  version = "7.2";
   pname = "quantum-espresso";
 
   src = fetchFromGitLab {
     owner = "QEF";
     repo = "q-e";
     rev = "qe-${version}";
-    sha256 = "1mkfmw0fq1dabplzdn6v1abhw0ds55gzlvbx3a9brv493whk21yp";
+    hash = "sha256-0q0QWX4BVjVHjcbKOBpjbBADuL+2S5LAALyrxmjVs4c=";
   };
 
-  passthru = {
-    inherit mpi;
-  };
+  # add git submodules manually and fix pkg-config file
+  prePatch = ''
+    chmod -R +rwx external/
 
-  preConfigure = ''
-    patchShebangs configure
+    substituteInPlace external/devxlib.cmake \
+      --replace "qe_git_submodule_update(external/devxlib)" ""
+    substituteInPlace external/CMakeLists.txt \
+      --replace "qe_git_submodule_update(external/pw2qmcpack)" "" \
+      --replace "qe_git_submodule_update(external/d3q)" "" \
+      --replace "qe_git_submodule_update(external/qe-gipaw)" ""
+
+    ${builtins.toString (builtins.attrValues
+      (builtins.mapAttrs
+        (name: val: ''
+          cp -r ${val}/* external/${name}/.
+          chmod -R +rwx external/${name}
+        '')
+        gitSubmodules
+      )
+    )}
+
+    substituteInPlace cmake/quantum_espresso.pc.in \
+      --replace 'libdir="''${prefix}/@CMAKE_INSTALL_LIBDIR@"' 'libdir="@CMAKE_INSTALL_FULL_LIBDIR@"'
   '';
 
-  nativeBuildInputs = [ gfortran ];
+  passthru = { inherit mpi; };
 
-  buildInputs = [ fftw blas lapack ]
-    ++ (lib.optionals useMpi [ mpi ]);
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    git
+    pkg-config
+  ];
 
-  configureFlags = if useMpi then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
+  buildInputs = [
+    fftw
+    blas
+    lapack
+    wannier90
+    libmbd
+    libxc
+    hdf5
+  ] ++ lib.optional enableMpi scalapack;
 
-  makeFlags = [ "all" ];
+  propagatedBuildInputs = lib.optional enableMpi mpi;
+  propagatedUserEnvPkgs = lib.optional enableMpi mpi;
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DWANNIER90_ROOT=${wannier90}"
+    "-DMBD_ROOT=${libmbd}"
+    "-DQE_ENABLE_OPENMP=ON"
+    "-DQE_ENABLE_LIBXC=ON"
+    "-DQE_ENABLE_HDF5=ON"
+    "-DQE_ENABLE_PLUGINS=pw2qmcpack"
+  ] ++ lib.optionals enableMpi [
+    "-DQE_ENABLE_MPI=ON"
+    "-DQE_ENABLE_MPI_MODULE=ON"
+    "-DQE_ENABLE_SCALAPACK=ON"
+  ];
 
   meta = with lib; {
     description = "Electronic-structure calculations and materials modeling at the nanoscale";

--- a/pkgs/by-name/li/libmbd/package.nix
+++ b/pkgs/by-name/li/libmbd/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ mpi ];
 
   meta = with lib; {
-    description = " Many-body dispersion library";
+    description = "Many-body dispersion library";
     homepage = "https://github.com/libmbd/libmbd";
     license = licenses.mpl20;
     platforms = platforms.linux;

--- a/pkgs/by-name/li/libmbd/package.nix
+++ b/pkgs/by-name/li/libmbd/package.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, cmake
+, mpi
+, blas
+, lapack
+, scalapack
+, gfortran
+} :
+
+assert !blas.isILP64;
+assert !lapack.isILP64;
+
+stdenv.mkDerivation rec {
+  pname = "libMBD";
+  version = "0.12.7";
+
+  src = fetchFromGitHub {
+    owner = "libmbd";
+    repo = pname;
+    rev = version;
+    hash = "sha256-39cvOUTAuuWLGOLdapR5trmCttCnijOWvPhSBTeTxTA=";
+  };
+
+  preConfigure = ''
+    cat > cmake/libMBDVersionTag.cmake << EOF
+      set(VERSION_TAG "${version}")
+    EOF
+  '';
+
+  nativeBuildInputs = [ cmake gfortran ];
+
+  buildInputs = [ blas lapack scalapack ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  meta = with lib; {
+    description = " Many-body dispersion library";
+    homepage = "https://github.com/libmbd/libmbd";
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/by-name/wa/wannier90/package.nix
+++ b/pkgs/by-name/wa/wannier90/package.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, gfortran
+, blas
+, lapack
+, python3
+, fetchFromGitHub
+}:
+assert (!blas.isILP64);
+assert blas.isILP64 == lapack.isILP64;
+
+stdenv.mkDerivation rec {
+  pname = "wannier90";
+  version = "3.1.0";
+
+  nativeBuildInputs = [ gfortran ];
+  buildInputs = [
+    blas
+    lapack
+  ];
+
+  src = fetchFromGitHub {
+    owner = "wannier-developers";
+    repo = "wannier90";
+    rev = "v${version}";
+    hash = "sha256-+Mq7lM6WuwAnK/2FlDz9gNRIg2sRazQRezb3BfD0veY=";
+  };
+
+  # test cases are removed as error bounds of wannier90 are obviously to tight
+  postPatch = ''
+    rm -r test-suite/tests/testpostw90_{fe_kpathcurv,fe_kslicecurv,si_geninterp,si_geninterp_wsdistance}
+    rm -r test-suite/tests/testw90_example26   # Fails without AVX optimizations
+    patchShebangs test-suite/run_tests test-suite/testcode/bin/testcode.py
+  '';
+
+  configurePhase = ''
+    cp config/make.inc.gfort make.inc
+  '';
+
+  buildFlags = [ "all" "dynlib" ];
+
+  preInstall = ''
+    installFlagsArray+=(
+      PREFIX=$out
+    )
+  '';
+
+  postInstall = ''
+    cp libwannier.so $out/lib/libwannier.so
+
+    mkdir $out/include
+    find ./src/obj/ -name "*.mod" -exec cp {} $out/include/. \;
+  '';
+
+  doCheck = true;
+  checkInputs = [ python3 ];
+  checkTarget = [ "test-serial" ];
+  preCheck = ''
+    export OMP_NUM_THREADS=4
+  '';
+
+  enableParallelBuilding = true;
+
+  hardeningDisable = [ "format" ];
+
+  meta = with lib; {
+    description = "Calculation of maximally localised Wannier functions";
+    homepage = "https://github.com/wannier-developers/wannier90";
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -768,6 +768,7 @@ mapAliases ({
   qt6ct = qt6Packages.qt6ct; # Added 2023-03-07
   qtcurve = libsForQt5.qtcurve; # Added 2020-11-07
   qtile-unwrapped = python3.pkgs.qtile; # Added 2023-05-12
+  quantum-espresso-mpi = quantum-espresso; # Added 2023-11-23
   qutebrowser-qt6 = throw "'qutebrowser-qt6' has been replaced by 'qutebrowser', since the the qt5 version has been removed"; # Added 2023-08-19
   quvi = throw "'quvi' has been removed, as it was broken and unmaintained"; # Added 2023-11-25
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38847,9 +38847,9 @@ with pkgs;
 
   pymol = callPackage ../applications/science/chemistry/pymol { };
 
-  quantum-espresso = callPackage ../applications/science/chemistry/quantum-espresso { };
-
-  quantum-espresso-mpi = callPackage ../applications/science/chemistry/quantum-espresso { useMpi = true; };
+  quantum-espresso = callPackage ../applications/science/chemistry/quantum-espresso {
+    hdf5 = hdf5-fortran;
+  };
 
   siesta = callPackage ../applications/science/chemistry/siesta { };
 


### PR DESCRIPTION
## Description of changes

Quantum-espresso update, skipping many versions in between: https://www.quantum-espresso.org/release-notes/release-notes-QE7-2.html

Also adds [wannier90](https://github.com/wannier-developers/wannier90) and [libmbd](https://github.com/libmbd/libmbd) as dependencies of the new quantum-espresso versions. Some other dependencies are built via Git submodules by quantum-espresso's cmake on the fly.

I wasn't able to add the GPU support as it requires the NVidia Fortran compiler from the Cuda HPC SDK, which is not yet in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
