### PR TITLE
[23.05] dualsensectl: init at 0.4

### DIFF
--- a/pkgs/tools/games/dualsensectl/default.nix
+++ b/pkgs/tools/games/dualsensectl/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     description = "Linux tool for controlling PS5 DualSense controller";
     homepage = "https://github.com/nowrep/dualsensectl";
     license = licenses.gpl2Only;
+    mainProgram = "dualsensectl";
     maintainers = with maintainers; [ azuwis ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/games/dualsensectl/default.nix
+++ b/pkgs/tools/games/dualsensectl/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, dbus
+, hidapi
+, udev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dualsensectl";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "nowrep";
+    repo = "dualsensectl";
+    rev = "v${version}";
+    hash = "sha256-OZmZ+ENBBKzRZ9jLIn9Bz7oGYrSAjZ5XlOR9fpN0cZs=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "/usr/" "/"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    hidapi
+    udev
+  ];
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "Linux tool for controlling PS5 DualSense controller";
+    homepage = "https://github.com/nowrep/dualsensectl";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ azuwis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/games/dualsensectl/default.nix
+++ b/pkgs/tools/games/dualsensectl/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dualsensectl";
-  version = "0.3";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "nowrep";
     repo = "dualsensectl";
     rev = "v${version}";
-    hash = "sha256-OZmZ+ENBBKzRZ9jLIn9Bz7oGYrSAjZ5XlOR9fpN0cZs=";
+    hash = "sha256-DrPVzbaLO2NgjNcEFyCs2W+dlbdpBeRX1ZfFenqz7IY=";
   };
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1528,6 +1528,8 @@ with pkgs;
 
   dolbybcsoftwaredecode = callPackage ../applications/audio/dolbybcsoftwaredecode { };
 
+  dualsensectl = callPackage ../tools/games/dualsensectl { };
+
   dwarfs = callPackage ../tools/filesystems/dwarfs { };
 
   etlegacy = callPackage ../games/etlegacy { lua = lua5_4; };


### PR DESCRIPTION
## Description of changes

Backport dualsensectl, a tool to configure PS5 DualSense controllers, to release-23.05:

- dualsensectl: init at 0.3 (#240340)
- dualsensectl: 0.3 -> 0.4
- dualsensectl: set meta.mainProgram

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
