### PR TITLE
libtypec: init at 0.6.1

### DIFF
--- a/pkgs/by-name/li/libtypec/package.nix
+++ b/pkgs/by-name/li/libtypec/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libusb1,
+  systemd,
+  libudev0-shim,
+  gtk3, # utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libtypec";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "libtypec";
+    repo = pname;
+    rev = "${pname}-${version}";
+    hash = "sha256-XkT0bgBjoJTAFa9NLZdzbJSpchiXxKjeu88PeT/AlPY=";
+  };
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libusb1
+    libudev0-shim
+    systemd
+    gtk3
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "utils" true)
+    "--prefix=${placeholder "dev"}"
+  ];
+
+  # Don't propagate out to the dev output to avoid pulling in GUI dependencies
+  propagatedBuildOutputs = [ "lib" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/libtypec/libtypec";
+    description = "generic diagnostic tool interface for usb-c ports";
+    longDescription = "libtypec is aimed to provide a generic interface abstracting all platform complexity for user space to develop tools for efficient USB-C port management. The library can also enable development of diagnostic and debug tools to debug system issues around USB-C/USB PD topology.";
+    platforms = platforms.linux;
+    license = with licenses; [
+      mit
+      gpl2Only
+    ];
+    maintainers = with maintainers; [ johnazoidberg ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Hi, **I need help with this**.

Out standing issues:
1. Am I doing the right thing to build a cmake subdir that's not included in the parent project?
2. Any suggestions on what to do about the `utils` binaries? They link against the local relative path to libtypec, which is incorrect and fails the reference check at the end of the build.

---

Init `libtypec` at `0.4.0`.

project url: https://github.com/Rajaram-Regupathy/libtypec
description: 

> “libtypec” is aimed to provide a generic interface abstracting all platform complexity for user space to develop tools for efficient USB-C port management. The library can also enable development of diagnostic and debug tools to debug system issues around USB-C/USB PD topology. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
