### PR TITLE
minecraft-autoupdate: init at 1.2.30

### DIFF
--- a/pkgs/games/minecraft-autoupdate/bootstrap.nix
+++ b/pkgs/games/minecraft-autoupdate/bootstrap.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, fetchurl
+, desktopItem
+, copyDesktopItems
+, makeWrapper
+, wrapGAppsHook
+, gobject-introspection
+, jre
+, libPath
+, envLibPath
+}:
+
+stdenv.mkDerivation rec {
+  pname = "minecraft-launcher";
+
+  # Version of the ado bootstrap launcher
+  # The version of the "core" package is separte
+  version = "1.2.30";
+
+  src = fetchurl {
+    # URL is found by using udpate script
+    url = "https://piston-data.mojang.com/v1/objects/bb5d7a5bd5476db2ce04f52b5c7a74ad8db455a7/minecraft-launcher";
+    sha256 = "sha256-yUzG4jtVI8JTCze0SmOAuFBGlegUTlVKkfMClr5ywnE=";
+  };
+
+  icon = fetchurl {
+    url = "https://launcher.mojang.com/download/minecraft-launcher.svg";
+    sha256 = "0w8z21ml79kblv20wh5lz037g130pxkgs8ll9s3bi94zn2pbrhim";
+  };
+
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook copyDesktopItems gobject-introspection ];
+
+  sourceRoot = ".";
+
+  dontUnpack = true;
+  dontWrapGApps = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt
+    cp ${src} $out/opt/minecraft-launcher
+    chmod +x $out/opt/minecraft-launcher
+
+    install -D $icon $out/share/icons/hicolor/symbolic/apps/minecraft-launcher.svg
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    patchelf \
+      --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+      --set-rpath '$ORIGIN/'":${libPath}" \
+      $out/opt/minecraft-launcher
+  '';
+
+  postFixup = ''
+    # Do not create `GPUCache` in current directory
+    makeWrapper $out/opt/minecraft-launcher $out/bin/minecraft-launcher \
+      --prefix LD_LIBRARY_PATH : ${envLibPath} \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --set JAVA_HOME ${lib.getBin jre} \
+      --chdir /tmp \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "Official bootstrap launcher for Minecraft, a sandbox-building game";
+    homepage = "https://minecraft.net";
+    maintainers = with maintainers; [ jonringer ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/games/minecraft-autoupdate/default.nix
+++ b/pkgs/games/minecraft-autoupdate/default.nix
@@ -1,0 +1,118 @@
+{ lib, stdenv
+, fetchurl
+, copyDesktopItems
+, makeDesktopItem
+, makeWrapper
+, wrapGAppsHook
+, writeShellScript
+, gobject-introspection
+, jre # old or modded versions of the game may require Java 8 (https://aur.archlinux.org/packages/minecraft-launcher/#pinned-674960)
+, pkgs
+, buildFHSEnv
+}:
+let
+  desktopItem = makeDesktopItem {
+    name = "minecraft-launcher";
+    exec = "minecraft-launcher";
+    icon = "minecraft-launcher";
+    comment = "Official launcher for Minecraft, a sandbox-building game";
+    desktopName = "Minecraft Launcher";
+    categories = [ "Game" ];
+  };
+
+  mkEnvLibs = pkgs: with pkgs; [
+    curl
+    libpulseaudio
+    systemd
+    alsa-lib # needed for narrator
+    flite # needed for narrator
+  ];
+
+  envLibPath = lib.makeLibraryPath (mkEnvLibs pkgs);
+
+  mkLibs = pkgs: with pkgs; ([
+    alsa-lib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    libdrm
+    libglvnd
+    libsecret
+    pango
+    gtk3
+    gtk3-x11
+    mesa
+    nspr
+    nss
+    stdenv.cc.cc
+    zlib
+    libuuid
+  ] ++
+  (with xorg; [
+    libX11
+    libxcb
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libXScrnSaver
+  ]));
+
+  libPath = lib.makeLibraryPath (mkLibs pkgs);
+
+  bootstrap = import ./bootstrap.nix {
+    inherit lib stdenv makeWrapper wrapGAppsHook copyDesktopItems gobject-introspection
+      desktopItem jre fetchurl libPath envLibPath;
+  };
+
+  generic = {
+    name ? "minecraft-launcher"
+    , runScript ? "minecraft-launcher"
+  }: buildFHSEnv {
+    inherit name runScript;
+
+    multiArch = false;
+
+    targetPkgs = pkgs: (mkEnvLibs pkgs) ++ (mkLibs pkgs) ++ [ bootstrap ];
+
+    unshareIpc = false;
+    unsharePid = false;
+
+    meta = bootstrap.meta;
+
+    passthru = {
+      inherit bootstrap run;
+      updateScript = ./update.sh;
+    };
+
+  };
+
+  fhs = generic { };
+
+  run = generic {
+    name = "minecraft-run";
+    runScript = writeShellScript "minecraft-run" ''
+      run="$1"
+      if [ "$run" = "" ]; then
+        echo "Usage: minecraft-run command-to-run args..." >&2
+        exit 1
+      fi
+      shift
+
+      exec -- "$run" "$@"
+    '';
+  };
+in
+  fhs
+

--- a/pkgs/games/minecraft-autoupdate/update.sh
+++ b/pkgs/games/minecraft-autoupdate/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -exu -o pipefail
+
+mainManifest=$(curl -s 'https://launchermeta.mojang.com/v1/products/launcher/6f083b80d5e6fabbc4236f81d0d8f8a350c665a9/linux.json')
+version=$(echo "$mainManifest" | jq -r '."launcher-core-ado"[0].version.name')
+launcherManifest=$(echo "$mainManifest" | jq -r '."launcher-bootstrap-ado"[0].manifest.url' | xargs curl -s )
+newSha=$(echo "$launcherManifest" | jq -r '.files."minecraft-launcher".downloads.raw.sha1')
+newURL=$(echo "$launcherManifest" | jq -r '.files."minecraft-launcher".downloads.raw.url')
+
+update-source-version minecraft-autoupdate.bootstrap "${version}" "${newSha}" "${newURL}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38048,6 +38048,7 @@ with pkgs;
   };
 
   minecraft = callPackage ../games/minecraft { };
+  minecraft-autoupdate = callPackage ../games/minecraft-autoupdate { };
 
   minecraft-server-hibernation = callPackage ../tools/games/minecraft/minecraft-server-hibernation { };
 


### PR DESCRIPTION
## Description of changes

Similar to #233909, this provides a buildFHSEnv  version of minecraft which is able to auto-update.

Honestly wasn't aware of the other PR, felt like doing this for "fun".

Not sure if `https://launchermeta.mojang.com/v1` or `https://redstone-launcher.mojang.com/release/v2/` is a more correct source. Seems like it might not be a huge difference given the nature of the bootstrap tool being able to auto-update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
