### PR TITLE
snowmachine: 1.0.1 -> 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16986,6 +16986,12 @@
     githubId = 9720532;
     name = "Sergei K";
   };
+  sontek = {
+    email = "sontek@gmail.com";
+    github = "sontek";
+    githubId = 151924;
+    name = "John Anderson";
+  };
   sophrosyne = {
     email = "joshuaortiz@tutanota.com";
     github = "sophrosyne97";

--- a/pkgs/by-name/sn/snowmachine/package.nix
+++ b/pkgs/by-name/sn/snowmachine/package.nix
@@ -20,6 +20,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/sontek/snowmachine";
     mainProgram = "snowmachine";
     license = with licenses; [ bsd3 ];
-    maintainers = with maintainers; [ djanatyn ];
+    maintainers = with maintainers; [ djanatyn sontek ];
   };
 }

--- a/pkgs/by-name/sn/snowmachine/package.nix
+++ b/pkgs/by-name/sn/snowmachine/package.nix
@@ -1,16 +1,16 @@
-{ buildPythonPackage, lib, click, colorama, fetchPypi, setuptools-git }:
+{ python3Packages, lib, fetchPypi }:
 
-buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "snowmachine";
-  version = "1.0.1";
+  version = "2.0.1";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1v385hhxy2a8vx5p0fhn0di8l4qfpb0a86j6nwsg0aw6ngb09qf1";
+    hash = "sha256:119e6da12f430af1519f1a9f091b77b7676c7a9dbeaab6616cb196fe793d8e61";
   };
 
-  buildInputs = [ setuptools-git ];
-  propagatedBuildInputs = [ click colorama ];
+  propagatedBuildInputs = with python3Packages; [ click colorama hatchling ];
 
   doCheck = false;
   pythonImportsCheck = [ "snowmachine" ];
@@ -18,6 +18,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A python script that will make your terminal snow";
     homepage = "https://github.com/sontek/snowmachine";
+    mainProgram = "snowmachine";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ djanatyn ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41684,8 +41684,6 @@ with pkgs;
 
   snowsql = callPackage ../applications/misc/snowsql { };
 
-  snowmachine = python3Packages.callPackage ../applications/misc/snowmachine { };
-
   sidequest = callPackage ../applications/misc/sidequest { };
 
   maphosts = callPackage ../tools/networking/maphosts { };


### PR DESCRIPTION
Snowmachine v2 has a few nice features like printing a christmas tree and has a more modern packaging system.

I verified this was working by testing locally in the folder:

```
nix-build -E 'with import <nixpkgs> {}; with pkgs.python3Packages; callPackage ./default.nix {}'
```

as well as running:

```
nix-shell -p nixpkgs-review --run "nixpkgs-review pr 271347"
```

They produced usable application at version 2.0.0.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
