### PR TITLE
gawkextlib.haru: fix compilation errors due to typos fixed in libharu

### DIFF
--- a/pkgs/tools/text/gawk/fix-typos-corrected-in-libharu-2.4.4.patch
+++ b/pkgs/tools/text/gawk/fix-typos-corrected-in-libharu-2.4.4.patch
@@ -1,0 +1,62 @@
+diff --git a/haru/pdf.c b/haru/pdf.c
+index d16f573..3129427 100644
+--- a/haru/pdf.c
++++ b/haru/pdf.c
+@@ -105,7 +105,7 @@ static awk_scalar_t HPDF_CS_PATTERN_node;
+ /*  LineCap */
+ static awk_scalar_t HPDF_BUTT_END_node;
+ static awk_scalar_t HPDF_ROUND_END_node;
+-static awk_scalar_t HPDF_PROJECTING_SCUARE_END_node;
++static awk_scalar_t HPDF_PROJECTING_SQUARE_END_node;
+ 
+ /*  _LineJoin */
+ static awk_scalar_t HPDF_MITER_JOIN_node;
+@@ -248,7 +248,7 @@ static awk_scalar_t HPDF_ENCODER_UNKNOWN_node;
+ /* ByteType */
+ static awk_scalar_t HPDF_BYTE_TYPE_SINGLE_node;
+ static awk_scalar_t HPDF_BYTE_TYPE_LEAD_node;
+-static awk_scalar_t HPDF_BYTE_TYPE_TRIAL_node;
++static awk_scalar_t HPDF_BYTE_TYPE_TRAIL_node;
+ static awk_scalar_t HPDF_BYTE_TYPE_UNKNOWN_node;
+ 
+ /* TextAlignment */
+@@ -308,7 +308,7 @@ static const struct varinit varinit[] = {
+ 	ENTRY(HPDF_CS_PATTERN, 1)
+ 	ENTRY(HPDF_BUTT_END, 1)
+ 	ENTRY(HPDF_ROUND_END, 1)
+-	ENTRY(HPDF_PROJECTING_SCUARE_END, 1)
++	ENTRY(HPDF_PROJECTING_SQUARE_END, 1)
+ 	ENTRY(HPDF_MITER_JOIN, 1)
+ 	ENTRY(HPDF_ROUND_JOIN, 1)
+ 	ENTRY(HPDF_BEVEL_JOIN, 1)
+@@ -417,7 +417,7 @@ static const struct varinit varinit[] = {
+ 	ENTRY(HPDF_ENCODER_UNKNOWN, 1)
+ 	ENTRY(HPDF_BYTE_TYPE_SINGLE, 1)
+ 	ENTRY(HPDF_BYTE_TYPE_LEAD, 1)
+-	ENTRY(HPDF_BYTE_TYPE_TRIAL, 1)
++	ENTRY(HPDF_BYTE_TYPE_TRAIL, 1)
+ 	ENTRY(HPDF_BYTE_TYPE_UNKNOWN, 1)
+ 	ENTRY(HPDF_TALIGN_LEFT, 1)
+ 	ENTRY(HPDF_TALIGN_RIGHT, 1)
+diff --git a/haru/pdf.h b/haru/pdf.h
+index a4ef39a..07cf168 100644
+--- a/haru/pdf.h
++++ b/haru/pdf.h
+@@ -86,7 +86,7 @@
+ 
+ #define DEFAULT_HPDF_BUTT_END HPDF_BUTT_END
+ #define DEFAULT_HPDF_ROUND_END HPDF_ROUND_END
+-#define DEFAULT_HPDF_PROJECTING_SCUARE_END HPDF_PROJECTING_SCUARE_END
++#define DEFAULT_HPDF_PROJECTING_SQUARE_END HPDF_PROJECTING_SQUARE_END
+ 
+ /*  _LineJoin */
+ #define DEFAULT_HPDF_MITER_JOIN HPDF_MITER_JOIN
+@@ -229,7 +229,7 @@
+ /* ByteType */
+ #define DEFAULT_HPDF_BYTE_TYPE_SINGLE HPDF_BYTE_TYPE_SINGLE
+ #define DEFAULT_HPDF_BYTE_TYPE_LEAD HPDF_BYTE_TYPE_LEAD
+-#define DEFAULT_HPDF_BYTE_TYPE_TRIAL HPDF_BYTE_TYPE_TRIAL 
++#define DEFAULT_HPDF_BYTE_TYPE_TRAIL HPDF_BYTE_TYPE_TRAIL
+ #define DEFAULT_HPDF_BYTE_TYPE_UNKNOWN HPDF_BYTE_TYPE_UNKNOWN 
+ 
+ /* TextAlignment */

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -85,12 +85,16 @@ let
       name = "gd";
       extraBuildInputs = [ gd ];
     };
-    # Build has been broken: https://github.com/NixOS/nixpkgs/issues/191072
-    # haru = buildExtension {
-    #   inherit gawkextlib;
-    #   name = "haru";
-    #   extraBuildInputs = [ libharu ];
-    # };
+    haru = buildExtension {
+      inherit gawkextlib;
+      name = "haru";
+      extraBuildInputs = [ libharu ];
+      patches = [
+        # Renames references to two identifiers with typos that libharu fixed in 2.4.4
+        # https://github.com/libharu/libharu/commit/88271b73c68c521a49a15e3555ef00395aa40810
+        ./fix-typos-corrected-in-libharu-2.4.4.patch
+      ];
+    };
     json = buildExtension {
       inherit gawkextlib;
       name = "json";

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -5,7 +5,7 @@
 
 let
   buildExtension = lib.makeOverridable
-    ({ name, gawkextlib, extraBuildInputs ? [ ], doCheck ? true }:
+    ({ name, gawkextlib, extraBuildInputs ? [ ], doCheck ? true, patches ? [ ] }:
       let is_extension = gawkextlib != null;
       in stdenv.mkDerivation rec {
         pname = "gawkextlib-${name}";
@@ -16,6 +16,8 @@ let
           rev = "f6c75b4ac1e0cd8d70c2f6c7a8d58b4d94cfde97";
           sha256 = "sha256-0p3CrQ3TBl7UcveZytK/9rkAzn69RRM2GwY2eCeqlkg=";
         };
+
+        inherit patches;
 
         postPatch = ''
           cd ${name}


### PR DESCRIPTION
## Description of changes

These two typos (SCUARE instead of SQUARE and TRIAL instead of TRAIL)
have been fixed in libharu 2.4.4 [1] [2], but the source code for
gawkextensions still uses the old names to this day [3].

[1]: https://github.com/libharu/libharu/issues/94
[2]: https://github.com/libharu/libharu/commit/88271b73c68c521a49a15e3555ef00395aa40810
[3]: https://sourceforge.net/p/gawkextlib/code/ci/f952fe2159ae3f712f4b230a15e8a03fa090e678/tree/haru/pdf.h#l89


- Re-enabled `haru` gawk extension
- Added a `patches` argument to `buildExtension`
- Added a patch file fixing `gawkextlib` references to the renamed identifiers.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
