### PR TITLE
ripgrep: fix shell completions when cross compiling

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -7,10 +7,12 @@
 , Security
 , withPCRE2 ? true
 , pcre2
-, enableManpages ? stdenv.hostPlatform.emulatorAvailable buildPackages
 }:
 
-rustPlatform.buildRustPackage rec {
+let
+  canRunRg = stdenv.hostPlatform.emulatorAvailable buildPackages;
+  rg = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/rg";
+in rustPlatform.buildRustPackage rec {
   pname = "ripgrep";
   version = "14.0.3";
 
@@ -30,24 +32,24 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = lib.optional withPCRE2 "pcre2";
 
-  preFixup = lib.optionalString enableManpages ''
-    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/rg --generate man > rg.1
+  preFixup = lib.optionalString canRunRg ''
+    ${rg} --generate man > rg.1
     installManPage rg.1
-  '' + ''
+
     installShellCompletion --cmd rg \
-      --bash <($out/bin/rg --generate complete-bash) \
-      --fish <($out/bin/rg --generate complete-fish) \
-      --zsh <($out/bin/rg --generate complete-zsh)
+      --bash <(${rg} --generate complete-bash) \
+      --fish <(${rg} --generate complete-fish) \
+      --zsh <(${rg} --generate complete-zsh)
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
     file="$(mktemp)"
     echo "abc\nbcd\ncde" > "$file"
-    $out/bin/rg -N 'bcd' "$file"
-    $out/bin/rg -N 'cd' "$file"
+    ${rg} -N 'bcd' "$file"
+    ${rg} -N 'cd' "$file"
   '' + lib.optionalString withPCRE2 ''
-    echo '(a(aa)aa)' | $out/bin/rg -P '\((a*|(?R))*\)'
+    echo '(a(aa)aa)' | ${rg} -P '\((a*|(?R))*\)'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/270521 fixed cross compilation but the result was missing shell completions. this patch fixes shell completions too.

```console
$ nix build '.#ripgrep'
$ tree result
result
├── bin
│   └── rg
└── share
    ├── bash-completion
    │   └── completions
    │       └── rg.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── rg.fish
    ├── man
    │   └── man1
    │       └── rg.1.gz
    └── zsh
        └── site-functions
            └── _rg

11 directories, 5 files

$ nix build '.#pkgsCross.aarch64-multiplatform.ripgrep'
$ tree result
result
├── bin
│   └── rg
└── share
    ├── bash-completion
    │   └── completions
    │       └── rg.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── rg.fish
    ├── man
    │   └── man1
    │       └── rg.1.gz
    └── zsh
        └── site-functions
            └── _rg

11 directories, 5 files
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
