### PR TITLE
python311Packages.keyrings-google-artifactregistry-auth: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/development/python-modules/keyrings-google-artifactregistry-auth/default.nix
+++ b/pkgs/development/python-modules/keyrings-google-artifactregistry-auth/default.nix
@@ -4,6 +4,7 @@
 , google-auth
 , keyring
 , pluggy
+, pythonOlder
 , requests
 , setuptools-scm
 , toml
@@ -11,11 +12,15 @@
 
 buildPythonPackage rec {
   pname = "keyrings.google-artifactregistry-auth";
-  version = "1.1.1";
+  version = "1.1.2";
+
+  disabled = pythonOlder "3.6";
+
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-vrA3+/awws4R2BAxn9wYDKuIZdqioWsQnDr3MYL/5E0=";
+    hash = "sha256-vWq7cnQNLf60pcA8OxBcb326FpyqKd7jlZaU8fAsd94=";
   };
 
   buildInputs = [
@@ -34,8 +39,11 @@ buildPythonPackage rec {
     "keyrings.gauth"
   ];
 
+  # upstream has no tests
+  doCheck = false;
 
   meta = with lib; {
+    changelog = "https://github.com/GoogleCloudPlatform/artifact-registry-python-tools/blob/main/HISTORY.md";
     description = "Python package which allows you to configure keyring to interact with Python repositories stored in Artifact Registry";
     homepage = "https://pypi.org/project/keyrings.google-artifactregistry-auth";
     license = licenses.asl20;


### PR DESCRIPTION
## Description of changes
Changelog: https://github.com/GoogleCloudPlatform/artifact-registry-python-tools/blob/main/HISTORY.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
