### PR TITLE
python311Packages.sigstore-rekor-types: init 0.0.11, python311Packages.sigstore-protobuf-specs: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/sigstore-protobuf-specs/default.nix
+++ b/pkgs/development/python-modules/sigstore-protobuf-specs/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, pythonOlder
+, flit-core
+, fetchPypi
+, buildPythonPackage
+, betterproto
+}:
+
+buildPythonPackage rec {
+  pname = "sigstore-protobuf-specs";
+  version = "0.2.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    pname = "sigstore_protobuf_specs";
+    inherit version;
+    hash = "sha256-wFwedHioCvDH3qnMLRHwR4JuTAKVc9VkE394jhE3c5E=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    betterproto
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "sigstore_protobuf_specs"
+  ];
+
+  meta = with lib; {
+    description = "Library for serializing and deserializing Sigstore messages";
+    homepage = "https://pypi.org/project/sigstore-protobuf-specs/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/sigstore-rekor-types/default.nix
+++ b/pkgs/development/python-modules/sigstore-rekor-types/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, pythonOlder
+, pydantic
+, flit-core
+, fetchFromGitHub
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "sigstore-rekor-types";
+  version = "0.0.11";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "sigstore-rekor-types";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-oOFdRiDp9USc3A+aaPExprEO2i/RERNahiyi2kVpkns=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    pydantic
+  ] ++ pydantic.optional-dependencies.email;
+
+  # Module has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python models for Rekor's API types";
+    homepage = "https://github.com/trailofbits/sigstore-rekor-types";
+    changelog = "https://github.com/trailofbits/sigstore-rekor-types/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12911,6 +12911,8 @@ self: super: with self; {
 
   sigrok = callPackage ../development/python-modules/sigrok { };
 
+  sigstore-protobuf-specs = callPackage ../development/python-modules/sigstore-protobuf-specs { };
+
   sigstore-rekor-types = callPackage ../development/python-modules/sigstore-rekor-types { };
 
   sigtools = callPackage ../development/python-modules/sigtools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12911,6 +12911,8 @@ self: super: with self; {
 
   sigrok = callPackage ../development/python-modules/sigrok { };
 
+  sigstore-rekor-types = callPackage ../development/python-modules/sigstore-rekor-types { };
+
   sigtools = callPackage ../development/python-modules/sigtools { };
 
   simanneal = callPackage ../development/python-modules/simanneal { };


### PR DESCRIPTION
## Description of changes

Python models for Rekor's API types

https://github.com/trailofbits/sigstore-rekor-types


Library for serializing and deserializing Sigstore messages

https://pypi.org/project/sigstore-protobuf-specs/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
