### PR TITLE
teeworlds: fix build on Darwin

### DIFF
--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -1,7 +1,6 @@
 { fetchFromGitHub, lib, stdenv, cmake, pkg-config, python3, alsa-lib
 , libX11, libGLU, SDL2, lua5_3, zlib, freetype, wavpack, icoutils
 , nixosTests
-, Carbon
 , Cocoa
 , buildClient ? true
 }:
@@ -45,17 +44,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     python3 lua5_3 zlib
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
   ] ++ lib.optionals buildClient ([
-    libGLU
     SDL2
     freetype
     wavpack
   ] ++ lib.optionals stdenv.isLinux [
+    libGLU
     alsa-lib
     libX11
-  ] ++ lib.optionals stdenv.isDarwin [
-    Carbon
-    Cocoa
   ]);
 
   cmakeFlags = [

--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation rec {
     substituteInPlace 'other/bundle/client/Info.plist.in' \
       --replace ${"'"}''${TARGET_CLIENT}' 'teeworlds' \
       --replace ${"'"}''${PROJECT_VERSION}' '${version}'
+
+    # Make sure some bundled dependencies are actually unbundled.
+    # This will fail compilation if one of these dependencies could not
+    # be found, instead of falling back to the bundled version.
+    rm -rf 'src/engine/external/wavpack/'
+    rm -rf 'src/engine/external/zlib/'
+    # md5, pnglite and json-parser (https://github.com/udp/json-parser)
+    # don't seem to be packaged in Nixpkgs, so don't unbundle them.
   '';
 
   nativeBuildInputs = [
@@ -44,12 +52,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     python3 lua5_3 zlib
+    wavpack
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa
   ] ++ lib.optionals buildClient ([
     SDL2
     freetype
-    wavpack
   ] ++ lib.optionals stdenv.isLinux [
     libGLU
     alsa-lib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38490,7 +38490,7 @@ with pkgs;
   teetertorture = callPackage ../games/teetertorture { };
 
   teeworlds = callPackage ../games/teeworlds {
-    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
   teeworlds-server = teeworlds.override { buildClient = false; };
 


### PR DESCRIPTION
## Description of changes
Fix build on Darwin.
Also fix unbundling of the wavpack dependency when building teeworlds-server.

ZHF #265948

cc @jtbx

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
