### PR TITLE
mpv: 0.36.0 -> 0.37.0 

### DIFF
--- a/pkgs/applications/video/mpv/darwin-sigtool-no-deep.patch
+++ b/pkgs/applications/video/mpv/darwin-sigtool-no-deep.patch
@@ -1,0 +1,13 @@
+diff --git a/TOOLS/osxbundle.py b/TOOLS/osxbundle.py
+index 98699e478b..d02ecf610e 100755
+--- a/TOOLS/osxbundle.py
++++ b/TOOLS/osxbundle.py
+@@ -39,7 +39,7 @@ def apply_plist_template(plist_file, version):
+         print(line.rstrip().replace('${VERSION}', version))
+ 
+ def sign_bundle(binary_name):
+-    sh('codesign --force --deep -s - ' + bundle_path(binary_name))
++    sh('codesign --force -s - ' + bundle_path(binary_name))
+ 
+ def bundle_version():
+     if os.path.exists('VERSION'):

--- a/pkgs/applications/video/mpv/darwin-sigtool-no-deep.patch
+++ b/pkgs/applications/video/mpv/darwin-sigtool-no-deep.patch
@@ -7,7 +7,7 @@ index 98699e478b..d02ecf610e 100755
  
  def sign_bundle(binary_name):
 -    sh('codesign --force --deep -s - ' + bundle_path(binary_name))
-+    sh('codesign --force -s - ' + bundle_path(binary_name))
++    sh('rcodesign sign ' + bundle_path(binary_name))
  
  def bundle_version():
      if os.path.exists('VERSION'):

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -83,7 +83,7 @@
 let
   inherit (darwin.apple_sdk_11_0.frameworks)
     AVFoundation Accelerate Cocoa CoreAudio CoreFoundation CoreMedia
-    MediaPlayer;
+    MediaPlayer VideoToolbox;
   luaEnv = lua.withPackages (ps: with ps; [ luasocket ]);
 
   overrideSDK = platform: version:
@@ -140,6 +140,9 @@ in stdenv'.mkDerivation (finalAttrs: {
     # Disable whilst Swift isn't supported
     (lib.mesonEnable "swift-build" swiftSupport)
     (lib.mesonEnable "macos-cocoa-cb" swiftSupport)
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Toggle explicitly because it fails on darwin
+    (lib.mesonEnable "videotoolbox-pl" vulkanSupport)
   ];
 
   mesonAutoFeatures = "auto";
@@ -160,6 +163,7 @@ in stdenv'.mkDerivation (finalAttrs: {
     ffmpeg
     freetype
     libass
+    libplacebo
     libpthreadstubs
     libuchardet
     luaEnv
@@ -188,7 +192,7 @@ in stdenv'.mkDerivation (finalAttrs: {
     ++ lib.optionals vaapiSupport       [ libva ]
     ++ lib.optionals vapoursynthSupport [ vapoursynth ]
     ++ lib.optionals vdpauSupport       [ libvdpau ]
-    ++ lib.optionals vulkanSupport      [ libplacebo shaderc vulkan-headers vulkan-loader ]
+    ++ lib.optionals vulkanSupport      [ shaderc vulkan-headers vulkan-loader ]
     ++ lib.optionals waylandSupport     [ wayland wayland-protocols libxkbcommon ]
     ++ lib.optionals x11Support         [ libX11 libXext libGLU libGL libXxf86vm libXrandr libXpresent ]
     ++ lib.optionals xineramaSupport    [ libXinerama ]
@@ -196,7 +200,7 @@ in stdenv'.mkDerivation (finalAttrs: {
     ++ lib.optionals zimgSupport        [ zimg ]
     ++ lib.optionals stdenv.isLinux     [ nv-codec-headers-11 ]
     ++ lib.optionals stdenv.isDarwin    [ libiconv ]
-    ++ lib.optionals stdenv.isDarwin    [ CoreFoundation Cocoa CoreAudio MediaPlayer Accelerate ]
+    ++ lib.optionals stdenv.isDarwin    [ Accelerate CoreFoundation Cocoa CoreAudio MediaPlayer VideoToolbox ]
     ++ lib.optionals (stdenv.isDarwin && swiftSupport) [ AVFoundation CoreMedia ];
 
   postBuild = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -113,6 +113,8 @@ in stdenv'.mkDerivation (finalAttrs: {
 
   env.NIX_LDFLAGS = lib.optionalString x11Support "-lX11 -lXext ";
 
+  patches = [ ./darwin-sigtool-no-deep.patch ];
+
   # A trick to patchShebang everything except mpv_identify.sh
   postPatch = ''
     pushd TOOLS
@@ -206,12 +208,6 @@ in stdenv'.mkDerivation (finalAttrs: {
   postBuild = lib.optionalString stdenv.isDarwin ''
     pushd .. # Must be run from the source dir because it uses relative paths
     python3 TOOLS/osxbundle.py -s build/mpv
-    # Swap binary and bundle symlink to sign bundle executable as symlinks
-    # cannot be signed
-    rm build/mpv.app/Contents/MacOS/mpv-bundle
-    mv build/mpv.app/Contents/MacOS/mpv build/mpv.app/Contents/MacOS/mpv-bundle
-    ln -s mpv-bundle build/mpv.app/Contents/MacOS/mpv
-    codesign --force --sign - build/mpv.app/Contents/MacOS/mpv-bundle
     popd
   '';
 

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -131,8 +131,6 @@ in stdenv'.mkDerivation (finalAttrs: {
     ''
   ];
 
-  env.NIX_LDFLAGS = lib.optionalString x11Support "-lX11 -lXext ";
-
   # Ensure we reference 'lib' (not 'out') of Swift.
   preConfigure = lib.optionalString swiftSupport ''
     export SWIFT_LIB_DYNAMIC="${lib.getLib swift.swift}/lib/swift/macosx"

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -20,7 +20,7 @@
 , libuchardet
 , libiconv
 , xcbuild
-, sigtool
+, rcodesign
 
 , waylandSupport ? stdenv.isLinux
   , wayland
@@ -156,7 +156,7 @@ in stdenv'.mkDerivation (finalAttrs: {
     ninja
     pkg-config
   ]
-  ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun sigtool ]
+  ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun rcodesign ]
   ++ lib.optionals swiftSupport [ swift ]
   ++ lib.optionals waylandSupport [ wayland-scanner ];
 

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -97,7 +97,7 @@ let
       '' + lib.optionalString stdenv.isDarwin ''
         # wrapProgram can't operate on symlinks
         rm "$out/Applications/mpv.app/Contents/MacOS/mpv"
-        makeWrapper "${mpv}/Applications/mpv.app/Contents/MacOS/mpv-bundle" "$out/Applications/mpv.app/Contents/MacOS/mpv" ${mostMakeWrapperArgs}
+        makeWrapper "${mpv}/Applications/mpv.app/Contents/MacOS/mpv" "$out/Applications/mpv.app/Contents/MacOS/mpv" ${mostMakeWrapperArgs}
       '';
 
       meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33765,7 +33765,7 @@ with pkgs;
   mpv-unwrapped = darwin.apple_sdk_11_0.callPackage ../applications/video/mpv {
     stdenv = if stdenv.isDarwin then swiftPackages.stdenv else stdenv;
     inherit lua;
-    inherit (darwin) sigtool;
+    inherit (darwin) sigtool; # otherwise it breaks splicing...
   };
 
   shaka-packager = callPackage ../applications/video/shaka-packager { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33765,7 +33765,6 @@ with pkgs;
   mpv-unwrapped = darwin.apple_sdk_11_0.callPackage ../applications/video/mpv {
     stdenv = if stdenv.isDarwin then swiftPackages.stdenv else stdenv;
     inherit lua;
-    inherit (darwin) sigtool; # otherwise it breaks splicing...
   };
 
   shaka-packager = callPackage ../applications/video/shaka-packager { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/270002
Waiting https://github.com/NixOS/nixpkgs/pull/269415
## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
