### PR TITLE
toml-cli: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14609,6 +14609,12 @@
     githubId = 5737016;
     name = "Philipp Schuster";
   };
+  phlip9 = {
+    email = "philiphayes9@gmail.com";
+    github = "phlip9";
+    githubId = 918989;
+    name = "Philip Hayes";
+  };
   Phlogistique = {
     email = "noe.rubinstein@gmail.com";
     github = "Phlogistique";

--- a/pkgs/by-name/to/toml-cli/package.nix
+++ b/pkgs/by-name/to/toml-cli/package.nix
@@ -1,0 +1,33 @@
+{ lib, fetchCrate, rustPlatform, testers, toml-cli }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "toml-cli";
+  version = "0.2.3";
+
+  src = fetchCrate {
+    inherit version;
+    pname = "toml-cli";
+    hash = "sha256-V/yMk/Zt3yvEx10nzRhY/7GYnQninGg9h63NSaQChSA=";
+  };
+
+  cargoHash = "sha256-v+GBn9mmiWcWnxmpH6JRPVz1fOSrsjWoY+l+bdzKtT4=";
+
+  cargoTestFlags = [
+    "--bin=toml"
+    # # The `CARGO_BIN_EXE_toml` build-time env doesn't appear to be resolving
+    # # correctly with buildRustPackage. Only run the unittests instead.
+    # "--test=integration"
+  ];
+
+  passthru.tests = {
+    version = testers.testVersion { package = toml-cli; };
+  };
+
+  meta = {
+    description = "A simple CLI for editing and querying TOML files";
+    homepage = "https://github.com/gnprice/toml-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phlip9 ];
+    mainProgram = "toml";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds the [`toml-cli`](https://github.com/gnprice/toml-cli) tool at version 0.2.3

> a simple CLI for editing and querying TOML files.
>
> useful
> - in shell scripts, for consulting or editing a config file
> - and in instructions a human can follow for editing a config file, as a command to copy-paste and run.
>
> A key property is that when editing, we seek to preserve formatting and comments -- the only change to the file should be the one the user specifically asked for

### Example usage

```bash
$ nix shell github:phlip9/nixpkgs/toml-cli#toml-cli
$ toml --version
toml-cli 0.2.3

$ cat <<EOF > foo.toml
# This is a toml file
key = "value"
int = 17

# It has some comments
[foo]
x = "foo-x"
y.yy = "foo-yy"
EOF

$ toml get foo.toml .
{"key":"value","int":17,"foo":{"x":"foo-x","y":{"yy":"foo-yy"}}}

$ toml get -r foo.toml foo.y.yy
foo-yy

$ toml set foo.toml foo.x "cool new value"
# This is a toml file
key = "value"
int = 17

# It has some comments
[foo]
x = "cool new value"
y.yy = "foo-yy"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
