### PR TITLE
pinocchio: 2.6.20 -> 2.6.21

### DIFF
--- a/pkgs/development/libraries/hpp-fcl/default.nix
+++ b/pkgs/development/libraries/hpp-fcl/default.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hpp-fcl";
-  version = "2.3.7";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "humanoid-path-planner";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-Bytm5uaHYsfMeZ+JKs75003iHNObRBGDpV7Rz9yW7jQ=";
+    hash = "sha256-qeAO1FV28L2nbQ/2mDeLMuWS2+FexQ1ORCtt+ztWHj0=";
   };
 
   strictDeps = true;

--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -13,14 +13,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pinocchio";
-  version = "2.6.20";
+  version = "2.6.21";
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-Pu/trCpqdue7sQKDbLhyxTfgj/+xRiVcG7Luz6ZQXtM=";
+    hash = "sha256-IaWAXzdzhU/wov+9ChzUeCp9SFNFV2/vGToXC35dkb8=";
   };
 
   # error: use of undeclared identifier '__sincos'
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals pythonSupport [
     "-DBUILD_WITH_LIBPYTHON=ON"
   ] ++ lib.optionals (pythonSupport && stdenv.isDarwin) [
-    # AssertionError: '.' != '/tmp/nix-build-pinocchio-2.6.20.drv/sou[84 chars].dae'
+    # AssertionError: '.' != '/tmp/nix-build-pinocchio-2.6.21.drv/sou[84 chars].dae'
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;test-py-bindings_geometry_model_urdf'"
   ] ++ lib.optionals (!pythonSupport) [
     "-DBUILD_PYTHON_INTERFACE=OFF"

--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -23,12 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IaWAXzdzhU/wov+9ChzUeCp9SFNFV2/vGToXC35dkb8=";
   };
 
-  # error: use of undeclared identifier '__sincos'
-  postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
-    substituteInPlace src/math/sincos.hpp \
-      --replace "__APPLE__" "0"
-  '';
-
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eigenpy";
-  version = "3.1.3";
+  version = "3.1.4";
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-8UuJA96pkXXRKDzQTjoz7w8TQrS5+nfLdsT0j9/oqz0=";
+    hash = "sha256-+1qjyWRE6a9KOopZln/7DyTTAQchAUoqd9HT83+zVuI=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

replace #270649, with:
- eigenpy 3.1.3 -> 3.1.4
- hpp-fcl 2.3.7 -> 2.4.0
- pinocchio 2.6.20 -> 2.6.21

ref.
https://github.com/stack-of-tasks/eigenpy/releases/tag/v3.1.4
https://github.com/humanoid-path-planner/hpp-fcl/releases/tag/v2.4.0
https://github.com/stack-of-tasks/pinocchio/releases/tag/v2.6.21

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
