### PR TITLE
patchutils: add man pages

### DIFF
--- a/pkgs/tools/text/patchutils/generic.nix
+++ b/pkgs/tools/text/patchutils/generic.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
+  outputs = [ "man" "out" ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ perl ] ++ extraBuildInputs;
   hardeningDisable = [ "format" ];
@@ -23,6 +25,9 @@ stdenv.mkDerivation rec {
       wrapProgram "$bin" \
         --prefix PATH : "$out/bin"
     done
+
+    mkdir -p $man/share/man/man1
+    cp doc/*.1 $man/share/man/man1
   '';
 
   doCheck = lib.versionAtLeast version "0.3.4";


### PR DESCRIPTION
## Description of changes

I checked the three versions of patchutils in all-pakcages and they still seem to build and contain the manpages now.