### PR TITLE
gamescope: 3.12.5 -> 3.13.19

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -32,9 +32,16 @@
 , lib
 , makeBinaryWrapper
 }:
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
   version = "3.13.19";
+
+  src = fetchFromGitHub {
+    owner = "ValveSoftware";
+    repo = "gamescope";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-US9S97ce8WuEi6mk2yyi9etsUNPUH2ypPTxdaMXM7cI=";
+  };
 
   vkroots = fetchFromGitHub {
     owner = "Joshua-Ashton";
@@ -50,16 +57,6 @@ let
     repo = "reshade";
     rev = "5c8b8f0993a46fcd2f471181b002fb7f549c33c5";
     hash = "sha256-73xoFoZeCIToxC42IdpMCEqajDM0JBEDSVfsZ4VUuQQ=";
-  };
-in
-stdenv.mkDerivation {
-  inherit pname version;
-
-  src = fetchFromGitHub {
-    owner = "ValveSoftware";
-    repo = "gamescope";
-    rev = "refs/tags/${version}";
-    hash = "sha256-US9S97ce8WuEi6mk2yyi9etsUNPUH2ypPTxdaMXM7cI=";
   };
 
   patches = [
@@ -118,11 +115,12 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "lib" ];
 
+  # HACK: We should ideally use pkg-config for all of these, but Gamescope doesn't look for (most of) these using pkg-config
   postUnpack = ''
     rm -rf source/subprojects/vkroots
-    ln -s ${vkroots} source/subprojects/vkroots
+    ln -s ${finalAttrs.vkroots} source/subprojects/vkroots
     rm -rf source/src/reshade
-    ln -s ${reshade} source/src/reshade
+    ln -s ${finalAttrs.reshade} source/src/reshade
     rm -rf source/thirdparty/SPIRV-Headers
     ln -s ${spirv-headers} source/thirdparty/SPIRV-Headers
   '';
@@ -146,4 +144,4 @@ stdenv.mkDerivation {
     platforms = platforms.linux;
     mainProgram = "gamescope";
   };
-}
+})

--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -28,18 +28,28 @@
 , wlroots
 , libliftoff
 , libdisplay-info
+, spirv-headers
 , lib
 , makeBinaryWrapper
 }:
 let
   pname = "gamescope";
-  version = "3.12.5";
+  version = "3.13.19";
 
   vkroots = fetchFromGitHub {
     owner = "Joshua-Ashton";
     repo = "vkroots";
-    rev = "26757103dde8133bab432d172b8841df6bb48155";
-    hash = "sha256-eet+FMRO2aBQJcCPOKNKGuQv5oDIrgdVPRO00c5gkL0=";
+    rev = "d5ef31abc7cb5c69aee4bcb67b10dd543c1ff7ac";
+    hash = "sha256-gNlSEeqy8svxrcUt1gYBacpjzdnfKS89yb//DiiCVTw=";
+  };
+
+  # equivalent to Joshua-Ashton/reshade/9fdbea6892f9959fdc18095d035976c574b268b7
+  # See https://github.com/crosire/reshade/pull/267
+  reshade = fetchFromGitHub {
+    owner = "crosire";
+    repo = "reshade";
+    rev = "5c8b8f0993a46fcd2f471181b002fb7f549c33c5";
+    hash = "sha256-73xoFoZeCIToxC42IdpMCEqajDM0JBEDSVfsZ4VUuQQ=";
   };
 in
 stdenv.mkDerivation {
@@ -49,7 +59,7 @@ stdenv.mkDerivation {
     owner = "ValveSoftware";
     repo = "gamescope";
     rev = "refs/tags/${version}";
-    hash = "sha256-u4pnKd5ZEC3CS3E2i8E8Wposd8Tu4ZUoQXFmr0runwE=";
+    hash = "sha256-US9S97ce8WuEi6mk2yyi9etsUNPUH2ypPTxdaMXM7cI=";
   };
 
   patches = [
@@ -74,6 +84,7 @@ stdenv.mkDerivation {
   buildInputs = [
     xorg.libXdamage
     xorg.libXcomposite
+    xorg.libXcursor
     xorg.libXrender
     xorg.libXext
     xorg.libXxf86vm
@@ -102,7 +113,6 @@ stdenv.mkDerivation {
     stb
     hwdata
     openvr
-    vkroots
     libdisplay-info
   ];
 
@@ -111,6 +121,10 @@ stdenv.mkDerivation {
   postUnpack = ''
     rm -rf source/subprojects/vkroots
     ln -s ${vkroots} source/subprojects/vkroots
+    rm -rf source/src/reshade
+    ln -s ${reshade} source/src/reshade
+    rm -rf source/thirdparty/SPIRV-Headers
+    ln -s ${spirv-headers} source/thirdparty/SPIRV-Headers
   '';
 
   # --debug-layers flag expects these in the path

--- a/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch
+++ b/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch
@@ -6,6 +6,6 @@ index 1311784..77043ac 100644
    default_options: [
      'cpp_std=c++14',
      'warning_level=2',
--    'force_fallback_for=wlroots,libliftoff',
+-    'force_fallback_for=wlroots,libliftoff,vkroots',
    ],
  )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1827,7 +1827,7 @@ with pkgs;
   };
 
   gamescope = callPackage ../applications/window-managers/gamescope {
-    wlroots = wlroots_0_16;
+    wlroots = wlroots_0_17;
   };
 
   gay = callPackage ../tools/misc/gay {  };


### PR DESCRIPTION
## Description of changes

Continuation of #270043
Closes #270043

### This package is still outdated

~~At the time of writing the latest version of Gamescope is 3.13.12. But that version uses wlroots 0.17, which requires #269359 to be merged first.~~

### New dependencies

reshade and SPIRV-Headers have been added as new build-time dependencies. The latter is packaged in nixpkgs and is (for now) substituted as a submodule.

The former is not packaged and is fetched from the upstream repository. Note that gamescope uses https://github.com/Joshua-Ashton/reshade/tree/9fdbea6892f9959fdc18095d035976c574b268b7, while we use https://github.com/crosire/reshade/tree/5c8b8f0993a46fcd2f471181b002fb7f549c33c5 which is just the upstream project, with the changes from Joshua-Ashton.

vkroots has also been bumped.

### Future work

It would be nice, if we could use pkg-config for SPIRV-Headers. I'd say this is an opportunity for an upstream contribution.

### All Changes

https://github.com/ValveSoftware/gamescope/compare/3.12.5...3.13.19


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
