### PR TITLE
hdrop: init at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16213,6 +16213,11 @@
     githubId = 5104601;
     name = "schnusch";
   };
+  Schweber = {
+    github = "Schweber";
+    githubId = 64630479;
+    name = "Schweber";
+  };
   sciencentistguy = {
     email = "jamie@quigley.xyz";
     name = "Jamie Quigley";

--- a/pkgs/by-name/hd/hdrop/package.nix
+++ b/pkgs/by-name/hd/hdrop/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, makeWrapper
+, scdoc
+, coreutils
+, util-linux
+, jq
+, libnotify
+, withHyprland ? true
+, hyprland
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "hdrop";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "Schweber";
+    repo = "hdrop";
+    rev = "v${version}";
+    hash = "sha256-VsM1wPl8edAnZUvYw3IeOHw/XQ2pvbLt0v3G0B8+iSA=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    scdoc
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hdrop --prefix PATH ':' \
+      "${lib.makeBinPath ([
+        coreutils
+        util-linux
+        jq
+        libnotify
+      ]
+      ++ lib.optional withHyprland hyprland)}"
+  '';
+
+  meta = with lib; {
+    description = "Emulate 'tdrop' in Hyprland (run, show and hide specific programs per keybind)";
+    homepage = "https://github.com/Schweber/hdrop";
+    changelog = "https://github.com/Schweber/hdrop/releases/tag/v${version}";
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Schweber ];
+    mainProgram = "hdrop";
+  };
+}


### PR DESCRIPTION
## Description of changes

I messed up #267356 and this is a new PR with a fresh fork. @AndersonTorres please continue with the review and thank you for your patience.

[hdrop](https://github.com/Schweber/hdrop) is a helper script for [Hyprland](https://github.com/hyprwm/Hyprland) window manager that allows the user to run, show and hide specified programs via keybinds.

I am the author of hdrop and would also like to be its maintainer on nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
