### PR TITLE
In-kernel Rust on Linux (Optional)

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -92,6 +92,24 @@ To use your custom kernel package in your NixOS configuration, set
 boot.kernelPackages = pkgs.linuxPackagesFor yourCustomKernel;
 ```
 
+## Rust
+
+The Linux kernel does not have Rust language support enabled by
+default. For kernels newer than 6.6, experimental Rust support can be
+enabled. In a NixOS configuration, set:
+
+```nix
+boot.kernelPatches = [
+  {
+    name = "Rust Support";
+    patch = null;
+    features = {
+      rust = true;
+    };
+  }
+];
+```
+
 ## Developing kernel modules {#sec-linux-config-developing-modules}
 
 This section was moved to the [Nixpkgs manual](https://nixos.org/nixpkgs/manual#sec-linux-kernel-developing-modules).

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -442,6 +442,7 @@ in {
   kerberos = handleTest ./kerberos/default.nix {};
   kernel-generic = handleTest ./kernel-generic.nix {};
   kernel-latest-ath-user-regd = handleTest ./kernel-latest-ath-user-regd.nix {};
+  kernel-rust = runTestOn ["x86_64-linux"] ./kernel-rust.nix;
   keter = handleTest ./keter.nix {};
   kexec = handleTest ./kexec.nix {};
   keycloak = discoverTests (import ./keycloak.nix);

--- a/nixos/tests/kernel-rust.nix
+++ b/nixos/tests/kernel-rust.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }: {
+  name = "kernel-rust";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ blitz ];
+  };
+
+  nodes.machine = { config, pkgs, ... }:
+    {
+      boot.kernelPackages = pkgs.linuxPackages_6_6;
+
+      boot.extraModulePackages = [
+        config.boot.kernelPackages.rust-out-of-tree-module
+      ];
+
+      boot.kernelPatches = [
+        {
+          name = "Rust Support";
+          patch = null;
+          features = {
+            rust = true;
+          };
+        }
+      ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("modprobe rust_out_of_tree")
+  '';
+}

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1061,6 +1061,9 @@ let
     } // optionalAttrs (versionAtLeast version "5.4" && stdenv.hostPlatform.system == "x86_64-linux") {
       CHROMEOS_LAPTOP = module;
       CHROMEOS_PSTORE = module;
+    } // optionalAttrs (versionAtLeast version "6.3" && stdenv.hostPlatform.system == "x86_64-linux") {
+      RUST = yes;
+      GCC_PLUGINS = no;
     };
   };
 in

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -384,9 +384,7 @@ let
     # of time to appear and this would hold up Linux kernel and Rust toolchain updates.
     #
     # Once Rust in the kernel has more users, we can reconsider enabling it by default.
-    rust = optionalAttrs ((features.rust or false)
-                          && versionAtLeast version "6.6"
-                          && stdenv.hostPlatform.system == "x86_64-linux") {
+    rust = optionalAttrs ((features.rust or false) && versionAtLeast version "6.6") {
       RUST = yes;
       GCC_PLUGINS = no;
     };

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -379,6 +379,18 @@ let
       DRM_VC4_HDMI_CEC = yes;
     };
 
+    # Enables Rust support in the Linux kernel. This is currently not enabled by default, because it requires
+    # patching the Linux kernel for the specific Rust toolchain in nixpkgs. These patches usually take a bit
+    # of time to appear and this would hold up Linux kernel and Rust toolchain updates.
+    #
+    # Once Rust in the kernel has more users, we can reconsider enabling it by default.
+    rust = optionalAttrs ((features.rust or false)
+                          && versionAtLeast version "6.6"
+                          && stdenv.hostPlatform.system == "x86_64-linux") {
+      RUST = yes;
+      GCC_PLUGINS = no;
+    };
+
     sound = {
       SND_DYNAMIC_MINORS  = yes;
       SND_AC97_POWER_SAVE = yes; # AC97 Power-Saving Mode
@@ -1061,9 +1073,6 @@ let
     } // optionalAttrs (versionAtLeast version "5.4" && stdenv.hostPlatform.system == "x86_64-linux") {
       CHROMEOS_LAPTOP = module;
       CHROMEOS_PSTORE = module;
-    } // optionalAttrs (versionAtLeast version "6.3" && stdenv.hostPlatform.system == "x86_64-linux") {
-      RUST = yes;
-      GCC_PLUGINS = no;
     };
   };
 in

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -9,6 +9,9 @@
 , pahole
 , lib
 , stdenv
+, rustc
+, rustPlatform
+, rust-bindgen
 
 , # The kernel source tarball.
   src
@@ -117,6 +120,8 @@ let
         map ({extraConfig ? "", ...}: extraConfig) kernelPatches;
     in lib.concatStringsSep "\n" ([baseConfigStr] ++ configFromPatches);
 
+  withRust = ((configfile.moduleStructuredConfig.settings.RUST or {}).tristate or null) == "y";
+
   configfile = stdenv.mkDerivation {
     inherit ignoreConfigErrors autoModules preferBuiltin kernelArch extraMakeFlags;
     pname = "linux-config";
@@ -130,7 +135,11 @@ let
     depsBuildBuild = [ buildPackages.stdenv.cc ];
     nativeBuildInputs = [ perl gmp libmpc mpfr ]
       ++ lib.optionals (lib.versionAtLeast version "4.16") [ bison flex ]
-      ++ lib.optional (lib.versionAtLeast version "5.2") pahole;
+      ++ lib.optional (lib.versionAtLeast version "5.2") pahole
+      ++ lib.optionals withRust [ rust-bindgen rustc ]
+    ;
+
+    RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
 
     platformName = stdenv.hostPlatform.linux-kernel.name;
     # e.g. "defconfig"
@@ -202,7 +211,7 @@ let
     inherit kernelPatches randstructSeed extraMakeFlags extraMeta configfile;
     pos = builtins.unsafeGetAttrPos "version" args;
 
-    config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
+    config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; } // lib.optionalAttrs withRust { CONFIG_RUST = "y"; };
   } // lib.optionalAttrs (modDirVersion != null) { inherit modDirVersion; });
 
   passthru = basicArgs // {

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -65,4 +65,27 @@
     name = "export-rt-sched-migrate";
     patch = ./export-rt-sched-migrate.patch;
   };
+
+  # The Rust fixes below usually come from the Asahi Linux tree:
+  # https://github.com/AsahiLinux/linux
+  #
+  # Check the asahi-wip branch.
+  rust-1-72-fix =  {
+    name = "rust-1.72-fix";
+    patch = fetchpatch {
+      name = "rust-1.72.patch";
+      url = "https://github.com/AsahiLinux/linux/commit/0a4d8dad3c64d6603c7a439717de1d7974c433f0.diff";
+      hash = "sha256-9WHmJGY20914Hl1IrYQuCbg55x9IUANPB2FvwG5CMcg=";
+    };
+  };
+
+  rust-1-73-fix = {
+    name = "rust-1.73-fix";
+    patch = fetchpatch {
+      name = "rust-1.73.patch";
+      url = "https://github.com/AsahiLinux/linux/commit/4a2b4a49d5a17df37c7bbf11964f05a2e8198165.diff";
+      hash = "sha256-jLVbVAsyigKSwhqZVaW7uXOAxxprdMFSf/ZAQZHph60=";
+    };
+  };
+
 }

--- a/pkgs/os-specific/linux/rust-out-of-tree-module/default.nix
+++ b/pkgs/os-specific/linux/rust-out-of-tree-module/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, kernel, linuxHeaders, pahole }:
+kernel.stdenv.mkDerivation {
+  name = "rust-out-of-tree-module";
+
+  src = fetchFromGitHub {
+    owner = "Rust-for-linux";
+    repo = "rust-out-of-tree-module";
+
+    rev = "7addf9dafba795524f6179a557f7272ecbe1b165";
+    hash = "sha256-Bj7WonZ499W/FajbxjM7yBkU9iTxTW7CrRbCSzWbsSc=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  makeFlags = kernel.makeFlags ++ [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+  meta = {
+    broken = !kernel.withRust;
+    description = "A basic template for an out-of-tree Linux kernel module written in Rust";
+    homepage = "https://github.com/Rust-for-Linux/rust-out-of-tree-module";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.blitz ];
+    platforms = lib.platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -182,6 +182,8 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.rust-1-72-fix
+        kernelPatches.rust-1-73-fix
       ];
     };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -460,6 +460,8 @@ in {
 
     facetimehd = callPackage ../os-specific/linux/facetimehd { };
 
+    rust-out-of-tree-module = if lib.versionAtLeast kernel.version "6.5" then callPackage ../os-specific/linux/rust-out-of-tree-module { } else null;
+
     tuxedo-keyboard = if lib.versionAtLeast kernel.version "4.14" then callPackage ../os-specific/linux/tuxedo-keyboard { } else null;
 
     jool = callPackage ../os-specific/linux/jool { };


### PR DESCRIPTION
## Description of changes

This MR adds optional and experimental Rust support for Linux kernels. It supersedes #234311. With this PR, you can use Rust support in Linux 6.6 and 6.7-rc2 (with the bindgen update mentioned below), if you opt-in to it via kernel features.

I've chosen the opt-in approach for now, because after a kernel or rustc updates, we might need to go hunt for patches and failure to find some should not block either Linux or rustc updates. But with this support, it should be vastly easier for people to experiment with Rust support already.

To make `linux_testing` work, we also need a bindgen update:

- ~~#271407~~
  - #255631

Because in previous incarnations of Rust support, we had the issue that Rust support was silently broken, I've also added the official out-of-tree Rust module as a test. Now you can test everything end-to-end.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
