### PR TITLE
fetchtorrent, fetchipfs: default to unfree

### DIFF
--- a/pkgs/build-support/fetchipfs/default.nix
+++ b/pkgs/build-support/fetchipfs/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , curl
 }:
 
@@ -41,8 +42,9 @@ if (!hasHash) then throw "Specify sha for fetchipfs fixed-output derivation" els
           postFetch
           ipfs
           url
-          port
-          meta;
+          port;
+
+  meta = { license = lib.licenses.unfree; } // meta;
 
   # Doing the download on a remote machine just duplicates network
   # traffic, so don't do that.

--- a/pkgs/build-support/fetchtorrent/default.nix
+++ b/pkgs/build-support/fetchtorrent/default.nix
@@ -14,6 +14,7 @@ in
 , recursiveHash ? true
 , postFetch ? ""
 , postUnpack ? ""
+, meta ? {}
 }:
 let
   afterSuccess = writeShellScript "fetch-bittorrent-done.sh" ''
@@ -34,6 +35,7 @@ runCommand name {
   outputHashAlgo = if hash != "" then null else "sha256";
   outputHash = hash;
   outputHashMode = if recursiveHash then "recursive" else "flat";
+  meta = { license = lib.licenses.unfree; } // meta;
 
   # url will be written to the derivation, meaning it can be parsed and utilized
   # by external tools, such as tools that may want to seed fetchtorrent calls

--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -1,25 +1,47 @@
-{ testers, fetchtorrent, ... }:
+{ testers, fetchtorrent, lib, ... }:
+
+let
+  wired-cd.meta.license = [
+    # track 1, 4 and 11
+    {
+      spdxID = "CC NC-SAMPLING+ 1.0 Deed";
+      fullName = "NonCommercial Sampling Plus 1.0 Generic";
+      url = "https://creativecommons.org/licenses/nc-sampling+/1.0/";
+      free = false; # for noncommercial purposes only
+    }
+    # the rest
+    {
+      spdxID = "CC SAMPLING+ 1.0 Deed";
+      fullName = "Sampling Plus 1.0 Generic";
+      url = "https://creativecommons.org/licenses/sampling+/1.0/";
+      free = true; # no use in advertisement
+    }
+  ];
+in
 
 {
   http-link = testers.invalidateFetcherByDrvHash fetchtorrent {
     url = "https://webtorrent.io/torrents/wired-cd.torrent";
     hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
     backend = "transmission";
+    inherit (wired-cd) meta;
   };
   magnet-link = testers.invalidateFetcherByDrvHash fetchtorrent {
     url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
     hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
     backend = "transmission";
+    inherit (wired-cd) meta;
   };
   http-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
     url = "https://webtorrent.io/torrents/wired-cd.torrent";
     hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
     backend = "rqbit";
+    inherit (wired-cd) meta;
   };
   magnet-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
     url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
     hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
     backend = "rqbit";
+    inherit (wired-cd) meta;
   };
 }
-


### PR DESCRIPTION
## Description of changes

Let's not _accidentally_ redistribute warez on hydra. This PR marks the tests unfree due to the terms of the test material, must be fixed in a follow-up.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
