### PR TITLE
pywalfox-native: fixup indentation

### DIFF
--- a/pkgs/by-name/py/pywalfox-native/package.nix
+++ b/pkgs/by-name/py/pywalfox-native/package.nix
@@ -1,22 +1,22 @@
 { lib, python3, fetchPypi }:
 
 python3.pkgs.buildPythonApplication rec {
-    pname = "pywalfox-native";
-    version = "2.7.4";
+  pname = "pywalfox-native";
+  version = "2.7.4";
 
-    src = fetchPypi {
-      inherit version;
-      pname = "pywalfox";
-      hash = "sha256-Wec9fic4lXT7gBY04D2EcfCb/gYoZcrYA/aMRWaA7WY=";
-    };
+  src = fetchPypi {
+    inherit version;
+    pname = "pywalfox";
+    hash = "sha256-Wec9fic4lXT7gBY04D2EcfCb/gYoZcrYA/aMRWaA7WY=";
+  };
 
-    pythonImportsCheck = [ "pywalfox" ];
+  pythonImportsCheck = [ "pywalfox" ];
 
-    meta = with lib; {
-      homepage = "https://github.com/Frewacom/pywalfox-native";
-      description = "Native app used alongside the Pywalfox addon";
-      mainProgram = "pywalfox";
-      license = licenses.mpl20;
-      maintainers = with maintainers; [ tsandrini ];
-    };
-  }
+  meta = with lib; {
+    homepage = "https://github.com/Frewacom/pywalfox-native";
+    description = "Native app used alongside the Pywalfox addon";
+    mainProgram = "pywalfox";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ tsandrini ];
+  };
+}


### PR DESCRIPTION
Fixes incorrect indentation (not fitting `.editorconfig`) introduced in [PR #271023](https://github.com/NixOS/nixpkgs/pull/271023) (pywalfox-native: init at 2.7.4 - 30fd50aaab13d76a7c915996c447a14b59faa215) 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
