### PR TITLE
qrtool: 0.8.4 -> 0.8.5

### DIFF
--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -2,27 +2,31 @@
 , stdenv
 , fetchFromGitHub
 , rustPlatform
-}:
-
-rustPlatform.buildRustPackage rec {
-  pname = "qrtool";
-  version = "0.8.4";
+, asciidoctor
+}: let
+  name = "qrtool";
+  version = "0.8.5";
+in rustPlatform.buildRustPackage {
+  pname = name;
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "sorairolake";
-    repo = "qrtool";
+    repo = name;
     rev = "v${version}";
-    sha256 = "sha256-FoWUGhNfVILpYxmsnSzRIM1+R9/xFxCF7W1sdiHaAiA=";
+    sha256 = "sha256-jrvNZGO1VIDo6Mz3NKda1C7qZUtF9T00CAFK8yoGWjc=";
   };
 
-  cargoSha256 = "sha256-mtejnHCkN2krgFAneyyBpvbv5PZO3GigM2DJqrbHim4=";
+  cargoSha256 = "sha256-JOnvlabCr3fZsIIRc2qTjf50Ga83zL8Aoo2sqzMBs7g=";
+
+  nativeBuildInputs = [ asciidoctor ];
 
   meta = with lib; {
     maintainers = with maintainers; [ philiptaron ];
     description = "An utility for encoding or decoding QR code";
     license = licenses.asl20;
-    homepage = "https://sorairolake.github.io/qrtool/book/index.html";
-    changelog = "https://sorairolake.github.io/qrtool/book/changelog.html";
-    mainProgram = "qrtool";
+    homepage = "https://sorairolake.github.io/${name}/book/index.html";
+    changelog = "https://sorairolake.github.io/${name}/book/changelog.html";
+    mainProgram = name;
   };
 }

--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , rustPlatform
 , asciidoctor
+, installShellFiles
 }: let
   name = "qrtool";
   version = "0.8.5";
@@ -19,7 +20,17 @@ in rustPlatform.buildRustPackage {
 
   cargoSha256 = "sha256-JOnvlabCr3fZsIIRc2qTjf50Ga83zL8Aoo2sqzMBs7g=";
 
-  nativeBuildInputs = [ asciidoctor ];
+  nativeBuildInputs = [ asciidoctor installShellFiles ];
+
+  postInstall = ''
+    # Built by ./build.rs using `asciidoctor`
+    installManPage ./target/*/release/build/${name}*/out/*.?
+
+    installShellCompletion --cmd ${name} \
+      --bash <($out/bin/${name} --generate-completion bash) \
+      --fish <($out/bin/${name} --generate-completion fish) \
+      --zsh <($out/bin/${name} --generate-completion zsh)
+  '';
 
   meta = with lib; {
     maintainers = with maintainers; [ philiptaron ];

--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -4,16 +4,15 @@
 , rustPlatform
 , asciidoctor
 , installShellFiles
-}: let
-  name = "qrtool";
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "qrtool";
   version = "0.8.5";
-in rustPlatform.buildRustPackage {
-  pname = name;
-  inherit version;
 
   src = fetchFromGitHub {
     owner = "sorairolake";
-    repo = name;
+    repo = "qrtool";
     rev = "v${version}";
     sha256 = "sha256-jrvNZGO1VIDo6Mz3NKda1C7qZUtF9T00CAFK8yoGWjc=";
   };
@@ -24,20 +23,20 @@ in rustPlatform.buildRustPackage {
 
   postInstall = ''
     # Built by ./build.rs using `asciidoctor`
-    installManPage ./target/*/release/build/${name}*/out/*.?
+    installManPage ./target/*/release/build/qrtool*/out/*.?
 
-    installShellCompletion --cmd ${name} \
-      --bash <($out/bin/${name} --generate-completion bash) \
-      --fish <($out/bin/${name} --generate-completion fish) \
-      --zsh <($out/bin/${name} --generate-completion zsh)
+    installShellCompletion --cmd qrtool \
+      --bash <($out/bin/qrtool --generate-completion bash) \
+      --fish <($out/bin/qrtool --generate-completion fish) \
+      --zsh <($out/bin/qrtool --generate-completion zsh)
   '';
 
   meta = with lib; {
     maintainers = with maintainers; [ philiptaron ];
-    description = "An utility for encoding or decoding QR code";
+    description = "A utility for encoding and decoding QR code images";
     license = licenses.asl20;
-    homepage = "https://sorairolake.github.io/${name}/book/index.html";
-    changelog = "https://sorairolake.github.io/${name}/book/changelog.html";
-    mainProgram = name;
+    homepage = "https://sorairolake.github.io/qrtool/book/index.html";
+    changelog = "https://sorairolake.github.io/qrtool/book/changelog.html";
+    mainProgram = "qrtool";
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/sorairolake/qrtool/compare/v0.8.4...v0.8.5

## Things done

Updated to the [0.8.5 tag](https://github.com/sorairolake/qrtool/tree/v0.8.5). I also added in the man pages and shell completions from the project, as I've just now learned how to do that.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).