### PR TITLE
buildPython*: support fixed-point arguments

### DIFF
--- a/pkgs/by-name/py/pyspread/package.nix
+++ b/pkgs/by-name/py/pyspread/package.nix
@@ -8,21 +8,20 @@
 }:
 
 let
-  # get rid of rec
-  pname = "pyspread";
-  version = "2.4";
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-MZlR2Rap5oMRfCmswg9W//FYFkSEki7eyMNhLoGZgJM=";
-  };
   inherit (libsForQt5)
     qtsvg
     wrapQtAppsHook
     ;
 in
-python3.pkgs.buildPythonApplication {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   format = "setuptools";
-  inherit pname version src;
+  pname = "pyspread";
+  version = "2.4";
+  src = fetchPypi {
+    pname = "pyspread";
+    inherit (finalAttrs) version;
+    hash = "sha256-MZlR2Rap5oMRfCmswg9W//FYFkSEki7eyMNhLoGZgJM=";
+  };
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -86,4 +85,4 @@ python3.pkgs.buildPythonApplication {
     mainProgram = "pyspread";
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -99,7 +99,12 @@ let
     "wheel"
   ];
 
-  cleanAttrs = flip removeAttrs [
+in
+
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
     "disabled"
     "checkPhase"
     "checkInputs"
@@ -114,8 +119,8 @@ let
     "build-system"
   ];
 
-in
-
+  extendDrvArgs =
+    finalAttrs:
 {
   # Build-time dependencies for the package
   nativeBuildInputs ? [ ],
@@ -197,10 +202,6 @@ in
   ...
 }@attrs:
 
-let
-  # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-  self = stdenv.mkDerivation (
-    finalAttrs:
     let
       getFinalPassthru =
         let
@@ -283,8 +284,7 @@ let
       name = namePrefix + attrs.name or "${finalAttrs.pname}-${finalAttrs.version}";
 
     in
-    (cleanAttrs attrs)
-    // {
+    {
       inherit name;
 
       inherit catchConflicts;
@@ -448,7 +448,7 @@ let
             "enabledTests"
           ] attrs
         )
-  );
+  ;
 
   # This derivation transformation function must be independent to `attrs`
   # for fixed-point arguments support in the future.
@@ -468,6 +468,4 @@ let
         };
     in
     drv: disablePythonPackage (toPythonModule drv);
-
-in
-transformDrv self
+}

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -121,86 +121,86 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
-{
-  # Build-time dependencies for the package
-  nativeBuildInputs ? [ ],
+    {
+      # Build-time dependencies for the package
+      nativeBuildInputs ? [ ],
 
-  # Run-time dependencies for the package
-  buildInputs ? [ ],
+      # Run-time dependencies for the package
+      buildInputs ? [ ],
 
-  # Dependencies needed for running the checkPhase.
-  # These are added to buildInputs when doCheck = true.
-  checkInputs ? [ ],
-  nativeCheckInputs ? [ ],
+      # Dependencies needed for running the checkPhase.
+      # These are added to buildInputs when doCheck = true.
+      checkInputs ? [ ],
+      nativeCheckInputs ? [ ],
 
-  # propagate build dependencies so in case we have A -> B -> C,
-  # C can import package A propagated by B
-  propagatedBuildInputs ? [ ],
+      # propagate build dependencies so in case we have A -> B -> C,
+      # C can import package A propagated by B
+      propagatedBuildInputs ? [ ],
 
-  # Python module dependencies.
-  # These are named after PEP-621.
-  dependencies ? [ ],
-  optional-dependencies ? { },
+      # Python module dependencies.
+      # These are named after PEP-621.
+      dependencies ? [ ],
+      optional-dependencies ? { },
 
-  # Python PEP-517 build systems.
-  build-system ? [ ],
+      # Python PEP-517 build systems.
+      build-system ? [ ],
 
-  # DEPRECATED: use propagatedBuildInputs
-  pythonPath ? [ ],
+      # DEPRECATED: use propagatedBuildInputs
+      pythonPath ? [ ],
 
-  # Enabled to detect some (native)BuildInputs mistakes
-  strictDeps ? true,
+      # Enabled to detect some (native)BuildInputs mistakes
+      strictDeps ? true,
 
-  outputs ? [ "out" ],
+      outputs ? [ "out" ],
 
-  # used to disable derivation, useful for specific python versions
-  disabled ? false,
+      # used to disable derivation, useful for specific python versions
+      disabled ? false,
 
-  # Raise an error if two packages are installed with the same name
-  # TODO: For cross we probably need a different PYTHONPATH, or not
-  # add the runtime deps until after buildPhase.
-  catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
+      # Raise an error if two packages are installed with the same name
+      # TODO: For cross we probably need a different PYTHONPATH, or not
+      # add the runtime deps until after buildPhase.
+      catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
 
-  # Additional arguments to pass to the makeWrapper function, which wraps
-  # generated binaries.
-  makeWrapperArgs ? [ ],
+      # Additional arguments to pass to the makeWrapper function, which wraps
+      # generated binaries.
+      makeWrapperArgs ? [ ],
 
-  # Skip wrapping of python programs altogether
-  dontWrapPythonPrograms ? false,
+      # Skip wrapping of python programs altogether
+      dontWrapPythonPrograms ? false,
 
-  # Don't use Pip to install a wheel
-  # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
-  # It's included here to prevent an infinite recursion.
-  dontUsePipInstall ? false,
+      # Don't use Pip to install a wheel
+      # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
+      # It's included here to prevent an infinite recursion.
+      dontUsePipInstall ? false,
 
-  # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
-  permitUserSite ? false,
+      # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
+      permitUserSite ? false,
 
-  # Remove bytecode from bin folder.
-  # When a Python script has the extension `.py`, bytecode is generated
-  # Typically, executables in bin have no extension, so no bytecode is generated.
-  # However, some packages do provide executables with extensions, and thus bytecode is generated.
-  removeBinBytecode ? true,
+      # Remove bytecode from bin folder.
+      # When a Python script has the extension `.py`, bytecode is generated
+      # Typically, executables in bin have no extension, so no bytecode is generated.
+      # However, some packages do provide executables with extensions, and thus bytecode is generated.
+      removeBinBytecode ? true,
 
-  # pyproject = true <-> format = "pyproject"
-  # pyproject = false <-> format = "other"
-  # https://github.com/NixOS/nixpkgs/issues/253154
-  pyproject ? null,
+      # pyproject = true <-> format = "pyproject"
+      # pyproject = false <-> format = "other"
+      # https://github.com/NixOS/nixpkgs/issues/253154
+      pyproject ? null,
 
-  # Several package formats are supported.
-  # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
-  # "wheel" : Install from a pre-compiled wheel.
-  # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
-  # "egg": Install a package from an egg.
-  # "other" : Provide your own buildPhase and installPhase.
-  format ? null,
+      # Several package formats are supported.
+      # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
+      # "wheel" : Install from a pre-compiled wheel.
+      # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
+      # "egg": Install a package from an egg.
+      # "other" : Provide your own buildPhase and installPhase.
+      format ? null,
 
-  meta ? { },
+      meta ? { },
 
-  doCheck ? true,
+      doCheck ? true,
 
-  ...
-}@attrs:
+      ...
+    }@attrs:
 
     let
       getFinalPassthru =
@@ -447,8 +447,7 @@ lib.extendMkDerivation {
             "enabledTestPaths"
             "enabledTests"
           ] attrs
-        )
-  ;
+        );
 
   # This derivation transformation function must be independent to `attrs`
   # for fixed-point arguments support in the future.

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -23,7 +23,11 @@ let
       origArgs:
       let
         result = f origArgs;
-        overrideWith = newArgs: origArgs // lib.toFunction newArgs origArgs;
+        overrideWith =
+          if lib.isFunction origArgs then
+            newArgs: lib.extends (_: lib.toFunction newArgs) origArgs
+          else
+            newArgs: origArgs // lib.toFunction newArgs origArgs;
       in
       if lib.isAttrs result then
         result


### PR DESCRIPTION
## Description of changes

This PR enables the fixed-point arguments support in `buildPythonPackage` and `buildPythonApplication` for Python 2 and 3 with slight modification against `mk-python-derivation.nix` with no rebuilds.

Prerequisites:
- #234651
- #375921
- #267296
- #271762

I will rebase this feature branch once the dependent PRs merge. The diff will be greatly shortened then.

Update: Rebased. This PR is now ready for review.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
