### PR TITLE
postgresql.pkgs.timescaledb_toolkit: 1.16.0 -> 1.18.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -1,27 +1,48 @@
 { lib
 , fetchFromGitHub
-, buildPgxExtension
+, buildPgrxExtension
 , postgresql
 , nixosTests
-, cargo-pgx_0_7_1
+, cargo-pgrx
+, fetchCrate
 , nix-update-script
 , stdenv
 }:
 
-(buildPgxExtension.override {cargo-pgx = cargo-pgx_0_7_1;})rec {
+let
+
+  cargo-pgrx_0_10_2 = cargo-pgrx.overrideAttrs (old: rec {
+    name = "cargo-pgrx-${version}";
+    version = "0.10.2";
+
+    src = fetchCrate {
+      pname = "cargo-pgrx";
+      inherit version;
+      hash = "sha256-FqjfbJmSy5UCpPPPk4bkEyvQCnaH9zYtkI7txgIn+ls=";
+    };
+
+    cargoDeps = old.cargoDeps.overrideAttrs (_: {
+      inherit src;
+      outputHash = "sha256-itU000vyVGnDUUZx6qOLJqiPdyNHikW2KNFzBmJPqv0=";
+    });
+  });
+
+in
+
+(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_10_2; }) rec {
   inherit postgresql;
 
   pname = "timescaledb_toolkit";
-  version = "1.16.0";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "timescaledb-toolkit";
     rev = version;
-    sha256 = "sha256-aivGURTsm0dGaFq75qR3wIkXwsbvBiDEg+qLMcqKMj8=";
+    hash = "sha256-Lm/LFBkG91GeWlJL9RBqP8W0tlhBEeGQ6kXUzzv4xRE=";
   };
 
-  cargoSha256 = "sha256-AO5nSgQYvTmohXbzjWvDylnBgS2WpKP6wFOnkUx7ksI=";
+  cargoHash = "sha256-LME8oftHmmiN8GU3eTBTSB6m0CE+KtDFRssL1g2Cjm8=";
   buildAndTestSubdir = "extension";
 
   passthru = {


### PR DESCRIPTION
## Description of changes

Upgrade timescaledb_toolkit to [1.18.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.18.0).

The current version 1.16.0 is broken, see: https://github.com/NixOS/nixpkgs/issues/269710 The newer package uses pgrx instead of pgx. Changing the builder to `buildPgrxExtension` using the correct `cargo-pgrx` version solves this issue.

I hope this can also be backported in 23.11, since the current version on there is broken.

Tested this on:
- postgres 15.5 on nixos unstable
- postgres 14.10 on nixos 23.11 

@typetetris

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
