### PR TITLE
transmission_4-{qt,gtk}: fix darwin build, install darwin application bundle

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -28,6 +28,7 @@
 , enableGTK3 ? false
 , gtkmm3
 , xorg
+, gnome
 , wrapGAppsHook
 , enableQt ? false
 , qt5
@@ -117,6 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableQt [ qt5.qttools qt5.qtbase ]
   ++ lib.optionals enableGTK3 [ gtkmm3 xorg.libpthreadstubs ]
+  ++ lib.optionals (stdenv.isDarwin && enableGTK3) [ gnome.adwaita-icon-theme ]
   ++ lib.optionals enableSystemd [ systemd ]
   ++ lib.optionals stdenv.isLinux [ inotify-tools ]
   ++ lib.optionals stdenv.isDarwin [ libiconv Foundation ];
@@ -154,6 +156,12 @@ stdenv.mkDerivation (finalAttrs: {
       -o $out/Applications/Transmission.app/Contents/Resources/AppIcon.icns \
       ../macosx/Images/Images.xcassets/AppIcon.appiconset
     write-darwin-bundle "$out" "Transmission" "${finalAttrs.meta.mainProgram}" "AppIcon"
+  '';
+
+  preFixup = lib.optionalString (stdenv.isDarwin && enableGTK3) ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
+    )
   '';
 
   passthru.tests = {

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -22,6 +22,8 @@
 , libnatpmp
 , libiconv
 , Foundation
+, libicns
+, writeDarwinBundle
   # Build options
 , enableGTK3 ? false
 , gtkmm3
@@ -94,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableGTK3 [ wrapGAppsHook ]
   ++ lib.optionals enableQt [ qt5.wrapQtAppsHook ]
+  ++ lib.optionals stdenv.isDarwin [ libicns writeDarwinBundle ]
   ;
 
   buildInputs = [
@@ -144,6 +147,13 @@ stdenv.mkDerivation (finalAttrs: {
     }
     EOF
     install -Dm0444 -t $out/share/icons ../qt/icons/transmission.svg
+  '' + lib.optionalString (stdenv.isDarwin && (enableQt || enableGTK3)) ''
+    mkdir -p $out/Applications/Transmission.app/Contents/{MacOS,Resources}
+    icnsutil \
+      -c icns \
+      -o $out/Applications/Transmission.app/Contents/Resources/AppIcon.icns \
+      ../macosx/Images/Images.xcassets/AppIcon.appiconset
+    write-darwin-bundle "$out" "Transmission" "${finalAttrs.meta.mainProgram}" "AppIcon"
   '';
 
   passthru.tests = {

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
     ] ++ lib.optionals stdenv.isDarwin [
       # Transmission sets this to 10.13 if not explicitly specified, see https://github.com/transmission/transmission/blob/0be7091eb12f4eb55f6690f313ef70a66795ee72/CMakeLists.txt#L7-L16.
       "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}"
+      # qt translation generation segfaults
+      "-DENABLE_NLS=OFF"
     ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Fixes build failure on darwin for `transmission_4-qt` and `transmission_4-gtk`
- Adds darwin desktop bundle for Qt and GTK apps
- Add adwaita as GTK icon theme on macOS where one might not be installed

Note the GTK app appears to have an (unrelated?) issue where the menu actions are greyed out, so the Qt app is preferable.
<img width="445" alt="image" src="https://github.com/NixOS/nixpkgs/assets/13267947/6a2fd5e7-606a-4318-8148-fdd735b98b76">


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
