### PR TITLE
mpdcron: fix build by correcting a C function conflict in nokogiri

### DIFF
--- a/pkgs/tools/audio/mpdcron/fix-canonicalize-conflict-with-glibc.patch
+++ b/pkgs/tools/audio/mpdcron/fix-canonicalize-conflict-with-glibc.patch
@@ -1,0 +1,22 @@
+diff --git a/ext/nokogiri/xml_document.c b/ext/nokogiri/xml_document.c
+index 1d2119c8..c1c87713 100644
+--- a/ext/nokogiri/xml_document.c
++++ b/ext/nokogiri/xml_document.c
+@@ -492,7 +492,7 @@ static int block_caller(void * ctx, xmlNodePtr _node, xmlNodePtr _parent)
+  * The block must return a non-nil, non-false value if the +obj+ passed in
+  * should be included in the canonicalized document.
+  */
+-static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
++static VALUE nokogiri_xml_document_canonicalize(int argc, VALUE* argv, VALUE self)
+ {
+   VALUE mode;
+   VALUE incl_ns;
+@@ -573,7 +573,7 @@ void init_xml_document()
+   rb_define_method(klass, "encoding", encoding, 0);
+   rb_define_method(klass, "encoding=", set_encoding, 1);
+   rb_define_method(klass, "version", version, 0);
+-  rb_define_method(klass, "canonicalize", canonicalize, -1);
++  rb_define_method(klass, "nokogiri_xml_document_canonicalize", canonicalize, -1);
+   rb_define_method(klass, "dup", duplicate_document, -1);
+   rb_define_method(klass, "url", url, 0);
+   rb_define_method(klass, "create_entity", create_entity, -1);

--- a/pkgs/tools/audio/mpdcron/gemset.nix
+++ b/pkgs/tools/audio/mpdcron/gemset.nix
@@ -18,6 +18,19 @@
       sha256 = "02bjydih0j515szfv9mls195cvpyidh6ixm7dwbl3s2sbaxxk5s4";
       type = "gem";
     };
+
+    dontBuild = false;
+    patches = [
+      # Fixes a naming conflict of nokogiri's `canonicalize` function
+      # with one defined in glibc. This has been fixed upstream in 2020
+      # in a much newer version (1.15.5), but through the divergence
+      # of the affected file, the commit isn't directly applicable to
+      # the one packaged here:
+      #
+      # https://github.com/sparklemotion/nokogiri/pull/2106/commits/7a74cdbe4538e964023e5a0fdca58d8af708b91e
+      # https://github.com/sparklemotion/nokogiri/issues/2105
+      ./fix-canonicalize-conflict-with-glibc.patch
+    ];
     version = "1.10.3";
   };
 }


### PR DESCRIPTION
Nokogiri fails to compile because it contains C code which has a naming conflict with recent versions of glibc (a function named `canonicalize`). The project has fixed this issue upstream [1], but the respective patch is likely not applicable directly [2] as the respective file has changed considerably since the version included in mpdcron [3]. Note that mpdcron is an old project that hasn´t seen any updates in years [4], so patching the old nokogiri version will likely still be easier than updating the dependency (as only two lines must be changed).

[1] https://github.com/sparklemotion/nokogiri/issues/2105
[2] https://github.com/sparklemotion/nokogiri/pull/2106/commits/7a74cdbe4538e964023e5a0fdca58d8af708b91e
[3] https://github.com/NixOS/nixpkgs/blob/8c7c42861b7a492bccca01910777c284c668e3fe/pkgs/tools/audio/mpdcron/gemset.nix#L21
[4] https://github.com/alip/mpdcron

## Description of changes

Apply the upstream patch from nokogiri 1.15.5 back to the nokogiri version used to package `mpdcron`.

Hydra build: https://hydra.nixos.org/build/241773455#tabs-summary
Hydra log: https://hydra.nixos.org/build/241773455/nixlog/1

Relevant log excerpt:

```
xml_document.c: At top level:
xml_document.c:495:14: error: conflicting types for 'canonicalize'; have 'VALUE(int,  VALUE *, VALUE)' {aka 'long unsigned int(int,  long unsigned int *, long unsigned int)'}
  495 | static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
      |              ^~~~~~~~~~~~
In file included from /nix/store/mrgib0s2ayr81xv1q84xsjg8ijybalq3-glibc-2.38-27-dev/include/features.h:503,
                 from /nix/store/mrgib0s2ayr81xv1q84xsjg8ijybalq3-glibc-2.38-27-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/mrgib0s2ayr81xv1q84xsjg8ijybalq3-glibc-2.38-27-dev/include/stdlib.h:26,
                 from ./nokogiri.h:4:
/nix/store/mrgib0s2ayr81xv1q84xsjg8ijybalq3-glibc-2.38-27-dev/include/bits/mathcalls.h:370:1: note: previous declaration of 'canonicalize' with type 'int(double *, const double *)'
  370 | __MATHDECL_1 (int, canonicalize,, (_Mdouble_ *__cx, const _Mdouble_ *__x));
      | ^~~~~~~~~~~~
xml_document.c: In function 'canonicalize':
/nix/store/2kw126cy93rix4pmh9lcl120njnb6r7r-ruby-3.1.4/include/ruby-3.1.0/ruby/internal/scan_args.h:375:62: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  375 |                      (rb_scan_args_verify(fmt, varc), vars), (char *)fmt, varc)
      |                                                              ^
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

