### PR TITLE
treewide: finalAttrs.doCheck -> finalAttrs.finalPackage.doCheck

### DIFF
--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     # pkg-config output patching hook expects prefix variable here
     substituteInPlace data/dbus-cpp.pc.in \
       --replace 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
   '';
 

--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = lib.optionalString finalAttrs.doCheck ''
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
     # Use wrapped python. Removing just the /usr/bin doesn't seem to work?
     substituteInPlace tests/httpbin.h.in \
       --replace '/usr/bin/python3' '${lib.getExe pythonEnv}'

--- a/pkgs/by-name/tr/trealla/package.nix
+++ b/pkgs/by-name/tr/trealla/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional enableSSL openssl
     ++ lib.optional (lineEditingLibrary == "readline") readline;
 
-  nativeCheckInputs = lib.optionals finalAttrs.doCheck [ valgrind ];
+  nativeCheckInputs = lib.optionals finalAttrs.finalPackage.doCheck [ valgrind ];
 
   strictDeps = true;
 

--- a/pkgs/desktops/lomiri/development/deviceinfo/default.nix
+++ b/pkgs/desktops/lomiri/development/deviceinfo/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DDISABLE_TESTS=${lib.boolToString (!finalAttrs.doCheck)}"
+    "-DDISABLE_TESTS=${lib.boolToString (!finalAttrs.finalPackage.doCheck)}"
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Tests need to be able to check locale
-  LC_ALL = lib.optionalString finalAttrs.doCheck "en_US.UTF-8";
+  LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
   nativeCheckInputs = [
     glibcLocales
   ];
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DWANT_DOC=${lib.boolToString withDocumentation}"
     "-DWANT_DEMO=${lib.boolToString withExamples}"
-    "-DWANT_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DWANT_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     # Keeps finding & using glib-compile-resources from buildInputs otherwise
     "-DCMAKE_PROGRAM_PATH=${lib.makeBinPath [ buildPackages.glib.dev ]}"
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-Denable_tests=${lib.boolToString finalAttrs.doCheck}"
+    "-Denable_tests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace doc/CMakeLists.txt \
       --replace "\''${CMAKE_INSTALL_DATAROOTDIR}/doc/libusermetrics-doc" "\''${CMAKE_INSTALL_DOCDIR}"
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     # Only needed by tests
     sed -i -e '/QTDBUSTEST/d' CMakeLists.txt
   '';
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DGSETTINGS_LOCALINSTALL=ON"
     "-DGSETTINGS_COMPILE=ON"
-    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -57,7 +57,7 @@ in {
     "-Dspectre=disabled"
 
     (lib.mesonEnable "glib" gobjectSupport)
-    (lib.mesonEnable "tests" finalAttrs.doCheck)
+    (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
     (lib.mesonEnable "xlib" x11Support)
     (lib.mesonEnable "xcb" xcbSupport)
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [

--- a/pkgs/development/libraries/epoll-shim/default.nix
+++ b/pkgs/development/libraries/epoll-shim/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PKGCONFIGDIR=${placeholder "out"}/lib/pkgconfig"
-    "-DBUILD_TESTING=${lib.boolToString finalAttrs.doCheck}"
+    "-DBUILD_TESTING=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
 
   # https://github.com/jiixyj/epoll-shim/issues/41

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -224,7 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ tzdata desktop-file-utils shared-mime-info ];
 
-  preCheck = lib.optionalString finalAttrs.doCheck or config.doCheckByDefault or false ''
+  preCheck = lib.optionalString finalAttrs.finalPackage.doCheck or config.doCheckByDefault or false ''
     export LD_LIBRARY_PATH="$NIX_BUILD_TOP/glib-${finalAttrs.version}/glib/.libs''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
     export TZDIR="${tzdata}/share/zoneinfo"
     export XDG_CACHE_HOME="$TMP"

--- a/pkgs/development/libraries/hnswlib/default.nix
+++ b/pkgs/development/libraries/hnswlib/default.nix
@@ -32,13 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   # this is a header-only library, so we don't need to build it
   # we need `cmake` only to run tests
-  nativeBuildInputs = lib.optionals finalAttrs.doCheck [
+  nativeBuildInputs = lib.optionals finalAttrs.finalPackage.doCheck [
     cmake
     python
   ];
 
   # we only want to run buildPhase when we run tests
-  dontBuild = !finalAttrs.doCheck;
+  dontBuild = !finalAttrs.finalPackage.doCheck;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/libraries/libayatana-common/default.nix
+++ b/pkgs/development/libraries/libayatana-common/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-DENABLE_LOMIRI_FEATURES=OFF"
     "-DGSETTINGS_LOCALINSTALL=ON"
     "-DGSETTINGS_COMPILE=ON"

--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmocka # cmake expects cmocka module
   ];
 
-  cmakeFlags = lib.optional finalAttrs.doCheck "-DWITH_TESTS=ON"
+  cmakeFlags = lib.optional finalAttrs.finalPackage.doCheck "-DWITH_TESTS=ON"
     ++ lib.optional (!stdenv.hostPlatform.isStatic) "-DBUILD_SHARED_LIBS=ON";
 
   # Tests are restricted while pkgsStatic.cmocka is broken. Tracked at:

--- a/pkgs/development/libraries/libqtdbusmock/default.nix
+++ b/pkgs/development/libraries/libqtdbusmock/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Workaround for "error: expected unqualified-id before 'public'" on "**signals"
     sed -i -e '/add_definitions/a -DQT_NO_KEYWORDS' CMakeLists.txt
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     # Don't build tests when we're not running them
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
   '';

--- a/pkgs/development/libraries/libqtdbustest/default.nix
+++ b/pkgs/development/libraries/libqtdbustest/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  postPatch =  lib.optionalString (!finalAttrs.doCheck) ''
+  postPatch =  lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     # Don't build tests when we're not running them
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
   '';

--- a/pkgs/development/libraries/libspatialindex/default.nix
+++ b/pkgs/development/libraries/libspatialindex/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DSIDX_BUILD_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DSIDX_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       "shutdown_close_pipe"
     ];
     tdRegexp = lib.concatStringsSep "\\|" toDisable;
-    in lib.optionalString (finalAttrs.doCheck) ''
+    in lib.optionalString (finalAttrs.finalPackage.doCheck) ''
       sed '/${tdRegexp}/d' -i test/test-list.h
     '';
 

--- a/pkgs/development/libraries/minizip-ng/default.nix
+++ b/pkgs/development/libraries/minizip-ng/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
     "-DMZ_OPENSSL=ON"
-    "-DMZ_BUILD_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
-    "-DMZ_BUILD_UNIT_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DMZ_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
+    "-DMZ_BUILD_UNIT_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DMZ_LIB_SUFFIX='-ng'"
   ] ++ lib.optionals stdenv.isDarwin [
     # missing header file

--- a/pkgs/development/libraries/msgpack-c/default.nix
+++ b/pkgs/development/libraries/msgpack-c/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DMSGPACK_BUILD_EXAMPLES=OFF" # examples are not installed even if built
-  ] ++ lib.optional (!finalAttrs.doCheck) "-DMSGPACK_BUILD_TESTS=OFF";
+  ] ++ lib.optional (!finalAttrs.finalPackage.doCheck) "-DMSGPACK_BUILD_TESTS=OFF";
 
   checkInputs = [
     gtest

--- a/pkgs/development/libraries/msgpack-cxx/default.nix
+++ b/pkgs/development/libraries/msgpack-cxx/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DMSGPACK_BUILD_DOCS=OFF" # docs are not installed even if built
-  ] ++ lib.optional finalAttrs.doCheck "-DMSGPACK_BUILD_TESTS=ON";
+  ] ++ lib.optional finalAttrs.finalPackage.doCheck "-DMSGPACK_BUILD_TESTS=ON";
 
   checkInputs = [
     zlib

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -43,10 +43,10 @@ in stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DJSON_BuildTests=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DJSON_BuildTests=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DJSON_FastTests=ON"
     "-DJSON_MultipleHeaders=ON"
-  ] ++ lib.optional finalAttrs.doCheck "-DJSON_TestDataDirectory=${testData}";
+  ] ++ lib.optional finalAttrs.finalPackage.doCheck "-DJSON_TestDataDirectory=${testData}";
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 

--- a/pkgs/development/libraries/open62541/default.nix
+++ b/pkgs/development/libraries/open62541/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
     "-DUA_NAMESPACE_ZERO=FULL"
 
-    "-DUA_BUILD_UNIT_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DUA_BUILD_UNIT_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ]
   ++ lib.optional withExamples "-DUA_BUILD_EXAMPLES=ON"
   ++ lib.optional (withEncryption != false)

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -102,10 +102,10 @@ stdenv.mkDerivation (finalAttrs: rec {
     (mkFlag qt5Support "QT5")
     (mkFlag qt6Support "QT6")
     (mkFlag gpgmeSupport "GPGME")
-  ] ++ lib.optionals finalAttrs.doCheck [
+  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
     "-DTESTDATADIR=${testData}"
   ];
-  disallowedReferences = lib.optional finalAttrs.doCheck testData;
+  disallowedReferences = lib.optional finalAttrs.finalPackage.doCheck testData;
 
   dontWrapQtApps = true;
 

--- a/pkgs/development/libraries/properties-cpp/default.nix
+++ b/pkgs/development/libraries/properties-cpp/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-C/BDEuKNMQHOjATO5aWBptjIlgfv6ykzjFAsHb6uP3Q=";
   };
 
-  postPatch = lib.optionalString (!finalAttrs.doCheck) ''
+  postPatch = lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     sed -i "/add_subdirectory(tests)/d" CMakeLists.txt
   '';
 

--- a/pkgs/development/libraries/qmenumodel/default.nix
+++ b/pkgs/development/libraries/qmenumodel/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace libqmenumodel/QMenuModel/CMakeLists.txt \
       --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
-  '' + lib.optionalString finalAttrs.doCheck ''
+  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
     patchShebangs tests/{client,script}/*.py
   '';
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DBUILD_TESTS=${if (finalAttrs.doCheck && stdenv.hostPlatform == stdenv.buildPlatform) then "ON" else "OFF"}"
+    "-DBUILD_TESTS=${if (finalAttrs.finalPackage.doCheck && stdenv.hostPlatform == stdenv.buildPlatform) then "ON" else "OFF"}"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/xtensor/default.nix
+++ b/pkgs/development/libraries/xtensor/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = let
     cmakeBool = x: if x then "ON" else "OFF";
   in [
-    "-DBUILD_TESTS=${cmakeBool finalAttrs.doCheck}"
+    "-DBUILD_TESTS=${cmakeBool finalAttrs.finalPackage.doCheck}"
     "-DXTENSOR_ENABLE_ASSERT=${cmakeBool enableAssertions}"
     "-DXTENSOR_CHECK_DIMENSION=${cmakeBool enableBoundChecks}"
   ];

--- a/pkgs/development/python-modules/xtensor-python/default.nix
+++ b/pkgs/development/python-modules/xtensor-python/default.nix
@@ -31,7 +31,7 @@ toPythonModule (stdenv.mkDerivation(finalAttrs: {
   ];
   doCheck = true;
   cmakeFlags = [
-    "-DBUILD_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DBUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/os-specific/linux/libnvme/default.nix
+++ b/pkgs/os-specific/linux/libnvme/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Ddocs=man"
-    (lib.mesonBool "tests" finalAttrs.doCheck)
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
     (lib.mesonBool "docs-build" withDocs)
   ];
 

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     (python3.withPackages (ps: with ps; [
       pillow
-    ] ++ lib.optionals finalAttrs.doCheck [
+    ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
       pygobject3
       python-dbusmock
     ]))
@@ -141,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DBUILD_DOXYGEN=OFF"
     "-DMIR_PLATFORM='gbm-kms;x11;eglstream-kms;wayland'"
-    "-DMIR_ENABLE_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DMIR_ENABLE_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
     # https://github.com/MirServer/mir/pull/1947#issuecomment-811810872
     "-DMIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN=ON"

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Unpack subproject sources
   postUnpack = ''(
     cd "$sourceRoot/subprojects"
-    ${lib.optionalString finalAttrs.doCheck ''
+    ${lib.optionalString finalAttrs.finalPackage.doCheck ''
       cp -R --no-preserve=mode,ownership ${cmocka.src} cmocka
     ''}
     cp -R --no-preserve=mode,ownership ${imgui.src} imgui-${imgui.version}
@@ -146,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dwith_wayland=enabled"
     "-Duse_system_spdlog=enabled"
-    "-Dtests=${if finalAttrs.doCheck then "enabled" else "disabled"}"
+    "-Dtests=${if finalAttrs.finalPackage.doCheck then "enabled" else "disabled"}"
   ] ++ lib.optionals gamescopeSupport [
     "-Dmangoapp=true"
     "-Dmangoapp_layer=true"
@@ -215,7 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
     addOpenGLRunpath "$out/lib/mangohud/libMangoHud.so"
   '' + lib.optionalString gamescopeSupport ''
     addOpenGLRunpath "$out/bin/mangoapp"
-  '' + lib.optionalString finalAttrs.doCheck ''
+  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
     # libcmocka.so is only used for tests
     rm "$out/lib/libcmocka.so"
   '';


### PR DESCRIPTION
## Description of changes

This will respect `doCheck = false;` overrides, common for cross.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
