### PR TITLE
rustc-wasm32: merge into rustc

### DIFF
--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -4,7 +4,7 @@
 , rocksdb
 , rust-jemalloc-sys-unprefixed
 , rustPlatform
-, rustc-wasm32
+, rustc
 , stdenv
 , Security
 , SystemConfiguration
@@ -61,8 +61,8 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
-    rustc-wasm32
-    rustc-wasm32.llvmPackages.lld
+    rustc
+    rustc.llvmPackages.lld
   ];
 
   # NOTE: jemalloc is used by default on Linux with unprefixed enabled

--- a/pkgs/applications/misc/pagefind/default.nix
+++ b/pkgs/applications/misc/pagefind/default.nix
@@ -7,7 +7,7 @@
 , binaryen
 , gzip
 , nodejs
-, rustc-wasm32
+, rustc
 , wasm-bindgen-cli
 , wasm-pack
 }:
@@ -66,8 +66,8 @@ rustPlatform.buildRustPackage rec {
     binaryen
     gzip
     nodejs
-    rustc-wasm32
-    rustc-wasm32.llvmPackages.lld
+    rustc
+    rustc.llvmPackages.lld
     wasm-bindgen-84
     wasm-pack
   ];

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -65,6 +65,8 @@ in stdenv.mkDerivation (finalAttrs: {
   # Increase codegen units to introduce parallelism within the compiler.
   RUSTFLAGS = "-Ccodegen-units=10";
 
+  RUSTDOCFLAGS = "-A rustdoc::broken-intra-doc-links";
+
   # We need rust to build rust. If we don't provide it, configure will try to download it.
   # Reference: https://github.com/rust-lang/rust/blob/master/src/bootstrap/configure.py
   configureFlags = let
@@ -99,6 +101,10 @@ in stdenv.mkDerivation (finalAttrs: {
     # std is built for all platforms in --target.
     "--target=${concatStringsSep "," ([
       stdenv.targetPlatform.rust.rustcTargetSpec
+
+    # Other targets that don't need any extra dependencies to build.
+    ] ++ optionals (!fastCross) [
+      "wasm32-unknown-unknown"
 
     # (build!=target): When cross-building a compiler we need to add
     # the build platform as well so rustc can compile build.rs

--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -7,7 +7,6 @@
 , nixosTests
 , rustPlatform
 , rustc
-, rustc-wasm32
 , stdenv
 , wasm-bindgen-cli
 , wasm-pack
@@ -48,7 +47,7 @@ let
     pname = commonDerivationAttrs.pname + "-frontend";
 
     nativeBuildInputs = [
-      wasm-pack wasm-bindgen-84 binaryen which rustc-wasm32 rustc-wasm32.llvmPackages.lld
+      wasm-pack wasm-bindgen-84 binaryen which rustc rustc.llvmPackages.lld
     ];
 
     buildPhase = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -828,6 +828,7 @@ mapAliases ({
   rtsp-simple-server = throw "rtsp-simple-server is rebranded as mediamtx, including default config path update"; # Added 2023-04-11
   runCommandNoCC = runCommand;
   runCommandNoCCLocal = runCommandLocal;
+  rustc-wasm32 = rustc; # Added 2023-12-01
   rxvt_unicode = rxvt-unicode-unwrapped; # Added 2020-02-02
   rxvt_unicode-with-plugins = rxvt-unicode; # Added 2020-02-02
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16923,19 +16923,6 @@ with pkgs;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 
-  # https://github.com/NixOS/nixpkgs/issues/89426
-  rustc-wasm32 = wrapRustc ((rustc.unwrapped.override {
-    stdenv = stdenv.override {
-      targetPlatform = lib.systems.elaborate {
-        # lib.systems.elaborate won't recognize "unknown" as the last component.
-        config = "wasm32-unknown-wasi";
-        rust.rustcTarget = "wasm32-unknown-unknown";
-      };
-    };
-  }).overrideAttrs (old: {
-    configureFlags = old.configureFlags ++ ["--set=build.docs=false"];
-  }));
-
   makeRustPlatform = callPackage ../development/compilers/rust/make-rust-platform.nix { };
 
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate { };


### PR DESCRIPTION
## Description of changes

Since wasm32-unknown-unknown doesn't require any extra platform-specific dependencies (e.g. libc), we might as well just always include in with rustc.  We could also include other targets fitting these criteria, but I wasn't able to find any others that actually build (not even wasm64-unknown-unknown).

The old rustc-wasm32 package disabled documentation, but we don't actually need to do that — we just need to allow for some broken links in the wasm32-unknown-unknown documentation.  Broken links in documentation are an upstream issue anyway.  There's no need we need to fail our build for them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
