### PR TITLE
nixos/kea: set StateDirectory (fixes #265826)

### DIFF
--- a/nixos/modules/services/networking/kea.nix
+++ b/nixos/modules/services/networking/kea.nix
@@ -254,7 +254,6 @@ in
       DynamicUser = true;
       User = "kea";
       ConfigurationDirectory = "kea";
-      StateDirectory = "kea";
       UMask = "0077";
     };
   in mkIf (cfg.ctrl-agent.enable || cfg.dhcp4.enable || cfg.dhcp6.enable || cfg.dhcp-ddns.enable) (mkMerge [
@@ -300,6 +299,7 @@ in
         ExecStart = "${package}/bin/kea-ctrl-agent -c /etc/kea/ctrl-agent.conf ${lib.escapeShellArgs cfg.ctrl-agent.extraArgs}";
         KillMode = "process";
         Restart = "on-failure";
+        StateDirectory = "kea-ctrl-agent kea";
         RuntimeDirectory = "kea-ctrl-agent";
       } // commonServiceConfig;
     };
@@ -348,6 +348,7 @@ in
           "CAP_NET_BIND_SERVICE"
           "CAP_NET_RAW"
         ];
+        StateDirectory = "kea-dhcp4 kea";
         RuntimeDirectory = "kea-dhcp4";
       } // commonServiceConfig;
     };
@@ -394,6 +395,7 @@ in
         CapabilityBoundingSet = [
           "CAP_NET_BIND_SERVICE"
         ];
+        StateDirectory = "kea-dhcp6 kea";
         RuntimeDirectory = "kea-dhcp6";
       } // commonServiceConfig;
     };
@@ -439,6 +441,7 @@ in
         CapabilityBoundingSet = [
           "CAP_NET_BIND_SERVICE"
         ];
+        StateDirectory = "kea-dhcp-ddns kea";
         RuntimeDirectory = "kea-dhcp-ddns";
       } // commonServiceConfig;
     };


### PR DESCRIPTION
## Description of changes

  Using #265826 as a starting point, add both a service-specific state
  directory and the the example state directory (/var/lib/kea). This
  addresses error messages like:

  `kea-dhcp4[xx]: Unable to use interprocess sync lockfile (Read-only file system): /var/run/kea/logger_lockfile`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [x] `tests.kea`
  - [x] 2h running DHCP server 
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
