### PR TITLE
mir: 2.15.0 -> 2.17.0

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -40,7 +40,7 @@
 , lomiri-notifications
 , lomiri-thumbnailer
 , maliit-keyboard
-, mir
+, mir_2_15
 , nixos-icons
 , pam
 , pkg-config
@@ -191,7 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-system-settings-unwrapped
     lomiri-ui-toolkit
     maliit-keyboard
-    mir
+    mir_2_15
     pam
     properties-cpp
     protobuf

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -16,7 +16,7 @@
 , lomiri-app-launch
 , lomiri-url-dispatcher
 , lttng-ust
-, mir
+, mir_2_15
 , process-cpp
 , qtbase
 , qtdeclarative
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-app-launch
     lomiri-url-dispatcher
     lttng-ust
-    mir
+    mir_2_15
     process-cpp
     protobuf
     qtbase

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -1,0 +1,227 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  testers,
+  cmake,
+  pkg-config,
+  python3,
+  boost,
+  egl-wayland,
+  freetype,
+  glib,
+  glm,
+  glog,
+  libdrm,
+  libepoxy,
+  libevdev,
+  libglvnd,
+  libinput,
+  libuuid,
+  libxcb,
+  libxkbcommon,
+  libxmlxx,
+  yaml-cpp,
+  lttng-ust,
+  mesa,
+  nettle,
+  udev,
+  wayland,
+  wayland-scanner,
+  xorg,
+  xwayland,
+  dbus,
+  gobject-introspection,
+  gtest,
+  umockdev,
+  wlcs,
+  validatePkgConfig,
+}:
+
+{
+  version,
+  pinned ? false,
+  hash,
+  patches ? [ ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mir";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "mir";
+    rev = "v${finalAttrs.version}";
+    inherit hash;
+  };
+
+  inherit patches;
+
+  postPatch = ''
+    # Fix scripts that get run in tests
+    patchShebangs tools/detect_fd_leaks.bash tests/acceptance-tests/wayland-generator/test_wayland_generator.sh.in
+
+    # Fix LD_PRELOADing in tests
+    substituteInPlace \
+      cmake/MirCommon.cmake \
+      tests/umock-acceptance-tests/CMakeLists.txt \
+      tests/unit-tests/platforms/gbm-kms/kms/CMakeLists.txt \
+      tests/unit-tests/CMakeLists.txt \
+      --replace-warn 'LD_PRELOAD=liblttng-ust-fork.so' 'LD_PRELOAD=${lib.getLib lttng-ust}/lib/liblttng-ust-fork.so' \
+      --replace-warn 'LD_PRELOAD=libumockdev-preload.so.0' 'LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0'
+
+    # Fix Xwayland default
+    substituteInPlace src/miral/x11_support.cpp \
+      --replace-fail '/usr/bin/Xwayland' '${lib.getExe xwayland}'
+
+    # Fix paths for generating drm-formats
+    substituteInPlace src/platform/graphics/CMakeLists.txt \
+      --replace-fail "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
+      --replace-fail "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # gdbus-codegen
+    lttng-ust # lttng-gen-tp
+    pkg-config
+    (python3.withPackages (
+      ps:
+      with ps;
+      [ pillow ]
+      ++ lib.optionals finalAttrs.finalPackage.doCheck [
+        pygobject3
+        python-dbusmock
+      ]
+    ))
+    validatePkgConfig
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    boost
+    egl-wayland
+    freetype
+    glib
+    glm
+    glog
+    libdrm
+    libepoxy
+    libevdev
+    libglvnd
+    libinput
+    libuuid
+    libxcb
+    libxkbcommon
+    libxmlxx
+    yaml-cpp
+    lttng-ust
+    mesa
+    nettle
+    udev
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.xorgproto
+    xwayland
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    gobject-introspection
+  ];
+
+  checkInputs = [
+    gtest
+    umockdev
+    wlcs
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_DOXYGEN" false)
+    (lib.cmakeFeature "MIR_PLATFORM" (
+      lib.strings.concatStringsSep ";" [
+        "gbm-kms"
+        "x11"
+        "eglstream-kms"
+        "wayland"
+      ]
+    ))
+    (lib.cmakeBool "MIR_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
+    # https://github.com/canonical/mir/pull/1947#issuecomment-811810872
+    (lib.cmakeBool "MIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN" true)
+    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (lib.strings.concatStringsSep ";" [ ]))
+    # These get built but don't get executed by default, yet they get installed when tests are enabled
+    (lib.cmakeBool "MIR_BUILD_PERFORMANCE_TESTS" false)
+    (lib.cmakeBool "MIR_BUILD_PLATFORM_TEST_HARNESS" false)
+    # https://github.com/canonical/mir/issues/2987
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106799
+    (lib.cmakeBool "MIR_USE_PRECOMPILED_HEADERS" false)
+    (lib.cmakeFeature "MIR_COMPILER_QUIRKS" (
+      lib.strings.concatStringsSep ";" [
+        # https://github.com/canonical/mir/issues/3017 actually affects x86_64 as well
+        "test_touchspot_controller.cpp:array-bounds"
+      ]
+    ))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export XDG_RUNTIME_DIR=$TMP
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    providedSessions = lib.optionals (lib.strings.versionOlder version "2.16.0") [
+      # More of an example than a fully functioning shell, some notes for the adventurous:
+      # - ~/.config/miral-shell.config is one possible user config location,
+      #   accepted options=value are according to `mir-shell --help`
+      # - default icon theme setting is DMZ-White, needs vanilla-dmz installed & on XCURSOR_PATH
+      #   or setting to be changed to an available theme
+      # - terminal emulator setting may need to be changed if miral-terminal script
+      #   does not know about preferred terminal
+      "mir-shell"
+    ];
+  } // lib.optionalAttrs (!pinned) {
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "A display server and Wayland compositor developed by Canonical";
+    homepage = "https://mir-server.io";
+    changelog = "https://github.com/canonical/mir/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [
+      onny
+      OPNA2608
+    ];
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "miral"
+      "mircommon"
+      "mircore"
+      "miroil"
+      "mirplatform"
+      "mir-renderer-gl-dev"
+      "mirrenderer"
+      "mirserver"
+      "mirtest"
+      "mirwayland"
+    ] ++ lib.optionals (lib.strings.versionOlder version "2.17.0") [
+      "mircookie"
+    ] ++ lib.optionals (lib.strings.versionAtLeast version "2.17.0") [
+      "mircommon-internal"
+      "mirserver-internal"
+    ];
+  };
+})

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -1,205 +1,33 @@
+{ callPackage, fetchpatch }:
+
+let
+  common = callPackage ./common.nix { };
+in
 {
-  stdenv,
-  lib,
-  fetchFromGitHub,
-  gitUpdater,
-  testers,
-  cmake,
-  pkg-config,
-  python3,
-  boost,
-  egl-wayland,
-  freetype,
-  glib,
-  glm,
-  glog,
-  libdrm,
-  libepoxy,
-  libevdev,
-  libglvnd,
-  libinput,
-  libuuid,
-  libxcb,
-  libxkbcommon,
-  libxmlxx,
-  yaml-cpp,
-  lttng-ust,
-  mesa,
-  nettle,
-  udev,
-  wayland,
-  wayland-scanner,
-  xorg,
-  xwayland,
-  dbus,
-  gobject-introspection,
-  gtest,
-  umockdev,
-  wlcs,
-  validatePkgConfig,
-}:
-
-stdenv.mkDerivation (finalAttrs: {
-  pname = "mir";
-  version = "2.17.0";
-
-  src = fetchFromGitHub {
-    owner = "canonical";
-    repo = "mir";
-    rev = "v${finalAttrs.version}";
+  mir = common {
+    version = "2.17.0";
     hash = "sha256-iDJ7NIFoSSXjMrHK2I6Linf7z0hvShj8fr6BGxgK5gE=";
   };
 
-  postPatch = ''
-    # Fix scripts that get run in tests
-    patchShebangs tools/detect_fd_leaks.bash tests/acceptance-tests/wayland-generator/test_wayland_generator.sh.in
-
-    # Fix LD_PRELOADing in tests
-    substituteInPlace \
-      cmake/MirCommon.cmake \
-      tests/umock-acceptance-tests/CMakeLists.txt \
-      tests/unit-tests/platforms/gbm-kms/kms/CMakeLists.txt \
-      tests/unit-tests/CMakeLists.txt \
-      --replace-warn 'LD_PRELOAD=liblttng-ust-fork.so' 'LD_PRELOAD=${lib.getLib lttng-ust}/lib/liblttng-ust-fork.so' \
-      --replace-warn 'LD_PRELOAD=libumockdev-preload.so.0' 'LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0'
-
-    # Fix Xwayland default
-    substituteInPlace src/miral/x11_support.cpp \
-      --replace-fail '/usr/bin/Xwayland' '${lib.getExe xwayland}'
-
-    # Fix paths for generating drm-formats
-    substituteInPlace src/platform/graphics/CMakeLists.txt \
-      --replace-fail "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
-      --replace-fail "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
-  '';
-
-  strictDeps = true;
-
-  nativeBuildInputs = [
-    cmake
-    glib # gdbus-codegen
-    lttng-ust # lttng-gen-tp
-    pkg-config
-    (python3.withPackages (
-      ps:
-      with ps;
-      [ pillow ]
-      ++ lib.optionals finalAttrs.finalPackage.doCheck [
-        pygobject3
-        python-dbusmock
-      ]
-    ))
-    validatePkgConfig
-    wayland-scanner
-  ];
-
-  buildInputs = [
-    boost
-    egl-wayland
-    freetype
-    glib
-    glm
-    glog
-    libdrm
-    libepoxy
-    libevdev
-    libglvnd
-    libinput
-    libuuid
-    libxcb
-    libxkbcommon
-    libxmlxx
-    yaml-cpp
-    lttng-ust
-    mesa
-    nettle
-    udev
-    wayland
-    xorg.libX11
-    xorg.libXcursor
-    xorg.xorgproto
-    xwayland
-  ];
-
-  nativeCheckInputs = [
-    dbus
-    gobject-introspection
-  ];
-
-  checkInputs = [
-    gtest
-    umockdev
-    wlcs
-  ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "BUILD_DOXYGEN" false)
-    (lib.cmakeFeature "MIR_PLATFORM" (
-      lib.strings.concatStringsSep ";" [
-        "gbm-kms"
-        "x11"
-        "eglstream-kms"
-        "wayland"
-      ]
-    ))
-    (lib.cmakeBool "MIR_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
-    # https://github.com/canonical/mir/pull/1947#issuecomment-811810872
-    (lib.cmakeBool "MIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN" true)
-    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (lib.strings.concatStringsSep ";" [ ]))
-    # These get built but don't get executed by default, yet they get installed when tests are enabled
-    (lib.cmakeBool "MIR_BUILD_PERFORMANCE_TESTS" false)
-    (lib.cmakeBool "MIR_BUILD_PLATFORM_TEST_HARNESS" false)
-    # https://github.com/canonical/mir/issues/2987
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106799
-    (lib.cmakeBool "MIR_USE_PRECOMPILED_HEADERS" false)
-    (lib.cmakeFeature "MIR_COMPILER_QUIRKS" (
-      lib.strings.concatStringsSep ";" [
-        # https://github.com/canonical/mir/issues/3017 actually affects x86_64 as well
-        "test_touchspot_controller.cpp:array-bounds"
-      ]
-    ))
-  ];
-
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-
-  preCheck = ''
-    export XDG_RUNTIME_DIR=$TMP
-  '';
-
-  outputs = [
-    "out"
-    "dev"
-  ];
-
-  passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { rev-prefix = "v"; };
-  };
-
-  meta = with lib; {
-    description = "A display server and Wayland compositor developed by Canonical";
-    homepage = "https://mir-server.io";
-    changelog = "https://github.com/canonical/mir/releases/tag/v${finalAttrs.version}";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
-      onny
-      OPNA2608
-    ];
-    platforms = platforms.linux;
-    pkgConfigModules = [
-      "miral"
-      "mircommon"
-      "mircommon-internal"
-      "mircore"
-      "miroil"
-      "mirplatform"
-      "mir-renderer-gl-dev"
-      "mirrenderer"
-      "mirserver"
-      "mirserver-internal"
-      "mirtest"
-      "mirwayland"
+  mir_2_15 = common {
+    version = "2.15.0";
+    pinned = true;
+    hash = "sha256-c1+gxzLEtNCjR/mx76O5QElQ8+AO4WsfcG7Wy1+nC6E=";
+    patches = [
+      # Fix gbm-kms tests
+      # Remove when version > 2.15.0
+      (fetchpatch {
+        name = "0001-mir-Fix-the-signature-of-drmModeCrtcSetGamma.patch";
+        url = "https://github.com/canonical/mir/commit/98250e9c32c5b9b940da2fb0a32d8139bbc68157.patch";
+        hash = "sha256-tTtOHGNue5rsppOIQSfkOH5sVfFSn/KPGHmubNlRtLI=";
+      })
+      # Fix external_client tests
+      # Remove when version > 2.15.0
+      (fetchpatch {
+        name = "0002-mir-Fix-cannot_start_X_Server_and_outdated_tests.patch";
+        url = "https://github.com/canonical/mir/commit/0704026bd06372ea8286a46d8c939286dd8a8c68.patch";
+        hash = "sha256-k+51piPQandbHdm+ioqpBrb+C7Aqi2kugchAehZ1aiU=";
+      })
     ];
   };
-})
+}

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -1,41 +1,42 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, gitUpdater
-, testers
-, cmake
-, pkg-config
-, python3
-, boost
-, egl-wayland
-, freetype
-, glib
-, glm
-, glog
-, libdrm
-, libepoxy
-, libevdev
-, libglvnd
-, libinput
-, libuuid
-, libxcb
-, libxkbcommon
-, libxmlxx
-, yaml-cpp
-, lttng-ust
-, mesa
-, nettle
-, udev
-, wayland
-, wayland-scanner
-, xorg
-, xwayland
-, dbus
-, gobject-introspection
-, gtest
-, umockdev
-, wlcs
-, validatePkgConfig
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  testers,
+  cmake,
+  pkg-config,
+  python3,
+  boost,
+  egl-wayland,
+  freetype,
+  glib,
+  glm,
+  glog,
+  libdrm,
+  libepoxy,
+  libevdev,
+  libglvnd,
+  libinput,
+  libuuid,
+  libxcb,
+  libxkbcommon,
+  libxmlxx,
+  yaml-cpp,
+  lttng-ust,
+  mesa,
+  nettle,
+  udev,
+  wayland,
+  wayland-scanner,
+  xorg,
+  xwayland,
+  dbus,
+  gobject-introspection,
+  gtest,
+  umockdev,
+  wlcs,
+  validatePkgConfig,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -54,25 +55,22 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tools/detect_fd_leaks.bash tests/acceptance-tests/wayland-generator/test_wayland_generator.sh.in
 
     # Fix LD_PRELOADing in tests
-    for needsPreloadFixing in \
+    substituteInPlace \
       cmake/MirCommon.cmake \
       tests/umock-acceptance-tests/CMakeLists.txt \
       tests/unit-tests/platforms/gbm-kms/kms/CMakeLists.txt \
-      tests/unit-tests/CMakeLists.txt
-    do
-      substituteInPlace $needsPreloadFixing \
-        --replace 'LD_PRELOAD=liblttng-ust-fork.so' 'LD_PRELOAD=${lib.getLib lttng-ust}/lib/liblttng-ust-fork.so' \
-        --replace 'LD_PRELOAD=libumockdev-preload.so.0' 'LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0'
-    done
+      tests/unit-tests/CMakeLists.txt \
+      --replace-warn 'LD_PRELOAD=liblttng-ust-fork.so' 'LD_PRELOAD=${lib.getLib lttng-ust}/lib/liblttng-ust-fork.so' \
+      --replace-warn 'LD_PRELOAD=libumockdev-preload.so.0' 'LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0'
 
     # Fix Xwayland default
     substituteInPlace src/miral/x11_support.cpp \
-      --replace '/usr/bin/Xwayland' '${lib.getExe xwayland}'
+      --replace-fail '/usr/bin/Xwayland' '${lib.getExe xwayland}'
 
     # Fix paths for generating drm-formats
     substituteInPlace src/platform/graphics/CMakeLists.txt \
-      --replace "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
-      --replace "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
+      --replace-fail "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
+      --replace-fail "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
   '';
 
   strictDeps = true;
@@ -82,12 +80,15 @@ stdenv.mkDerivation (finalAttrs: {
     glib # gdbus-codegen
     lttng-ust # lttng-gen-tp
     pkg-config
-    (python3.withPackages (ps: with ps; [
-      pillow
-    ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
-      pygobject3
-      python-dbusmock
-    ]))
+    (python3.withPackages (
+      ps:
+      with ps;
+      [ pillow ]
+      ++ lib.optionals finalAttrs.finalPackage.doCheck [
+        pygobject3
+        python-dbusmock
+      ]
+    ))
     validatePkgConfig
     wayland-scanner
   ];
@@ -133,28 +134,31 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_DOXYGEN" false)
-    (lib.cmakeFeature "MIR_PLATFORM" (lib.strings.concatStringsSep ";" [
-      "gbm-kms"
-      "x11"
-      "eglstream-kms"
-      "wayland"
-    ]))
+    (lib.cmakeFeature "MIR_PLATFORM" (
+      lib.strings.concatStringsSep ";" [
+        "gbm-kms"
+        "x11"
+        "eglstream-kms"
+        "wayland"
+      ]
+    ))
     (lib.cmakeBool "MIR_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
     # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
     # https://github.com/canonical/mir/pull/1947#issuecomment-811810872
     (lib.cmakeBool "MIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN" true)
-    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (lib.strings.concatStringsSep ";" [
-    ]))
+    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (lib.strings.concatStringsSep ";" [ ]))
     # These get built but don't get executed by default, yet they get installed when tests are enabled
     (lib.cmakeBool "MIR_BUILD_PERFORMANCE_TESTS" false)
     (lib.cmakeBool "MIR_BUILD_PLATFORM_TEST_HARNESS" false)
     # https://github.com/canonical/mir/issues/2987
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106799
     (lib.cmakeBool "MIR_USE_PRECOMPILED_HEADERS" false)
-    (lib.cmakeFeature "MIR_COMPILER_QUIRKS" (lib.strings.concatStringsSep ";" [
-      # https://github.com/canonical/mir/issues/3017 actually affects x86_64 as well
-      "test_touchspot_controller.cpp:array-bounds"
-    ]))
+    (lib.cmakeFeature "MIR_COMPILER_QUIRKS" (
+      lib.strings.concatStringsSep ";" [
+        # https://github.com/canonical/mir/issues/3017 actually affects x86_64 as well
+        "test_touchspot_controller.cpp:array-bounds"
+      ]
+    ))
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -163,13 +167,14 @@ stdenv.mkDerivation (finalAttrs: {
     export XDG_RUNTIME_DIR=$TMP
   '';
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-    };
+    updateScript = gitUpdater { rev-prefix = "v"; };
   };
 
   meta = with lib; {
@@ -177,7 +182,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://mir-server.io";
     changelog = "https://github.com/canonical/mir/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ onny OPNA2608 ];
+    maintainers = with maintainers; [
+      onny
+      OPNA2608
+    ];
     platforms = platforms.linux;
     pkgConfigModules = [
       "miral"

--- a/pkgs/servers/mir/update.sh
+++ b/pkgs/servers/mir/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused jq common-updater-scripts
+
+set -eou pipefail
+
+version="$(curl --silent "https://api.github.com/repos/canonical/mir/releases" | jq '.[0].tag_name' --raw-output)"
+
+update-source-version mir "${version:1}" --file=./pkgs/servers/mir/default.nix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26175,7 +26175,9 @@ with pkgs;
     buildGoModule = buildGo122Module;
   };
 
-  mir = callPackage ../servers/mir { };
+  inherit (callPackage ../servers/mir { })
+    mir
+    mir_2_15;
 
   miriway = callPackage ../applications/window-managers/miriway { };
 


### PR DESCRIPTION
## Description of changes

Checked:
- `mir`
- `miriway`
- `miriway.passthru.tests`

Wayland session has been removed by upstream: "This is not a useful, nor good example"

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
