### PR TITLE
pollymc: init at 8.0

### DIFF
--- a/pkgs/games/pollymc/default.nix
+++ b/pkgs/games/pollymc/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, canonicalize-jars-hook
+, cmake
+, cmark
+, Cocoa
+, ninja
+, jdk17
+, zlib
+, qtbase
+, quazip
+, extra-cmake-modules
+, tomlplusplus
+, ghc_filesystem
+, gamemode
+, msaClientID ? null
+, gamemodeSupport ? stdenv.isLinux
+,
+}:
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PrismLauncher";
+    repo = "libnbtplusplus";
+    rev = "a5e8fd52b8bf4ab5d5bcc042b2a247867589985f";
+    hash = "sha256-A5kTgICnx+Qdq3Fir/bKTfdTt/T1NQP2SC+nhN1ENug=";
+  };
+in
+
+assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is only available on Linux";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pollymc-unwrapped";
+  version = "8.0";
+
+  src = fetchFromGitHub {
+    owner = "fn2006";
+    repo = "PollyMC";
+    rev = finalAttrs.version;
+    hash = "sha256-DF1lxQHetDKZEpRrRZ0HQWqqMDAGNiTZoCJUARdXFSk=";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja canonicalize-jars-hook ];
+  buildInputs =
+    [
+      qtbase
+      zlib
+      quazip
+      ghc_filesystem
+      tomlplusplus
+      cmark
+    ]
+    ++ lib.optional gamemodeSupport gamemode
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+
+  hardeningEnable = lib.optionals stdenv.isLinux [ "pie" ];
+
+  cmakeFlags = [
+    # downstream branding
+    "-DLauncher_BUILD_PLATFORM=nixpkgs"
+  ] ++ lib.optionals (msaClientID != null) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
+  ++ lib.optionals (lib.versionOlder qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=5" ]
+  ++ lib.optionals stdenv.isDarwin [ "-DINSTALL_BUNDLE=nodeps" "-DMACOSX_SPARKLE_UPDATE_FEED_URL=''" ];
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    mainProgram = "pollymc";
+    homepage = "https://github.com/fn2006/PollyMC";
+    description = "DRM-free Prism Launcher fork with support for custom auth servers";
+    platforms = with platforms; linux ++ darwin;
+    changelog = "https://github.com/fn2006/PollyMC/releases/tag/${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ evan-goode ];
+  };
+})

--- a/pkgs/games/pollymc/wrapper.nix
+++ b/pkgs/games/pollymc/wrapper.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  symlinkJoin,
+  pollymc-unwrapped,
+  wrapQtAppsHook,
+  addOpenGLRunpath,
+  qtbase, # needed for wrapQtAppsHook
+  qtsvg,
+  qtwayland,
+  xorg,
+  libpulseaudio,
+  libGL,
+  glfw,
+  openal,
+  jdk8,
+  jdk17,
+  gamemode,
+  flite,
+  mesa-demos,
+  udev,
+  libusb1,
+  msaClientID ? null,
+  gamemodeSupport ? stdenv.isLinux,
+  textToSpeechSupport ? stdenv.isLinux,
+  controllerSupport ? stdenv.isLinux,
+  jdks ? [jdk17 jdk8],
+  additionalLibs ? [],
+  additionalPrograms ? [],
+}: let
+  pollymcFinal = pollymc-unwrapped.override {
+    inherit msaClientID gamemodeSupport;
+  };
+in
+  symlinkJoin {
+    name = "pollymc-${pollymcFinal.version}";
+
+    paths = [pollymcFinal];
+
+    nativeBuildInputs = [
+      wrapQtAppsHook
+    ];
+
+    buildInputs =
+      [
+        qtbase
+        qtsvg
+      ]
+      ++ lib.optional (lib.versionAtLeast qtbase.version "6" && stdenv.isLinux) qtwayland;
+
+    postBuild = ''
+      wrapQtAppsHook
+    '';
+
+    qtWrapperArgs = let
+      runtimeLibs =
+        (with xorg; [
+          libX11
+          libXext
+          libXcursor
+          libXrandr
+          libXxf86vm
+        ])
+        ++ [
+          # lwjgl
+          libpulseaudio
+          libGL
+          glfw
+          openal
+          stdenv.cc.cc.lib
+
+          # oshi
+          udev
+        ]
+        ++ lib.optional gamemodeSupport gamemode.lib
+        ++ lib.optional textToSpeechSupport flite
+        ++ lib.optional controllerSupport libusb1
+        ++ additionalLibs;
+
+      runtimePrograms =
+        [
+          xorg.xrandr
+          mesa-demos # need glxinfo
+        ]
+        ++ additionalPrograms;
+    in
+      ["--prefix POLLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
+      ++ lib.optionals stdenv.isLinux [
+        "--set LD_LIBRARY_PATH ${addOpenGLRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+        # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+        "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
+      ];
+
+    inherit (pollymcFinal) meta;
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38216,6 +38216,18 @@ with pkgs;
 
   prismlauncher = qt6Packages.callPackage ../games/prismlauncher/wrapper.nix { };
 
+  pollymc-qt5-unwrapped = libsForQt5.callPackage ../games/pollymc {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
+  pollymc-qt5 = libsForQt5.callPackage ../games/pollymc/wrapper.nix { pollymc-unwrapped = pollymc-qt5-unwrapped; };
+
+  pollymc-unwrapped = qt6Packages.callPackage ../games/pollymc {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
+  pollymc = qt6Packages.callPackage ../games/pollymc/wrapper.nix { };
+
   pong3d = callPackage ../games/pong3d { };
 
   pokerth = libsForQt5.callPackage ../games/pokerth {


### PR DESCRIPTION
## Description of changes

[PollyMC](https://github.com/fn2006/PollyMC) is a libre [Minecraft](https://minecraft.net) launcher and a fork of [Prism Launcher](https://github.com/PrismLauncher/PrismLauncher) that:

- Removes the DRM to allow use without a Microsoft account
- Adds support for alternative Minecraft API servers, such as [Ely.by](https://github.com/elyby)
- Adds back the ability to download FTB modpacks from within the launcher
- Adds back support for Mojang accounts (though online-mode servers still won't work with Mojang accounts)

**PollyMC** (two Ls) is NOT AFFILIATED with **PolyMC** (one L). The project originated as a fork of PolyMC, hence the name.

I'll also note that while PollyMC allows users to play Minecraft without verifying that they have a license from Mojang, it is GPLv3 software and does not distribute any of the game's proprietary files. The game itself is downloaded directly from Mojang's servers at runtime, exactly like Prism Launcher. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Builds on macOS or aarch64 have not been tested, but this derivation is almost identical to Prism Launcher, which is already in nixpkgs.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
