### PR TITLE
beamPackages.mixRelease: deterministic erlang builds

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -6,6 +6,10 @@
 , buildInputs ? [ ]
 , nativeBuildInputs ? [ ]
 , erlangCompilerOptions ? [ ]
+  # Deterministic Erlang builds remove full system paths from debug information
+  # among other things to keep builds more reproducible. See their docs for more:
+  # https://www.erlang.org/doc/man/compile
+, erlangDeterministicBuilds ? true
 , beamDeps ? [ ]
 , propagatedBuildInputs ? [ ]
 , postPatch ? ""
@@ -35,7 +39,7 @@ let
 
     ERL_COMPILER_OPTIONS =
       let
-        options = [ "deterministic" ] ++ erlangCompilerOptions;
+        options = erlangCompilerOptions ++ lib.optionals erlangDeterministicBuilds [ "deterministic" ];
       in
       "[${lib.concatStringsSep "," options}]";
 

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -5,6 +5,7 @@
 , src
 , buildInputs ? [ ]
 , nativeBuildInputs ? [ ]
+, erlangCompilerOptions ? [ ]
 , beamDeps ? [ ]
 , propagatedBuildInputs ? [ ]
 , postPatch ? ""
@@ -31,6 +32,13 @@ let
     MIX_ENV = mixEnv;
     MIX_DEBUG = if enableDebugInfo then 1 else 0;
     HEX_OFFLINE = 1;
+
+    ERL_COMPILER_OPTIONS =
+      let
+        options = [ "deterministic" ] ++ erlangCompilerOptions;
+      in
+      "[${lib.concatStringsSep "," options}]";
+
     LC_ALL = "C.UTF-8";
 
     # add to ERL_LIBS so other modules can find at runtime.
@@ -108,4 +116,3 @@ let
   });
 in
 lib.fix pkg
-

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -33,6 +33,11 @@
   # See https://www.erlang.org/doc/man/compile
 , erlangCompilerOptions ? [ ]
 
+  # Deterministic Erlang builds remove full system paths from debug information
+  # among other things to keep builds more reproducible. See their docs for more:
+  # https://www.erlang.org/doc/man/compile
+, erlangDeterministicBuilds ? true
+
   # Mix dependencies provided as a fixed output derivation
 , mixFodDeps ? null
 
@@ -100,7 +105,7 @@ stdenv.mkDerivation (overridable // {
 
   ERL_COMPILER_OPTIONS =
     let
-      options = [ "deterministic" ] ++ erlangCompilerOptions;
+      options = erlangCompilerOptions ++ lib.optionals erlangDeterministicBuilds [ "deterministic" ];
     in
     "[${lib.concatStringsSep "," options}]";
 

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -25,6 +25,12 @@
 , mixEnv ? "prod"
 , compileFlags ? [ ]
 
+  # Options to be passed to the Erlang compiler. As documented in the reference
+  # manual, these must be valid Erlang terms. They will be turned into an
+  # erlang list and set as the ERL_COMPILER_OPTIONS environment variable.
+  # See https://www.erlang.org/doc/man/compile
+, erlangCompilerOptions ? [ ]
+
   # Mix dependencies provided as a fixed output derivation
 , mixFodDeps ? null
 
@@ -63,7 +69,7 @@
 }@attrs:
 let
   # Remove non standard attributes that cannot be coerced to strings
-  overridable = builtins.removeAttrs attrs [ "compileFlags" "mixNixDeps" ];
+  overridable = builtins.removeAttrs attrs [ "compileFlags" "erlangCompilerOptions" "mixNixDeps" ];
 in
 assert mixNixDeps != { } -> mixFodDeps == null;
 assert stripDebug -> !enableDebugInfo;
@@ -88,6 +94,8 @@ stdenv.mkDerivation (overridable // {
   # some older dependencies still use rebar.
   MIX_REBAR = "${rebar}/bin/rebar";
   MIX_REBAR3 = "${rebar3}/bin/rebar3";
+
+  ERL_COMPILER_OPTIONS = "[${lib.strings.concatStringsSep "," ([ "deterministic" ] ++ erlangCompilerOptions)}]";
 
   LC_ALL = "C.UTF-8";
 


### PR DESCRIPTION
## Description of changes

This PR sets an Erlang compiler option that makes Erlang builds "deterministic." The real upshot of this is that debug information inside compiled Erlang modules no longer contains full system paths. These system paths would sometimes refer to the Erlang Nix package making them one of the trickier reasons why Erlang was being kept around as a runtime dependency for built mix releases.

The new option can be disabled with `erlangDeterministicBuilds = false`.

As a side effect of adding the `deterministic` Erlang option, I exposed an optional attr so that it is easy to specify any additional options without worrying about conflict with the deterministic option.

In addition to removing those references previously located inside `beam` files, this PR reintroduces logic previously in place to clean Erlang references from other non-beam files. As far as I understand, removing the beam references was the biggest remaining unknown (ref. https://github.com/plastic-gun/nix-mix-release-unwanted-references). Speaking of which, I would be very grateful for eyes on this from @c4710n who worked on the issue of mistaken Erlang references most recently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
