### PR TITLE
gnomeExtensions.system-monitor: GNOME 45 compatibility

### DIFF
--- a/pkgs/desktops/gnome/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome/extensions/system-monitor/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv, substituteAll, fetchFromGitHub, fetchpatch, glib, glib-networking, libgtop, gnome }:
+{ lib, stdenv, substituteAll, fetchFromGitHub, glib, libgtop, gnome }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-system-monitor";
-  version = "unstable-2023-01-21";
+  version = "unstable-2023-11-20";
 
+  # Sourced from fork pending paradoxxxzero/gnome-shell-system-monitor-applet#767
   src = fetchFromGitHub {
-    owner = "paradoxxxzero";
+    owner = "mgalgs";
     repo = "gnome-shell-system-monitor-applet";
-    rev = "21d7b4e7a03ec8145b0b90c4f0b15c27d6f53788";
-    hash = "sha256-XDqWxTyaFEWPdXMTklcNQxqql73ESXAIF6TjMFHaj7g=";
+    rev = "5827e7960f9891bdaa53f0663ea5135423ff8b18";
+    hash = "sha256-mw5YfQcZYY3FijekV0xMDSDXG5t0SemPIkACng6NMPo=";
   };
 
   nativeBuildInputs = [
@@ -17,16 +18,9 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # GNOME 44 compatibility
-    (fetchpatch {
-      url = "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/788/commits/e69349942791140807c01d472dfe5e0ddf5c73c0.patch";
-      hash = "sha256-g5Ocpvp7eO/pBkDBZsxgXH7e8rdPBUUxDSwK2hJHKbY=";
-    })
     (substituteAll {
       src = ./paths_and_nonexisting_dirs.patch;
-      clutter_path = gnome.mutter.libdir; # only needed for GNOME < 40.
       gtop_path = "${libgtop}/lib/girepository-1.0";
-      glib_net_path = "${glib-networking}/lib/girepository-1.0";
     })
   ];
 
@@ -37,14 +31,14 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
-    extensionUuid = "system-monitor@paradoxxx.zero.gmail.com";
-    extensionPortalSlug = "system-monitor";
+    extensionUuid = "system-monitor-next@paradoxxx.zero.gmail.com";
+    extensionPortalSlug = "system-monitor-next";
   };
 
   meta = with lib; {
     description = "Display system informations in gnome shell status bar";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ andersk ];
-    homepage = "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet";
+    homepage = "https://github.com/mgalgs/gnome-shell-system-monitor-applet";
   };
 }

--- a/pkgs/desktops/gnome/extensions/system-monitor/paths_and_nonexisting_dirs.patch
+++ b/pkgs/desktops/gnome/extensions/system-monitor/paths_and_nonexisting_dirs.patch
@@ -1,33 +1,10 @@
-diff --git a/system-monitor@paradoxxx.zero.gmail.com/extension.js b/system-monitor@paradoxxx.zero.gmail.com/extension.js
-index de5e3d7..2d7824d 100644
---- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
-+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
-@@ -18,6 +18,9 @@
- 
- // Author: Florian Mounier aka paradoxxxzero
- 
-+imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
-+imports.gi.GIRepository.Repository.prepend_search_path('@glib_net_path@');
-+
- /* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
-  * by loading the new libnm.so. Should go away eventually */
- 
-@@ -407,7 +410,7 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
-         this.connected = false;
- 
-         this._volumeMonitor = Gio.VolumeMonitor.get();
+--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
++++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+@@ -31 +31,3 @@
+-import GTop from "gi://GTop";
++import GIRepository from 'gi://GIRepository';
++GIRepository.Repository.prepend_search_path('@girepository_search_path_gtop@');
++const { default: GTop } = await import('gi://GTop');
+@@ -403 +405 @@
 -        let sys_mounts = ['/home', '/tmp', '/boot', '/usr', '/usr/local'];
 +        let sys_mounts = ['/home', '/tmp', '/boot'];
-         this.base_mounts = ['/'];
-         sys_mounts.forEach((sMount) => {
-             if (this.is_sys_mount(sMount + '/')) {
-diff --git a/system-monitor@paradoxxx.zero.gmail.com/prefs.js b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
-index 81d667c..0da4809 100644
---- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
-+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
-@@ -1,3 +1,5 @@
-+imports.gi.GIRepository.Repository.prepend_search_path('@clutter_path@');
-+
- const Gtk = imports.gi.Gtk;
- const Gio = imports.gi.Gio;
- const Gdk = imports.gi.Gdk;


### PR DESCRIPTION
## Description of changes

system-monitor has been unmaintained upstream and currently fails to run with:

> <img src="https://github.com/NixOS/nixpkgs/assets/1844746/72dc41c5-def8-4a0e-bd83-4c479e0e5abe" width="576" alt="The extension is incompatible with the current GNOME version" />

Per discussion in paradoxxxzero/gnome-shell-system-monitor-applet#767 maintenance is expected to resume, but during the interim the most usable source is the fork [mgalgs/gnome-shell-system-monitor-applet](https://github.com/mgalgs/gnome-shell-system-monitor-applet).

I’ve drafted an updated derivation that works for me in an overlay, but I’m not sure how to correctly integrate it into the rest of the `gnomeExtensions` packaging.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of extension
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
