### PR TITLE
hareThirdParty.hare-toml: init at 0.1.0

### DIFF
--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, hare
+, scdoc
+, lib
+, fetchFromGitea
+, fetchpatch
+, nix-update-script
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-toml";
+  version = "0.1.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "lunacb";
+    repo = "hare-toml";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-JKK5CcDmAW7FH7AzFwgsr9i13eRSXDUokWfZix7f4yY=";
+  };
+
+  patches = [
+    # Remove `abort()` calls from never returning expressions.
+    (fetchpatch {
+      name = "remove-abort-from-never-returning-expressions.patch";
+      url = "https://codeberg.org/lunacb/hare-toml/commit/f26e7cdfdccd2e82c9fce7e9fca8644b825b40f1.patch";
+      hash = "sha256-DFbrxiaV4lQlFmMzo5GbMubIQ4hU3lXgsJqoyeFWf2g=";
+    })
+    # Fix make's install target to install the correct files
+    (fetchpatch {
+      name = "install-correct-files-with-install-target.patch";
+      url = "https://codeberg.org/lunacb/hare-toml/commit/b79021911fe7025a8f5ddd97deb2c4d18c67b25e.patch";
+      hash = "sha256-IL+faumX6BmdyePXTzsSGgUlgDBqOXXzShupVAa7jlQ=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    scdoc
+    hare
+  ];
+
+  makeFlags = [
+    "HARECACHE=.harecache"
+    "PREFIX=${builtins.placeholder "out"}"
+  ];
+
+  checkTarget = "check_local";
+
+  doCheck = true;
+
+  dontConfigure = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A TOML implementation for Hare";
+    homepage = "https://codeberg.org/lunacb/hare-toml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onemoresuza ];
+    inherit (hare.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -5,8 +5,8 @@ let
   inherit (self) callPackage;
 in
 {
-
   hare-compress = callPackage ../development/hare-third-party/hare-compress { };
   hare-ev = callPackage ../development/hare-third-party/hare-ev { };
   hare-json = callPackage ../development/hare-third-party/hare-json { };
+  hare-toml = callPackage ../development/hare-third-party/hare-toml { };
 })


### PR DESCRIPTION
## Description of changes

Initialize [`hare-toml`](https://codeberg.org/lunacb/hare-toml), an implementation of the **TOML** format for `Hare`, at `0.1.0`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
