### PR TITLE
Xfce updates 2023-12-02

### DIFF
--- a/pkgs/desktops/xfce/applications/parole/default.nix
+++ b/pkgs/desktops/xfce/applications/parole/default.nix
@@ -1,15 +1,25 @@
-{ lib, mkXfceDerivation, dbus, dbus-glib
-, gst_all_1, gtk3, libnotify, libxfce4ui, libxfce4util
-, taglib, xfconf }:
+{ lib
+, mkXfceDerivation
+, dbus
+, dbus-glib
+, gst_all_1
+, gtk3
+, libnotify
+, libX11
+, libxfce4ui
+, libxfce4util
+, taglib
+, xfconf
+}:
 
 # Doesn't seem to find H.264 codec even though built with gst-plugins-bad.
 
 mkXfceDerivation {
   category = "apps";
   pname = "parole";
-  version = "4.18.0";
+  version = "4.18.1";
 
-  sha256 = "sha256-TLH9ZUggjclJlbBg3EBVgbcrdiMZ8n+cGDgfNgYNiPI=";
+  sha256 = "sha256-g+Wy90tHpCeylbU7aUa8578ehmuyWI5WlCK7YdJKlNQ=";
 
   postPatch = ''
     substituteInPlace src/plugins/mpris2/Makefile.am \
@@ -25,6 +35,7 @@ mkXfceDerivation {
     gst-plugins-ugly
     gtk3
     libnotify
+    libX11
     libxfce4ui
     libxfce4util
     taglib

--- a/pkgs/desktops/xfce/core/tumbler/default.nix
+++ b/pkgs/desktops/xfce/core/tumbler/default.nix
@@ -16,9 +16,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "tumbler";
-  version = "4.18.1";
+  version = "4.18.2";
 
-  sha256 = "sha256-hn77W8IsvwNc9xSuDe9rXw9499olOvvJ2P7q+26HIG8=";
+  sha256 = "sha256-thioE0q2qnV4weJFPz8OWoHIRuUcXnQEviwBtCWsSV4=";
 
   buildInputs = [
     libxfce4util

--- a/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
@@ -12,9 +12,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-power-manager";
-  version = "4.18.2";
+  version = "4.18.3";
 
-  sha256 = "sha256-1+DP5CACzzj96FyRTeCdVEFORnpzFT49d9Uk1iijbFs=";
+  sha256 = "sha256-CuW2siApho7u8P01t15dAiqNAiwQzAMZsEugYuKN4kM=";
 
   buildInputs = [
     gtk3

--- a/pkgs/desktops/xfce/core/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings/default.nix
@@ -16,9 +16,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-settings";
-  version = "4.18.3";
+  version = "4.18.4";
 
-  sha256 = "sha256-QGh5th790qkvqchUfi+kOAJ9A1M+zEIzMxOM5eCGPEk=";
+  sha256 = "sha256-f6ldTmTSvfRjn6j/LKIoFI3cbYZFtNdnAq3dQewc948=";
 
   postPatch = ''
     for f in xfsettingsd/pointers.c dialogs/mouse-settings/main.c; do


### PR DESCRIPTION
## Description of changes


https://github.com/xfce-mirror/xfce4-settings/compare/xfce4-settings-4.18.3...xfce4-settings-4.18.4
https://github.com/xfce-mirror/xfce4-power-manager/compare/xfce4-power-manager-4.18.2...xfce4-power-manager-4.18.3
https://github.com/xfce-mirror/tumbler/compare/tumbler-4.18.1...tumbler-4.18.2
https://github.com/xfce-mirror/parole/compare/parole-4.18.0...parole-4.18.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
