### PR TITLE
nixos/matrix-appservice-irc: fix syscall filter

### DIFF
--- a/nixos/modules/services/matrix/appservice-irc.nix
+++ b/nixos/modules/services/matrix/appservice-irc.nix
@@ -214,7 +214,7 @@ in {
         RestrictRealtime = true;
         PrivateMounts = true;
         SystemCallFilter = [
-          "@system-service @pkey"
+          "@system-service @pkey @chown"
           "~@privileged @resources"
         ];
         SystemCallArchitectures = "native";


### PR DESCRIPTION
The pre-start script requires `@chown`; the service fails without it.

This was broken in https://github.com/NixOS/nixpkgs/pull/246123. CC @mweinelt.
