### PR TITLE
haskellPackages.csound-expression-opcodes: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -930,6 +930,18 @@ self: super: {
     doCheck = false; # https://github.com/chrisdone/hindent/issues/299
   }) super.hindent);
 
+  csound-expression-opcodes =
+    assert super.csound-expression-opcodes.version == "0.0.5.1";
+    overrideCabal (drv: {
+      src = (pkgs.fetchFromGitHub {
+        owner = "spell-music";
+        repo = "csound-expression";
+        rev = "345df2c91c9831dd895f58951990165598504814";
+        hash = "sha256-6qPiKsZwZpqB2kmckKDKyQPTcWPIaVwi+EYs74tRod0=";
+      }) + "/csound-expression-opcodes";
+      editedCabalFile = null;
+    }) super.csound-expression-opcodes;
+
   # https://github.com/basvandijk/concurrent-extra/issues/12
   concurrent-extra = dontCheck super.concurrent-extra;
 


### PR DESCRIPTION
## Description of changes

`haskellPackages.csound-expression-opcodes` currently does not build:
```
[ 1 of 26] Compiling Csound.Typed.Opcode.AbletonLinkOpcodes ( src/Csound/Typed/Opcode/AbletonLinkOpcodes.hs, dist/build/Csound/Typed/Opcode/AbletonLinkOpcodes.o, dist/build/Csound/Typed/Opcode/AbletonLinkOpcodes.dyn_o )

src/Csound/Typed/Opcode/AbletonLinkOpcodes.hs:23:26: error:
    • Couldn't match type ‘[Char]’
                     with ‘text-2.0.2:Data.Text.Internal.Text’
      Expected: Name
        Actual: String
    • In the first argument of ‘opcs’, namely ‘"link_beat_force"’
      In the expression:
        opcs "link_beat_force" [(Xr, [Ir, Kr, Kr, ....])] [a1, a2]
      In an equation for ‘f’:
          f a1 a2 = opcs "link_beat_force" [(Xr, [Ir, Kr, ....])] [a1, a2]
   |
23 |     where f a1 a2 = opcs "link_beat_force" [(Xr,[Ir,Kr,Kr,Kr])] [a1,a2]
   |                          ^^^^^^^^^^^^^^^^^

```

Applying the latest changes from git where it's already fixed. See also https://github.com/NixOS/nixpkgs/pull/270705

Any suggestions on how to apply this without running danger to get overwritten by hackage2nix autogeneration would be appreciated.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
