### PR TITLE
librenms-agent: init, nixos/librenms-agent: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -807,6 +807,7 @@
   ./services/monitoring/karma.nix
   ./services/monitoring/kthxbye.nix
   ./services/monitoring/librenms.nix
+  ./services/monitoring/librenms-agent.nix
   ./services/monitoring/loki.nix
   ./services/monitoring/longview.nix
   ./services/monitoring/mackerel-agent.nix

--- a/nixos/modules/services/monitoring/librenms-agent.nix
+++ b/nixos/modules/services/monitoring/librenms-agent.nix
@@ -1,0 +1,62 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.services.librenms-agent;
+in {
+  options.services.librenms-agent = {
+    enable = lib.mkEnableOption "LibreNMS agent";
+
+    package = lib.mkPackageOption pkgs "librenms-agent" {};
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 6556;
+      description = lib.mdDoc "Port where the LibreNMS Agent will listen.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Open port for LibreNMS Agent.
+      '';
+    };
+
+    ipAddressAllow = lib.mkOption {
+      example = [ "192.168.1.0/24" ];
+      type = lib.types.listOf lib.types.str;
+      description = ''
+        Allows access to the LibreNMS Agent only for the given addresses.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.sockets.librenms-agent = {
+      description = "Check_MK LibreNMS Agent Socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = toString cfg.port;
+        Accept = "yes";
+      };
+    };
+
+    systemd.services."librenms-agent@" = {
+      description = "Check_MK LibreNMS Agent Service";
+      after = [ "network.target" "librenms-agent.socket" ];
+      requires = [ "librenms-agent.socket" ];
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        StandardOutput = "socket";
+        IPAddressDeny = "any";
+        IPAddressAllow = cfg.ipAddressAllow;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+  meta.maintainers = [ lib.maintainers.eliandoran ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -468,6 +468,7 @@ in {
   libinput = handleTest ./libinput.nix {};
   libreddit = handleTest ./libreddit.nix {};
   librenms = handleTest ./librenms.nix {};
+  librenms-agent = handleTest ./librenms-agent.nix {};
   libresprite = handleTest ./libresprite.nix {};
   libreswan = handleTest ./libreswan.nix {};
   librewolf = handleTest ./firefox.nix { firefoxPackage = pkgs.librewolf; };

--- a/nixos/tests/librenms-agent.nix
+++ b/nixos/tests/librenms-agent.nix
@@ -1,0 +1,25 @@
+let
+  host = "127.0.0.1";
+  port = 6557;
+in import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "librenms-agent";
+
+  nodes.librenms-agent = {
+    environment.systemPackages = with pkgs; [
+      inetutils
+    ];
+
+    services.librenms-agent = {
+      enable = true;
+      port = port;
+      ipAddressAllow = [ host ];
+      openFirewall = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("sockets.target")
+    machine.succeed("telnet ${host} ${toString port} | grep AgentOS");
+  '';
+})

--- a/pkgs/by-name/li/librenms-agent/package.nix
+++ b/pkgs/by-name/li/librenms-agent/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, nixosTests }:
 
 stdenv.mkDerivation {
   pname = "librenms-agent";
@@ -19,6 +19,8 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  passthru.tests = nixosTests.librenms-agent;
 
   meta = with lib; {
     description = "Agent that provides data to LibreNMS";

--- a/pkgs/by-name/li/librenms-agent/package.nix
+++ b/pkgs/by-name/li/librenms-agent/package.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ eliandoran ];
     platforms = platforms.linux;
+    mainProgram = "check_mk_agent";
   };
 }

--- a/pkgs/by-name/li/librenms-agent/package.nix
+++ b/pkgs/by-name/li/librenms-agent/package.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "librenms-agent";
+  version = "1.2.6b5";
+
+  src = fetchFromGitHub {
+    owner = "librenms";
+    repo = "librenms-agent";
+    # upstream provides no git tags
+    rev = "f6d6ff5b88bd47e738754fe72c4a4e5eb4e78d08";
+    hash = "sha256-b62xkwJ09BQe/XRXZqnOr5JUpLjLIqYRETr/wTim/h4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 0750 check_mk_agent -t $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Agent that provides data to LibreNMS";
+    homepage = "https://github.com/librenms/librenms-agent";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ eliandoran ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [`librenms-agent`](https://github.com/librenms/librenms-agent) which is a nice companion to the recently-introduced LibreNMS service.

## Things done

Add a new `librenms-agent` package and a socket-based service based on the [setup instructions](https://docs.librenms.org/Extensions/Agent-Setup/) of the agent.

In addition, added customizable `listenStream` and `ipAddressAllow` options for slightly better security. Since the agent itself has no authentication, I've made `ipAddressAllow` mandatory.

The upstream agent has support for reporting the status of [third-party applications](https://docs.librenms.org/Extensions/Applications/). This is currently not supported by the service due to the fact that enabling and configuring these integrations is quite imperative (and introduce additional dependencies). It would be possible to create options for each one of them, but would require quite a bit of effort in development & testing.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
