### PR TITLE
mpvScripts.buildLua: Strip `mpv-` from `pname` when inferring `scriptName`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -20,11 +20,17 @@ lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
   , extraScripts ? []
   , ... }@args:
   let
+    strippedName = with builtins;
+      let groups = match "mpv[-_](.*)" pname; in
+      if groups != null
+      then head groups
+      else pname
+    ;
     # either passthru.scriptName, inferred from scriptPath, or from pname
     scriptName = (args.passthru or {}).scriptName or (
       if args ? scriptPath
       then fileName args.scriptPath
-      else "${pname}.lua"
+      else "${strippedName}.lua"
     );
     scriptPath = args.scriptPath or "./${scriptName}";
   in {

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -17,8 +17,6 @@ buildLua rec {
       'youtube_dl_executable = "${lib.getBin yt-dlp}/bin/yt-dlp"',
   '';
 
-  scriptPath = "playlistmanager.lua";
-
   meta = with lib; {
     description = "Mpv lua script to create and manage playlists";
     homepage = "https://github.com/jonniek/mpv-playlistmanager";

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -15,7 +15,6 @@ buildLua rec {
     hash = "sha256-yrcTxqpLnOI1Tq3khhflO3wzhyeTPuvKifyH5/P57Ns=";
   };
 
-  scriptPath = "quality-menu.lua";
   extraScripts = lib.optional oscSupport "quality-menu-osc.lua";
 
   meta = with lib; {

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -11,8 +11,6 @@ buildLua {
     hash = "sha256-5u5WBvWOEydJrnr/vilEgW4+fxkxM6wNjb9Fyyxx/1c=";
   };
 
-  scriptPath = "thumbfast.lua";
-
   passthru.extraWrapperArgs = [
     "--prefix" "PATH" ":" "${lib.getBin mpv-unwrapped}/bin"
   ];


### PR DESCRIPTION
## Description of changes

Under `mpvScripts`:
- `buildLua`: strip `mpv-` and `mpv_` from `pname` when inferring a script's name;
- simplify `mpv-playlistmanager`, `quality-menu` and `thumbfast` as a result.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
