### PR TITLE
include-what-you-use: Fix the cmake flags for standalone build according to the official docs

### DIFF
--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = with llvmPackages; [ cmake llvm.dev llvm python3 ];
   buildInputs = with llvmPackages; [ libclang clang-unwrapped python3 ];
 
-  cmakeFlags = [ "-DIWYU_LLVM_ROOT_PATH=${llvmPackages.clang-unwrapped}" ];
+  cmakeFlags = [ "-DCMAKE_PREFIX_PATH=${llvmPackages.llvm.dev}" ];
 
   postInstall = ''
     substituteInPlace $out/bin/iwyu_tool.py \


### PR DESCRIPTION
The current flags that we path to cmake for IWYU are for `clang =< 6` We need to pass `CMAKE_PREFIX_PATH` instead of `IWYU_LLVM_ROOT_PATH` according to the official docs at https://github.com/include-what-you-use/include-what-you-use#how-to-build-standalone.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've tried to build this package for llvm 16 with the following overlay: 

```nix
            iwyu = (prev.include-what-you-use.overrideAttrs (old:
              let
                version = "0.20";
              in {
                inherit version;

                src = prev.fetchurl {
                  url = "${old.meta.homepage}/downloads/${old.pname}-${version}.src.tar.gz";
                  hash = "sha256-dfzh5khfKA+PE/TC0JCxHS/SECtQhXUHyEE6kZt6+Jk=";
                };

              })).override {
                llvmPackages = prev.__splicedPackages.llvmPackages_16;
              };
```

but it failed due to a link error due to the bug that this patch is fixing:  
```
       last 10 log lines:
       > >>> referenced by /nix/store/2dqx3hrd5ynfm411jdsn7r29kh2l26s7-clang-x86_64-unknown-linux-musl-16.0.6-lib/lib/libclang-cpp.so.16
       >
       > x86_64-unknown-linux-musl-ld: error: undefined reference due to --no-allow-shlib-undefined: llvm::ARM::getExtensionFeatures(unsigned long, std::__1::vector<llvm::StringRef, std::__1::allocator<llvm::StringRef>>&)@LLVM_16
       > >>> referenced by /nix/store/2dqx3hrd5ynfm411jdsn7r29kh2l26s7-clang-x86_64-unknown-linux-musl-16.0.6-lib/lib/libclang-cpp.so.16
       >
       > x86_64-unknown-linux-musl-ld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
       > clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
       > make[2]: *** [CMakeFiles/include-what-you-use.dir/build.make:307: bin/include-what-you-use] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:246: CMakeFiles/include-what-you-use.dir/all] Error 2
       > make: *** [Makefile:146: all] Error 2
       For full logs, run 'nix log /nix/store/6zbm5ad8bagpaj4v2pl4z5zhhxp13fvz-include-what-you-use-x86_64-unknown-linux-musl-0.20.drv'.
```
