### PR TITLE
hayabusa: init at unstable-2023-11-29

### DIFF
--- a/pkgs/by-name/ha/hayabusa/package.nix
+++ b/pkgs/by-name/ha/hayabusa/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, vulkan-loader
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hayabusa";
+  version = "unstable-2023-11-29";
+
+  src = fetchFromGitHub {
+    owner = "notarin";
+    repo = "hayabusa";
+    rev = "306167c632173f6633e51c5610fe32af7718ec25";
+    hash = "sha256-e2zoVIhxcE9cUypi8Uzz3YZe2JvIaEVuWOGpqHVtxn8=";
+  };
+
+  cargoHash = "sha256-aoticMTrKZkRtjVXgdiBfyXJN3YcwBpM3yt07BBd3do=";
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    vulkan-loader
+  ];
+
+  postPatch = ''
+    substituteInPlace src/daemon/hayabusa.service \
+      --replace "/usr/local" "$out"
+  '';
+
+  postInstall = ''
+    install -Dm444 src/daemon/hayabusa.service -t $out/lib/systemd/system/
+  '';
+
+  meta = {
+    description = "A swift rust fetch program";
+    homepage = "https://github.com/notarin/hayabusa";
+    license = lib.licenses.cc-by-nc-nd-40;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    mainProgram = "hayabusa";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds hayabusa, a swift rust fetcher.

Testing this requires allowing the unfree package `hayabusa`, as well as the following system config:

```nix
{pkgs, ...}: {
  environment.systemPackages = [pkgs.hayabusa];
  systemd.packages = [pkgs.hayabusa];
}
```

Homepage: https://github.com/Notarin/hayabusa

Fixes #271018.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
