### PR TITLE
elixir: enable Erlang compiler option - deterministic

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -20,7 +20,7 @@
 } @ args:
 
 let
-  inherit (lib) getVersion versionAtLeast optional;
+  inherit (lib) getVersion versionAtLeast optional concatStringsSep;
 
 in
 assert versionAtLeast (getVersion erlang) minimumOTPVersion;
@@ -36,7 +36,12 @@ stdenv.mkDerivation ({
   LANG = "C.UTF-8";
   LC_TYPE = "C.UTF-8";
 
-  buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
+  ERLC_OPTS =
+    let
+      erlc_opts = [ "deterministic" ]
+        ++ optional debugInfo "debug_info";
+    in
+    "[${concatStringsSep "," erlc_opts}]";
 
   preBuild = ''
     patchShebangs ${escriptPath} || true


### PR DESCRIPTION
## Description of changes

This PR is trying to:
+ remove all non-deterministic information from Elixir builds:
   - As the Erlang compiler doc said, the `deterministic` compiler option: 
   > Omit the options and source tuples in the list returned by Module:module_info(compile), and reduce the paths in stack traces to the module name alone. **This option will make it easier to achieve reproducible builds.**
   - due to the reproducible nature of Nix, I don't provide an option to disable this.

+ improve the way to pass `ERL_COMPILER_OPTIONS`:
  - if we search `ERL_COMPILER_OPTIONS`, we will find [this line](https://github.com/plastic-forks/elixir/blob/9daef619419a505391094d19ebb578b449dea8d8/Makefile#L8).
  - and, `ERLC_OPTS` is the standard way to pass Erlang compiler options when building Elixir.
  - above mentioned line has already existed for 4 years, so there shouldn't be any compatibility issues. (The minimum version of Elixir supported by nixpkgs is 1.10, which is released at 2020/01/27)
---

Before this PR:
```
$ nix build .#legacyPackages.x86_64-darwin.elixir

$ rg "/nix/store/.*/erlang" result --files-with-matches --binary
result/lib/elixir/lib/elixir/ebin/elixir_parser.beam

# The BEAM file contains a source path to /nix/store/*erlang, which undermines the 
# benefits brought by mix release.
#
# Because, the elixir itself always references to erlang, due to Automatic Runtime 
# Dependencies, Erlang is always included as a runtime dependency.
#
# But, Erlang shouldn't be a runtime dependency when using mix release.
```

After this PR:
```
$ nix build .#legacyPackages.x86_64-darwin.elixir

$ rg "/nix/store/.*/erlang" result --files-with-matches --binary
# no more files referencing erlang. ;)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
