### PR TITLE
mikutter: fix build against current glib

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mikutter/deps/gemset.nix
+++ b/pkgs/applications/networking/instant-messengers/mikutter/deps/gemset.nix
@@ -129,6 +129,19 @@
       type = "gem";
     };
     version = "3.4.1";
+    dontBuild = false;
+    patches = [
+      # This patch fixes a duplicated declaration of `g_bookmark_file_get_type`
+      # that has been fixed upstream [1] [2]. Note that the source file paths
+      # in the patch file don't exactly match the upstream repo, which is why
+      # we cannot simply fetch the patch from GitHub.
+      #
+      # Can be removed with v. >= 4.1.2
+      #
+      # [1]: https://github.com/ruby-gnome/ruby-gnome/commit/396d2d377bd85d9bdd73b26210e323129deea1f4
+      # [2]: https://github.com/ruby-gnome/ruby-gnome/issues/1547
+      ./ruby-glib2-fix-duplicated-function-declaration.patch
+    ];
   };
   gobject-introspection = {
     dependencies = ["glib2"];

--- a/pkgs/applications/networking/instant-messengers/mikutter/deps/ruby-glib2-fix-duplicated-function-declaration.patch
+++ b/pkgs/applications/networking/instant-messengers/mikutter/deps/ruby-glib2-fix-duplicated-function-declaration.patch
@@ -1,0 +1,21 @@
+This patch was adapted from:
+https://github.com/ruby-gnome/ruby-gnome/commit/396d2d377bd85d9bdd73b26210e323129deea1f4.patch
+
+--- a/ext/glib2/rbglib_bookmarkfile.c
++++ b/ext/glib2/rbglib_bookmarkfile.c
+@@ -21,6 +21,7 @@
+ 
+ #include "rbgprivate.h"
+ 
++#ifndef G_TYPE_BOOKMARK_FILE
+ /************************************************/
+ static GBookmarkFile*
+ bookmarkfile_copy(const GBookmarkFile* file)
+@@ -48,6 +49,7 @@ g_bookmark_file_get_type(void)
+ /************************************************/
+ 
+ #define G_TYPE_BOOKMARK_FILE (g_bookmark_file_get_type())
++#endif
+ 
+ #define RG_TARGET_NAMESPACE cBookmarkFile
+ #define _SELF(self) ((GBookmarkFile*)(RVAL2BOXED(self, G_TYPE_BOOKMARK_FILE)))


### PR DESCRIPTION
When compiled against current versions of glib, the `glib2` gem in `ruby-gnome` fails to build because of a duplicated declaration of the function `g_bookmark_file_get_type`.

This has already been fixed upstream [1] [2], but the respective patch needs a small adjustment to the path of the affected source file in order to work with `mikutter`'s gemset declaration.

[1]: https://github.com/ruby-gnome/ruby-gnome/commit/396d2d377bd85d9bdd73b26210e323129deea1f4
[2]: https://github.com/ruby-gnome/ruby-gnome/issues/1547

## Description of changes

Add a patch that fixes the build of `glib2` from `ruby-gnome` against current versions of `glib`.

Failing Hydra build: https://hydra.nixos.org/build/241836610#tabs-summary
Hydra log: https://hydra.nixos.org/build/241836610/nixlog/2

Relevant log excerpt:
```
rbglib_bookmarkfile.c:39:1: error: static declaration of 'g_bookmark_file_get_type' follows non-static declaration
   39 | g_bookmark_file_get_type(void)
      | ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/ybmdzvab1s6hfkfj4hm848pgdxzlc36g-glib-2.78.1-dev/include/glib-2.0/gobject/gboxed.h:29,
                 from /nix/store/ybmdzvab1s6hfkfj4hm848pgdxzlc36g-glib-2.78.1-dev/include/glib-2.0/gobject/gobject.h:31,
                 from /nix/store/ybmdzvab1s6hfkfj4hm848pgdxzlc36g-glib-2.78.1-dev/include/glib-2.0/gobject/gbinding.h:31,
                 from /nix/store/ybmdzvab1s6hfkfj4hm848pgdxzlc36g-glib-2.78.1-dev/include/glib-2.0/glib-object.h:24,
                 from rbgobject.h:25,
                 from rbgprivate.h:31,
                 from rbglib_bookmarkfile.c:22:
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
