### PR TITLE
ryzen_smu: init at 0.1.5, ryzen_monitor_ng: init at 2.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14863,6 +14863,12 @@
       fingerprint = "7756 E88F 3C6A 47A5 C5F0  CDFB AB54 6777 F93E 20BF";
     }];
   };
+  phdyellow = {
+    name = "Phil Dyer";
+    email = "phildyer@protonmail.com";
+    github = "PhDyellow";
+    githubId = 7740661;
+  };
   phfroidmont = {
     name = "Paul-Henri Froidmont";
     email = "nix.contact-j9dw4d@froidmont.org";

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -50,6 +50,10 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [maubot](https://github.com/maubot/maubot), a plugin-based Matrix bot framework. Available as [services.maubot](#opt-services.maubot.enable).
 
+- [ryzen-monitor-ng](https://github.com/mann1x/ryzen_monitor_ng), a desktop AMD CPU power monitor and controller, similar to Ryzen Master but for Linux. Available as [programs.ryzen-monitor-ng](#opt-programs.ryzen-monitor-ng.enable)
+
+- [ryzen-smu](https://gitlab.com/leogx9r/ryzen_smu), Linux kernel driver to expose the SMU (System Management Unit) for certain AMD Ryzen Processors. Includes the userspace program `monitor_cpu`. Available at [hardward.cpu.amd.ryzen-smu](#opt-hardware.cpu.amd.ryzen-smu.enable)
+
 - systemd's gateway, upload, and remote services, which provides ways of sending journals across the network. Enable using [services.journald.gateway](#opt-services.journald.gateway.enable), [services.journald.upload](#opt-services.journald.upload.enable), and [services.journald.remote](#opt-services.journald.remote.enable).
 
 - [GNS3](https://www.gns3.com/), a network software emulator. Available as [services.gns3-server](#opt-services.gns3-server.enable).

--- a/nixos/modules/hardware/cpu/amd-ryzen-smu.nix
+++ b/nixos/modules/hardware/cpu/amd-ryzen-smu.nix
@@ -1,0 +1,26 @@
+{ config
+, lib
+, ...
+}:
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.hardware.cpu.amd.ryzen-smu;
+  ryzen-smu = config.boot.kernelPackages.ryzen-smu;
+in
+{
+  options.hardware.cpu.amd.ryzen-smu = {
+    enable = mkEnableOption ''
+        ryzen_smu, a linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen Processors.
+
+        WARNING: Damage cause by use of your AMD processor outside of official AMD specifications or outside of factory settings are not covered under any AMD product warranty and may not be covered by your board or system manufacturer's warranty
+      '';
+  };
+
+  config = mkIf cfg.enable {
+    boot.kernelModules = [ "ryzen-smu" ];
+    boot.extraModulePackages = [ ryzen-smu ];
+    environment.systemPackages = [ ryzen-smu ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ Cryolitia phdyellow ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -54,6 +54,7 @@
   ./hardware/corectrl.nix
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/amd-sev.nix
+  ./hardware/cpu/amd-ryzen-smu.nix
   ./hardware/cpu/intel-microcode.nix
   ./hardware/cpu/intel-sgx.nix
   ./hardware/cpu/x86-msr.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -245,6 +245,7 @@
   ./programs/regreet.nix
   ./programs/rog-control-center.nix
   ./programs/rust-motd.nix
+  ./programs/ryzen-monitor-ng.nix
   ./programs/screen.nix
   ./programs/seahorse.nix
   ./programs/sedutil.nix

--- a/nixos/modules/programs/ryzen-monitor-ng.nix
+++ b/nixos/modules/programs/ryzen-monitor-ng.nix
@@ -1,0 +1,35 @@
+{ pkgs
+, config
+, lib
+, ...
+}:
+let
+  inherit (lib) mkEnableOption mkPackageOption mkIf;
+  cfg = config.programs.ryzen-monitor-ng;
+in
+{
+  options = {
+    programs.ryzen-monitor-ng = {
+      enable =  mkEnableOption ''
+        ryzen_monitor_ng, a userspace application for setting and getting Ryzen SMU (System Management Unit) parameters via the ryzen_smu kernel driver.
+
+        Monitor power information of Ryzen processors via the PM table of the SMU.
+
+        SMU Set and Get for many parameters and CO counts.
+
+        https://github.com/mann1x/ryzen_monitor_ng
+
+        WARNING: Damage cause by use of your AMD processor outside of official AMD specifications or outside of factory settings are not covered under any AMD product warranty and may not be covered by your board or system manufacturer's warranty
+      '';
+
+      package = mkPackageOption pkgs "ryzen-monitor-ng" {};
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    hardware.cpu.amd.ryzen-smu.enable = true;
+  };
+
+  meta.maintainers = with lib.maintainers; [ Cryolitia phdyellow ];
+}

--- a/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
+++ b/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "ryzen-monitor-ng";
+  version = "2.0.5-unstable-2023-11-05";
+
+  # Upstream has not updated ryzen_smu header version
+  # This fork corrects ryzen_smu header version and
+  # adds support for Matisse AMD CPUs.
+  src = fetchFromGitHub {
+    owner = "plasmin";
+    repo = "ryzen_monitor_ng";
+    rev = "8b7854791d78de731a45ce7d30dd17983228b7b1";
+    hash = "sha256-fcW2fEsCFliRnMFnboR0jchzVIlCYbr2AE6AS06cb6o=";
+  };
+
+  ## Remove binaries committed into upstream repo
+  preBuild = ''
+    rm src/ryzen_monitor
+  '';
+
+  makeTargets = [ "clean" "install" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv ./src/ryzen_monitor $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Access Ryzen SMU information exposed by the ryzen_smu driver";
+    homepage = "https://github.com/mann1x/ryzen_monitor_ng";
+    license = licenses.agpl3Only;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ phdyellow ];
+    mainProgram = "ryzen_monitor";
+  };
+}

--- a/pkgs/os-specific/linux/ryzen-smu/default.nix
+++ b/pkgs/os-specific/linux/ryzen-smu/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, kernel
+}:
+
+let
+  version = "0.1.5-unstable-2024-01-03";
+
+  ## Upstream has not been merging PRs.
+  ## Nixpkgs maintainers are providing a
+  ## repo with PRs merged until upstream is
+  ## updated.
+  src = fetchFromGitHub {
+    owner = "Cryolitia";
+    repo = "ryzen_smu";
+    rev = "ce1aa918efa33ca79998f0f7d467c04d4b07016c";
+    hash = "sha256-s9SSmbL6ixWqZUKEhrZdxN4xoWgk+8ClZPoKq2FDAAE=";
+  };
+
+  monitor-cpu = stdenv.mkDerivation {
+    pname = "monitor-cpu";
+    inherit version src;
+
+    makeFlags = [
+      "-C userspace"
+    ];
+
+    installPhase = ''
+    runHook preInstall
+
+    install userspace/monitor_cpu -Dm755 -t $out/bin
+
+    runHook postInstall
+  '';
+  };
+
+in
+stdenv.mkDerivation {
+  pname = "ryzen-smu-${kernel.version}";
+  inherit version src;
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "TARGET=${kernel.modDirVersion}"
+    "KERNEL_BUILD=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install ryzen_smu.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/ryzen_smu
+    install ${monitor-cpu}/bin/monitor_cpu -Dm755 -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen Processors";
+    homepage = "https://gitlab.com/leogx9r/ryzen_smu";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ Cryolitia phdyellow ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "monitor_cpu";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -551,6 +551,8 @@ in {
 
     ithc = callPackage ../os-specific/linux/ithc { };
 
+    ryzen-smu = callPackage ../os-specific/linux/ryzen-smu { };
+
     zenpower = callPackage ../os-specific/linux/zenpower { };
 
     zfs_2_1 = callPackage ../os-specific/linux/zfs/2_1.nix {


### PR DESCRIPTION
## Description of changes

ryzen_monitor_ng is a tool for monitoring power information on desktop AMD processors.
It can also set parameters for the CPU, so can offer some of the features of Ryzen Master on Linux.

It depends on the linux kernel driver ryzen_smu.

ryzen_smu includes a userspace program `monitor_cpu`.

https://gitlab.com/mann1x/ryzen_smu

https://github.com/mann1x/ryzen_monitor_ng


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
