### PR TITLE
nixos/plasma5: Dont add samba a second time to `environment.systemPackages`

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -295,7 +295,7 @@ in
         ++ lib.optional config.powerManagement.enable powerdevil
         ++ lib.optional config.services.colord.enable pkgs.colord-kde
         ++ lib.optional config.services.hardware.bolt.enable pkgs.plasma5Packages.plasma-thunderbolt
-        ++ lib.optionals config.services.samba.enable [ kdenetwork-filesharing pkgs.samba ]
+        ++ lib.optional config.services.samba.enable kdenetwork-filesharing
         ++ lib.optional config.services.xserver.wacom.enable pkgs.wacomtablet
         ++ lib.optional config.services.flatpak.enable flatpak-kcm;
 


### PR DESCRIPTION
If `services.samba.enable` is true, the the samba Module already adds the samba Package. If a User sets a differnet Package in `services.samba.package` then `environment.systemPackages` will contain two different samba Packages.
```
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/testparm' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/testparm'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/testparm' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/testparm'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/nmbd' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/nmbd'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/nmbd' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/nmbd'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/smbcontrol' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/smbcontrol'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/smbcontrol' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/smbcontrol'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/gentest' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/gentest'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/gentest' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/gentest'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/smbpasswd' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/smbpasswd'
system-path> warning: collision between `/nix/store/rw5fzn10lb21xk3myc0d4m49j69d0crs-samba-4.19.2/bin/smbd' and `/nix/store/ssxn9pnl293knqghcjvpbzb6ysg0f7fv-samba-4.19.2/bin/smbd'
...
```
(The original samba will still stay in the closure as `kdenetwork-filesharing` depends on it.)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
