### PR TITLE
treewide: deprecate `libelf` package in favor of `elfutils`

### DIFF
--- a/pkgs/applications/audio/lv2lint/default.nix
+++ b/pkgs/applications/audio/lv2lint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkg-config, meson, ninja, lv2, lilv, curl, libelf }:
+{ stdenv, lib, fetchurl, pkg-config, meson, ninja, lv2, lilv, curl }:
 
 stdenv.mkDerivation rec {
   pname = "lv2lint";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];
-  buildInputs = [ lv2 lilv curl libelf ];
+  buildInputs = [ lv2 lilv curl ];
 
   meta = with lib; {
     description = "Check whether a given LV2 plugin is up to the specification";

--- a/pkgs/applications/emulators/dynamips/default.nix
+++ b/pkgs/applications/emulators/dynamips/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, libelf
+, elfutils
 , libpcap
 , nix-update-script
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libelf libpcap ];
+  buildInputs = [ elfutils libpcap ];
 
   cmakeFlags = [ "-DDYNAMIPS_CODE=stable" ];
 

--- a/pkgs/applications/emulators/mgba/default.nix
+++ b/pkgs/applications/emulators/mgba/default.nix
@@ -1,18 +1,19 @@
 { lib
 , stdenv
-, fetchFromGitHub
 , SDL2
 , cmake
+, elfutils
+, fetchFromGitHub
 , ffmpeg
 , libedit
-, libelf
 , libepoxy
+, libsForQt5
 , libzip
 , lua5_4
 , minizip
 , pkg-config
-, libsForQt5
 , wrapGAppsHook
+, zstd
 }:
 
 let
@@ -48,9 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
+    elfutils
     ffmpeg
     libedit
-    libelf
     libepoxy
     libzip
     lua
@@ -58,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
     qtmultimedia
     qttools
+    zstd
   ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/elf-dissector/default.nix
+++ b/pkgs/applications/misc/elf-dissector/default.nix
@@ -2,23 +2,23 @@
 , stdenv
 , fetchgit
 , cmake
+, elfutils
 , extra-cmake-modules
-, wrapQtAppsHook
 , kitemmodels
 , libiberty
-, libelf
 , libdwarf
 , libopcodes
+, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "elf-dissector";
-  version = "unstable-2023-06-06";
+  version = "unstable-2023-11-25";
 
   src = fetchgit {
     url = "https://invent.kde.org/sdk/elf-dissector.git";
-    rev = "de2e80438176b4b513150805238f3333f660718c";
-    hash = "sha256-2yHPVPu6cncXhFCJvrSodcRFVAxj4vn+e99WhtiZniM=";
+    rev = "888ef6581df0400db45e0a7829a7336531b12641";
+    sha256 = "sha256-V0cn3lAE5MSEUfiSY2q08ig/S1PWu9Scz558IVM97b0=";
   };
 
   patches = [
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
 
-  buildInputs = [ kitemmodels libiberty libelf libdwarf libopcodes ];
+  buildInputs = [ kitemmodels libiberty elfutils libopcodes libdwarf ];
 
   meta = with lib; {
     homepage = "https://invent.kde.org/sdk/elf-dissector";

--- a/pkgs/applications/misc/elf-dissector/fix_build_for_src_lib_disassembler_disassembler.diff
+++ b/pkgs/applications/misc/elf-dissector/fix_build_for_src_lib_disassembler_disassembler.diff
@@ -1,12 +1,16 @@
 diff --git a/src/lib/disassmbler/disassembler.cpp b/src/lib/disassmbler/disassembler.cpp
-index 3277544..e77ffc4 100644
+index 8ff058e..dbd4bbe 100644
 --- a/src/lib/disassmbler/disassembler.cpp
 +++ b/src/lib/disassmbler/disassembler.cpp
-@@ -127,7 +127,7 @@ QString Disassembler::disassembleBinutils(const unsigned char* data, uint64_t si
+@@ -144,11 +144,7 @@ QString Disassembler::disassembleBinutils(const unsigned char* data, uint64_t si
      QString result;
      disassembler_ftype disassemble_fn;
      disassemble_info info;
+-#if BINUTILS_VERSION >= BINUTILS_VERSION_CHECK(2, 39)
+-    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf, fprintf_styled);
+-#else
 -    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf);
+-#endif
 +    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf, qstring_printf);
  
      info.application_data = this;

--- a/pkgs/applications/misc/opencpn/default.nix
+++ b/pkgs/applications/misc/opencpn/default.nix
@@ -7,6 +7,7 @@
 , cmake
 , curl
 , dbus
+, elfutils
 , fetchFromGitHub
 , fetchpatch
 , flac
@@ -15,7 +16,6 @@
 , libGLU
 , libarchive
 , libdatrie
-, libelf
 , libepoxy
 , libexif
 , libogg
@@ -83,12 +83,12 @@ stdenv.mkDerivation rec {
     # gtk3 propagates AppKit from the 10.12 SDK
     AppKit
   ] ++ [
+    elfutils
     gtk3
     jasper
     libGLU
     libarchive
     libdatrie
-    libelf
     libepoxy
     libexif
     libogg

--- a/pkgs/applications/networking/ids/suricata/default.nix
+++ b/pkgs/applications/networking/ids/suricata/default.nix
@@ -5,12 +5,12 @@
 , llvm
 , pkg-config
 , makeWrapper
+, elfutils
 , file
 , hyperscan
 , jansson
 , libbpf
 , libcap_ng
-, libelf
 , libevent
 , libmaxminddb
 , libnet
@@ -50,10 +50,10 @@ stdenv.mkDerivation rec {
   ;
 
   buildInputs = [
+    elfutils
     jansson
     libbpf
     libcap_ng
-    libelf
     libevent
     libmagic
     libmaxminddb

--- a/pkgs/applications/science/electronics/nvc/default.nix
+++ b/pkgs/applications/science/electronics/nvc/default.nix
@@ -3,13 +3,12 @@
 , fetchFromGitHub
 , autoreconfHook
 , check
-, flex
-, pkg-config
-, which
 , elfutils
-, libelf
+, flex
 , libffi
 , llvm
+, pkg-config
+, which
 , zlib
 , zstd
 }:
@@ -34,14 +33,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    elfutils
     libffi
     llvm
     zlib
     zstd
-  ] ++ lib.optionals stdenv.isLinux [
-    elfutils
-  ] ++ lib.optionals (!stdenv.isLinux) [
-    libelf
   ];
 
   preConfigure = ''
@@ -52,9 +48,9 @@ stdenv.mkDerivation rec {
   configureScript = "../configure";
 
   configureFlags = [
-    "--enable-vhpi"
     "--disable-lto"
   ];
+  dontDisableStatic = true;
 
   doCheck = true;
 

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -1,10 +1,26 @@
-{ stdenv, lib, fetchFromGitLab, cmake, perl, python3, boost
-, fortranSupport ? false, gfortran
-, buildDocumentation ? false, fig2dev, ghostscript, doxygen
-, buildJavaBindings ? false, openjdk
-, buildPythonBindings ? true, python3Packages
-, modelCheckingSupport ? false, libunwind, libevent, elfutils # Inside elfutils: libelf and libdw
-, bmfSupport ? true, eigen
+{ stdenv
+, lib
+, fetchFromGitLab
+, cmake
+, perl
+, python3
+, boost
+, fortranSupport ? false
+, gfortran
+, buildDocumentation ? false
+, fig2dev
+, ghostscript
+, doxygen
+, buildJavaBindings ? false
+, openjdk
+, buildPythonBindings ? true
+, python3Packages
+, modelCheckingSupport ? false
+, libunwind
+, libevent
+, elfutils # Inside elfutils: libelf and libdw
+, bmfSupport ? true
+, eigen
 , minimalBindings ? false
 , debug ? false
 , optimize ? (!debug)
@@ -71,7 +87,7 @@ stdenv.mkDerivation rec {
   ];
   makeFlags = optional debug "VERBOSE=1";
 
-  # needed to run tests and to ensure correct shabangs in output scripts
+  # needed to run tests and to ensure correct shebangs in output scripts
   preBuild = ''
     patchShebangs ..
   '';
@@ -100,7 +116,7 @@ stdenv.mkDerivation rec {
     # manually install the python binding if requested.
     mkdir -p $python/lib/python${lib.versions.majorMinor python3.version}/site-packages/
     cp ./lib/simgrid.cpython*.so $python/lib/python${lib.versions.majorMinor python3.version}/site-packages/
-   '';
+  '';
 
   # improve debuggability if requested
   hardeningDisable = lib.optionals debug [ "fortify" ];

--- a/pkgs/applications/virtualization/libnvidia-container/default.nix
+++ b/pkgs/applications/virtualization/libnvidia-container/default.nix
@@ -1,17 +1,17 @@
 { stdenv
 , lib
 , addOpenGLRunpath
+, elfutils
 , fetchFromGitHub
-, pkg-config
-, libelf
+, go
 , libcap
 , libseccomp
-, rpcsvc-proto
 , libtirpc
 , makeWrapper
-, substituteAll
+, pkg-config
 , removeReferencesTo
-, go
+, rpcsvc-proto
+, substituteAll
 }:
 let
   modprobeVersion = "495.44";
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config go rpcsvc-proto makeWrapper removeReferencesTo ];
 
-  buildInputs = [ libelf libcap libseccomp libtirpc ];
+  buildInputs = [ elfutils libcap libseccomp libtirpc ];
 
   makeFlags = [
     "WITH_LIBELF=yes"

--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -3,11 +3,11 @@
 , fetchFromGitHub
 , boost
 , cacert
+, elfutils
 , fmt_9
 , git
 , gmpxx
 , libclang
-, libelf
 , libunwind
 , llvm
 , ninja
@@ -71,17 +71,17 @@ stdenv.mkDerivation {
   inherit src;
 
   nativeBuildInputs = [
-    sbcl
-    git
-    pkg-config
-    fmt_9
-    gmpxx
-    libelf
     boost
-    libunwind
-    ninja
-    llvm
+    elfutils
+    fmt_9
+    git
+    gmpxx
     libclang
+    libunwind
+    llvm
+    ninja
+    pkg-config
+    sbcl
   ];
 
   configurePhase = ''

--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -47,7 +47,8 @@ let
     outputHash = "sha256-vgwThjn2h3nKnShtKoHgaPdH/FDHv28fLMQvKFEwG6o=";
   };
 
-in llvmPackages_15.stdenv.mkDerivation {
+in
+llvmPackages_15.stdenv.mkDerivation {
   pname = "clasp";
   version = "2.2.0";
   inherit src;
@@ -66,31 +67,31 @@ in llvmPackages_15.stdenv.mkDerivation {
     libclang
   ]);
   configurePhase = ''
-  export SOURCE_DATE_EPOCH=1
-  export ASDF_OUTPUT_TRANSLATIONS=$(pwd):$(pwd)/__fasls
-  tar xf ${reposTarball}
-  sbcl --script koga \
-    --skip-sync \
-    --cc=$NIX_CC/bin/cc \
-    --cxx=$NIX_CC/bin/c++ \
-    --reproducible-build \
-    --package-path=/ \
-    --bin-path=$out/bin \
-    --lib-path=$out/lib \
-    --share-path=$out/share
-'';
+    export SOURCE_DATE_EPOCH=1
+    export ASDF_OUTPUT_TRANSLATIONS=$(pwd):$(pwd)/__fasls
+    tar xf ${reposTarball}
+    sbcl --script koga \
+      --skip-sync \
+      --cc=$NIX_CC/bin/cc \
+      --cxx=$NIX_CC/bin/c++ \
+      --reproducible-build \
+      --package-path=/ \
+      --bin-path=$out/bin \
+      --lib-path=$out/lib \
+      --share-path=$out/share
+  '';
   buildPhase = ''
-  ninja -C build
-'';
+    ninja -C build
+  '';
   installPhase = ''
-  ninja -C build install
-'';
+    ninja -C build install
+  '';
 
   meta = {
     description = "A Common Lisp implementation based on LLVM with C++ integration";
-    license = lib.licenses.lgpl21Plus ;
+    license = lib.licenses.lgpl21Plus;
     maintainers = lib.teams.lisp.members;
-    platforms = ["x86_64-linux" "x86_64-darwin"];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     # Upstream claims support, but breaks with:
     # error: use of undeclared identifier 'aligned_alloc'
     broken = llvmPackages_15.stdenv.isDarwin;

--- a/pkgs/development/compilers/wcc/default.nix
+++ b/pkgs/development/compilers/wcc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "wcc-unstable";
-  version = "2018-04-05";
+  version = "2023-02-04";
 
   src = fetchFromGitHub {
     owner = "endrazine";
     repo = "wcc";
-    rev = "f141963ff193d7e1931d41acde36d20d7221e74f";
-    sha256 = "1f0w869x0176n5nsq7m70r344gv5qvfmk7b58syc0jls8ghmjvb4";
+    rev = "825448004e5e53c3ab9a9dac0886544bc499d259";
+    sha256 = "sha256-Cy7CkqzpgmNPQrg/ubTxLi8vWMSQtGY/a7Trb3e6L+o=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/wcc/default.nix
+++ b/pkgs/development/compilers/wcc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, capstone, libbfd, libelf, libiberty, readline }:
+{ lib, stdenv, fetchFromGitHub, capstone, elfutils, libbfd, libiberty, readline }:
 
 stdenv.mkDerivation {
   pname = "wcc-unstable";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ capstone libbfd libelf libiberty readline ];
+  buildInputs = [ capstone elfutils libbfd libiberty readline ];
 
   postPatch = ''
     sed -i src/wsh/include/libwitch/wsh.h src/wsh/scripts/INDEX \

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,12 +1,12 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, cmake
 , bison
+, cmake
+, elfutils
 , flex
-, libusb-compat-0_1
-, libelf
 , libftdi1
+, libusb-compat-0_1
 , readline
   # documentation building is broken on darwin
 , docSupport ? (!stdenv.isDarwin)
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     texi2html
   ];
 
-  buildInputs = [ libusb-compat-0_1 libelf libftdi1 readline ];
+  buildInputs = [ elfutils libusb-compat-0_1 libftdi1 readline ];
 
   cmakeFlags = lib.optionals docSupport [
     "-DBUILD_DOC=ON"

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,7 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb-compat-0_1, libelf
-, libftdi1, readline
-# documentation building is broken on darwin
-, docSupport ? (!stdenv.isDarwin), texliveMedium, texinfo, texi2html, unixtools }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, bison
+, flex
+, libusb-compat-0_1
+, libelf
+, libftdi1
+, readline
+  # documentation building is broken on darwin
+, docSupport ? (!stdenv.isDarwin)
+, texliveMedium
+, texinfo
+, texi2html
+, unixtools
+}:
 
 stdenv.mkDerivation rec {
   pname = "avrdude";

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -8,14 +8,30 @@
 , pkg-config
 , perl
 , python3
-, libiconv, zlib, libffi, pcre2, libelf, gnome, libselinux, bash, gnum4, gtk-doc, docbook_xsl, docbook_xml_dtd_45, libxslt
-# use util-linuxMinimal to avoid circular dependency (util-linux, systemd, glib)
+, libiconv
+, zlib
+, libffi
+, pcre2
+, libelf
+, gnome
+, libselinux
+, bash
+, gnum4
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_45
+, libxslt
+  # use util-linuxMinimal to avoid circular dependency (util-linux, systemd, glib)
 , util-linuxMinimal ? null
 , buildPackages
 
-# this is just for tests (not in the closure of any regular package)
-, coreutils, dbus, libxml2, tzdata
-, desktop-file-utils, shared-mime-info
+  # this is just for tests (not in the closure of any regular package)
+, coreutils
+, dbus
+, libxml2
+, tzdata
+, desktop-file-utils
+, shared-mime-info
 , darwin
 , makeHardcodeGsettingsPatch
 , testers
@@ -107,12 +123,18 @@ stdenv.mkDerivation (finalAttrs: {
     finalAttrs.setupHook
     pcre2
   ] ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-    bash gnum4 # install glib-gettextize and m4 macros for other apps to use
+    bash
+    gnum4 # install glib-gettextize and m4 macros for other apps to use
   ] ++ lib.optionals stdenv.isLinux [
     libselinux
     util-linuxMinimal # for libmount
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    AppKit Carbon Cocoa CoreFoundation CoreServices Foundation
+    AppKit
+    Carbon
+    Cocoa
+    CoreFoundation
+    CoreServices
+    Foundation
   ]) ++ lib.optionals buildDocs [
     # Note: this needs to be both in buildInputs and nativeBuildInputs. The
     # Meson gtkdoc module uses find_program to look it up (-> build dep), but
@@ -152,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dnls=enabled"
     "-Ddevbindir=${placeholder "dev"}/bin"
   ] ++ lib.optionals (!stdenv.isDarwin) [
-    "-Dman=true"                # broken on Darwin
+    "-Dman=true" # broken on Darwin
   ] ++ lib.optionals stdenv.isFreeBSD [
     "-Db_lundef=false"
     "-Dxattr=false"
@@ -258,9 +280,9 @@ stdenv.mkDerivation (finalAttrs: {
     };
 
     mkHardcodeGsettingsPatch =
-      {
-        src,
-        glib-schema-to-var,
+      { src
+      , glib-schema-to-var
+      ,
       }:
       builtins.trace
         "glib.mkHardcodeGsettingsPatch is deprecated, please use makeHardcodeGsettingsPatch instead"
@@ -272,15 +294,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "C library of programming buildings blocks";
-    homepage    = "https://wiki.gnome.org/Projects/GLib";
-    license     = licenses.lgpl21Plus;
+    homepage = "https://wiki.gnome.org/Projects/GLib";
+    license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members ++ (with maintainers; [ lovek323 raskin ]);
     pkgConfigModules = [
       "gio-2.0"
       "gobject-2.0"
       "gthread-2.0"
     ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
 
     longDescription = ''
       GLib provides the core application building blocks for libraries

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -12,7 +12,7 @@
 , zlib
 , libffi
 , pcre2
-, libelf
+, elfutils
 , gnome
 , libselinux
 , bash
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
   setupHook = ./setup-hook.sh;
 
   buildInputs = [
-    libelf
+    elfutils
     finalAttrs.setupHook
     pcre2
   ] ++ lib.optionals (!stdenv.hostPlatform.isWindows) [

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -22,7 +22,7 @@
 , libffi
 , libomxil-bellagio
 , libva-minimal
-, libelf
+, elfutils
 , libvdpau
 , libglvnd
 , libunwind
@@ -245,26 +245,26 @@ let
     ++ lib.optional (vulkanLayers != [ ]) "-D vulkan-layers=${builtins.concatStringsSep "," vulkanLayers}";
 
     buildInputs = with xorg; [
+      elfutils
       expat
       glslang
-      llvmPackages.libllvm
-      libglvnd
-      xorgproto
       libX11
       libXext
-      libxcb
-      libXt
       libXfixes
-      libxshmfence
       libXrandr
-      libffi
-      libvdpau
-      libelf
+      libXt
       libXvMC
+      libffi
+      libglvnd
       libpthreadstubs
+      libunwind
+      libvdpau
+      libxcb
+      libxshmfence
+      llvmPackages.libllvm
+      xorgproto
       openssl /*or another sha1 provider*/
       zstd
-      libunwind
       python3Packages.python # for shebang
     ] ++ lib.optionals haveWayland [ wayland wayland-protocols ]
     ++ lib.optionals stdenv.isLinux [ libomxil-bellagio libva-minimal udev lm_sensors ]

--- a/pkgs/development/libraries/spdk/default.nix
+++ b/pkgs/development/libraries/spdk/default.nix
@@ -1,26 +1,27 @@
-{ lib, stdenv
+{ lib
+, stdenv
+, ensureNewerSourcesForZipFilesHook
 , fetchFromGitHub
-, ncurses
-, python3
 , cunit
 , dpdk
+, elfutils
+, jansson
 , libaio
 , libbsd
+, libnl
+, libpcap
 , libuuid
+, ncurses
 , numactl
 , openssl
 , pkg-config
+, python3
 , zlib
-, libpcap
-, libnl
-, libelf
-, jansson
-, ensureNewerSourcesForZipFilesHook
+, zstd
 }:
 
 stdenv.mkDerivation rec {
   pname = "spdk";
-
   version = "23.09";
 
   src = fetchFromGitHub {
@@ -41,17 +42,18 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cunit
     dpdk
+    elfutils
     jansson
     libaio
     libbsd
-    libelf
-    libuuid
-    libpcap
     libnl
+    libpcap
+    libuuid
+    ncurses
     numactl
     openssl
-    ncurses
     zlib
+    zstd
   ];
 
   patches = [

--- a/pkgs/development/rocm-modules/5/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/5/rocm-runtime/default.nix
@@ -2,16 +2,16 @@
 , stdenv
 , fetchFromGitHub
 , rocmUpdateScript
-, pkg-config
 , cmake
-, xxd
+, elfutils
+, libdrm
+, libxml2
+, numactl
+, pkg-config
 , rocm-device-libs
 , rocm-thunk
-, libelf
-, libdrm
-, numactl
 , valgrind
-, libxml2
+, xxd
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,12 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    rocm-thunk
-    libelf
+    elfutils
     libdrm
-    numactl
-    valgrind
     libxml2
+    numactl
+    rocm-thunk
+    valgrind
   ];
 
   postPatch = ''

--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -1,23 +1,22 @@
 { lib
 , mkDerivation
+, fetchFromGitHub
 , cmake
 , elfutils
 , extra-cmake-modules
-, fetchFromGitHub
 , kconfigwidgets
+, kddockwidgets
 , ki18n
 , kio
 , kitemmodels
 , kitemviews
 , kparts
 , kwindowsystem
-, libelf
 , qtbase
-, threadweaver
 , qtx11extras
-, zstd
-, kddockwidgets
 , rustc-demangle
+, threadweaver
+, zstd
 }:
 
 mkDerivation rec {
@@ -36,22 +35,22 @@ mkDerivation rec {
     cmake
     extra-cmake-modules
   ];
+
   buildInputs = [
-    (elfutils.override { enableDebuginfod = true; }) # perfparser needs to find debuginfod.h
+    elfutils
     kconfigwidgets
+    kddockwidgets
     ki18n
     kio
     kitemmodels
     kitemviews
     kparts
     kwindowsystem
-    libelf
     qtbase
-    threadweaver
     qtx11extras
-    zstd
-    kddockwidgets
     rustc-demangle
+    threadweaver
+    zstd
   ];
 
   # hotspot checks for the presence of third party libraries'

--- a/pkgs/development/tools/misc/prelink/default.nix
+++ b/pkgs/development/tools/misc/prelink/default.nix
@@ -1,8 +1,8 @@
 { stdenv
 , lib
-, fetchgit
 , autoreconfHook
-, libelf
+, elfutils
+, fetchgit
 , libiberty
 }:
 
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.libc
-    libelf
+    elfutils
     libiberty
+    stdenv.cc.libc
   ];
 
   # most tests fail

--- a/pkgs/development/tools/misc/vtable-dumper/default.nix
+++ b/pkgs/development/tools/misc/vtable-dumper/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libelf }:
+{ lib, stdenv, fetchFromGitHub, elfutils }:
 
 stdenv.mkDerivation rec {
   pname = "vtable-dumper";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0sl7lnjr2l4c2f7qaazvpwpzsp4gckkvccfam88wcq9f7j9xxbyp";
   };
 
-  buildInputs = [ libelf ];
+  buildInputs = [ elfutils ];
   makeFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {

--- a/pkgs/development/tools/profiling/EZTrace/default.nix
+++ b/pkgs/development/tools/profiling/EZTrace/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   fetchFromGitLab,
   gfortran,
-  libelf,
+  elfutils,
   libiberty,
   zlib,
   # Once https://gitlab.com/eztrace/eztrace/-/issues/41
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gfortran autoreconfHook ];
-  buildInputs = [ libelf libiberty zlib libbfd_2_38 libopcodes_2_38 ];
+  buildInputs = [ elfutils libiberty zlib libbfd_2_38 libopcodes_2_38 ];
 
   meta = with lib; {
     description = "Tool that aims at generating automatically execution trace from HPC programs";

--- a/pkgs/development/tools/profiling/malt/default.nix
+++ b/pkgs/development/tools/profiling/malt/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, lib
+{ stdenv
+, lib
 , fetchFromGitHub
-, cmake, nodejs, libelf, libunwind
+, cmake
+, nodejs
+, libelf
+, libunwind
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/tools/profiling/malt/default.nix
+++ b/pkgs/development/tools/profiling/malt/default.nix
@@ -2,9 +2,9 @@
 , lib
 , fetchFromGitHub
 , cmake
-, nodejs
-, libelf
+, elfutils
 , libunwind
+, nodejs
 }:
 
 stdenv.mkDerivation rec {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libelf libunwind ];
+  buildInputs = [ elfutils libunwind ];
 
   meta = with lib; {
     description = "Memory tool to find where you allocate your memory";

--- a/pkgs/development/tools/simavr/default.nix
+++ b/pkgs/development/tools/simavr/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , makeSetupHook
 , fetchFromGitHub
-, libelf
+, elfutils
 , which
 , pkg-config
 , freeglut
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which pkg-config avrgcc ]
     ++ lib.optional stdenv.isDarwin setupHookDarwin;
-  buildInputs = [ libelf freeglut libGLU libGL ]
+  buildInputs = [ elfutils freeglut libGLU libGL ]
     ++ lib.optional stdenv.isDarwin GLUT;
 
   # remove forbidden references to $TMPDIR

--- a/pkgs/development/tools/simavr/default.nix
+++ b/pkgs/development/tools/simavr/default.nix
@@ -1,17 +1,29 @@
-{ lib, stdenv, makeSetupHook, fetchFromGitHub, libelf, which, pkg-config, freeglut
-, avrgcc, avrlibc
-, libGLU, libGL
-, GLUT }:
+{ lib
+, stdenv
+, makeSetupHook
+, fetchFromGitHub
+, libelf
+, which
+, pkg-config
+, freeglut
+, avrgcc
+, avrlibc
+, libGLU
+, libGL
+, GLUT
+}:
 
 let
-  setupHookDarwin = makeSetupHook {
-    name = "darwin-avr-gcc-hook";
-    substitutions = {
-      darwinSuffixSalt = stdenv.cc.suffixSalt;
-      avrSuffixSalt = avrgcc.suffixSalt;
-    };
-  } ./setup-hook-darwin.sh;
-in stdenv.mkDerivation rec {
+  setupHookDarwin = makeSetupHook
+    {
+      name = "darwin-avr-gcc-hook";
+      substitutions = {
+        darwinSuffixSalt = stdenv.cc.suffixSalt;
+        avrSuffixSalt = avrgcc.suffixSalt;
+      };
+    } ./setup-hook-darwin.sh;
+in
+stdenv.mkDerivation rec {
   pname = "simavr";
   version = "1.7";
 
@@ -45,9 +57,9 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A lean and mean Atmel AVR simulator";
-    homepage    = "https://github.com/buserror/simavr";
-    license     = licenses.gpl3;
-    platforms   = platforms.unix;
+    homepage = "https://github.com/buserror/simavr";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ goodrone ];
   };
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -10,7 +10,7 @@
 , numactl
 , libbpf
 , zlib
-, libelf
+, elfutils
 , jansson
 , openssl
 , libpcap
@@ -50,10 +50,11 @@ stdenv.mkDerivation {
     python3.pkgs.sphinx
     python3.pkgs.pyelftools
   ];
+
   buildInputs = [
     jansson
     libbpf
-    libelf
+    elfutils
     libpcap
     numactl
     openssl.dev

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -7,7 +7,7 @@
 , pkg-config
 , db
 , iptables
-, libelf
+, elfutils
 , libmnl
 , gitUpdater
 }:
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ]; # netem requires $HOSTCC
   nativeBuildInputs = [ bison flex pkg-config ];
-  buildInputs = [ db iptables libelf libmnl ];
+  buildInputs = [ db iptables elfutils libmnl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -1,6 +1,14 @@
-{ lib, stdenv, fetchurl
-, buildPackages, bison, flex, pkg-config
-, db, iptables, libelf, libmnl
+{ lib
+, stdenv
+, fetchurl
+, buildPackages
+, bison
+, flex
+, pkg-config
+, db
+, iptables
+, libelf
+, libmnl
 , gitUpdater
 }:
 

--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, kernel, perl, kmod, libelf }:
+{ lib, stdenv, fetchurl, kernel, perl, kmod, elfutils }:
 let
   version = "1.63";
 in
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     sha256 = "1v6b66jhisl110jfl00hm43lmnrav32vs39d85gcbxrjqnmcx08g";
   };
 
-  buildInputs = [ perl libelf ];
+  buildInputs = [ perl elfutils ];
 
   meta = {
     description = "Ndis driver wrapper for the Linux kernel";

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -2,18 +2,19 @@
 , stdenv
 , fetchurl
 , autoreconfHook
-, pkg-config
 , dpdk
+, elfutils
+, jansson
 , libbpf
+, libbsd
 , libconfig
+, libnl
 , libpcap
 , numactl
 , openssl
+, pkg-config
 , zlib
-, libbsd
-, libelf
-, jansson
-, libnl
+, zstd
 }:
 
 stdenv.mkDerivation rec {
@@ -32,16 +33,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dpdk
+    elfutils
+    jansson
+    libbpf
+    libbsd
     libconfig
+    libnl
     libpcap
     numactl
     openssl
     zlib
-    libbsd
-    libelf
-    jansson
-    libbpf
-    libnl
+    zstd
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/servers/frr/clippy-helper.nix
+++ b/pkgs/servers/frr/clippy-helper.nix
@@ -8,7 +8,7 @@
 , flex
 , bison
 , pkg-config
-, libelf
+, elfutils
 , perl
 , python3
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libelf
+    elfutils
     python3
   ];
 

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -15,7 +15,7 @@
 , c-ares
 , json_c
 , libcap
-, libelf
+, elfutils
 , libunwind
 , libyang
 , net-snmp
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     c-ares
     json_c
-    libelf
+    elfutils
     libunwind
     libyang
     openssl

--- a/pkgs/tools/misc/rmlint/default.nix
+++ b/pkgs/tools/misc/rmlint/default.nix
@@ -5,7 +5,7 @@
 , gobject-introspection
 , gtksourceview3
 , json-glib
-, libelf
+, elfutils
 , makeWrapper
 , pango
 , pkg-config
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     json-glib
-    libelf
+    elfutils
     util-linux
   ] ++ lib.optionals withGui [
     cairo

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , kernel ? null
-, libelf
+, elfutils
 , nasm
 , python3
 , withDriver ? false
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
   KSRC = lib.optionalString withDriver "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 
   nativeBuildInputs = [
-    libelf
+    elfutils
     nasm
   ] ++ lib.optionals withDriver kernel.moduleBuildDependencies;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9229,7 +9229,12 @@ with pkgs;
 
   hotpatch = callPackage ../development/libraries/hotpatch { };
 
-  hotspot = libsForQt5.callPackage ../development/tools/analysis/hotspot { };
+  hotspot = libsForQt5.callPackage ../development/tools/analysis/hotspot {
+    elfutils = elfutils.override {
+      # perfparser needs to find debuginfod.h
+      enableDebuginfod = true;
+    };
+  };
 
   hpccm = with python3Packages; toPythonApplication hpccm;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5855,6 +5855,8 @@ with pkgs;
 
   libnvme = callPackage ../os-specific/linux/libnvme { };
 
+  libnvidia-container = callPackage ../applications/virtualization/libnvidia-container { };
+
   librenms = callPackage ../servers/monitoring/librenms { };
 
   libxnd = callPackage ../development/libraries/libxnd { };
@@ -24192,9 +24194,8 @@ with pkgs;
   mkNvidiaContainerPkg = { name, containerRuntimePath, configTemplate, additionalPaths ? [] }:
     let
       nvidia-container-toolkit = callPackage ../applications/virtualization/nvidia-container-toolkit {
-        inherit containerRuntimePath configTemplate libnvidia-container;
+        inherit containerRuntimePath configTemplate;
       };
-      libnvidia-container =(callPackage ../applications/virtualization/libnvidia-container { });
     in symlinkJoin {
       inherit name;
       paths = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25998,7 +25998,10 @@ with pkgs;
 
   # Clasp Common Lisp
   clasp-common-lisp = wrapLisp {
-    pkg = callPackage ../development/compilers/clasp { };
+    pkg = callPackage ../development/compilers/clasp {
+      stdenv = clang15Stdenv;
+      inherit (llvmPackages_15) llvm libclang;
+    };
     faslExt = "fasp";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31324,9 +31324,7 @@ with pkgs;
 
   electrum-ltc = libsForQt5.callPackage ../applications/misc/electrum/ltc.nix { };
 
-  elf-dissector = libsForQt5.callPackage ../applications/misc/elf-dissector {
-    libdwarf = libdwarf_20210528;
-  };
+  elf-dissector = libsForQt5.callPackage ../applications/misc/elf-dissector { };
 
   elfx86exts = callPackage ../applications/misc/elfx86exts { };
 


### PR DESCRIPTION
## Description of changes

Does almost everything for #271473.

> `libelf` did not see an update since 2014: https://github.com/Distrotech/libelf. `elfutils` is a popular API compatible ELF parser that most users expect.

As @Artturin notes: 
> Arch has the `libelf` package as an output of the `elfutils` package.
1. https://archlinux.org/packages/core/x86_64/libelf/
2. https://gitlab.archlinux.org/archlinux/packaging/packages/elfutils/-/blob/main/PKGBUILD?ref_type=heads#L142

## Things done

I made a commit per package changed. Some required more attention than others. A few required `zstd` added to their packages, as that's evidently a difference between `libelf` and `elfutils`.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).