### PR TITLE
buildPython*: use `lib.extendDerivation'` to fix overriding issues caused by `lib.extendDerivation`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -114,7 +114,7 @@ let
     inherit (self.stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (self.customisation) overrideDerivation makeOverridable
-      callPackageWith callPackagesWith extendDerivation hydraJob
+      callPackageWith callPackagesWith extendDerivation extendDerivation' hydraJob
       makeScope makeScopeWithSplicing makeScopeWithSplicing';
     inherit (self.derivations) lazyDerivation;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -39,3 +39,20 @@ In addition to numerous new and upgraded packages, this release has the followin
   child). Or you can set `boot.kernel.sysctl."kernel.yama.ptrace_scope"` to 0.
 
 - The `hardware.pulseaudio` module now sets permission of pulse user home directory to 755 when running in "systemWide" mode. It fixes [issue 114399](https://github.com/NixOS/nixpkgs/issues/114399).
+
+- [`lib.extendDerivation'`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.customisation.extendDerivation-prime) is added to provide an alternative to [`lib.extendDerivation`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.customisation.extendDerivation) aware of existing attributes that provides overriding.
+
+  Specifically, it defaults to re-apply the attribute updates to the overriding results:
+  ```nix
+  helloWithAns = lib.extendDerivation' {
+    passthru = { ans = 42; };
+  } pkgs.hello
+
+  helloWithAns.ans
+  => 42
+
+  (helloWithAns.overrideAttrs { }).ans
+  => 42
+  ```
+
+  Argument `overriderNames` specifies the names of the attributes that performs overriding. This is useful for language-specific build helpers (e.g. `buildPythonPackage`) and the resulting derivations.

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -300,7 +300,16 @@ let
   passthru.updateScript = let
       filename = builtins.head (lib.splitString ":" self.meta.position);
     in attrs.passthru.updateScript or [ update-python-libraries filename ];
-in lib.extendDerivation
-  (disabled -> throw "${name} not supported for interpreter ${python.executable}")
-  passthru
-  self
+in lib.extendDerivation' {
+    condition = disabled -> throw "${name} not supported for interpreter ${python.executable}";
+    inherit passthru;
+    overriderNames = [
+      "override"
+      "overrideAttrs"
+      "overrideDerivation"
+      "overridePythonAttrs"
+    ];
+    # false if `overridePythonAttrs` is passed through `<pkg>.passthru`
+    # true otherwise
+    keepOverriders = !(attrs?passthru && attrs.passthru?overridePythonAttrs);
+  } self

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -25,7 +25,15 @@
       valid = value: pythonPackages.hasPythonModule value || providesSetupHook value || lib.elem value exceptions;
       func = name: value:
         if lib.isDerivation value then
-          lib.extendDerivation (valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.") {} value
+          lib.extendDerivation' {
+            condition = valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.";
+            overriderNames = [
+              "override"
+              "overrideAttrs"
+              "overrideDerivation"
+              "overridePythonAttrs"
+            ];
+          } value
         else
           value;
     in lib.mapAttrs func items;

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -244,7 +244,16 @@ let
   passthru.updateScript = let
       filename = builtins.head (lib.splitString ":" self.meta.position);
     in attrs.passthru.updateScript or [ update-python-libraries filename ];
-in lib.extendDerivation
-  (disabled -> throw "${name} not supported for interpreter ${python.executable}")
-  passthru
-  self
+in lib.extendDerivation' {
+    condition = disabled -> throw "${name} not supported for interpreter ${python.executable}";
+    inherit passthru;
+    overriderNames = [
+      "override"
+      "overrideAttrs"
+      "overrideDerivation"
+      "overridePythonAttrs"
+    ];
+    # false if `overridePythonAttrs` is passed through `<pkg>.passthru`
+    # true otherwise
+    keepOverriders = !(attrs?passthru && attrs.passthru?overridePythonAttrs);
+  } self

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -31,7 +31,78 @@ let
         expr = ((stdenvNoCC.mkDerivation { pname = "hello-no-final-attrs"; }).overrideAttrs { pname = "hello-no-final-attrs-overridden"; }).pname == "hello-no-final-attrs-overridden";
         expected = true;
       })
-    ];
+      ({
+        name = "extendDerivation-passthru";
+        expr = helloWithAns0.ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation-multi-passthru";
+        expr = helloMultiWithAns0.man.ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-noKeepOverridable-passthru";
+        expr = helloWithAns1.ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-noKeepOverridable-multi-passthru";
+        expr = helloMultiWithAns1.man.ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-passthru";
+        expr = helloWithAns2.ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-multi-overrideAttrs";
+        expr = (helloMultiWithAns2.man.overrideAttrs { }).outputName == "man";
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-overrideAttrs-passthru";
+        expr = (helloWithAns2.overrideAttrs { }).ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-overrideDerivation-passthru";
+        expr = (helloWithAns2.overrideDerivation (_: { })).ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-override-passthru";
+        expr = (helloWithAns2.override { }).ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-multi-overrideAttrs-passthru";
+        expr = (helloMultiWithAns2.overrideAttrs { }).man.ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-multi-on-output-overrideAttrs-outputName";
+        expr = (helloMultiWithAns2.man.overrideAttrs { }).outputName == "man";
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-multi-on-output-overrideAttrs-passthru";
+        expr = (helloMultiWithAns2.man.overrideAttrs { }).ans == 42;
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-spreadOverriders-multi-on-output-override-outputName";
+        expr = (helloMultiWithAns3.man.override { }).outputName == "man";
+        expected = true;
+      })
+      ({
+        name = "extendDerivation'-spreadOverriders-multi-on-output-override-passthru";
+        expr = (helloMultiWithAns3.man.override { }).ans == 42;
+        expected = true;
+      })
+    ]
+    ;
 
   addEntangled = origOverrideAttrs: f:
     origOverrideAttrs (
@@ -55,6 +126,38 @@ let
   overrides1 = example.overrideAttrs (_: super: { pname = "a-better-${super.pname}"; });
 
   repeatedOverrides = overrides1.overrideAttrs (_: super: { pname = "${super.pname}-with-blackjack"; });
+
+  helloWithAns0 = lib.extendDerivation true { ans = 42; } pkgs.hello;
+
+  helloWithAns1 = lib.extendDerivation' {
+    keepOverriders = false;
+    passthru = { ans = 42; };
+  } pkgs.hello;
+
+  helloWithAns2 = lib.extendDerivation' {
+    passthru = { ans = 42; };
+  } pkgs.hello;
+
+  helloMulti = pkgs.hello.overrideAttrs {
+    outputs = [ "out" "info" "man" ];
+  };
+
+  helloMultiWithAns0 = lib.extendDerivation true { ans = 42; } helloMulti;
+
+  helloMultiWithAns1 = lib.extendDerivation' {
+    keepOverriders = false;
+    passthru = { ans = 42; };
+  } helloMulti;
+
+  helloMultiWithAns2 = lib.extendDerivation' {
+    passthru = { ans = 42; };
+  } helloMulti;
+
+  helloMultiWithAns3 = lib.extendDerivation' {
+    spreadOverriders = true;
+    passthru = { ans = 42; };
+  } helloMulti;
+
 in
 
 stdenvNoCC.mkDerivation {

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -62,5 +62,5 @@ stdenvNoCC.mkDerivation {
   passthru = { inherit tests; };
   buildCommand = ''
     touch $out
-  '' + lib.concatMapStringsSep "\n" (t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${t.name} success') || (echo '${t.name} fail' && exit 1)") tests;
+  '' + lib.concatMapStringsSep "\n" (t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo ${lib.escapeShellArg t.name}' success') || (echo ${lib.escapeShellArg t.name}' fail' && exit 1)") tests;
 }


### PR DESCRIPTION
## Description of changes

Split from #269785
Depends on #269785, will be shorter once the dependent PR gets merged.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
