### PR TITLE
[Backport release-23.11] dnf5: 5.1.7 -> 5.1.8, re-enable tests, add man pages, fix hash

### DIFF
--- a/pkgs/tools/package-management/dnf5/default.nix
+++ b/pkgs/tools/package-management/dnf5/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "rpm-software-management";
     repo = "dnf5";
     rev = finalAttrs.version;
-    hash = "sha256-4ht2KraWKL774QPfZz1OgAuFtPVsMis9WiDS+QFP8JY=";
+    hash = "sha256-1g3g+6EborZd2ppPMZcy0Wjv07zetATHb/sCkuZz5UM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/package-management/dnf5/default.nix
+++ b/pkgs/tools/package-management/dnf5/default.nix
@@ -14,6 +14,7 @@
 , libsmartcols
 , libsolv
 , libxml2
+, libyaml
 , pcre2
 , rpm
 , sdbus-cpp
@@ -25,13 +26,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dnf5";
-  version = "5.1.7";
+  version = "5.1.8";
 
   src = fetchFromGitHub {
     owner = "rpm-software-management";
     repo = "dnf5";
     rev = finalAttrs.version;
-    hash = "sha256-SXgl4YFWl1A3N2/IkDftvBl6Rwhnymxe8AqqaekGHTc=";
+    hash = "sha256-4ht2KraWKL774QPfZz1OgAuFtPVsMis9WiDS+QFP8JY=";
   };
 
   nativeBuildInputs = [ cmake createrepo_c gettext help2man pkg-config ];
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsmartcols
     libsolv
     libxml2
+    libyaml
     pcre2.dev
     rpm
     sdbus-cpp

--- a/pkgs/tools/package-management/dnf5/default.nix
+++ b/pkgs/tools/package-management/dnf5/default.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DWITH_PERL5=OFF"
     "-DWITH_PYTHON3=OFF"
     "-DWITH_RUBY=OFF"
-    "-DWITH_TESTS=OFF"
     # TODO: fix man installation paths
     "-DWITH_MAN=OFF"
     "-DWITH_PLUGIN_RHSM=OFF" # Red Hat Subscription Manager plugin

--- a/pkgs/tools/package-management/dnf5/default.nix
+++ b/pkgs/tools/package-management/dnf5/default.nix
@@ -23,6 +23,7 @@
 , sphinx
 , sqlite
 , systemd
+, testers
 , toml11
 , zchunk
 }:
@@ -103,6 +104,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   dontFixCmake = true;
+
+  passthru.tests = {
+    version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
 
   meta = with lib; {
     description = "Next-generation RPM package management system";


### PR DESCRIPTION
## Description of changes

Backporting PRs https://github.com/NixOS/nixpkgs/pull/269512 and https://github.com/NixOS/nixpkgs/pull/270669

Supersedes https://github.com/NixOS/nixpkgs/pull/270148

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
