### PR TITLE
[release-23.05] forgejo: mark as insecure

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -118,5 +118,28 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ emilylange urandom bendlas ];
     broken = stdenv.isDarwin;
     mainProgram = "gitea";
+    knownVulnerabilities = [
+      ''
+        Forgejo's API and web endpoints before version 1.20.5-1 are affected by multiple
+        critical security vulnerabilities.
+
+        Non-exhaustive list:
+         - reveal comments from issues and pull-requests from private repositories
+         - delete comments from issues and pull-requests
+         - get private release attachments
+         - delete releases and tags
+         - get ssh deployment keys (public key)
+         - get OAuth2 applications (except for the secret)
+         - 2FA not being enforced for the container registry login (docker login)
+
+        There isn't a clear way how to backport and validate all those fixes to the now EOL
+        forgejo 1.19.x and we, the forgejo nixpkgs maintainers, decided against bumping the
+        release from 1.19.x to 1.20.x due to its breaking nature.
+        Given nixpkgs 23.11 has been released by now and nixpkgs 23.05 will reach EOL very
+        soon (2023-12-31), please update to nixpkgs 23.11 instead.
+
+        Upstream: https://forgejo.org/2023-11-release-v1-20-5-1/
+      ''
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

Abort eval with the following error (exact formatting from my terminal):
```
Known issues:
 - Forgejo's API and web endpoints before version 1.20.5-1 are affected by multiple
critical security vulnerabilities.

Non-exhaustive list:
 - reveal comments from issues and pull-requests from private repositories
 - delete comments from issues and pull-requests
 - get private release attachments
 - delete releases and tags
 - get ssh deployment keys (public key)
 - get OAuth2 applications (except for the secret)
 - 2FA not being enforced for the container registry login (docker login)

There isn't a clear way how to backport and validate all those fixes to the now EOL
forgejo 1.19.x and we, the forgejo nixpkgs maintainers, decided against bumping the
release from 1.19.x to 1.20.x due to its breaking nature.
Given nixpkgs 23.11 has been released by now and nixpkgs 23.05 will reach EOL very
soon (2023-12-31), please update to nixpkgs 23.11 instead.

Upstream: https://forgejo.org/2023-11-release-v1-20-5-1/
```

https://forgejo.org/2023-11-release-v1-20-5-1/

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
