### PR TITLE
sgfutils: init at 0.25-unstable-2017-11-27

### DIFF
--- a/pkgs/by-name/sg/sgfutils/package.nix
+++ b/pkgs/by-name/sg/sgfutils/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, openssl
+, iconv
+, makeWrapper
+, imagemagick
+, makeFontsConf
+}:
+stdenv.mkDerivation
+{
+  pname = "sgfutils";
+  version = "0.25-unstable-2017-11-27";
+  src = fetchFromGitHub {
+    owner = "yangboz";
+    repo = "sgfutils";
+    rev = "11ab171c46cc16cc71ac6fc901d38ea88d6532a4";
+    hash = "sha256-KWYgTxz32WK3MKouj1WAJtZmleKt5giCpzQPwfWruZQ=";
+  };
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ iconv ];
+  buildPhase = ''
+    runHook preBuild
+    make all
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp sgf sgfsplit sgfvarsplit sgfstrip sgfinfo sgfmerge sgftf \
+      sgfcheck sgfdb sgfdbinfo sgfcharset sgfcmp sgfx \
+      ngf2sgf nip2sgf nk2sgf gib2sgf sgftopng ugi2sgf \
+      $out/bin
+    runHook postInstall
+  '';
+  postFixup = ''
+    wrapProgram $out/bin/sgftopng \
+      --prefix PATH : ${lib.makeBinPath [ imagemagick ]} \
+      --set-default FONTCONFIG_FILE ${makeFontsConf { fontDirectories = []; }}
+  '';
+  meta = with lib; {
+    homepage = "https://homepages.cwi.nl/~aeb/go/sgfutils/html/sgfutils.html";
+    description = "Command line utilities that help working with SGF files";
+    longDescription = ''
+      The package sgfutils is a collection of command line utilities that help working with SGF files,
+      especially when they describe go (igo, weiqi, baduk) games.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ggpeti ];
+    platforms = platforms.all; # tested on x86_64-linux and aarch64-darwin
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [sgfutils](https://homepages.cwi.nl/~aeb/go/sgfutils/html/sgfutils.html) package - [someone is writing a book with the help of this](https://www.reddit.com/r/baduk/comments/185087q/comment/kb6jqjm/?utm_source=reddit&utm_medium=web2x&context=3).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

note from the PR author: I checked the release notes checkboxes because each implication is vacuously true i.e. this change is just a leaf package, not a major or breaking change, and not a module

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
