### PR TITLE
lib.escapeRegex: fix with `boost::regex` implementation

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -530,7 +530,7 @@ rec {
        escapeRegex "[^a-z]*"
        => "\\[\\^a-z]\\*"
   */
-  escapeRegex = escape (stringToCharacters "\\[{()^$?*+|.");
+  escapeRegex = escape (stringToCharacters "\\[{}()^$?*+|.");
 
   /* Quotes a string if it can't be used as an identifier directly.
 


### PR DESCRIPTION
https://github.com/NixOS/nix/pull/7762 switched `nix` to use the `boost::regex` implementation, which expects that all literal braces are escaped. That is, the regex `\{crate}` no longer parses. We modify `lib.escapeRegex` to accommodate this change. Fortunately, the old regex implementation doesn't mind if closing braces are escaped as well, so this is backwards compatible and we don't need to worry about version-gating it.

Here's how `nix` works without this patch:

Old regex implementation:

    $ nix repl nixpkgs
    Welcome to Nix 2.18.1. Type :? for help.

    Loading installable 'flake:nixpkgs#'...
    Added 5 variables.
    nix-repl> builtins.match (lib.escapeRegex "{}") "{}"
    [ ]

    $ ~/nix/result/bin/nix repl nixpkgs
    Welcome to Nix 2.20.0pre20231130_dirty. Type :? for help.

`boost::regex` implementation:

    $ ~/nix/result/bin/nix repl nixpkgs
    Welcome to Nix 2.20.0pre20231130_dirty. Type :? for help.

    Loading installable 'flake:nixpkgs#'...
    Added 5 variables.
    nix-repl> builtins.match (lib.escapeRegex "{}") "{}"
    error:
           … while calling the 'match' builtin

             at «string»:1:1:

                1| builtins.match (lib.escapeRegex "{}") "{}"
                 | ^

           error: invalid regular expression '\{}'

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
