### PR TITLE
cudaPackages: [doc] apply markdown lints to internal doc

### DIFF
--- a/pkgs/development/cuda-modules/README.md
+++ b/pkgs/development/cuda-modules/README.md
@@ -1,30 +1,47 @@
-# cuda-modules
+# Cuda modules
 
 > [!NOTE]
-> This document is meant to help CUDA maintainers understand the structure of the CUDA packages in Nixpkgs. It is not meant to be a user-facing document.
+> This document is meant to help CUDA maintainers understand the structure of
+> the CUDA packages in Nixpkgs. It is not meant to be a user-facing document.
 > For a user-facing document, see [the CUDA section of the manual](../../../doc/languages-frameworks/cuda.section.md).
 
-The files in this directory are added (in some way) to the `cudaPackages` package set by [cuda-packages.nix](../../top-level/cuda-packages.nix).
+The files in this directory are added (in some way) to the `cudaPackages`
+package set by [cuda-packages.nix](../../top-level/cuda-packages.nix).
 
 ## Top-level files
 
-Top-level nix files are included in the initial creation of the `cudaPackages` scope. These are typically required for the creation of the finalized `cudaPackages` scope:
+Top-level nix files are included in the initial creation of the `cudaPackages`
+scope. These are typically required for the creation of the finalized
+`cudaPackages` scope:
 
 - `backend-stdenv.nix`: Standard environment for CUDA packages.
 - `flags.nix`: Flags set, or consumed by, NVCC in order to build packages.
 - `gpus.nix`: A list of supported NVIDIA GPUs.
-- `nvcc-compatibilities.nix`: NVCC releases and the version range of GCC/Clang they support.
+- `nvcc-compatibilities.nix`: NVCC releases and the version range of GCC/Clang
+    they support.
 
 ## Top-level directories
 
 - `cuda`: CUDA redistributables! Provides extension to `cudaPackages` scope.
-- `cudatoolkit`: monolothic CUDA Toolkit run-file installer. Provides extension to `cudaPackages` scope.
+- `cudatoolkit`: monolothic CUDA Toolkit run-file installer. Provides extension
+    to `cudaPackages` scope.
 - `cudnn`: NVIDIA cuDNN library.
 - `cutensor`: NVIDIA cuTENSOR library.
 - `generic-builders`:
-  - Contains a builder `manifest.nix` which operates on the `Manifest` type defined in `modules/generic/manifests`. Most packages are built using this builder.
-  - Contains a builder `multiplex.nix` which leverages the Manifest builder. In short, the Multiplex builder adds multiple versions of a single package to single instance of the CUDA Packages package set. It is used primarily for packages like `cudnn` and `cutensor`.
-- `modules`: Nixpkgs modules to check the shape and content of CUDA redistributable and feature manifests. These modules additionally use shims provided by some CUDA packages to allow them to re-use the `genericManifestBuilder`, even if they don't have manifest files of their own. `cudnn` and `tensorrt` are examples of packages which provide such shims. These modules are further described in the [Modules](./modules/README.md) documentation.
+  - Contains a builder `manifest.nix` which operates on the `Manifest` type
+      defined in `modules/generic/manifests`. Most packages are built using this
+      builder.
+  - Contains a builder `multiplex.nix` which leverages the Manifest builder. In
+      short, the Multiplex builder adds multiple versions of a single package to
+      single instance of the CUDA Packages package set. It is used primarily for
+      packages like `cudnn` and `cutensor`.
+- `modules`: Nixpkgs modules to check the shape and content of CUDA
+    redistributable and feature manifests. These modules additionally use shims
+    provided by some CUDA packages to allow them to re-use the
+    `genericManifestBuilder`, even if they don't have manifest files of their
+    own. `cudnn` and `tensorrt` are examples of packages which provide such
+    shims. These modules are further described in the
+    [Modules](./modules/README.md) documentation.
 - `nccl`: NVIDIA NCCL library.
 - `nccl-tests`: NVIDIA NCCL tests.
 - `saxpy`: Example CMake project that uses CUDA.

--- a/pkgs/development/cuda-modules/modules/README.md
+++ b/pkgs/development/cuda-modules/modules/README.md
@@ -1,27 +1,56 @@
 # Modules
 
-Modules as they are used in `modules` exist primarily to check the shape and content of CUDA redistributable and feature manifests. They are ultimately meant to reduce the repetitive nature of repackaging CUDA redistributables.
+Modules as they are used in `modules` exist primarily to check the shape and
+content of CUDA redistributable and feature manifests. They are ultimately meant
+to reduce the repetitive nature of repackaging CUDA redistributables.
 
-Building most redistributables follows a pattern of a manifest indicating which packages are available at a location, their versions, and their hashes. To avoid creating builders for each and every derivation, modules serve as a way for us to use a single `genericManifestBuilder` to build all redistributables.
+Building most redistributables follows a pattern of a manifest indicating which
+packages are available at a location, their versions, and their hashes. To avoid
+creating builders for each and every derivation, modules serve as a way for us
+to use a single `genericManifestBuilder` to build all redistributables.
 
 ## `generic`
 
-The modules in `generic` are reusable components meant to check the shape and content of NVIDIA's CUDA redistributable manifests, our feature manifests (which are derived from NVIDIA's manifests), or hand-crafted Nix expressions describing available packages. They are used by the `genericManifestBuilder` to build CUDA redistributables.
+The modules in `generic` are reusable components meant to check the shape and
+content of NVIDIA's CUDA redistributable manifests, our feature manifests (which
+are derived from NVIDIA's manifests), or hand-crafted Nix expressions describing
+available packages. They are used by the `genericManifestBuilder` to build CUDA
+redistributables.
 
-Generally, each package which relies on manifests or Nix release expressions will create an alias to the relevant generic module. For example, the [module for CUDNN](./cudnn/default.nix) aliases the generic module for release expressions, while the [module for CUDA redistributables](./cuda/default.nix) aliases the generic module for manifests.
+Generally, each package which relies on manifests or Nix release expressions
+will create an alias to the relevant generic module. For example, the [module
+for CUDNN](./cudnn/default.nix) aliases the generic module for release
+expressions, while the [module for CUDA redistributables](./cuda/default.nix)
+aliases the generic module for manifests.
 
-Alternatively, additional fields or values may need to be configured to account for the particulars of a package. For example, while the release expressions for [CUDNN](./cudnn/releases.nix) and [TensorRT](./tensorrt/releases.nix) are very close, they differ slightly in the fields they have. The [module for CUDNN](./modules/cudnn/default.nix) is able to use the generic module for release expressions, while the [module for TensorRT](./modules/tensorrt/default.nix) must add additional fields to the generic module.
+Alternatively, additional fields or values may need to be configured to account
+for the particulars of a package. For example, while the release expressions for
+[CUDNN](./cudnn/releases.nix) and [TensorRT](./tensorrt/releases.nix) are very
+close, they differ slightly in the fields they have. The [module for
+CUDNN](./modules/cudnn/default.nix) is able to use the generic module for
+release expressions, while the [module for
+TensorRT](./modules/tensorrt/default.nix) must add additional fields to the
+generic module.
 
 ### `manifests`
 
-The modules in `generic/manifests` define the structure of NVIDIA's CUDA redistributable manifests and our feature manifests.
+The modules in `generic/manifests` define the structure of NVIDIA's CUDA
+redistributable manifests and our feature manifests.
 
-NVIDIA's redistributable manifests are retrieved from their web server, while the feature manifests are produced by [`cuda-redist-find-features`](https://github.com/connorbaker/cuda-redist-find-features).
+NVIDIA's redistributable manifests are retrieved from their web server, while
+the feature manifests are produced by
+[`cuda-redist-find-features`](https://github.com/connorbaker/cuda-redist-find-features).
 
 ### `releases`
 
-The modules in `generic/releases` define the structure of our hand-crafted Nix expressions containing information necessary to download and repackage CUDA redistributables. These expressions are created when NVIDIA-provided manifests are unavailable or otherwise unusable. For example, though CUDNN has manifests, a bug in NVIDIA's CI/CD causes manifests for different versions of CUDA to use the same name, which leads to the manifests overwriting each other.
+The modules in `generic/releases` define the structure of our hand-crafted Nix
+expressions containing information necessary to download and repackage CUDA
+redistributables. These expressions are created when NVIDIA-provided manifests
+are unavailable or otherwise unusable. For example, though CUDNN has manifests,
+a bug in NVIDIA's CI/CD causes manifests for different versions of CUDA to use
+the same name, which leads to the manifests overwriting each other.
 
 ### `types`
 
-The modules in `generic/types` define reusable types used in both `generic/manifests` and `generic/releases`.
+The modules in `generic/types` define reusable types used in both
+`generic/manifests` and `generic/releases`.


### PR DESCRIPTION
## Description of changes

This cosmetic PR cleans up two internal (for maintainers) README files in the `cuda-modules` repository by applying markdown-lint suggestions, making them more readable in the editor IMHO (while it should not change the representation for common mark viewer, beside one trivial rewording). This is a preliminary pass before adding  documentation about `cuda_compat`.

It's currently based on #256324, as the latter changes the documentation as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
