### PR TITLE
appimageTools.wrapAppImage: remove version from `pname`

### DIFF
--- a/doc/build-helpers/special/fhs-environments.section.md
+++ b/doc/build-helpers/special/fhs-environments.section.md
@@ -6,7 +6,11 @@ It uses Linux' namespaces feature to create temporary lightweight environments w
 Accepted arguments are:
 
 - `name`
-        The name of the environment and the wrapper executable.
+        The name of the environment, and the wrapper executable if `pname` is unset.
+- `pname`
+        The pname of the environment and the wrapper executable.
+- `version`
+        The version of the environment.
 - `targetPkgs`
         Packages to be installed for the main host's architecture (i.e. x86_64 on x86_64 installations). Along with libraries binaries are also installed.
 - `multiPkgs`

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -208,6 +208,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `cudaPackages.autoFixElfFiles` has been deprecated for `pkgs.autoFixElfFiles`. Functionality has not changed, but the setuphook has been renamed and moved to the top-level package scope.
 
+- `appimageTools.wrapAppImage` now create the binary at `$out/bin/${pname}` rather than `$out/bin/${pname}-${version}`, which will break downstream workarounds.
+
 - `pdns` was updated to version [v4.9.x](https://doc.powerdns.com/authoritative/changelog/4.9.html), which introduces breaking changes. Check out the [Upgrade Notes](https://doc.powerdns.com/authoritative/upgrading.html#to-4-9-0) for details.
 
 - `unrar` was updated to v7. See [changelog](https://www.rarlab.com/unrar7notes.htm) for more information.

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -490,6 +490,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - The initrd ssh daemon module got a new option to add authorized keys via a list of files using `boot.initrd.network.ssh.authorizedKeyFiles`.
 
+- `appimage`, `appimageTools.wrapAppImage` and `buildFHSEnvBubblewrap` now properly accepts `pname` and `version`.
+
 - Programs written in [Nim](https://nim-lang.org/) are built with libraries selected by lockfiles.
   The `nimPackages` and `nim2Packages` sets have been removed.
   See https://nixos.org/manual/nixpkgs/unstable#nim for more information.

--- a/pkgs/applications/audio/cider/default.nix
+++ b/pkgs/applications/audio/cider/default.nix
@@ -12,8 +12,6 @@ appimageTools.wrapType2 rec {
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
     in ''
-      mv $out/bin/${pname}-${version} $out/bin/${pname}
-
       source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/applications/audio/museeks/default.nix
+++ b/pkgs/applications/audio/museeks/default.nix
@@ -17,8 +17,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     mkdir -p $out/share/${pname}
     cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
     cp -a ${appimageContents}/usr/share/icons $out/share/

--- a/pkgs/applications/audio/nuclear/default.nix
+++ b/pkgs/applications/audio/nuclear/default.nix
@@ -21,10 +21,6 @@ appimageTools.wrapType2 {
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
     cp -r ${appimageContents}/usr/share/icons $out/share
-
-    # unless linked, the binary is placed in $out/bin/nuclear-someVersion
-    # link it to $out/bin/nuclear
-    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -20,7 +20,6 @@ in appimageTools.wrapType2 {
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''
-    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/plexamp.desktop $out/share/applications/plexamp.desktop
     install -m 444 -D ${appimageContents}/plexamp.png \
       $out/share/icons/hicolor/512x512/apps/plexamp.png

--- a/pkgs/applications/audio/sonixd/default.nix
+++ b/pkgs/applications/audio/sonixd/default.nix
@@ -16,8 +16,6 @@ appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
@@ -33,4 +31,3 @@ appimageTools.wrapType2 rec {
     mainProgram = "sonixd";
   };
 }
-

--- a/pkgs/applications/blockchains/crypto-org-wallet/default.nix
+++ b/pkgs/applications/blockchains/crypto-org-wallet/default.nix
@@ -3,19 +3,17 @@
 let
   pname = "chain-desktop-wallet";
   version = "0.1.1";
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://github.com/crypto-com/${pname}/releases/download/v${version}/${name}-x86_64.AppImage";
+    url = "https://github.com/crypto-com/${pname}/releases/download/v${version}/${pname}-${version}-x86_64.AppImage";
     sha256 = "12076hf8dlz0hg1pb2ixwlslrh8gi6s1iawnvhnn6vz4jmjvq356";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit name src; };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
 in appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     ${imagemagick}/bin/convert ${appimageContents}/${pname}.png -resize 512x512 ${pname}_512.png
     install -m 444 -D ${pname}_512.png $out/share/icons/hicolor/512x512/apps/${pname}.png

--- a/pkgs/applications/blockchains/framesh/default.nix
+++ b/pkgs/applications/blockchains/framesh/default.nix
@@ -16,7 +16,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/frame.desktop $out/share/applications/frame.desktop
     install -m 444 -D ${appimageContents}/frame.png \
       $out/share/icons/hicolor/512x512/apps/frame.png

--- a/pkgs/applications/blockchains/ledger-live-desktop/default.nix
+++ b/pkgs/applications/blockchains/ledger-live-desktop/default.nix
@@ -17,7 +17,6 @@ appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/ledger-live-desktop.desktop $out/share/applications/ledger-live-desktop.desktop
     install -m 444 -D ${appimageContents}/ledger-live-desktop.png $out/share/icons/hicolor/1024x1024/apps/ledger-live-desktop.png
     ${imagemagick}/bin/convert ${appimageContents}/ledger-live-desktop.png -resize 512x512 ledger-live-desktop_512.png

--- a/pkgs/applications/blockchains/mycrypto/default.nix
+++ b/pkgs/applications/blockchains/mycrypto/default.nix
@@ -5,7 +5,6 @@ let
   pname = "MyCrypto";
   version = "1.7.17";
   sha256 = "20eb48989b5ae5e60e438eff6830ac79a0d89ac26dff058097260e747e866444"; # Taken from release's checksums.txt.gpg
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/mycryptohq/mycrypto/releases/download/${version}/linux-x86-64_${version}_MyCrypto.AppImage";
@@ -13,7 +12,7 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 
   desktopItem = makeDesktopItem {
@@ -26,14 +25,12 @@ let
   };
 
 in appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   multiArch = false; # no p32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
 
   extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
-
     mkdir -p $out/share
     cp -rt $out/share ${desktopItem}/share/applications ${appimageContents}/usr/share/icons
     chmod -R +w $out/share

--- a/pkgs/applications/blockchains/zecwallet-lite/default.nix
+++ b/pkgs/applications/blockchains/zecwallet-lite/default.nix
@@ -12,8 +12,6 @@ appimageTools.wrapType2 rec {
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
     in ''
-      mv $out/bin/${pname}-${version} $out/bin/${pname}
-
       install -m 444 -D ${contents}/zecwallet-lite.desktop -t $out/share/applications
       substituteInPlace $out/share/applications/zecwallet-lite.desktop \
         --replace 'Exec=AppRun' "Exec=$out/bin/zecwallet-lite"

--- a/pkgs/applications/editors/codux/default.nix
+++ b/pkgs/applications/editors/codux/default.nix
@@ -19,7 +19,6 @@ appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
     substituteInPlace $out/share/applications/${pname}.desktop  --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/graphics/pureref/default.nix
+++ b/pkgs/applications/graphics/pureref/default.nix
@@ -12,10 +12,6 @@ appimageTools.wrapType1 rec {
     curl "https://www.pureref.com/files/build.php?build=LINUX64.Appimage&version=${version}&downloadKey=$key" --output $out
   '';
 
-  extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-  '';
-
   meta = with lib; {
     description = "Reference Image Viewer";
     homepage = "https://www.pureref.com";

--- a/pkgs/applications/graphics/upscayl/default.nix
+++ b/pkgs/applications/graphics/upscayl/default.nix
@@ -26,8 +26,6 @@ in
       cp ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
       cp ${appimageContents}/${pname}.png $out/share/pixmaps/${pname}.png
 
-      mv $out/bin/${pname}-${version} $out/bin/${pname}
-
       substituteInPlace $out/share/applications/${pname}.desktop \
         --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
     '';

--- a/pkgs/applications/misc/bazecor/default.nix
+++ b/pkgs/applications/misc/bazecor/default.nix
@@ -37,8 +37,6 @@ appimageTools.wrapAppImage rec {
   # to allow non-root modifications to the keyboards.
 
   extraInstallCommands = ''
-    mv $out/bin/bazecor-* $out/bin/bazecor
-
     install -m 444 -D ${src}/Bazecor.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/Bazecor.desktop \
       --replace 'Exec=Bazecor' 'Exec=bazecor'

--- a/pkgs/applications/misc/devdocs-desktop/default.nix
+++ b/pkgs/applications/misc/devdocs-desktop/default.nix
@@ -3,7 +3,6 @@
 let
   version = "0.7.2";
   pname = "devdocs-desktop";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/egoist/devdocs-desktop/releases/download/v${version}/DevDocs-${version}.AppImage";
@@ -11,14 +10,13 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 
 in appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/devdocs.desktop $out/share/applications/devdocs.desktop
     install -m 444 -D ${appimageContents}/devdocs.png $out/share/icons/hicolor/0x0/apps/devdocs.png
     substituteInPlace $out/share/applications/devdocs.desktop \

--- a/pkgs/applications/misc/firefly-desktop/default.nix
+++ b/pkgs/applications/misc/firefly-desktop/default.nix
@@ -16,7 +16,6 @@ in appimageTools.wrapType2 {
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications $out/share/pixmaps
-    mv $out/bin/${pname}-${version} $out/bin/firefly-desktop
     cp ${appimageContents}/desktop.desktop $out/share/applications/firefly-desktop.desktop
     substituteInPlace $out/share/applications/firefly-desktop.desktop \
       --replace 'Exec=AppRun' 'Exec=firefly-desktop' \

--- a/pkgs/applications/misc/fspy/default.nix
+++ b/pkgs/applications/misc/fspy/default.nix
@@ -11,10 +11,6 @@ let
 in appimageTools.wrapType2 {
   inherit pname version src;
 
-  extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-  '';
-
   meta = with lib; {
     description = "A cross platform app for quick and easy still image camera matching";
     license = licenses.gpl3;

--- a/pkgs/applications/misc/golden-cheetah-bin/default.nix
+++ b/pkgs/applications/misc/golden-cheetah-bin/default.nix
@@ -17,7 +17,7 @@ appimageTools.wrapType2 {
   extraPkgs = pkgs: with pkgs; [ R zlib libusb-compat-0_1 ];
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/GoldenCheetah
+    mv $out/bin/${pname} $out/bin/GoldenCheetah
     mkdir -p $out/share/applications
     mkdir -p $out/share/pixmaps
     cp ${appimageContents}/GoldenCheetah.desktop $out/share/applications/

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -52,7 +52,6 @@ let
     multiArch = false; # no 32bit needed
     extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
     extraInstallCommands = ''
-      mv $out/bin/{${pname}-${version},${pname}}
       source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/applications/misc/lunatask/default.nix
+++ b/pkgs/applications/misc/lunatask/default.nix
@@ -18,8 +18,6 @@ appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     install -m 444 -D ${appimageContents}/${pname}.png $out/share/icons/hicolor/512x512/apps/${pname}.png
     substituteInPlace $out/share/applications/${pname}.desktop \

--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -27,9 +27,6 @@ appimageTools.wrapType2 rec {
   ];
 
   extraInstallCommands = ''
-    # Strip version from binary name.
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/marktext.desktop $out/share/applications/marktext.desktop
     substituteInPlace $out/share/applications/marktext.desktop \
       --replace "Exec=AppRun" "Exec=${pname} --"

--- a/pkgs/applications/misc/neo4j-desktop/default.nix
+++ b/pkgs/applications/misc/neo4j-desktop/default.nix
@@ -2,21 +2,19 @@
 let
   pname = "neo4j-desktop";
   version = "1.5.8";
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://s3-eu-west-1.amazonaws.com/dist.neo4j.org/${pname}/linux-offline/${name}-x86_64.AppImage";
+    url = "https://s3-eu-west-1.amazonaws.com/dist.neo4j.org/${pname}/linux-offline/${pname}-${version}-x86_64.AppImage";
     hash = "sha256-RqzR4TuvDasbkj/wKvOOS7r46sXDxvw3B5ydFGZeHX8=";
   };
 
-  appimageContents = appimageTools.extract { inherit name src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraPkgs = pkgs: with pkgs; [ libsecret ];
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/misc/notable/default.nix
+++ b/pkgs/applications/misc/notable/default.nix
@@ -5,15 +5,13 @@ let
   version = "1.8.4";
   sha256 = "0rvz8zwsi62kiq89pv8n2wh9h5yb030kvdr1vf65xwqkhqcrzrby";
 
-  name = "${pname}-${version}";
-
   src = fetchurl {
     url = "https://github.com/notable/notable/releases/download/v${version}/Notable-${version}.AppImage";
     inherit sha256;
   };
 
   appimageContents = appimageTools.extract {
-    inherit name src;
+    inherit pname version src;
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -29,7 +27,6 @@ appimageTools.wrapType2 rec {
   multiArch = false; # no 32bit needed
   extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [ p.at-spi2-atk p.at-spi2-core ];
   extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
     install -m 444 -D ${appimageContents}/notable.desktop $out/share/applications/notable.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/notable.png \
       $out/share/icons/hicolor/1024x1024/apps/notable.png

--- a/pkgs/applications/misc/notesnook/default.nix
+++ b/pkgs/applications/misc/notesnook/default.nix
@@ -51,7 +51,6 @@ let
     multiPkgs = null; # no 32bit needed
     extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
     extraInstallCommands = ''
-      mv $out/bin/{${pname}-${version},${pname}}
       install -Dm444 ${appimageContents}/notesnook.desktop -t $out/share/applications
       install -Dm444 ${appimageContents}/notesnook.png -t $out/share/pixmaps
       substituteInPlace $out/share/applications/notesnook.desktop \

--- a/pkgs/applications/misc/protonup-qt/default.nix
+++ b/pkgs/applications/misc/protonup-qt/default.nix
@@ -12,7 +12,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},${pname}}
     mkdir -p $out/share/{applications,pixmaps}
     cp ${appimageContents}/net.davidotek.pupgui2.desktop $out/share/applications/${pname}.desktop
     cp ${appimageContents}/net.davidotek.pupgui2.png $out/share/pixmaps/${pname}.png

--- a/pkgs/applications/misc/remnote/default.nix
+++ b/pkgs/applications/misc/remnote/default.nix
@@ -40,7 +40,7 @@ in
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 ${appexec}/bin/remnote-${version} $out/bin/remnote
+    install -Dm755 ${appexec}/bin/remnote $out/bin/remnote
     install -Dm444 "${desktopItem}/share/applications/"* -t $out/share/applications/
     install -Dm444 ${icon} $out/share/pixmaps/remnote.png
 

--- a/pkgs/applications/misc/todoist-electron/default.nix
+++ b/pkgs/applications/misc/todoist-electron/default.nix
@@ -28,7 +28,6 @@ in appimageTools.wrapAppImage {
 
   extraInstallCommands = ''
     # Add desktop convencience stuff
-    mv $out/bin/{${pname}-*,${pname}}
     install -Dm444 ${appimageContents}/todoist.desktop -t $out/share/applications
     install -Dm444 ${appimageContents}/todoist.png -t $out/share/pixmaps
     substituteInPlace $out/share/applications/todoist.desktop \

--- a/pkgs/applications/misc/zettlr/generic.nix
+++ b/pkgs/applications/misc/zettlr/generic.nix
@@ -10,22 +10,20 @@
 
 # Based on https://gist.github.com/msteen/96cb7df66a359b827497c5269ccbbf94 and joplin-desktop nixpkgs.
 let
-  name = "${pname}-${version}";
   src = fetchurl {
     url = "https://github.com/Zettlr/Zettlr/releases/download/v${version}/Zettlr-${version}-x86_64.appimage";
     inherit hash;
   };
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 in
 appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   multiArch = false; # no 32bit needed
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ texliveMedium pandoc ];
   extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
     install -m 444 -D ${appimageContents}/Zettlr.desktop $out/share/applications/Zettlr.desktop
     install -m 444 -D ${appimageContents}/Zettlr.png $out/share/icons/hicolor/512x512/apps/Zettlr.png
     substituteInPlace $out/share/applications/Zettlr.desktop \

--- a/pkgs/applications/networking/Sylk/default.nix
+++ b/pkgs/applications/networking/Sylk/default.nix
@@ -6,7 +6,7 @@ let
 in
 
 appimageTools.wrapType2 rec {
-  name = "${pname}-${version}";
+  inherit pname version;
 
   src = fetchurl {
     url = "http://download.ag-projects.com/Sylk/Sylk-${version}-x86_64.AppImage";
@@ -19,7 +19,6 @@ appimageTools.wrapType2 rec {
 
   multiArch = false; # no 32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
-  extraInstallCommands = "mv $out/bin/{${name},${pname}}";
 
   meta = with lib; {
     description = "Sylk WebRTC client";

--- a/pkgs/applications/networking/browsers/polypane/default.nix
+++ b/pkgs/applications/networking/browsers/polypane/default.nix
@@ -20,7 +20,6 @@ in appimageTools.wrapType2 {
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''
-    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     install -m 444 -D ${appimageContents}/${pname}.png \
       $out/share/icons/hicolor/512x512/apps/${pname}.png

--- a/pkgs/applications/networking/cluster/openlens/default.nix
+++ b/pkgs/applications/networking/cluster/openlens/default.nix
@@ -19,8 +19,6 @@ appimageTools.wrapType2 {
   unshareIpc = false;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/open-lens.desktop $out/share/applications/${pname}.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/open-lens.png \
        $out/share/icons/hicolor/512x512/apps/${pname}.png

--- a/pkgs/applications/networking/cozy-drive/default.nix
+++ b/pkgs/applications/networking/cozy-drive/default.nix
@@ -6,19 +6,17 @@
 let
   pname = "cozydrive";
   version = "3.38.0";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/cozy-labs/cozy-desktop/releases/download/v${version}/Cozy-Drive-${version}-x86_64.AppImage";
     sha256 = "3liOzZVOjtV1cGrKlOKiFRRqnt8KHPr5Ye5HU0e/BYo=";
   };
-  appimageContents = appimageTools.extract { inherit name src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/cozydrive.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/cozydrive.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/networking/feedreaders/fluent-reader/default.nix
+++ b/pkgs/applications/networking/feedreaders/fluent-reader/default.nix
@@ -14,8 +14,6 @@ in appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     mkdir -p $out/share/${pname}
     cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
     install -Dm 444 ${appimageContents}/${pname}.desktop -t $out/share/applications

--- a/pkgs/applications/networking/instant-messengers/beeper/default.nix
+++ b/pkgs/applications/networking/instant-messengers/beeper/default.nix
@@ -35,8 +35,6 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mv bin/${name} bin/${pname}
-
     mkdir -p $out/
     cp -r bin $out/bin
 

--- a/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix
@@ -30,8 +30,6 @@ in
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs;
 
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},caprine}
-
     mkdir -p $out/share
     "${xorg.lndir}/bin/lndir" -silent "${extracted}/usr/share" "$out/share"
     ln -s ${extracted}/caprine.png $out/share/icons/caprine.png

--- a/pkgs/applications/networking/instant-messengers/keet/default.nix
+++ b/pkgs/applications/networking/instant-messengers/keet/default.nix
@@ -14,8 +14,6 @@ in appimageTools.wrapType2 {
   inherit src pname version;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
@@ -44,8 +44,6 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mv bin/session-desktop-${version} bin/session-desktop
-
     mkdir -p $out/
     cp -r bin $out/bin
 

--- a/pkgs/applications/networking/instant-messengers/zulip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zulip/default.nix
@@ -23,7 +23,6 @@ in appimageTools.wrapType2 {
   runScript = "appimage-exec.sh -w ${appimageContents} -- \${NIXOS_OZONE_WL:+\${WAYLAND_DISPLAY:+--ozone-platform-hint=auto}}";
 
   extraInstallCommands = ''
-    mv "$out/bin/${pname}-${version}" "$out/bin/${pname}"
     install -m 444 -D ${appimageContents}/zulip.desktop $out/share/applications/zulip.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/zulip.png \
       $out/share/icons/hicolor/512x512/apps/zulip.png

--- a/pkgs/applications/networking/irc/irccloud/default.nix
+++ b/pkgs/applications/networking/irc/irccloud/default.nix
@@ -3,7 +3,6 @@
 let
   pname = "irccloud";
   version = "0.16.0";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/irccloud/irccloud-desktop/releases/download/v${version}/IRCCloud-${version}-linux-x86_64.AppImage";
@@ -11,16 +10,15 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraPkgs = pkgs: with pkgs; [ at-spi2-core ];
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
       $out/share/icons/hicolor/512x512/apps/irccloud.png

--- a/pkgs/applications/networking/mailreaders/electron-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/electron-mail/default.nix
@@ -3,19 +3,17 @@
 let
   pname = "electron-mail";
   version = "5.1.8";
-  name = "ElectronMail-${version}";
 
   src = fetchurl {
     url = "https://github.com/vladimiry/ElectronMail/releases/download/v${version}/electron-mail-${version}-linux-x86_64.AppImage";
     sha256 = "sha256-btqlxFrQUyb728i99IE65A9jwEFNvJ5b6zji0kwwATU=";
   };
 
-  appimageContents = appimageTools.extract { inherit name src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/networking/mailreaders/tutanota-desktop/default.nix
+++ b/pkgs/applications/networking/mailreaders/tutanota-desktop/default.nix
@@ -17,8 +17,6 @@ appimageTools.wrapType2 rec {
   extraInstallCommands =
     let appimageContents = appimageTools.extract { inherit pname version src; };
     in ''
-      mv $out/bin/${pname}-${version} $out/bin/${pname}
-
       install -Dm 444 ${appimageContents}/tutanota-desktop.desktop -t $out/share/applications
       install -Dm 444 ${appimageContents}/tutanota-desktop.png -t $out/share/pixmaps
 

--- a/pkgs/applications/networking/newsreaders/raven-reader/default.nix
+++ b/pkgs/applications/networking/newsreaders/raven-reader/default.nix
@@ -14,8 +14,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     mkdir -p $out/share/${pname}
     cp -a ${appimageContents}/locales $out/share/${pname}
     cp -a ${appimageContents}/resources $out/share/${pname}

--- a/pkgs/applications/networking/station/default.nix
+++ b/pkgs/applications/networking/station/default.nix
@@ -3,7 +3,6 @@
 let
   pname = "station";
   version = "1.52.2";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/getstation/desktop-app-releases/releases/download/${version}/Station-${version}-x86_64.AppImage";
@@ -11,10 +10,10 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 in appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   profile = ''
     export LC_ALL=C.UTF-8
@@ -23,7 +22,6 @@ in appimageTools.wrapType2 rec {
   multiArch = false;
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
     install -m 444 -D ${appimageContents}/browserx.desktop $out/share/applications/browserx.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/browserx.png \
       $out/share/icons/hicolor/512x512/apps/browserx.png

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -23,7 +23,7 @@ in appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/$name $out/bin/${executableName}
+    mv $out/bin/$pname $out/bin/${executableName}
     install -m 444 -D ${appimageContents}/${executableName}.desktop $out/share/applications/${executableName}.desktop
     ${imagemagick}/bin/convert ${appimageContents}/${executableName}.png -resize 512x512 ${pname}_512.png
     install -m 444 -D ${pname}_512.png $out/share/icons/hicolor/512x512/apps/${executableName}.png

--- a/pkgs/applications/office/notion-app-enhanced/default.nix
+++ b/pkgs/applications/office/notion-app-enhanced/default.nix
@@ -2,20 +2,17 @@
 let
   pname = "notion-app-enhanced";
   version = "2.0.18-1";
-  name = "${pname}-v${version}";
 
   src = fetchurl {
     url = "https://github.com/notion-enhancer/notion-repackaged/releases/download/v${version}/Notion-Enhanced-${version}.AppImage";
     sha256 = "sha256-SqeMnoMzxxaViJ3NPccj3kyMc1xvXWULM6hQIDZySWY=";
   };
 
-  appimageContents = appimageTools.extract { inherit name src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/office/p3x-onenote/default.nix
+++ b/pkgs/applications/office/p3x-onenote/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, appimageTools, desktop-file-utils, fetchurl }:
 
 let
+  pname = "p3x-onenote";
   version = "2023.4.117";
-  name = "p3x-onenote-${version}";
 
   plat = {
     aarch64-linux = "-arm64";
@@ -22,18 +22,17 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 in
 appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
     mkdir -p $out/share/pixmaps $out/share/licenses/p3x-onenote
     cp ${appimageContents}/p3x-onenote.png $out/share/pixmaps/
     cp ${appimageContents}/p3x-onenote.desktop $out
     cp ${appimageContents}/LICENSE.electron.txt $out/share/licenses/p3x-onenote/LICENSE
-    mv $out/bin/${name} $out/bin/p3x-onenote
 
     ${desktop-file-utils}/bin/desktop-file-install --dir $out/share/applications \
       --set-key Exec --set-value $out/bin/p3x-onenote \

--- a/pkgs/applications/office/timeular/default.nix
+++ b/pkgs/applications/office/timeular/default.nix
@@ -24,7 +24,6 @@ in appimageTools.wrapType2 rec {
   ];
 
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},${pname}}
     install -m 444 -D ${appimageContents}/timeular.desktop $out/share/applications/timeular.desktop
     install -m 444 -D ${appimageContents}/timeular.png $out/share/icons/hicolor/512x512/apps/timeular.png
     substituteInPlace $out/share/applications/timeular.desktop \

--- a/pkgs/applications/office/tusk/default.nix
+++ b/pkgs/applications/office/tusk/default.nix
@@ -34,7 +34,6 @@ in appimageTools.wrapType2 rec {
   multiArch = false; # no 32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},${pname}}
     mkdir "$out/share"
     ln -s "${desktopItem}/share/applications" "$out/share/"
   '';

--- a/pkgs/applications/science/biology/jbrowse/default.nix
+++ b/pkgs/applications/science/biology/jbrowse/default.nix
@@ -19,9 +19,7 @@ appimageTools.wrapType2 {
   unshareIpc = false;
 
   extraInstallCommands = ''
-    mkdir -p $out/bin
-    mv $out/bin/jbrowse-${version} $out/bin/jbrowse-desktop
-
+    mv $out/bin/jbrowse $out/bin/jbrowse-desktop
     install -m 444 -D ${appimageContents}/jbrowse-desktop.desktop $out/share/applications/jbrowse-desktop.desktop
     install -m 444 -D ${appimageContents}/jbrowse-desktop.png \
        $out/share/icons/hicolor/512x512/apps/jbrowse-desktop.png

--- a/pkgs/applications/video/davinci-resolve/default.nix
+++ b/pkgs/applications/video/davinci-resolve/default.nix
@@ -181,7 +181,6 @@ let
 in
 buildFHSEnv {
   inherit (davinci) pname version;
-  name = null;
 
   targetPkgs = pkgs: with pkgs; [
     alsa-lib

--- a/pkgs/applications/video/electronplayer/electronplayer.nix
+++ b/pkgs/applications/video/electronplayer/electronplayer.nix
@@ -2,21 +2,18 @@
 let
   pname = "electronplayer";
   version = "2.0.8";
-  name = "${pname}-${version}";
 
   #TODO: remove the -rc4 from the tag in the url when possible
   src = fetchurl {
-    url = "https://github.com/oscartbeaumont/ElectronPlayer/releases/download/v${version}-rc4/${name}.AppImage";
+    url = "https://github.com/oscartbeaumont/ElectronPlayer/releases/download/v${version}-rc4/${pname}-${version}.AppImage";
     sha256 = "wAsmSFdbRPnYnDyWQSbtyj+GLJLN7ibksUE7cegfkhI=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit name src; };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=ElectronPlayer'

--- a/pkgs/applications/video/lbry/default.nix
+++ b/pkgs/applications/video/lbry/default.nix
@@ -1,14 +1,12 @@
 { lib, fetchurl, appimageTools}:
 
-let
+appimageTools.wrapAppImage rec {
   pname = "lbry-desktop";
   version = "0.53.9";
-in appimageTools.wrapAppImage rec {
-  name = "${pname}-${version}";
 
   # Fetch from GitHub Releases and extract
   src = appimageTools.extract {
-    inherit name;
+    inherit pname version;
     src = fetchurl {
       url = "https://github.com/lbryio/lbry-desktop/releases/download/v${version}/LBRY_${version}.AppImage";
       # Gotten from latest-linux.yml
@@ -24,7 +22,7 @@ in appimageTools.wrapAppImage rec {
   # General fixup
   extraInstallCommands = ''
     # Firstly, rename the executable to lbry for convinence
-    mv $out/bin/${name} $out/bin/lbry
+    mv $out/bin/${pname} $out/bin/lbry
 
     # Now, install assets such as the desktop file and icons
     install -m 444 -D ${src}/lbry.desktop -t $out/share/applications

--- a/pkgs/applications/video/losslesscut-bin/build-from-appimage.nix
+++ b/pkgs/applications/video/losslesscut-bin/build-from-appimage.nix
@@ -32,7 +32,6 @@ in
   extraPkgs = ps: appimageTools.defaultFhsEnvArgs.multiPkgs ps;
 
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},losslesscut}
     (
       mkdir -p $out/share
       cd ${extracted}/usr

--- a/pkgs/applications/video/molotov/default.nix
+++ b/pkgs/applications/video/molotov/default.nix
@@ -12,7 +12,6 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D \
       ${appimageContents}/@molotovdesktop-wrapper.desktop \
       $out/share/applications/${pname}.desktop

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -39,15 +39,12 @@ rec {
   wrapType1 = wrapType2;
 
   wrapAppImage = args@{
-    name ? "${args.pname}-${args.version}",
     src,
     extraPkgs,
     meta ? {},
     ...
   }: buildFHSEnv
     (defaultFhsEnvArgs // {
-      inherit name;
-
       targetPkgs = pkgs: [ appimage-exec ]
         ++ defaultFhsEnvArgs.targetPkgs pkgs ++ extraPkgs pkgs;
 
@@ -58,10 +55,10 @@ rec {
       } // meta;
     } // (removeAttrs args (builtins.attrNames (builtins.functionArgs wrapAppImage))));
 
-  wrapType2 = args@{ name ? "${args.pname}-${args.version}", src, extraPkgs ? pkgs: [ ], ... }: wrapAppImage
+  wrapType2 = args@{ src, extraPkgs ? pkgs: [ ], ... }: wrapAppImage
     (args // {
-      inherit name extraPkgs;
-      src = extract { inherit name src; };
+      inherit extraPkgs;
+      src = extract (lib.filterAttrs (key: value: builtins.elem key [ "name" "pname" "version" "src" ]) args);
 
       # passthru src to make nix-update work
       # hack to keep the origin position (unsafeGetAttrPos)
@@ -73,8 +70,6 @@ rec {
     });
 
   defaultFhsEnvArgs = {
-    name = "appimage-env";
-
     # Most of the packages were taken from the Steam chroot
     targetPkgs = pkgs: with pkgs; [
       gtk3

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -56,7 +56,7 @@ rec {
       meta = {
         sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       } // meta;
-    } // (removeAttrs args ([ "pname" "version" ] ++ (builtins.attrNames (builtins.functionArgs wrapAppImage)))));
+    } // (removeAttrs args (builtins.attrNames (builtins.functionArgs wrapAppImage))));
 
   wrapType2 = args@{ name ? "${args.pname}-${args.version}", src, extraPkgs ? pkgs: [ ], ... }: wrapAppImage
     (args // {

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -8,14 +8,14 @@
 , pkgsi686Linux
 }:
 
-{ name ? null
-, profile ? ""
+{ profile ? ""
 , targetPkgs ? pkgs: []
 , multiPkgs ? pkgs: []
 , multiArch ? false # Whether to include 32bit packages
 , extraBuildCommands ? ""
 , extraBuildCommandsMulti ? ""
 , extraOutputsToInstall ? []
+, ... # for name, or pname+version
 } @ args:
 
 # HOWTO:
@@ -35,6 +35,10 @@
 
 let
   inherit (stdenv) is64bit;
+
+  name = if (args ? pname && args ? version)
+    then "${args.pname}-${args.version}"
+    else args.name;
 
   # "use of glibc_multi is only supported on x86_64-linux"
   isMultiBuild = multiArch && stdenv.system == "x86_64-linux";

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -9,10 +9,7 @@
 , bubblewrap
 }:
 
-{ name ? null
-, pname ? null
-, version ? null
-, runScript ? "bash"
+{ runScript ? "bash"
 , extraInstallCommands ? ""
 , meta ? {}
 , passthru ? {}
@@ -29,7 +26,7 @@
 , ...
 } @ args:
 
-assert (pname != null || version != null) -> (name == null && pname != null); # You must declare either a name or pname + version (preferred).
+assert (!args ? pname || !args ? version) -> (args ? name); # You must provide name if pname or version (preferred) is missing.
 
 let
   inherit (lib)
@@ -43,9 +40,10 @@ let
 
   inherit (lib.attrsets) removeAttrs;
 
-  pname = if args ? name && args.name != null then args.name else args.pname;
-  versionStr = optionalString (version != null) ("-" + version);
-  name = pname + versionStr;
+  name = args.name or "${args.pname}-${args.version}";
+  executableName = args.pname or args.name;
+  # we don't know which have been supplied, and want to avoid defaulting missing attrs to null. Passed into runCommandLocal
+  nameAttrs = lib.filterAttrs (key: value: builtins.elem key [ "name" "pname" "version" ]) args;
 
   buildFHSEnv = callPackage ./buildFHSEnv.nix { };
 
@@ -270,8 +268,7 @@ let
   '';
 
   bin = writeShellScript "${name}-bwrap" (bwrapCmd { initArgs = ''"$@"''; });
-in runCommandLocal name {
-  inherit pname version;
+in runCommandLocal name (nameAttrs // {
   inherit meta;
 
   passthru = passthru // {
@@ -285,9 +282,9 @@ in runCommandLocal name {
     '';
     inherit args fhsenv;
   };
-} ''
+}) ''
   mkdir -p $out/bin
-  ln -s ${bin} $out/bin/${pname}
+  ln -s ${bin} $out/bin/${executableName}
 
   ${extraInstallCommands}
 ''

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -47,10 +47,9 @@ let
 
   buildFHSEnv = callPackage ./buildFHSEnv.nix { };
 
-  fhsenv = buildFHSEnv (removeAttrs (args // { inherit name; }) [
+  fhsenv = buildFHSEnv (removeAttrs args [
     "runScript" "extraInstallCommands" "meta" "passthru" "extraPreBwrapCmds" "extraBwrapArgs" "dieWithParent"
     "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc" "privateTmp"
-    "pname" "version"
   ]);
 
   etcBindEntries = let

--- a/pkgs/by-name/al/alvr/package.nix
+++ b/pkgs/by-name/al/alvr/package.nix
@@ -16,8 +16,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/alvr-${version} $out/bin/alvr
-
     install -Dm444 ${appimageContents}/alvr.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/alvr.desktop \
       --replace 'Exec=alvr_dashboard' 'Exec=alvr'

--- a/pkgs/by-name/ar/arduino-ide/package.nix
+++ b/pkgs/by-name/ar/arduino-ide/package.nix
@@ -18,8 +18,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},${pname}}
-
     install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications/
     install -Dm444 ${appimageContents}/${pname}.png -t $out/share/pixmaps/
   '';

--- a/pkgs/by-name/be/beekeeper-studio/package.nix
+++ b/pkgs/by-name/be/beekeeper-studio/package.nix
@@ -30,7 +30,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/{${pname}-${version},${pname}}
     source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/${pname} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -19,7 +19,6 @@ in appimageTools.wrapType2 {
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libthai ];
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/caido.desktop -t $out/share/applications
     install -m 444 -D ${appimageContents}/caido.png \
       $out/share/icons/hicolor/512x512/apps/caido.png

--- a/pkgs/by-name/ch/chrysalis/package.nix
+++ b/pkgs/by-name/ch/chrysalis/package.nix
@@ -22,8 +22,6 @@ in appimageTools.wrapType2 rec {
   # to allow non-root modifications to the keyboards.
 
   extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
-
     install -m 444 \
       -D ${appimageContents}/usr/lib/chrysalis/resources/static/udev/60-kaleidoscope.rules \
       -t $out/lib/udev/rules.d

--- a/pkgs/by-name/hi/hifile/package.nix
+++ b/pkgs/by-name/hi/hifile/package.nix
@@ -17,8 +17,6 @@ in appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/HiFile.desktop $out/share/applications/HiFile.desktop
     install -m 444 -D ${appimageContents}/HiFile.png $out/share/icons/hicolor/512x512/apps/HiFile.png
     substituteInPlace $out/share/applications/HiFile.desktop \

--- a/pkgs/by-name/ho/hoppscotch/package.nix
+++ b/pkgs/by-name/ho/hoppscotch/package.nix
@@ -63,8 +63,6 @@ else appimageTools.wrapType2 {
       appimageContents = appimageTools.extractType2 { inherit pname version src; };
     in
     ''
-      mv $out/bin/${pname}-${version} $out/bin/${pname}
-
       # Install .desktop files
       install -Dm444 ${appimageContents}/hoppscotch.desktop -t $out/share/applications
       install -Dm444 ${appimageContents}/hoppscotch.png -t $out/share/pixmaps

--- a/pkgs/by-name/im/immersed-vr/linux.nix
+++ b/pkgs/by-name/im/immersed-vr/linux.nix
@@ -7,8 +7,4 @@
 appimageTools.wrapType2 rec {
   inherit pname version src meta;
   name = "${pname}-${version}";
-
-  extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
-  '';
 }

--- a/pkgs/by-name/ja/jan/package.nix
+++ b/pkgs/by-name/ja/jan/package.nix
@@ -17,7 +17,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/jan-${version} $out/bin/jan
     install -Dm444 ${appimageContents}/jan.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/jan.desktop \
       --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=jan'

--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm644 ${appimageContents}/.DirIcon $out/share/icons/hicolor/scalable/apps/jetbrains-toolbox.svg
-    makeWrapper ${appimage}/bin/${pname}-${version} $out/bin/${pname} \
+    makeWrapper ${appimage}/bin/${pname} $out/bin/${pname} \
       --append-flags "--update-failed" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [icu]}
 

--- a/pkgs/by-name/kc/kchat/package.nix
+++ b/pkgs/by-name/kc/kchat/package.nix
@@ -23,7 +23,7 @@ appimageTools.wrapType2 rec {
       cp -r ${contents}/{locales,resources} "$out/share/lib/kchat"
       cp -r ${contents}/usr/* "$out"
       cp "${contents}/kchat-desktop.desktop" "$out/share/applications/"
-      mv "$out/bin/kchat-${version}" "$out/bin/${meta.mainProgram}"
+      mv "$out/bin/kchat" "$out/bin/${meta.mainProgram}" || true
       substituteInPlace $out/share/applications/kchat-desktop.desktop --replace 'Exec=AppRun' 'Exec=${meta.mainProgram}'
     '';
 

--- a/pkgs/by-name/km/kmeet/package.nix
+++ b/pkgs/by-name/km/kmeet/package.nix
@@ -23,7 +23,7 @@ appimageTools.wrapType2 rec {
       cp -r ${contents}/{locales,resources} "$out/share/lib/kmeet"
       cp -r ${contents}/usr/* "$out"
       cp "${contents}/kMeet.desktop" "$out/share/applications/"
-      mv "$out/bin/kmeet-${version}" "$out/bin/${meta.mainProgram}"
+      mv "$out/bin/kmeet" "$out/bin/${meta.mainProgram}" || true
       substituteInPlace $out/share/applications/kMeet.desktop --replace 'Exec=AppRun' 'Exec=${meta.mainProgram}'
     '';
 

--- a/pkgs/by-name/li/listen1/package.nix
+++ b/pkgs/by-name/li/listen1/package.nix
@@ -13,7 +13,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/listen1.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/listen1.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -20,7 +20,6 @@ appimageTools.wrapType2 {
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications
-    mv $out/bin/lmstudio-${version} $out/bin/lmstudio
     cp -r ${appimageContents}/usr/share/icons $out/share
     install -m 444 -D ${appimageContents}/lm-studio.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/lm-studio.desktop \

--- a/pkgs/by-name/lu/lunar-client/package.nix
+++ b/pkgs/by-name/lu/lunar-client/package.nix
@@ -16,7 +16,6 @@ appimageTools.wrapType2 rec {
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
     in ''
-      mv $out/bin/{lunar-client-*,lunar-client}
       source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/lunar-client \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/by-name/mi/miru/package.nix
+++ b/pkgs/by-name/mi/miru/package.nix
@@ -23,7 +23,6 @@ appimageTools.wrapType2 rec {
       cp -r ${contents}/{locales,resources} "$out/share/lib/miru"
       cp -r ${contents}/usr/* "$out"
       cp "${contents}/${pname}.desktop" "$out/share/applications/"
-      mv "$out/bin/${pname}-${version}" "$out/bin/${pname}"
       substituteInPlace $out/share/applications/${pname}.desktop --replace 'Exec=AppRun' 'Exec=${pname}'
     '';
 

--- a/pkgs/by-name/mq/mqttx/package.nix
+++ b/pkgs/by-name/mq/mqttx/package.nix
@@ -34,7 +34,6 @@ appimageTools.wrapType2 {
   extraPkgs = pkgs: [ ];
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     install -m 444 -D ${appimageContents}/${pname}.png $out/share/icons/hicolor/1024x1024/apps/${pname}.png
 

--- a/pkgs/by-name/no/nosql-workbench/package.nix
+++ b/pkgs/by-name/no/nosql-workbench/package.nix
@@ -68,9 +68,6 @@ if stdenv.isDarwin then stdenv.mkDerivation {
       inherit pname version src;
     };
   in ''
-    # Replace version from binary name
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     # Install XDG Desktop file and its icon
     install -Dm444 ${appimageContents}/nosql-workbench.desktop -t $out/share/applications
     install -Dm444 ${appimageContents}/nosql-workbench.png -t $out/share/pixmaps

--- a/pkgs/by-name/on/onlyoffice-bin_latest/package.nix
+++ b/pkgs/by-name/on/onlyoffice-bin_latest/package.nix
@@ -164,7 +164,7 @@ in
 # Curl still needs to be in runtimeLibs because the library is used directly in other parts of the code.
 # Fonts are also discovered by looking in /usr/share/fonts, so adding fonts to targetPkgs will include them
 buildFHSEnv {
-  name = derivation.name;
+  inherit (derivation) pname version;
 
   targetPkgs = pkgs': [
     curl
@@ -175,7 +175,6 @@ buildFHSEnv {
   runScript = "/bin/onlyoffice-desktopeditors";
 
   extraInstallCommands = ''
-    mv $out/bin/$name $out/bin/onlyoffice-desktopeditors
     mkdir -p $out/share
     ln -s ${derivation}/share/icons $out/share
     cp -r ${derivation}/share/applications $out/share

--- a/pkgs/by-name/pa/parsify/package.nix
+++ b/pkgs/by-name/pa/parsify/package.nix
@@ -15,8 +15,6 @@ appimageTools.wrapType2 rec {
   extraInstallCommands =
   let contents = appimageTools.extract { inherit pname version src; };
   in ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${contents}/@parsifydesktop.desktop -t $out/share/applications
 
     substituteInPlace $out/share/applications/@parsifydesktop.desktop \

--- a/pkgs/by-name/si/simplex-chat-desktop/package.nix
+++ b/pkgs/by-name/si/simplex-chat-desktop/package.nix
@@ -28,8 +28,6 @@ in appimageTools.wrapType2 {
     ];
 
     extraInstallCommands = ''
-      mv $out/bin/${pname}-${version} $out/bin/${pname}
-
       install --mode=444 -D ${appimageContents}/chat.simplex.app.desktop --target-directory=$out/share/applications
       substituteInPlace $out/share/applications/chat.simplex.app.desktop \
         --replace 'Exec=simplex' 'Exec=${pname}'

--- a/pkgs/by-name/sp/spacedrive/package.nix
+++ b/pkgs/by-name/sp/spacedrive/package.nix
@@ -65,9 +65,6 @@ else appimageTools.wrapType2 {
       appimageContents = appimageTools.extractType2 { inherit pname version src; };
     in
     ''
-      # Remove version from entrypoint
-      mv $out/bin/spacedrive-${version} $out/bin/spacedrive
-
       # Install .desktop files
       install -Dm444 ${appimageContents}/com.spacedrive.desktop -t $out/share/applications
       install -Dm444 ${appimageContents}/spacedrive.png -t $out/share/pixmaps

--- a/pkgs/development/tools/altair-graphql-client/default.nix
+++ b/pkgs/development/tools/altair-graphql-client/default.nix
@@ -15,8 +15,6 @@ appimageTools.wrapType2 {
   inherit src pname version;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/development/web/bloomrpc/default.nix
+++ b/pkgs/development/web/bloomrpc/default.nix
@@ -25,7 +25,6 @@ appimageTools.wrapType2 {
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''
-    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     install -m 444 -D ${appimageContents}/${pname}.png \
       $out/share/icons/hicolor/512x512/apps/${pname}.png

--- a/pkgs/development/web/bootstrap-studio/default.nix
+++ b/pkgs/development/web/bootstrap-studio/default.nix
@@ -13,8 +13,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/bstudio.desktop -t $out/share/applications
 
     substituteInPlace $out/share/applications/bstudio.desktop \

--- a/pkgs/games/anki/bin.nix
+++ b/pkgs/games/anki/bin.nix
@@ -52,7 +52,6 @@ let
 
   fhsEnvAnki = buildFHSEnv (appimageTools.defaultFhsEnvArgs // {
     inherit pname version;
-    name = null; # Appimage sets it to "appimage-env"
 
     profile = ''
       # anki vendors QT and mixing QT versions usually causes crashes

--- a/pkgs/games/badlion-client/default.nix
+++ b/pkgs/games/badlion-client/default.nix
@@ -15,7 +15,6 @@ in
     inherit pname version src;
 
     extraInstallCommands = ''
-      mv $out/bin/{${pname}-${version},${pname}}
       install -Dm444 ${appimageContents}/BadlionClient.desktop $out/share/applications/BadlionClient.desktop
       install -Dm444 ${appimageContents}/BadlionClient.png $out/share/pixmaps/BadlionClient.png
       substituteInPlace $out/share/applications/BadlionClient.desktop \

--- a/pkgs/games/osu-lazer/bin.nix
+++ b/pkgs/games/osu-lazer/bin.nix
@@ -64,7 +64,7 @@ else appimageTools.wrapType2 {
       contents = appimageTools.extract { inherit pname version src; };
     in
     ''
-      mv -v $out/bin/${pname}-${version} $out/bin/osu\!
+      mv -v $out/bin/${pname} $out/bin/osu\!
       install -m 444 -D ${contents}/osu\!.desktop -t $out/share/applications
       for i in 16 32 48 64 96 128 256 512 1024; do
         install -D ${contents}/osu\!.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png

--- a/pkgs/tools/misc/betterdiscord-installer/default.nix
+++ b/pkgs/tools/misc/betterdiscord-installer/default.nix
@@ -2,20 +2,17 @@
 let
   pname = "betterdiscord-installer";
   version = "1.0.0-beta";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/BetterDiscord/Installer/releases/download/v${version}/Betterdiscord-Linux.AppImage";
     sha256 = "103acb11qmvjmf6g9lgsfm5jyahfwfdqw0x9w6lmv1hzwbs26dsr";
   };
 
-  appimageContents = appimageTools.extract { inherit name src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/betterdiscord.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/betterdiscord.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -35,7 +35,6 @@ in appimageTools.wrapAppImage {
 
   extraInstallCommands = ''
     # Add desktop convencience stuff
-    mv $out/bin/{${pname}-*,${pname}}
     install -Dm444 ${appimageContents}/flexoptix-app.desktop -t $out/share/applications
     install -Dm444 ${appimageContents}/flexoptix-app.png -t $out/share/pixmaps
     substituteInPlace $out/share/applications/flexoptix-app.desktop \

--- a/pkgs/tools/misc/mathpix-snipping-tool/default.nix
+++ b/pkgs/tools/misc/mathpix-snipping-tool/default.nix
@@ -2,20 +2,17 @@
 let
   pname = "mathpix-snipping-tool";
   version = "03.00.0072";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://download.mathpix.com/linux/Mathpix_Snipping_Tool-x86_64.v${version}.AppImage";
     sha256 = "1igg8wnshmg9f23qqw1gqb85h1aa3461c1n7dmgw6sn4lrrrh5ms";
   };
 
-  appimageContents = appimageTools.extract { inherit name src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
-
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
 
     cp -r ${appimageContents}/usr/share/icons $out/share

--- a/pkgs/tools/misc/via/default.nix
+++ b/pkgs/tools/misc/via/default.nix
@@ -3,16 +3,15 @@
 let
   pname = "via";
   version = "3.0.0";
-  name = "${pname}-${version}";
   src = fetchurl {
     url = "https://github.com/the-via/releases/releases/download/v${version}/via-${version}-linux.AppImage";
     name = "via-${version}-linux.AppImage";
     sha256 = "sha256-+uTvmrqHK7L5VA/lUHCZZeRYPUrcVA+vjG7venxuHhs=";
   };
-  appimageContents = appimageTools.extractType2 { inherit name src; };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
 in
 appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   profile = ''
     # Skip prompt to add udev rule.
@@ -21,7 +20,6 @@ appimageTools.wrapType2 {
   '';
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/via-nativia.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/via-nativia.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/tools/misc/vial/default.nix
+++ b/pkgs/tools/misc/vial/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchurl, appimageTools }:
 let
-  name = "vial-${version}";
   version = "0.7.1";
   pname = "Vial";
 
@@ -9,13 +8,12 @@ let
     hash = "sha256-pOcrxZ6vbnbdE/H4Kxufxm/ZovaYBXjFpVpKZYV7f3c=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit name src; };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
 in
 appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
 

--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -26,7 +26,6 @@ appimageTools.wrapType2 rec {
       wooting-udev-rules
       xorg.libxkbfile
     ]);
-  extraInstallCommands = "mv $out/bin/{${pname}-${version},${pname}}";
 
   meta = with lib; {
     homepage = "https://wooting.io/wootility";

--- a/pkgs/tools/networking/mockoon/default.nix
+++ b/pkgs/tools/networking/mockoon/default.nix
@@ -21,8 +21,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -Dm 444 ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
 

--- a/pkgs/tools/networking/motrix/default.nix
+++ b/pkgs/tools/networking/motrix/default.nix
@@ -19,8 +19,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -Dm 444 ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
 

--- a/pkgs/tools/networking/requestly/default.nix
+++ b/pkgs/tools/networking/requestly/default.nix
@@ -18,8 +18,6 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
-
     install -Dm 444 ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';

--- a/pkgs/tools/security/buttercup-desktop/default.nix
+++ b/pkgs/tools/security/buttercup-desktop/default.nix
@@ -15,7 +15,6 @@ in appimageTools.wrapType2 {
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsecret ];
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/buttercup.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/buttercup.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'


### PR DESCRIPTION
## Description of changes

Prior to this PR:
```nix
nix-repl> mendeley.name
"mendeley-2.105.0"

nix-repl> mendeley.pname
"mendeley-2.105.0"
```

With this PR:

```nix
nix-repl> mendeley.name
"mendeley-2.105.0"

nix-repl> mendeley.pname
"mendeley"
```

The erroneous `pname`s has been the source of many issues, especially since the wrapped software tends to be unfree. `nixpkgs.config.allowUnfreePredicate`, even when using `lib.getName` would need to include the version number. Fixes like [this](https://github.com/NixOS/nixpkgs/compare/9cf0738eaf72b9f0c02e0e78d9443a1e2d7fa3e1..7bd1880b94bd721df440cd9c3c1dcc34181f40ac) will become a thing of the past.

An other common fix we don't need to apply any more is `mv $out/bin/$pname $out/bin/${pname}` to strip the version from the resulting binary in `bin/`. Here is a listing of the likely affected files which this PR will fix before dropping the `WIP:` prefix:

<details>
<summary><code>rg wrapType -l | xargs grep mv</code></summary>

```
pkgs/applications/video/molotov/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/video/losslesscut-bin/build-from-appimage.nix:    mv $out/bin/{${pname}-${version},losslesscut}
pkgs/applications/graphics/upscayl/default.nix:      mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/video/electronplayer/electronplayer.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/graphics/pureref/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/editors/codux/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/networking/cozy-drive/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/networking/instant-messengers/keet/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/networking/instant-messengers/session-desktop/default.nix:    mv bin/session-desktop-${version} bin/session-desktop
pkgs/applications/networking/instant-messengers/beeper/default.nix:    mv bin/${name} bin/${pname}
pkgs/applications/networking/instant-messengers/zulip/default.nix:    mv "$out/bin/${pname}-${version}" "$out/bin/${pname}"
pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix:    mv $out/bin/{${pname}-${version},caprine}
pkgs/applications/networking/mailreaders/electron-mail/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/networking/cluster/openlens/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/networking/cluster/lens/linux.nix:      mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/networking/feedreaders/fluent-reader/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/networking/station/default.nix:    mv $out/bin/{${name},${pname}}
pkgs/applications/networking/Sylk/default.nix:  extraInstallCommands = "mv $out/bin/{${name},${pname}}";
pkgs/applications/networking/newsreaders/raven-reader/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/networking/irc/irccloud/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/audio/sonixd/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/audio/cider/default.nix:      mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/audio/museeks/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/audio/ytmdesktop/default.nix:    mv $out/bin/{${name},${pname}}
pkgs/applications/misc/neo4j-desktop/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/misc/marktext/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/misc/fspy/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/misc/notable/default.nix:    mv $out/bin/{${name},${pname}}
pkgs/applications/misc/devdocs-desktop/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/misc/joplin-desktop/default.nix:      mv $out/bin/{${pname}-${version},${pname}}
pkgs/applications/misc/zettlr/generic.nix:    mv $out/bin/{${name},${pname}}
pkgs/applications/misc/chrysalis/default.nix:    mv $out/bin/{${name},${pname}}
pkgs/applications/misc/lunatask/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/misc/protonup-qt/default.nix:    mv $out/bin/{${pname}-${version},${pname}}
pkgs/applications/misc/notesnook/default.nix:      mv $out/bin/{${pname}-${version},${pname}}
pkgs/applications/misc/mobilecoin-wallet/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/misc/firefly-desktop/default.nix:    mv $out/bin/${pname}-${version} $out/bin/firefly-desktop
pkgs/applications/misc/golden-cheetah-bin/default.nix:    mv $out/bin/${pname}-${version} $out/bin/GoldenCheetah
pkgs/applications/misc/anytype/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/office/timeular/default.nix:    mv $out/bin/{${pname}-${version},${pname}}
pkgs/applications/version-management/radicle-upstream/default.nix:      mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/science/biology/jbrowse/default.nix:    mv $out/bin/jbrowse-${version} $out/bin/jbrowse-desktop
pkgs/applications/office/notion-app-enhanced/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/office/p3x-onenote/default.nix:    armv7l-linux = "-armv7l";
pkgs/applications/office/p3x-onenote/default.nix:    armv7l-linux = "1pvr8f1ccl4nyfmshn3v3jfaa5x519rsy57g4pdapffj10vpbkb8";
pkgs/applications/office/p3x-onenote/default.nix:    mv $out/bin/${name} $out/bin/p3x-onenote
pkgs/applications/office/p3x-onenote/default.nix:    platforms = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
pkgs/applications/office/mendeley/default.nix:    mv $out/bin/$pname $out/bin/${executableName}
pkgs/applications/office/tusk/default.nix:    mv $out/bin/{${pname}-${version},${pname}}
pkgs/applications/blockchains/crypto-org-wallet/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/blockchains/trezor-suite/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/applications/blockchains/mycrypto/default.nix:    mv $out/bin/{${name},${pname}}
pkgs/applications/blockchains/mycrypto/default.nix:    mv $out/share/icons/hicolor/{0x0,256x256}
pkgs/applications/blockchains/ledger-live-desktop/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/applications/blockchains/zecwallet-lite/default.nix:      mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/development/web/bootstrap-studio/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/development/tools/altair-graphql-client/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/tools/networking/mockoon/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/tools/networking/motrix/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/tools/networking/requestly/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/tools/misc/via/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/tools/misc/wootility/default.nix:  extraInstallCommands = "mv $out/bin/{${pname}-${version},${pname}}";
pkgs/tools/misc/vial/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/tools/misc/mathpix-snipping-tool/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/tools/misc/betterdiscord-installer/default.nix:    sha256 = "103acb11qmvjmf6g9lgsfm5jyahfwfdqw0x9w6lmv1hzwbs26dsr";
pkgs/tools/misc/betterdiscord-installer/default.nix:    mv $out/bin/${name} $out/bin/${pname}
pkgs/tools/security/buttercup-desktop/default.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/by-name/hi/hifile/package.nix:    mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/by-name/si/simplex-chat-desktop/package.nix:      mv $out/bin/${pname}-${version} $out/bin/${pname}
pkgs/by-name/be/beekeeper-studio/package.nix:    mv $out/bin/{${pname}-${version},${pname}}
pkgs/by-name/im/immersed-vr/package.nix:    mv $out/bin/{${name},${pname}}
pkgs/by-name/lu/lunar-client/package.nix:    mv $out/bin/{${pname}-${version},${pname}}
pkgs/games/osu-lazer/bin.nix:      mv -v $out/bin/${pname}-${version} $out/bin/osu\!
```
</details>

I'll run a nixpkgs-review over night

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes #262506 (parallel effort)
closes #262350
~~fixes `#267508`~~


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
