### PR TITLE
nixos/mysql-auth: fix passwords in config files

### DIFF
--- a/nixos/modules/config/mysql.nix
+++ b/nixos/modules/config/mysql.nix
@@ -6,6 +6,8 @@ let
   cfg = config.users.mysql;
 in
 {
+  meta.maintainers = [ maintainers.netali ];
+
   options = {
     users.mysql = {
       enable = mkEnableOption (lib.mdDoc "Authentication against a MySQL/MariaDB database");
@@ -358,7 +360,7 @@ in
       user = "root";
       group = "root";
       mode = "0600";
-      # password will be added from password file in activation script
+      # password will be added from password file in systemd oneshot
       text = ''
         users.host=${cfg.host}
         users.db_user=${cfg.user}
@@ -423,34 +425,45 @@ in
       mode = "0600";
       user = config.services.nscd.user;
       group = config.services.nscd.group;
-      # password will be added from password file in activation script
+      # password will be added from password file in systemd oneshot
       text = ''
         username ${cfg.user}
       '';
     };
 
-    # preStart script to append the password from the password file
-    # to the configuration files. It also fixes the owner of the
-    # libnss-mysql-root.cfg because it is changed to root after the
-    # password is appended.
-    systemd.services.mysql.preStart = ''
-      if [[ -r ${cfg.passwordFile} ]]; then
-        org_umask=$(umask)
-        umask 0077
+    systemd.services.mysql-auth-pw-init = {
+      description = "Adds the mysql password to the mysql auth config files";
 
-        conf_nss="$(mktemp)"
-        cp /etc/libnss-mysql-root.cfg $conf_nss
-        printf 'password %s\n' "$(cat ${cfg.passwordFile})" >> $conf_nss
-        mv -fT "$conf_nss" /etc/libnss-mysql-root.cfg
-        chown ${config.services.nscd.user}:${config.services.nscd.group} /etc/libnss-mysql-root.cfg
+      before = [ "nscd.service" ];
+      wantedBy = [ "multi-user.target" ];
 
-        conf_pam="$(mktemp)"
-        cp /etc/security/pam_mysql.conf $conf_pam
-        printf 'users.db_passwd=%s\n' "$(cat ${cfg.passwordFile})" >> $conf_pam
-        mv -fT "$conf_pam" /etc/security/pam_mysql.conf
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        Group = "root";
+      };
 
-        umask $org_umask
-      fi
-    '';
+      restartTriggers = [
+        config.environment.etc."security/pam_mysql.conf".source
+        config.environment.etc."libnss-mysql.cfg".source
+        config.environment.etc."libnss-mysql-root.cfg".source
+      ];
+
+      script = ''
+        if [[ -r ${cfg.passwordFile} ]]; then
+          umask 0077
+          conf_nss="$(mktemp)"
+          cp /etc/libnss-mysql-root.cfg $conf_nss
+          printf 'password %s\n' "$(cat ${cfg.passwordFile})" >> $conf_nss
+          mv -fT "$conf_nss" /etc/libnss-mysql-root.cfg
+          chown ${config.services.nscd.user}:${config.services.nscd.group} /etc/libnss-mysql-root.cfg
+
+          conf_pam="$(mktemp)"
+          cp /etc/security/pam_mysql.conf $conf_pam
+          printf 'users.db_passwd=%s\n' "$(cat ${cfg.passwordFile})" >> $conf_pam
+          mv -fT "$conf_pam" /etc/security/pam_mysql.conf
+        fi
+      '';
+    };
   };
 }

--- a/nixos/tests/auth-mysql.nix
+++ b/nixos/tests/auth-mysql.nix
@@ -84,7 +84,7 @@ in
           getpwuid = ''
             SELECT name, 'x', uid, gid, name, CONCAT('/home/', name), "/run/current-system/sw/bin/bash" \
             FROM users \
-            WHERE id=%1$u \
+            WHERE uid=%1$u \
             LIMIT 1
           '';
           getspnam = ''
@@ -140,6 +140,7 @@ in
 
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_unit("mysql.service")
+    machine.wait_until_succeeds("cat /etc/security/pam_mysql.conf | grep users.db_passwd")
     machine.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
 
     with subtest("Local login"):

--- a/pkgs/os-specific/linux/libnss-mysql/default.nix
+++ b/pkgs/os-specific/linux/libnss-mysql/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, which, libmysqlclient }:
+{ lib
+, nixosTests
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, which
+, libmysqlclient
+}:
 
 stdenv.mkDerivation rec {
   pname = "libnss-mysql";
@@ -19,6 +26,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rm -r $out/etc
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) auth-mysql;
+  };
 
   meta = with lib; {
     description = "MySQL module for the Solaris Nameservice Switch (NSS)";

--- a/pkgs/os-specific/linux/pam_mysql/default.nix
+++ b/pkgs/os-specific/linux/pam_mysql/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pam, pkg-config, libmysqlclient, mariadb, libxcrypt }:
+{ lib
+, nixosTests
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pam
+, pkg-config
+, libmysqlclient
+, mariadb
+, libxcrypt
+}:
 
 stdenv.mkDerivation rec {
   pname = "pam_mysql";
@@ -13,6 +24,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson pkg-config ninja ];
   buildInputs = [ pam libmysqlclient mariadb libxcrypt ];
+
+  passthru.tests = {
+    inherit (nixosTests) auth-mysql;
+  };
 
   meta = with lib; {
     description = "PAM authentication module against a MySQL database";


### PR DESCRIPTION
## Description of changes
The script to append the passwords to the MySQL-Auth configuration files got broken in  #263203 by commit b5617e0575c36b16779e2948518d0fc299198ebb. This PR fixes this by moving the script to a separate systemd oneshot. It also adds me as a maintainer for the module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
