### PR TITLE
pureref: download source automatically

### DIFF
--- a/pkgs/applications/graphics/pureref/default.nix
+++ b/pkgs/applications/graphics/pureref/default.nix
@@ -1,14 +1,16 @@
-{ lib, appimageTools, requireFile }:
+{ lib, appimageTools, runCommand, curl, gnugrep, cacert }:
 
 appimageTools.wrapType1 rec {
   pname = "pureref";
   version = "1.11.1";
 
-  src = requireFile {
-    name = "PureRef-${version}_x64.Appimage";
-    sha256 = "05naywdgykqrsgc3xybskr418cyvbx7vqs994yv9w8zf98gxvbvm";
-    url = "https://www.pureref.com/download.php";
-  };
+  src = runCommand "PureRef-${version}_x64.Appimage" {
+    nativeBuildInputs = [ curl gnugrep cacert ];
+    outputHash = "sha256-da/dH0ruI562JylpvE9f2zMUSJ56+T7Y0xlP/xr3yhY=";
+  } ''
+    key="$(curl "https://www.pureref.com/download.php" --silent | grep '%3D%3D' | cut -d '"' -f2)"
+    curl "https://www.pureref.com/files/build.php?build=LINUX64.Appimage&version=${version}&downloadKey=$key" --output $out
+  '';
 
   extraInstallCommands = ''
     mv $out/bin/${pname}-${version} $out/bin/${pname}


### PR DESCRIPTION
Mentioned in https://github.com/NixOS/nixpkgs/issues/250520

## Description of changes

Download the appimage through a runCommand FOD, instead of requireFile. [Inspired by the AUR package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=pureref) 

The download form requires a key to download. Just curl the download page, grep it out, and we're good to go.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
