### PR TITLE
[Backport release-23.11] mattermost: 8.1.4 -> 8.1.7

### DIFF
--- a/pkgs/servers/mattermost/0001-module-replace-public.patch
+++ b/pkgs/servers/mattermost/0001-module-replace-public.patch
@@ -1,8 +1,0 @@
---- a/go.mod
-+++ b/go.mod
-@@ -218,3 +217,5 @@ exclude (
- 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
- 	github.com/willf/bitset v1.2.0
- )
-+
-+replace github.com/mattermost/mattermost/server/public => ./public

--- a/pkgs/servers/mattermost/0001-module-replace-public.patch
+++ b/pkgs/servers/mattermost/0001-module-replace-public.patch
@@ -1,0 +1,8 @@
+--- a/go.mod
++++ b/go.mod
+@@ -218,3 +217,5 @@ exclude (
+ 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
+ 	github.com/willf/bitset v1.2.0
+ )
++
++replace github.com/mattermost/mattermost/server/public => ./public

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -8,23 +8,21 @@
 
 buildGoModule rec {
   pname = "mattermost";
-  version = "9.2.2";
+  version = "8.1.6";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost";
     rev = "v${version}";
-    hash = "sha256-53L2F20vaLLxtQS3DP/u0ZxLtnXHmjfcOMbXd4i+A6Y=";
+    hash = "sha256-vJ5+ZiA7bOKvA2VMMIOkIEKz/XN/m/cQViJgKlyHUp0=";
   } + "/server";
 
   webapp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-    hash = "sha256-/6SKqSXH8sW70rYt4MmABWNQP/JDAA1lxuvCJhqEoTI=";
+    hash = "sha256-crpX2creK2tbmIULWi3perRGtFWaKw9m8v7OCjBd1Fw=";
   };
 
-  vendorHash = "sha256-v8aKZyb4emrwuIgSBDgla5wzwyt6PVGakbXjB9JVaCk=";
-
-  patches = [ ./0001-module-replace-public.patch ];
+  vendorHash = "sha256-25nyneJ+ynM9WdnnLd4L3a720ecKdhJ1vyRG5lx2mgY=";
 
   subPackages = [ "cmd/mattermost" ];
 
@@ -35,12 +33,10 @@ buildGoModule rec {
     "-w"
     "-X github.com/mattermost/mattermost/server/public/model.Version=${version}"
     "-X github.com/mattermost/mattermost/server/public/model.BuildNumber=${version}-nixpkgs"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=n/a"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=1970-01-01"
     "-X github.com/mattermost/mattermost/server/public/model.BuildHash=v${version}"
     "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=none"
     "-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=false"
-    "-X github.com/mattermost/mattermost/server/public/model.MockCWS=false"
-    "-X github.com/mattermost/mattermost/server/public/model.MattermostGiphySdkKey="
   ];
 
   postInstall = ''

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -8,21 +8,21 @@
 
 buildGoModule rec {
   pname = "mattermost";
-  version = "8.1.6";
+  version = "8.1.7";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost";
     rev = "v${version}";
-    hash = "sha256-vJ5+ZiA7bOKvA2VMMIOkIEKz/XN/m/cQViJgKlyHUp0=";
+    hash = "sha256-ZpjdJ1Uck0kM+togUKpxRij8V0jQX+12Meks+L1Tc90=";
   } + "/server";
 
   webapp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-    hash = "sha256-crpX2creK2tbmIULWi3perRGtFWaKw9m8v7OCjBd1Fw=";
+    hash = "sha256-eORIoZLoxWdvuRlirJ7djBTgueIzlzIhRAoURy58zCA=";
   };
 
-  vendorHash = "sha256-25nyneJ+ynM9WdnnLd4L3a720ecKdhJ1vyRG5lx2mgY=";
+  vendorHash = "sha256-RPnCAxksKppsjVtZYhwcoJuAmMJ85AstuoBFChKwAOk=";
 
   subPackages = [ "cmd/mattermost" ];
 

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -8,33 +8,39 @@
 
 buildGoModule rec {
   pname = "mattermost";
-  version = "8.1.4";
+  version = "9.2.2";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost";
     rev = "v${version}";
-    hash = "sha256-mubKY1nzTmysg015368z/ORqIIOAGPUEthhXNrW1sPk=";
+    hash = "sha256-53L2F20vaLLxtQS3DP/u0ZxLtnXHmjfcOMbXd4i+A6Y=";
   } + "/server";
 
   webapp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-    hash = "sha256-st900RxTLwIXg0lyUZZnYom99fbiafF7ignaqF1YwME=";
+    hash = "sha256-/6SKqSXH8sW70rYt4MmABWNQP/JDAA1lxuvCJhqEoTI=";
   };
 
-  vendorHash = "sha256-UFZlBZJf/AtJiY+EtekSrnwUmrYnH151XnRyRQFTft0=";
+  vendorHash = "sha256-v8aKZyb4emrwuIgSBDgla5wzwyt6PVGakbXjB9JVaCk=";
+
+  patches = [ ./0001-module-replace-public.patch ];
 
   subPackages = [ "cmd/mattermost" ];
+
+  tags = [ "production" ];
 
   ldflags = [
     "-s"
     "-w"
     "-X github.com/mattermost/mattermost/server/public/model.Version=${version}"
     "-X github.com/mattermost/mattermost/server/public/model.BuildNumber=${version}-nixpkgs"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=1970-01-01"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=n/a"
     "-X github.com/mattermost/mattermost/server/public/model.BuildHash=v${version}"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=v${version}"
+    "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=none"
     "-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=false"
+    "-X github.com/mattermost/mattermost/server/public/model.MockCWS=false"
+    "-X github.com/mattermost/mattermost/server/public/model.MattermostGiphySdkKey="
   ];
 
   postInstall = ''
@@ -51,7 +57,7 @@ buildGoModule rec {
     description = "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle";
     homepage = "https://www.mattermost.org";
     license = with licenses; [ agpl3 asl20 ];
-    maintainers = with maintainers; [ ryantm numinit kranzes ];
+    maintainers = with maintainers; [ ryantm numinit kranzes mgdelacroix ];
     mainProgram = "mattermost";
   };
 }


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/269691 based on the fact that the update contains security fixes