### PR TITLE
cloudlogoffline: init at 1.1.4

### DIFF
--- a/pkgs/by-name/cl/cloudlogoffline/package.nix
+++ b/pkgs/by-name/cl/cloudlogoffline/package.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qt5
+, makeDesktopItem
+, copyDesktopItems
+}:
+stdenv.mkDerivation (self: {
+  pname = "cloudlogoffline";
+  version = "1.1.4";
+  rev = "185f294ec36d7ebe40e37d70148b15f58d60bf0d";
+  hash = "sha256-UEi7q3NbTgkg4tSjiksEO05YE4yjRul4qB9hFPswnK0=";
+
+  src = fetchFromGitHub {
+    inherit (self) rev hash;
+    owner = "myzinsky";
+    repo = "cloudLogOffline";
+  };
+
+  nativeBuildInputs = [
+    qt5.qmake
+    qt5.wrapQtAppsHook
+  ]
+  ++ lib.optionals (!stdenv.isDarwin) [
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qtgraphicaleffects
+    qt5.qtlocation
+    qt5.qtpositioning
+    qt5.qtquickcontrols2
+    qt5.qtsvg
+  ];
+
+  postPatch = let
+    targetDir = if stdenv.isDarwin then "Applications" else "bin";
+  in ''
+    substituteInPlace CloudLogOffline.pro \
+      --replace 'target.path = /opt/$''${TARGET}/bin' "target.path = $out/${targetDir}"
+  '';
+
+  postInstall = lib.optionalString (!stdenv.isDarwin) ''
+    install -d $out/share/pixmaps
+    install -m644 images/logo_circle.svg $out/share/pixmaps/cloudlogoffline.svg
+  '';
+
+  desktopItems = lib.optionals (!stdenv.isDarwin) [
+    (makeDesktopItem {
+      name = "cloudlogoffline";
+      desktopName = "CloudLogOffline";
+      exec = "CloudLogOffline";
+      icon = "cloudlogoffline";
+      comment = self.meta.description;
+      genericName = "Ham radio contact logbook";
+      categories = [ "Network" "Utility" "HamRadio" ];
+    })
+  ];
+
+  meta = {
+    description = "Offline frontend for Cloudlog";
+    homepage = "https://github.com/myzinsky/cloudLogOffline";
+    license = [ lib.licenses.lgpl3 ];
+    mainProgram = "CloudLogOffline";
+    maintainers = [ lib.maintainers.dblsaiko ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds cloudlogoffline, a companion app to [Cloudlog](https://www.magicbug.co.uk/cloudlog/) (pkgs.cloudlog)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requestst, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
