### PR TITLE
coqPackages_8_16: fix evaluation with math-comp ≥ 2.0

### DIFF
--- a/pkgs/development/coq-modules/coq-bits/default.nix
+++ b/pkgs/development/coq-modules/coq-bits/default.nix
@@ -1,18 +1,18 @@
-{ lib, mkCoqDerivation, coq, mathcomp-algebra, version ? null }:
+{ lib, mkCoqDerivation, coq, mathcomp, version ? null }:
 
 mkCoqDerivation {
   pname = "coq-bits";
   repo = "bits";
   inherit version;
-  defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.10" "8.16"; out = "1.1.0"; }
-    { case = range "8.7"  "8.15"; out = "1.0.0"; }
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
+    { cases = [ (range "8.10" "8.16") (isLt "2.0") ]; out = "1.1.0"; }
+    { cases = [ (range "8.7"  "8.15") (isLt "2.0") ]; out = "1.0.0"; }
   ] null;
 
   release."1.1.0".sha256 = "sha256-TCw1kSXeW0ysIdLeNr+EGmpGumEE9i8tinEMp57UXaE=";
   release."1.0.0".sha256 = "0nv5mdgrd075dpd8bc7h0xc5i95v0pkm0bfyq5rj6ii1s54dwcjl";
 
-  propagatedBuildInputs = [ mathcomp-algebra ];
+  propagatedBuildInputs = [ mathcomp.algebra ];
 
   meta = with lib; {
     description = "A formalization of bitset operations in Coq";

--- a/pkgs/development/coq-modules/extructures/default.nix
+++ b/pkgs/development/coq-modules/extructures/default.nix
@@ -10,7 +10,7 @@
   inherit version;
   defaultVersion = with lib.versions; lib.switch [coq.coq-version ssreflect.version] [
     { cases = [(range "8.17" "8.18") (isGe "2.0.0")  ]; out = "0.4.0"; }
-    { cases = [(range "8.11" "8.18") (isGe "1.12.0") ]; out = "0.3.1"; }
+    { cases = [(range "8.11" "8.18") (range "1.12.0" "1.18.0") ]; out = "0.3.1"; }
     { cases = [(range "8.11" "8.14") (isLe "1.12.0") ]; out = "0.3.0"; }
     { cases = [(range "8.10" "8.12") (isLe "1.12.0") ]; out = "0.2.2"; }
   ] null;

--- a/pkgs/development/coq-modules/gaia-hydras/default.nix
+++ b/pkgs/development/coq-modules/gaia-hydras/default.nix
@@ -12,8 +12,8 @@ mkCoqDerivation rec {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [coq.coq-version mathcomp.version] [
-    { cases = [ (range "8.13" "8.16") (isGe "1.12.0") ]; out = "0.9"; }
-    { cases = [ (range "8.13" "8.14") (isGe "1.12.0") ]; out = "0.5"; }
+    { cases = [ (range "8.13" "8.16") (range "1.12.0" "1.18.0") ]; out = "0.9"; }
+    { cases = [ (range "8.13" "8.14") (range "1.12.0" "1.18.0") ]; out = "0.5"; }
   ] null;
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

Disable coq-bits, extructures, and gaia-hydra

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
