### PR TITLE
mpvScripts.sponsorblock: Simplify with `buildLua`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -36,6 +36,9 @@ lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
     dontBuild = true;
     preferLocalBuild = true;
 
+    # Prevent `patch` from emitting `.orig` files (that end up in the output)
+    patchFlags = [ "--no-backup-if-mismatch" "-p1" ];
+
     outputHashMode = "recursive";
     installPhase = ''
       runHook preInstall

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -1,7 +1,7 @@
-{ lib, stdenvNoCC, fetchFromGitHub, fetchpatch, python3, nix-update-script }:
+{ lib, buildLua, fetchFromGitHub, fetchpatch, python3, nix-update-script }:
 
 # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.sponsorblock ]; }`
-stdenvNoCC.mkDerivation {
+buildLua {
   pname = "mpv_sponsorblock";
   version = "unstable-2023-01-30";
 
@@ -11,8 +11,6 @@ stdenvNoCC.mkDerivation {
     rev = "7785c1477103f2fafabfd65fdcf28ef26e6d7f0d";
     sha256 = "sha256-iUXaTWWFEdxhxClu2NYbQcThlvYty3A2dEYGooeAVAQ=";
   };
-
-  dontBuild = true;
 
   patches = [
     # Use XDG_DATA_HOME and XDG_CACHE_HOME if defined for UID and DB
@@ -34,23 +32,16 @@ stdenvNoCC.mkDerivation {
       --replace 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
   '';
 
-  installPhase = ''
-    mkdir -p $out/share/mpv/scripts
-    cp -r sponsorblock.lua sponsorblock_shared $out/share/mpv/scripts/
-  '';
+  postInstall = "cp -a sponsorblock_shared $out/share/mpv/scripts/";
 
-  passthru = {
-    scriptName = "sponsorblock.lua";
-    updateScript = nix-update-script {
-      extraArgs = [ "--version=branch" ];
-    };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
   };
 
   meta = with lib; {
     description = "Script for mpv to skip sponsored segments of YouTube videos";
     homepage = "https://github.com/po5/mpv_sponsorblock";
     license = licenses.gpl3;
-    platforms = platforms.all;
     maintainers = with maintainers; [ pacien ];
   };
 }


### PR DESCRIPTION
## Description of changes

Under `mpvScripts`:
- `buildLua`:
  - strip `mpv_` from `pname` when inferring `scriptName`; (from #270916)
  - stop `patch` from emitting `.orig` files;
   the issue isn't specific to `buildLua`, `sponsorblock` previously included that file in its output.
- `sponsorblock`: simplify using the `buildLua` helper.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
