### PR TITLE
[23.11] wireshark: 4.0.10 -> 4.0.11

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -52,7 +52,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.0.10";
+  version = "4.0.11";
 
   outputs = [ "out" "dev" ];
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-R8CoatIZC7vkKn4UZ3G7h5qBexfKMdJJ0swi+IxAjG0=";
+    hash = "sha256-tyYcL9K/TcW7Q+VrfYJPnqWh4pc06CKK7YHDEJjM090=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-6174 / wnpa-sec-2023-28 and wnpa-sec-2023-29.

Changes:
https://www.wireshark.org/docs/relnotes/wireshark-4.0.11.html
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


Result of `nixpkgs-review pr 271532` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>32 packages built:</summary>
  <ul>
    <li>compactor</li>
    <li>credslayer</li>
    <li>credslayer.dist</li>
    <li>dbmonster</li>
    <li>haka</li>
    <li>hfinger</li>
    <li>hfinger.dist</li>
    <li>ostinato</li>
    <li>python310Packages.dissect</li>
    <li>python310Packages.dissect-cobaltstrike</li>
    <li>python310Packages.dissect-cobaltstrike.dist</li>
    <li>python310Packages.dissect.dist</li>
    <li>python310Packages.manuf</li>
    <li>python310Packages.manuf.dist</li>
    <li>python310Packages.pyshark</li>
    <li>python310Packages.pyshark.dist</li>
    <li>python311Packages.dissect</li>
    <li>python311Packages.dissect-cobaltstrike</li>
    <li>python311Packages.dissect-cobaltstrike.dist</li>
    <li>python311Packages.dissect.dist</li>
    <li>python311Packages.manuf</li>
    <li>python311Packages.manuf.dist</li>
    <li>python311Packages.pyshark</li>
    <li>python311Packages.pyshark.dist</li>
    <li>qtwirediff</li>
    <li>termshark</li>
    <li>tshark</li>
    <li>tshark.dev</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
    <li>wireshark</li>
    <li>wireshark.dev</li>
  </ul>
</details>