### PR TITLE
mpvScripts.mpv-webm: unstable-2023-02-23 → 2023-11-18

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -15,7 +15,7 @@ in lib.recurseIntoAttrs
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { inherit buildLua; };
-    mpv-webm = callPackage ./mpv-webm.nix { };
+    mpv-webm = callPackage ./mpv-webm.nix { inherit buildLua; };
     mpvacious = callPackage ./mpvacious.nix { inherit buildLua; };
     quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { inherit buildLua; };

--- a/pkgs/applications/video/mpv/scripts/mpv-webm.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-webm.nix
@@ -1,10 +1,10 @@
 { lib
-, stdenvNoCC
+, buildLua
 , fetchFromGitHub
 , luaPackages
 }:
 
-stdenvNoCC.mkDerivation {
+buildLua {
   pname = "mpv-webm";
   version = "unstable-2023-02-23";
 
@@ -15,16 +15,9 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-aetkQ1gU/6Yys5FJS/N06ED9tCSvL6BAgUGdNmNmpbU=";
   };
 
+  dontBuild = false;
   nativeBuildInputs = [ luaPackages.moonscript ];
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/mpv/scripts
-    install -m 644 build/webm.lua $out/share/mpv/scripts/
-    runHook postInstall
-  '';
-
-  passthru.scriptName = "webm.lua";
+  scriptPath = "build/webm.lua";
 
   meta = with lib; {
     description = "Simple WebM maker for mpv, with no external dependencies";

--- a/pkgs/applications/video/mpv/scripts/mpv-webm.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-webm.nix
@@ -6,13 +6,13 @@
 
 buildLua {
   pname = "mpv-webm";
-  version = "unstable-2023-02-23";
+  version = "unstable-2023-11-18";
 
   src = fetchFromGitHub {
     owner = "ekisu";
     repo = "mpv-webm";
-    rev = "a18375932e39e9b2a40d9c7ab52ea367b41e2558";
-    hash = "sha256-aetkQ1gU/6Yys5FJS/N06ED9tCSvL6BAgUGdNmNmpbU=";
+    rev = "6b5863f68275b3dc91c2507284c039ec8a4cbd97";
+    hash = "sha256-rJamBm6FyxWcJO7VXXOUTO9piWCkPfEVdqGKGeJ/h0c=";
   };
 
   dontBuild = false;

--- a/pkgs/applications/video/mpv/scripts/mpv-webm.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-webm.nix
@@ -2,6 +2,7 @@
 , buildLua
 , fetchFromGitHub
 , luaPackages
+, nix-update-script
 }:
 
 buildLua {
@@ -18,6 +19,10 @@ buildLua {
   dontBuild = false;
   nativeBuildInputs = [ luaPackages.moonscript ];
   scriptPath = "build/webm.lua";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = with lib; {
     description = "Simple WebM maker for mpv, with no external dependencies";


### PR DESCRIPTION
## Description of changes

In `mpvScripts.mpv-webm`:
- simplified using `buildLua`;
- updated to the current version;
- added `updateScript` so the bot will help keep it up-to-date.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @pbsds


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
