### PR TITLE
gcc-arm-embedded-11: Fixed hydra build issue due to large derivation size.

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, fetchurl
 , ncurses5
 , python38
 , libxcrypt-legacy
@@ -14,45 +13,57 @@ stdenv.mkDerivation rec {
   platform = {
     aarch64-linux = "aarch64";
     x86_64-darwin = "darwin-x86_64";
-    x86_64-linux  = "x86_64";
+    x86_64-linux = "x86_64";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  src = fetchurl {
+  outputs = [ "out" "arm_none_eabi" ];
+
+  src = builtins.fetchTarball {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-arm-none-eabi.tar.xz";
     sha256 = {
       aarch64-linux = "0pmm5r0k5mxd5drbn2s8a7qkm8c4fi8j5y31c70yrp0qs08kqwbc";
       x86_64-darwin = "1kr9kd9p2xk84fa99zf3gz5lkww2i9spqkjigjwakfkzbva56qw2";
-      x86_64-linux  = "08b1w1zmj4z80k59zmlc1bf34lg8d7z65fwvp5ir2pb1d1zxh86l";
+      x86_64-linux = "0zg754z0s8fx3qwh8jssf6rslnx9xmgcd2va6lykc8vlk8v5r19y";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
   dontConfigure = true;
   dontBuild = true;
-  dontPatchELF = true;
   dontStrip = true;
+  # this works, but automatic patchelf is run (and fails on 32-bit, relocatable files)
+  # when running auditTmpdir. noAuditTmpdir disables it, but it's not a good idea.
+  # This needs either a fix for patchelf or the script that feeds it the "wrong" ELF.
+  dontPatchELF = true;
 
   installPhase = ''
     mkdir -p $out
     cp -r * $out
+    # arm-none-eabi is a big boy and the complete outputs exceeds hydra's max_output_size.
+    moveToOutput "arm-none-eabi" "$arm_none_eabi"
+    # Link to it here in case anyone refers to it.
+    ln -s "$arm_none_eabi" "$out/arm-none-eabi"
+
+    # Wrap gdb with correct Python path.
+    mv $out/bin/arm-none-eabi-gdb $out/bin/arm-none-eabi-gdb-unwrapped
+    cat <<EOF > $out/bin/arm-none-eabi-gdb
+      #!${runtimeShell}
+      export PYTHONPATH=${python38}/lib/python3.8
+      export PYTHONHOME=${python38}/bin/python3.8
+      exec $out/bin/arm-none-eabi-gdb-unwrapped "\$@"
+    EOF
+    chmod +x $out/bin/arm-none-eabi-gdb
   '';
 
+  # Fix rpath for pre-compiled native binaries.
+  # WARNING: The target bineries in arm-none-eabi are not patched and may not work.
   preFixup = ''
-    find $out -type f | while read f; do
+    # We find all ELF files that are not for 32-bit (target files).
+    # This package only serves 64 bit systems anyways.
+    for f in $(find $out -type f -exec file {} \; | awk -F: '$2 ~ /ELF/ && ! /32-bit/ {print $1}'); do
       patchelf "$f" > /dev/null 2>&1 || continue
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
       patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 libxcrypt-legacy ]} "$f" || true
     done
-  '';
-
-  postFixup = ''
-    mv $out/bin/arm-none-eabi-gdb $out/bin/arm-none-eabi-gdb-unwrapped
-    cat <<EOF > $out/bin/arm-none-eabi-gdb
-    #!${runtimeShell}
-    export PYTHONPATH=${python38}/lib/python3.8
-    export PYTHONHOME=${python38}/bin/python3.8
-    exec $out/bin/arm-none-eabi-gdb-unwrapped "\$@"
-    EOF
-    chmod +x $out/bin/arm-none-eabi-gdb
   '';
 
   meta = with lib; {


### PR DESCRIPTION

## Description of changes

Moved large (>2GB) folder `arm-none-eabi` and link to it to the derivation.
Also adjusted search for ELF files and moved to fetchTarball for source.

Inspected the cause of a swarm of patchelf failures inspite of `dontPatchELF` toggle enabled: https://github.com/NixOS/patchelf/issues/536

If the changes are ok, I propose applying them to the other versions as well for this PR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
