### PR TITLE
treecat: init at 1.0.2-unstable-2023-11-28

### DIFF
--- a/pkgs/by-name/tr/treecat/package.nix
+++ b/pkgs/by-name/tr/treecat/package.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchFromSourcehut
+, hare
+, haredo
+, lib
+, scdoc
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "treecat";
+  version = "1.0.2-unstable-2023-11-28";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromSourcehut {
+    owner = "~autumnull";
+    repo = "treecat";
+    rev = "d277aed99eb48eef891b76916a61029989c41d2d";
+    hash = "sha256-4A01MAGkBSSzkyRw4omNbLoX8z+pHfoUO7/6QvEUu70=";
+  };
+
+  nativeBuildInputs = [
+    hare
+    haredo
+    scdoc
+  ];
+
+  dontConfigure = true;
+
+  preBuild = ''
+    HARECACHE="$(mktemp -d)"
+    export HARECACHE
+    export PREFIX="${builtins.placeholder "out"}"
+  '';
+
+  meta = {
+    description = "Serialize a directory to a tree diagram, and vice versa";
+    longDescription = ''
+      Treecat is an amalgamation of `tree(1)` and `cat(1)`, with the added
+      bonus that it can reconstruct its output back into the original filetree.
+    '';
+    homepage = "https://sr.ht/~autumnull/treecat/";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ onemoresuza ];
+    mainProgram = "treecat";
+    inherit (hare.meta) platforms badPlatforms;
+  };
+})


### PR DESCRIPTION
## Description of changes

Initializes [`treecat`](https://sr.ht/~autumnull/treecat):

> [A]n amalgamation of `tree(1)` and `cat(1)`, with the added bonus that
> it can reconstruct its output back into the original filetree.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
