### PR TITLE
haskellPackages.csound-expression-typed: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -897,6 +897,20 @@ self: super: {
   # 2022-03-19: Testsuite is failing: https://github.com/puffnfresh/haskell-jwt/issues/2
   jwt = dontCheck super.jwt;
 
+  # Compilation on recent GHC is fixed on git, but not yet on hackage
+  # https://github.com/spell-music/csound-expression/pull/68
+  csound-expression-typed =
+    assert super.csound-expression-typed.version == "0.2.7";
+    overrideCabal (drv: {
+      src = (pkgs.fetchFromGitHub {
+        owner = "spell-music";
+        repo = "csound-expression";
+        rev = "345df2c91c9831dd895f58951990165598504814";
+        hash = "sha256-6qPiKsZwZpqB2kmckKDKyQPTcWPIaVwi+EYs74tRod0=";
+      }) + "/csound-expression-typed";
+      editedCabalFile = null;
+    }) super.csound-expression-typed;
+
   # Build the latest git version instead of the official release. This isn't
   # ideal, but Chris doesn't seem to make official releases any more.
   structured-haskell-mode = overrideCabal (drv: {


### PR DESCRIPTION
## Description of changes

`haskellPackages.csound-expression-typed` currently does not build:
```
[ 3 of 63] Compiling Csound.Typed.GlobalState.Opcodes ( src/Csound/Typed/GlobalState/Opcodes.hs, dist/build/Csound/Typed/GlobalState/Opcodes.o, dist/build/Csound/Typed/GlobalState/Opcodes.dyn_o )

src/Csound/Typed/GlobalState/Opcodes.hs:91:11: error:
    • Couldn't match expected type ‘IfRate’ with actual type ‘Rate’
    • In the first argument of ‘when1’, namely ‘Kr’
      In the first argument of ‘($)’, namely ‘when1 Kr (kAlive <* - 10)’
      In a stmt of a 'do' block: when1 Kr (kAlive <* - 10) $ do turnoff
   |
91 |     when1 Kr (kAlive <* -10) $ do
   |           ^^
```

Applying the latest changes from git where it's already fixed. See also https://github.com/NixOS/nixpkgs/pull/270705

Any suggestions on how to apply this without running danger to get overwritten by hackage2nix autogeneration would be appreciated.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
