### PR TITLE
srt: Add mingw32 build support

### DIFF
--- a/pkgs/development/libraries/srt/default.nix
+++ b/pkgs/development/libraries/srt/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, cmake, openssl
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, openssl
+, windows
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +19,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    windows.mingw_w64_pthreads
+  ];
+
+  patches = lib.optionals stdenv.hostPlatform.isMinGW [
+    ./no-msvc-compat-headers.patch
+  ];
 
   cmakeFlags = [
     # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
@@ -29,9 +42,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Secure, Reliable, Transport";
-    homepage    = "https://github.com/Haivision/srt";
-    license     = licenses.mpl20;
+    homepage = "https://github.com/Haivision/srt";
+    license = licenses.mpl20;
     maintainers = with maintainers; [ nh2 ];
-    platforms   = platforms.all;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/srt/no-msvc-compat-headers.patch
+++ b/pkgs/development/libraries/srt/no-msvc-compat-headers.patch
@@ -1,0 +1,10 @@
+--- srt-1.3.2/common/filelist_win32.maf.orig	2018-06-15 21:44:11.000000000 +0200
++++ srt-1.3.2/common/filelist_win32.maf	2018-09-25 20:26:36.903688700 +0200
+@@ -4,7 +4,6 @@
+ #
+ # These are included by platform_sys.h header contained in ../srtcore/filelist.maf
+ #
+-win/unistd.h
+ 
+ SOURCES
+ win_time.cpp


### PR DESCRIPTION
get mingw support for qt6.

## Description of changes
Added mingw support for srt package
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
