### PR TITLE
mpvScripts.uosc: 4.7.0 → 5.1.1

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -5,15 +5,6 @@ let
   inherit (lib) hasPrefix hasSuffix removeSuffix;
   escapedList = with lib; concatMapStringsSep " " (s: "'${escape [ "'" ] s}'");
   fileName = pathStr: lib.last (lib.splitString "/" pathStr);
-  nameFromPath = pathStr:
-    let fN = fileName pathStr; in
-    if hasSuffix ".lua" fN then
-      fN
-    else if !(hasPrefix "." fN) then
-      "${fN}.lua"
-    else
-      null
-  ;
   scriptsDir = "$out/share/mpv/scripts";
 in
 lib.makeOverridable (
@@ -23,8 +14,8 @@ lib.makeOverridable (
   let
     # either passthru.scriptName, inferred from scriptPath, or from pname
     scriptName = (args.passthru or {}).scriptName or (
-      if args ? scriptPath && nameFromPath args.scriptPath != null
-      then nameFromPath args.scriptPath
+      if args ? scriptPath
+      then fileName args.scriptPath
       else "${pname}.lua"
     );
     scriptPath = args.scriptPath or "./${scriptName}";

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -22,7 +22,7 @@ in lib.recurseIntoAttrs
     sponsorblock = callPackage ./sponsorblock.nix { };
     thumbfast = callPackage ./thumbfast.nix { inherit buildLua; };
     thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };
-    uosc = callPackage ./uosc.nix { };
+    uosc = callPackage ./uosc.nix { inherit buildLua; };
     visualizer = callPackage ./visualizer.nix { };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };

--- a/pkgs/applications/video/mpv/scripts/uosc.nix
+++ b/pkgs/applications/video/mpv/scripts/uosc.nix
@@ -1,6 +1,6 @@
-{ stdenvNoCC, lib, fetchFromGitHub, makeFontsConf }:
+{ buildLua, lib, fetchFromGitHub, makeFontsConf }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+buildLua (finalAttrs: {
   pname = "uosc";
   version = "4.7.0";
 
@@ -16,19 +16,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace "mp.find_config_file('scripts')" "\"$out/share/mpv/scripts\""
   '';
 
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/mpv/
-    cp -r scripts $out/share/mpv
+  scriptPath = "scripts/uosc.lua";
+  postInstall = ''
+    cp -r scripts/uosc_shared $out/share/mpv/
     cp -r fonts $out/share
-
-    runHook postInstall
   '';
 
-  passthru.scriptName = "uosc.lua";
   # the script uses custom "texture" fonts as the background for ui elements.
   # In order for mpv to find them, we need to adjust the fontconfig search path.
   passthru.extraWrapperArgs = [

--- a/pkgs/applications/video/mpv/scripts/uosc.nix
+++ b/pkgs/applications/video/mpv/scripts/uosc.nix
@@ -1,35 +1,50 @@
-{ buildLua, lib, fetchFromGitHub, makeFontsConf }:
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, makeFontsConf
+, buildLua
+, buildGoModule
+}:
 
 buildLua (finalAttrs: {
   pname = "uosc";
-  version = "4.7.0";
+  version = "5.1.1";
+  scriptPath = "src/uosc";
 
   src = fetchFromGitHub {
     owner = "tomasklaen";
     repo = "uosc";
     rev = finalAttrs.version;
-    hash = "sha256-JqlBjhwRgmXl6XfHYTwtNWZj656EDHjcdWOlCgihF5I=";
+    hash = "sha256-+4k8T1yX3IRXK3XkUShsuJSH9w1Zla7CaRENcIqX4iM=";
   };
 
-  postPatch = ''
-    substituteInPlace scripts/uosc.lua \
-      --replace "mp.find_config_file('scripts')" "\"$out/share/mpv/scripts\""
-  '';
+  tools = buildGoModule {
+    pname = "uosc-bin";
+    inherit (finalAttrs) version src;
+    vendorHash = "sha256-nkY0z2GiDxfNs98dpe+wZNI3dAXcuHaD/nHiZ2XnZ1Y=";
+  };
 
-  scriptPath = "scripts/uosc.lua";
-  postInstall = ''
-    cp -r scripts/uosc_shared $out/share/mpv/
-    cp -r fonts $out/share
-  '';
+  # Patch lua script to get the path to its `ziggy` binary form the environment
+  patches = [
+    # uosc#814: Support overriding `ziggy_path` via environment variable
+    (fetchpatch {
+      url = "https://github.com/tomasklaen/uosc/commit/4fdf68a1bcb510824d66f35ecc7672a6452a44b2.patch";
+      hash = "sha256-igUqFf8e7LVIIjGxACdIWAeZxjF/yqaCL4QRXrzNQXk=";
+    })
+  ];
 
   # the script uses custom "texture" fonts as the background for ui elements.
   # In order for mpv to find them, we need to adjust the fontconfig search path.
+  postInstall = "cp -r src/fonts $out/share";
   passthru.extraWrapperArgs = [
     "--set"
     "FONTCONFIG_FILE"
     (toString (makeFontsConf {
       fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
     }))
+    "--set"
+    "MPV_UOSC_ZIGGY"
+    (lib.getExe' finalAttrs.tools "ziggy")
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Under `mpvScripts`:
- `buildLua`:
  - fix bug introduced in #266505: the wrong `scriptName` was generated for scripts packaged as directories; (`scripts/${name}/main.lua`)
  - support passing explicitly-recursive attrsets;
- `uosc`:
  - refactor using `buildLua`;
  - update to v5.1.1, patch to pass the `ziggy` binary (built for the relevant platform) via an environment variable.

@apfelkuchen6, does this seem to you like a sensible way to handle the custom Go binary that uosc now uses?


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)  
  Ran mpv with uosc through `wrapMpv`, the script's UI was available and functional.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
