### PR TITLE
ocamlPackages.merlin: 4.12 → 4.13

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -31,15 +31,7 @@ let
   hashes = {
     "4.7-412" = "sha256-0U3Ia7EblKULNy8AuXFVKACZvGN0arYJv7BWiBRgT0Y=";
     "4.7-413" = "sha256-aVmGWS4bJBLuwsxDKsng/n0A6qlyJ/pnDTcYab/5gyU=";
-    "4.8-414" = "sha256-HMXWhcVOXW058y143rNBcfEOmjt2tZJXcXKHmKZ5i68=";
-    "4.8-500" = "sha256-n5NHKuo0/lZmfe7WskqnW3xm1S0PmXKSS93BDKrpjCI=";
-    "4.9-414" = "sha256-4j/EeBNZEmn/nSfIIJiOUgpmLIndCvfqZSshUXSZy/0=";
-    "4.9-500" = "sha256-uQfGazoxTxclHSiTfjji+tKJv8MKqRdHMPD/xfMZlSY=";
-    "4.10-414" = "sha256-/a1OqASISpb06eh2gsam1rE3wovM4CT8ybPV86XwR2c=";
-    "4.10-500" = "sha256-m9+Qz8DT94yNSwpamTVLQKISHtRVBWnZD3t/yyujSZ0=";
-    "4.12-414" = "sha256-tgMUT4KyFeJubYVY1Sdv9ZvPB1JwcqEGcCuwuMqXHRQ=";
     "4.12-500" = "sha256-j49R7KVzNKlXDL7WibTHxPG4VSOVv0uaz5/yMZZjkH8=";
-    "4.12-501" = "sha256-zMwzI1SXQDWQ9PaKL4o3J6JlRjmEs7lkXrwauy+QiMA=";
     "4.13-414" = "sha256-AlzxqTuh5AkW9dnPIv51abv7r0A/VOS3JOT5IHix2wM=";
     "4.13-501" = "sha256-G/VrI+qBVj2wxuB2qE9P1M73IvDmqmTrBFAA6mp+NRE=";
   };

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -15,7 +15,18 @@
 }:
 
 let
-  merlinVersion = if lib.versionAtLeast ocaml.version "4.14" then "4.12" else "4.7";
+  # Each releases of Merlin support a limited range of versions of OCaml.
+  merlinVersions = {
+    "4.12.0" = "4.7-412";
+    "4.12.1" = "4.7-412";
+    "4.13.0" = "4.7-413";
+    "4.13.1" = "4.7-413";
+    "4.14.0" = "4.13-414";
+    "4.14.1" = "4.13-414";
+    "5.0.0" = "4.12-500";
+    "5.1.0" = "4.13-501";
+    # "5.1.1" = "4.13.1-501";
+  };
 
   hashes = {
     "4.7-412" = "sha256-0U3Ia7EblKULNy8AuXFVKACZvGN0arYJv7BWiBRgT0Y=";
@@ -29,21 +40,15 @@ let
     "4.12-414" = "sha256-tgMUT4KyFeJubYVY1Sdv9ZvPB1JwcqEGcCuwuMqXHRQ=";
     "4.12-500" = "sha256-j49R7KVzNKlXDL7WibTHxPG4VSOVv0uaz5/yMZZjkH8=";
     "4.12-501" = "sha256-zMwzI1SXQDWQ9PaKL4o3J6JlRjmEs7lkXrwauy+QiMA=";
+    "4.13-414" = "sha256-AlzxqTuh5AkW9dnPIv51abv7r0A/VOS3JOT5IHix2wM=";
+    "4.13-501" = "sha256-G/VrI+qBVj2wxuB2qE9P1M73IvDmqmTrBFAA6mp+NRE=";
   };
 
-  ocamlVersionShorthand =
-    let
-      v = lib.splitVersion ocaml.version;
-      major = builtins.elemAt v 0;
-      minor = builtins.elemAt v 1;
-      minor_prefix = if builtins.stringLength minor < 2 then "0" else "";
-    in "${toString major}${minor_prefix}${toString minor}";
-
-  version = "${merlinVersion}-${ocamlVersionShorthand}";
+  version = lib.getAttr ocaml.version merlinVersions;
 in
 
-if !lib.hasAttr version hashes
-then builtins.throw "merlin ${merlinVersion} is not available for OCaml ${ocaml.version}"
+if !lib.hasAttr ocaml.version merlinVersions
+then builtins.throw "merlin is not available for OCaml ${ocaml.version}"
 else
 
 buildDunePackage {


### PR DESCRIPTION
## Description of changes

The range of supported versions of OCaml for each versions of Merlin is no longer monotonic and can't be expressed with `lib.versionAtLeast` easily.
The latest version of Merlin is now explicitly mapped for each version of OCaml.

The second commit takes advantage of the new representation, which makes the set of required source versions explicit, to drop unused hashes. Closes https://github.com/NixOS/nixpkgs/pull/257646

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
