### PR TITLE
yosys: add option to build with Python binding

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -3,6 +3,7 @@
 , abc-verifier
 , bash
 , bison
+, boost
 , fetchFromGitHub
 , flex
 , libffi
@@ -18,6 +19,7 @@
 , yosys-bluespec
 , yosys-ghdl
 , yosys-symbiflow
+, enablePython ? false # enable python binding
 }:
 
 # NOTE: as of late 2020, yosys has switched to an automation robot that
@@ -68,6 +70,10 @@ let
     ghdl     = yosys-ghdl;
   } // (yosys-symbiflow);
 
+  boost_python = boost.override {
+    enablePython = true;
+    python = python3;
+  };
 
 in stdenv.mkDerivation (finalAttrs: {
   pname   = "yosys";
@@ -90,7 +96,7 @@ in stdenv.mkDerivation (finalAttrs: {
     (python3.withPackages (pp: with pp; [
       click
     ]))
-  ];
+  ] ++ lib.optional enablePython boost_python;
 
   makeFlags = [ "PREFIX=${placeholder "out"}"];
 
@@ -123,6 +129,10 @@ in stdenv.mkDerivation (finalAttrs: {
       echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (allegedly ${finalAttrs.version}), failing."
       exit 1
     fi
+  '' + lib.optionalString enablePython ''
+    echo "ENABLE_PYOSYS := 1" >> Makefile.conf
+    echo "PYTHON_DESTDIR := $out/${python3.sitePackages}" >> Makefile.conf
+    echo "BOOST_PYTHON_LIB := -lboost_python${lib.versions.major python3.version}${lib.versions.minor python3.version}" >> Makefile.conf
   '';
 
   checkTarget = "test";

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -19,7 +19,7 @@
 , yosys-bluespec
 , yosys-ghdl
 , yosys-symbiflow
-, enablePython ? false # enable python binding
+, enablePython ? true # enable python binding
 }:
 
 # NOTE: as of late 2020, yosys has switched to an automation robot that

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17424,6 +17424,7 @@ with pkgs;
   yasm = callPackage ../development/compilers/yasm { };
 
   yosys = callPackage ../development/compilers/yosys { };
+  yosysWithPython = callPackage ../development/compilers/yosys { enablePython = true; };
   yosys-bluespec = callPackage ../development/compilers/yosys/plugins/bluespec.nix { };
   yosys-ghdl = callPackage ../development/compilers/yosys/plugins/ghdl.nix { };
   yosys-synlig = callPackage ../development/compilers/yosys/plugins/synlig.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17424,7 +17424,6 @@ with pkgs;
   yasm = callPackage ../development/compilers/yasm { };
 
   yosys = callPackage ../development/compilers/yosys { };
-  yosysWithPython = callPackage ../development/compilers/yosys { enablePython = true; };
   yosys-bluespec = callPackage ../development/compilers/yosys/plugins/bluespec.nix { };
   yosys-ghdl = callPackage ../development/compilers/yosys/plugins/ghdl.nix { };
   yosys-synlig = callPackage ../development/compilers/yosys/plugins/synlig.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16021,6 +16021,11 @@ self: super: with self; {
 
   yolink-api = callPackage ../development/python-modules/yolink-api { };
 
+  yosys = toPythonModule (pkgs.yosys.override {
+    python3 = python;
+    enablePython = true;
+  });
+
   youless-api = callPackage ../development/python-modules/youless-api { };
 
   youtube-dl = callPackage ../tools/misc/youtube-dl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16023,7 +16023,6 @@ self: super: with self; {
 
   yosys = toPythonModule (pkgs.yosys.override {
     python3 = python;
-    enablePython = true;
   });
 
   youless-api = callPackage ../development/python-modules/youless-api { };


### PR DESCRIPTION
## Description of changes

Yosys comes with Python bindings and the support to load Python plugins, though this is not enabled on most builds out in the world. Add this as an optional feature to the nixpkgs derivation. Hook up the derivation with the bindings enabled under ~~`yosysWithPython`~~ `yosys` and also as a Python module `python3Packages.yosys`. The first will be useful if people run `yosys`, then load a Python plugin. The second is useful if someone wants to use Yosys as a library from a Python program.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
