### PR TITLE
haskellPackages.csound-expression: unbreak on recent GHC

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -936,6 +936,18 @@ self: super: {
   # https://github.com/pxqr/base32-bytestring/issues/4
   base32-bytestring = dontCheck super.base32-bytestring;
 
+  csound-expression =
+    assert super.csound-expression.version == "5.4.3";
+    overrideCabal (drv: {
+      src = (pkgs.fetchFromGitHub {
+        owner = "spell-music";
+        repo = "csound-expression";
+        rev = "345df2c91c9831dd895f58951990165598504814";
+        hash = "sha256-6qPiKsZwZpqB2kmckKDKyQPTcWPIaVwi+EYs74tRod0=";
+      }) + "/csound-expression";
+      editedCabalFile = null;
+    }) super.csound-expression;
+
   # Djinn's last release was 2014, incompatible with Semigroup-Monoid Proposal
   # https://github.com/augustss/djinn/pull/8
   djinn = appendPatch (fetchpatch {


### PR DESCRIPTION
## Description of changes

`haskellPackages.csound-expression` from hackage does not build on recent GHC versions:
```
[12 of 49] Compiling Csound.Options   ( src/Csound/Options.hs, dist/build/Csound/Options.o, dist/build/Csound/Options.dyn_o )

src/Csound/Options.hs:65:61: error:
    • Couldn't match type ‘[Char]’
                     with ‘text-2.0.2:Data.Text.Internal.Text’
      Expected: text-2.0.2:Data.Text.Internal.Text
        Actual: String
    • In the first argument of ‘Jack’, namely ‘name’
      In the second argument of ‘($)’, namely
        ‘Jack name "input" "output"’
      In the ‘rtaudio’ field of a record
   |
65 | setJack name = def { csdFlags = def { rtaudio = Just $ Jack name "input" "output" } }
   |                                                             ^^^^
```

This PR switches over to the source code from git where it's already fixed. See also https://github.com/NixOS/nixpkgs/pull/270705

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
