### PR TITLE
livekit: init at 1.5.1

### DIFF
--- a/pkgs/by-name/li/livekit-cli/package.nix
+++ b/pkgs/by-name/li/livekit-cli/package.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "livekit-cli";
+  version = "1.3.4";
+
+  src = fetchFromGitHub {
+    owner = "livekit";
+    repo = "livekit-cli";
+    rev = "v${version}";
+    hash = "sha256-pzVzfs0bwG9n7fa0ouQiCFrbXAqkfovEIjVmrHFdqtI=";
+  };
+
+  vendorHash = "sha256-pM5DeaukY6x4RDryLvSEQASSwtOaLiiLObjhdWBYd8k=";
+
+  subPackages = [ "cmd/livekit-cli" ];
+
+  meta = with lib; {
+    description = "Command line interface to LiveKit";
+    homepage = "https://livekit.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mgdelacroix ];
+    mainProgram = "livekit-cli";
+  };
+}

--- a/pkgs/by-name/li/livekit/package.nix
+++ b/pkgs/by-name/li/livekit/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "livekit";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "livekit";
+    repo = "livekit";
+    rev = "v${version}";
+    hash = "sha256-3KRES/2mGO6b1ZZEGx29Yu5wgEG4NOJ7/J0xPvQiNWk=";
+  };
+
+  vendorHash = "sha256-5wByIkMs3321u4/2vPpsZ/L5zlcgrZo0b+NjeMR1RWE=";
+
+  subPackages = [ "cmd/server" ];
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/livekit-server
+  '';
+
+  meta = with lib; {
+    description = "End-to-end stack for WebRTC. SFU media server and SDKs";
+    homepage = "https://livekit.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mgdelacroix ];
+    mainProgram = "livekit-server";
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds both [livekit](https://github.com/livekit/livekit) and [livekit-cli](https://github.com/livekit/livekit-cli). [LiveKit](https://livekit.io/) is an open source WebRTC stack that has everything needed to build scalable and real-time video, audio, and data experiences in your applications.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).