### PR TITLE
qMasterPassword: 1.2.4 -> 2.0

### DIFF
--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -3,27 +3,33 @@
 , fetchFromGitHub
 , libX11
 , libXtst
-, qmake
+, cmake
 , qtbase
 , qttools
+, qtwayland
 , openssl
 , libscrypt
 , wrapQtAppsHook
+, x11Support ? true
+, waylandSupport ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "qMasterPassword";
-  version = "1.2.4";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "bkueng";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-VQ1ZkXaZ5sUbtWa/GreTr5uXvnZ2Go6owJ2ZBK25zns=";
+    hash = "sha256-4qxPjrf6r2S0l/hcs6bqfJm56jdDz+0a0xEkqGBYGBs=";
   };
 
-  buildInputs = [ qtbase libX11 libXtst openssl libscrypt ];
-  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
+  buildInputs = [ qtbase qtwayland openssl libscrypt ] ++ lib.optionals x11Support [ libX11 libXtst ];
+  nativeBuildInputs = [ cmake qttools wrapQtAppsHook ];
+  cmakeFlags = lib.optionals waylandSupport [
+    "-DDISABLE_FILL_FORM_SHORTCUTS=1"
+  ];
 
   # Upstream install is mostly defunct. It hardcodes target.path and doesn't
   # install anything but the binary.
@@ -34,15 +40,13 @@ stdenv.mkDerivation rec {
   '' else ''
     mkdir -p $out/bin
     mkdir -p $out/share/{applications,doc/qMasterPassword,icons/qmasterpassword,icons/hicolor/512x512/apps,qMasterPassword/translations}
-    mv qMasterPassword $out/bin
-    mv data/qMasterPassword.desktop $out/share/applications
-    mv LICENSE README.md $out/share/doc/qMasterPassword
-    mv data/icons/app_icon.png $out/share/icons/hicolor/512x512/apps/qmasterpassword.png
-    mv data/icons/* $out/share/icons/qmasterpassword
-    lrelease ./data/translations/translation_de.ts
-    lrelease ./data/translations/translation_pl.ts
-    mv ./data/translations/translation_de.qm $out/share/qMasterPassword/translations/translation_de.qm
-    mv ./data/translations/translation_pl.qm $out/share/qMasterPassword/translations/translation_pl.qm
+    cp qMasterPassword $out/bin
+    cp $src/data/qMasterPassword.desktop $out/share/applications
+    cp $src/LICENSE $src/README.md $out/share/doc/qMasterPassword
+    cp $src/data/icons/app_icon.png $out/share/icons/hicolor/512x512/apps/qmasterpassword.png
+    cp $src/data/icons/* $out/share/icons/qmasterpassword
+    cp ./translations/translation_de.qm $out/share/qMasterPassword/translations/translation_de.qm
+    cp ./translations/translation_pl.qm $out/share/qMasterPassword/translations/translation_pl.qm
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -10,6 +10,8 @@
 , openssl
 , libscrypt
 , wrapQtAppsHook
+, testers
+, qMasterPassword
 , x11Support ? true
 , waylandSupport ? false
 }:
@@ -48,6 +50,13 @@ stdenv.mkDerivation rec {
     cp ./translations/translation_de.qm $out/share/qMasterPassword/translations/translation_de.qm
     cp ./translations/translation_pl.qm $out/share/qMasterPassword/translations/translation_pl.qm
   '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = qMasterPassword;
+      version = "v${version}";
+    };
+  };
 
   meta = with lib; {
     description = "Stateless Master Password Manager";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40950,7 +40950,7 @@ with pkgs;
     gtk2 = gtk2-x11;
   };
 
-  qMasterPassword = libsForQt5.callPackage ../applications/misc/qMasterPassword { };
+  qMasterPassword = qt6Packages.callPackage ../applications/misc/qMasterPassword { };
 
   qmake2cmake = python3Packages.callPackage ../tools/misc/qmake2cmake { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40952,6 +40952,11 @@ with pkgs;
 
   qMasterPassword = qt6Packages.callPackage ../applications/misc/qMasterPassword { };
 
+  qMasterPassword-wayland = qt6Packages.callPackage ../applications/misc/qMasterPassword {
+    x11Support = false;
+    waylandSupport = true;
+  };
+
   qmake2cmake = python3Packages.callPackage ../tools/misc/qmake2cmake { };
 
   qtrvsim = libsForQt5.callPackage ../applications/science/computer-architecture/qtrvsim { };


### PR DESCRIPTION
## Description of changes

https://github.com/bkueng/qMasterPassword/compare/v1.2.4...v2.0

- Use Qt6

- Add wayland variant which uses no x11 build dependencies and disables form filling features, see https://github.com/bkueng/qMasterPassword/pull/46



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
