### PR TITLE
Upgrade openwrt packages

### DIFF
--- a/pkgs/by-name/uc/ucode/package.nix
+++ b/pkgs/by-name/uc/ucode/package.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, json_c
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ucode";
+  version = "0.0.20231102";
+
+  src = fetchFromGitHub {
+    owner = "jow-";
+    repo = "ucode";
+    rev = "v${version}";
+    hash = "sha256-dJjlwuQLS73D6W/bmhWLPPaT7himQyO1RvD+MXVxBMw=";
+  };
+
+  buildInputs = [
+    json_c
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "JavaScript-like language with optional templating";
+    homepage = "https://github.com/jow-/ucode";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/by-name/ud/udebug/package.nix
+++ b/pkgs/by-name/ud/udebug/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, cmake
+, fetchgit
+, pkg-config
+, ubus
+, libubox
+, ucode
+, json_c
+}:
+
+stdenv.mkDerivation {
+  pname = "udebug";
+  version = "unstable-2023-11-28";
+
+  src = fetchgit {
+    url = "https://git.openwrt.org/project/udebug.git";
+    rev = "d49aadabb7a147b99a3e6299a77d7fda4e266091";
+    hash = "sha256-5I50q+oUQ5f82ngKl7bX50J+3pBviNk3iVEChNjt5wY=";
+  };
+
+  buildInputs = [
+    ubus
+    libubox
+    ucode
+    json_c
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "OpenWrt debugging helper library/service";
+    homepage = "https://git.openwrt.org/?p=project/udebug.git;a=summary";
+    license = licenses.free;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/development/libraries/libubox/default.nix
+++ b/pkgs/development/libraries/libubox/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "libubox";
-  version = "unstable-2023-11-03";
+  version = "unstable-2023-11-28";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/libubox.git";
-    rev = "f7d1569113110ea8df071d2ea64fd17aaf5b42c9";
-    hash = "sha256-W0+QXI0gJ4WwrlRMPAJOChvilZ4zlAf4kXrfgBAkQAE=";
+    rev = "e80dc00ee90c29ef56ae28f414b0e5bb361206e7";
+    hash = "sha256-R4Yz4C63LQTNBKyNyiLMQHfc5KJBPFldP1trmtEBb9U=";
   };
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=OFF" (if with_lua then "-DLUAPATH=${placeholder "out"}/lib/lua" else "-DBUILD_LUA=OFF") ];

--- a/pkgs/development/libraries/ubus/default.nix
+++ b/pkgs/development/libraries/ubus/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "ubus";
-  version = "unstable-2023-11-14";
+  version = "unstable-2023-11-28";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ubus.git";
-    rev = "b3e8c4ef07ebb6f0f34a5c1f0dc1539068363619";
-    hash = "sha256-H/QrLMhdEC1LnSxHpp/90OdKbfHRqLVWUnzyQlsVO8c=";
+    rev = "f84eb5998c6ea2d34989ca2d3254e56c66139313";
+    hash = "sha256-5pIovqIeJczWAA9KQPKFnTnGRrIZVdSNdxBR8AEFtO4=";
   };
 
   cmakeFlags = [ "-DBUILD_LUA=OFF" ];

--- a/pkgs/development/libraries/ustream-ssl/default.nix
+++ b/pkgs/development/libraries/ustream-ssl/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "ustream-ssl";
-  version = "unstable-2023-02-25";
+  version = "unstable-2023-11-11";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ustream-ssl.git";
-    rev = "498f6e268d4d2b0ad33b430f4ba1abe397d31496";
-    hash = "sha256-qwF3pzJ/nUTaJ8NZtgLyXnSozekY3dovxK3ZWHPGORM=";
+    rev = "263b9a97cf7e1e2467319c23832b705fc01190b5";
+    hash = "sha256-RLHU6swNbS3DL3QbKnwU4BbD0EFGKCrHHp0hbnoSssw=";
   };
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -1,23 +1,48 @@
-{ stdenv, file, lib, fetchFromGitHub, autoreconfHook, bison, flex, pkg-config
-, pythonSupport ? false, swig ? null, python ? null}:
+{ stdenv
+, file
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, bison
+, flex
+, pkg-config
+, doxygen
+, graphviz
+, mscgen
+, asciidoc
+, sourceHighlight
+, pythonSupport ? false
+, swig ? null
+, python ? null
+}:
 
 stdenv.mkDerivation rec {
   pname = "libnl";
-  version = "3.7.0";
+  version = "3.8.0";
 
   src = fetchFromGitHub {
     repo = "libnl";
     owner = "thom311";
     rev = "libnl${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "sha256-Ty9NdWKWB29MTRfG5OJlSE0mSTN3Wy+sR4KtuExXcB4=";
+    hash = "sha256-zVpoRlB5xDfo6wJkCJGGptuCXkNkriudtZF2Job9YD4=";
   };
 
   outputs = [ "bin" "dev" "out" "man" ] ++ lib.optional pythonSupport "py";
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook bison flex pkg-config file ]
-    ++ lib.optional pythonSupport swig;
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    pkg-config
+    file
+    doxygen
+    graphviz
+    mscgen
+    asciidoc
+    sourceHighlight
+  ] ++ lib.optional pythonSupport swig;
 
   postBuild = lib.optionalString (pythonSupport) ''
       cd python

--- a/pkgs/tools/networking/netifd/default.nix
+++ b/pkgs/tools/networking/netifd/default.nix
@@ -1,17 +1,52 @@
-{ lib, stdenv, cmake, fetchgit, libnl, libubox, uci, ubus, json_c, pkg-config }:
+{ lib
+, stdenv
+, cmake
+, fetchgit
+, libnl
+, libubox
+, uci
+, ubus
+, json_c
+, pkg-config
+, udebug
+}:
 
 stdenv.mkDerivation {
   pname = "netifd";
-  version = "unstable-2021-04-03";
+  version = "unstable-2023-11-27";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/netifd.git";
-    rev = "327da9895327bc56b23413ee91a6e6b6e0e4329d";
-    sha256 = "0jvk2hx8kbkc6d72gh9rwap8ds6qgnmny6306vvzxy68v03xikwv";
+    rev = "02bc2e14d1d37500e888c0c53ac41398a56b5579";
+    hash = "sha256-aMs/Y50+1Yk/j5jGubjBCRcPGw03oIitvEygaxRlr90=";
   };
 
-  buildInputs = [ libnl libubox uci ubus json_c ];
-  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    libnl.dev
+    libubox
+    uci
+    ubus
+    json_c
+    udebug
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  postPatch = ''
+    # by default this assumes the build directory is the source directory
+    # since we let cmake build in it's own build directory, we need to use
+    # $PWD (which at the time of this script being run is the directory with the source code)
+    # to adjust the paths
+    sed "s|./make_ethtool_modes_h.sh|$PWD/make_ethtool_modes_h.sh|g" -i CMakeLists.txt
+    sed "s|./ethtool-modes.h|$PWD/ethtool-modes.h|g" -i CMakeLists.txt
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12") [
+    "-Wno-error=maybe-uninitialized"
+  ]);
 
   meta = with lib; {
     description = "OpenWrt Network interface configuration daemon";

--- a/pkgs/tools/networking/uqmi/default.nix
+++ b/pkgs/tools/networking/uqmi/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "uqmi";
-  version = "unstable-2019-06-27";
+  version = "unstable-2023-10-30";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uqmi.git";
-    rev = "1965c713937495a5cb029165c16acdb6572c3f87";
-    sha256 = "1gn8sdcl4lwfs3lwabmnjbvdhhk1l42bwbajwds7j4936fpbklx0";
+    rev = "eea292401c388a4eb59c0caf5d00aa046c6059f4";
+    hash = "sha256-Uz5GjGcSKatbii09CsvzsYMz8Vm+Am4RUeCZuFIK1Ag=";
   };
 
   postPatch = ''
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12") [
     # Needed with GCC 12 but breaks on darwin (with clang) or older gcc
     "-Wno-error=dangling-pointer"
+    "-Wno-error=maybe-uninitialized"
   ]);
 
   meta = with lib; {


### PR DESCRIPTION
- libubox: unstable-2023-11-03 -> unstable-2023-11-28
- ubus: unstable-2023-11-14 -> unstable-2023-11-28
- ustream-ssl: unstable-2023-02-25 -> unstable-2023-11-11
- netifd: unstable-2021-04-03 -> unstable-2023-11-27
- uqmi: unstable-2019-06-27 -> unstable-2023-10-30
- libnl: 3.7.0 -> 3.8.0
- ucode: init at 0.0.20231102
- udebug: init at unstable-2023-11-28

## Description of changes

Upgrade openwrt packages, add new dependencies
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
