### PR TITLE
circt: add shared libs and split llvm

### DIFF
--- a/pkgs/development/compilers/circt/circt-llvm.nix
+++ b/pkgs/development/compilers/circt/circt-llvm.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, cmake
+, ninja
+, circt
+, llvm
+, python3
+}: stdenv.mkDerivation {
+  pname = circt.pname + "-llvm";
+  inherit (circt) version src;
+
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  nativeBuildInputs = [ cmake ninja python3 ];
+
+  preConfigure = ''
+    cd llvm/llvm
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DLLVM_ENABLE_BINDINGS=OFF"
+    "-DLLVM_ENABLE_OCAMLDOC=OFF"
+    "-DLLVM_BUILD_EXAMPLES=OFF"
+    "-DLLVM_OPTIMIZED_TABLEGEN=ON"
+    "-DLLVM_ENABLE_PROJECTS=mlir"
+    "-DLLVM_TARGETS_TO_BUILD="
+
+    # This option is needed to install llvm-config
+    "-DLLVM_INSTALL_UTILS=ON"
+  ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  postInstall = ''
+    # move llvm-config to $dev to resolve a circular dependency
+    moveToOutput "bin/llvm-config*" "$dev"
+
+    # move all lib files to $lib except lib/cmake
+    moveToOutput "lib" "$lib"
+    moveToOutput "lib/cmake" "$dev"
+
+    # patch configuration files so each path points to the new $lib or $dev paths
+    substituteInPlace "$dev/lib/cmake/llvm/LLVMConfig.cmake" \
+      --replace 'set(LLVM_BINARY_DIR "''${LLVM_INSTALL_PREFIX}")' 'set(LLVM_BINARY_DIR "'"$lib"'")'
+    substituteInPlace \
+      "$dev/lib/cmake/llvm/LLVMExports-release.cmake" \
+      "$dev/lib/cmake/mlir/MLIRTargets-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/lib" "$lib/lib/lib" \
+      --replace "\''${_IMPORT_PREFIX}/lib/objects-Release" "$lib/lib/objects-Release" \
+      --replace "$out/bin/llvm-config" "$dev/bin/llvm-config" # patch path for llvm-config
+  '';
+
+  doCheck = true;
+  checkTarget = "check-mlir";
+
+  meta = llvm.meta // {
+    inherit (circt.meta) maintainers;
+  };
+}


### PR DESCRIPTION
## Description of changes
This changes adds circt's shared libs and splits the build of llvm.

This fixes the previous attempt #259725 where it was hard to split the output of circt and LLVM.
It now builds LLVM first using the submodule source from circt, and then using that result, builds circt.

~~The only downside is that the circt tests are not passing, because of the lack of llvm-lit. I may come back to this issue later.~~ Edit: fixed

cc: @SharzyL @NickCao @sequencer 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
