### PR TITLE
resholve: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -52,13 +52,13 @@ Here's a simple example of how `resholve.mkDerivation` is already used in nixpkg
 
 resholve.mkDerivation rec {
   pname = "dgoss";
-  version = "0.3.18";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
-    owner = "aelsabbahy";
+    owner = "goss-org";
     repo = "goss";
-    rev = "v${version}";
-    sha256 = "01ssc7rnnwpyhjv96qy8drsskghbfpyxpsahk8s62lh8pxygynhv";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dpMTUBMEG5tDi7E6ZRg1KHqIj5qDlvwfwJEgq/5z7RE=";
   };
 
   dontConfigure = true;
@@ -81,11 +81,12 @@ resholve.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://github.com/aelsabbahy/goss/blob/v${version}/extras/dgoss/README.md";
+    homepage = "https://github.com/goss-org/goss/blob/v${version}/extras/dgoss/README.md";
+    changelog = "https://github.com/goss-org/goss/releases/tag/v${version}";
     description = "Convenience wrapper around goss that aims to bring the simplicity of goss to docker containers";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ hyzual ];
+    maintainers = with maintainers; [ hyzual anthonyroussel ];
   };
 }
 ```

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -36,14 +36,14 @@ rec {
   # not exposed in all-packages
   resholveBuildTimeOnly = removeKnownVulnerabilities resholve;
   # resholve itself
-  resholve = callPackage ./resholve.nix {
+  resholve = (callPackage ./resholve.nix {
     inherit (source) rSrc version;
     inherit (deps.oil) oildev;
     inherit (deps) configargparse;
     inherit resholve-utils;
     # used only in tests
     resholve = resholveBuildTimeOnly;
-  };
+  });
   # funcs to validate and phrase invocations of resholve
   # and use those invocations to build packages
   resholve-utils = callPackage ./resholve-utils.nix {

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -10,14 +10,9 @@
   Notes on specific dependencies:
   - if/when python2.7 is removed from nixpkgs, this may need to figure
   out how to build oil's vendored python2
-  - I'm not sure if glibcLocales is worth the addition here. It's to fix
-  a libc test oil runs. My oil fork just disabled the libc tests, but
-  I haven't quite decided if that's the right long-term call, so I
-  didn't add a patch for it here yet.
 */
 
 rec {
-  # binlore = callPackage ./binlore.nix { };
   oil = callPackage ./oildev.nix {
     inherit python27;
     inherit six;

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,17 +3,11 @@
 }:
 
 rec {
-  version = "0.9.0";
-  rSrc =
-    # local build -> `make ci`; `make clean` to restore
-    # return to remote source
-    # if builtins.pathExists ./.local
-    # then ./.
-    # else
-      fetchFromGitHub {
-        owner = "abathur";
-        repo = "resholve";
-        rev = "v${version}";
-        hash = "sha256-FRdCeeC2c3bMEXekEyilgW0PwFfUWGstZ5mXdmRPM5w=";
-      };
+  version = "0.9.1";
+  rSrc = fetchFromGitHub {
+    owner = "abathur";
+    repo = "resholve";
+    rev = "v${version}";
+    hash = "sha256-hkLKQKhEMD1UQ9EunPmx5Tsh44q4+tYj820OXF2ueUo=";
+  };
 }

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -121,13 +121,17 @@ rec {
   cli = stdenv.mkDerivation {
     name = "resholve-test";
     src = rSrc;
+
+    dontBuild = true;
+
     installPhase = ''
       mkdir $out
       cp *.ansi $out/
     '';
+
     doCheck = true;
     buildInputs = [ resholve ];
-    nativeCheckInputs = [ coreutils bats python27 ];
+    nativeCheckInputs = [ coreutils bats ];
     # LOGLEVEL="DEBUG";
 
     # default path


### PR DESCRIPTION
## Description of changes

Bugfix release: https://github.com/abathur/resholve/blob/master/CHANGELOG.md#v091-nov-28-2023

Also ~syncing some minor nix/doc changes from the resholve repo.

Result of `nixpkgs-review pr 270841` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>25 packages built:</summary>
  <ul>
    <li>aaxtomp3</li>
    <li>arch-install-scripts</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>dgoss</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>kicadAddons.kikit</li>
    <li>kicadAddons.kikit-library</li>
    <li>kikit</li>
    <li>kikit.dist</li>
    <li>locate-dominating-file</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>pdfmm</li>
    <li>s0ix-selftest-tool</li>
    <li>shunit2</li>
    <li>wgnord</li>
    <li>wsl-vpnkit</li>
    <li>yadm</li>
    <li>zxfer</li>
  </ul>
</details>

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>kicadAddons.kikit</li>
    <li>kicadAddons.kikit-library</li>
    <li>kikit</li>
    <li>kikit.dist</li>
  </ul>
</details>
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>aaxtomp3</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>locate-dominating-file</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>shunit2</li>
    <li>yadm</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
