### PR TITLE
Enable `stdenv` customization through `(buildPython*.override { inherit stdenv; })`

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -557,6 +557,19 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
   with the `pipInstallHook`.
 - `unittestCheckHook` will run tests with `python -m unittest discover`. See [example usage](#using-unittestcheckhook).
 
+#### Overriding build helpers {#overriding-python-build-helpers}
+
+Like many of the build helpers provided by Nixpkgs, Python build helpers typically provide a `<function>.override` attribute.
+It works like [`<pkg>.override`](#sec-pkg-override), and can be used to override the dependencies of each build helper.
+
+This allows specifying the stdenv to be used by `buildPythonPackage` or `buildPythonApplication`. The default (`python.stdenv`) can be overridden as follows:
+
+```nix
+buildPythonPackage.override { stdenv = customStdenv; } {
+  # package attrs...
+}
+```
+
 ## User Guide {#user-guide}
 
 ### Using Python {#using-python}

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -3807,6 +3807,9 @@
   "buildpythonpackage-parameters": [
     "index.html#buildpythonpackage-parameters"
   ],
+  "overriding-python-build-helpers": [
+    "index.html#overriding-python-build-helpers"
+  ],
   "overriding-python-packages": [
     "index.html#overriding-python-packages"
   ],

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -314,6 +314,10 @@
 
 - `emacs` now disables the GC mark trace buffer by default. This improves GC performance by 5%, but can make GC issues harder to debug. This is configurable with `withGcMarkTrace`.
 
+- Passing `stdenv` to `buildPythonPackage` or `buildPythonApplication` has been deprecated and will trigger an error in a future release.
+  Instead, you should _override_ the python build helper, e.g., `(buildPythonPackage.override { stdenv = customStdenv; })`.
+  See [](#overriding-python-build-helpers).
+
 - `buildPythonPackage` and `buildPythonApplication` now default to `nix-update-script` as their default `updateScript`. This should improve automated updates, since nix-update is better maintained than the in-tree update script and has more robust fetcher support.
 
 - `plasma6`: Fixed the `ksycoca` cache not being re-built when `$XDG_CACHE_HOME` is set to something that isn't `$HOME/.cache`.

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -4,6 +4,8 @@
   lib,
   config,
   python,
+  # Allow passing in a custom stdenv to buildPython*.override
+  stdenv,
   wrapPython,
   unzip,
   ensureNewerSourcesForZipFilesHook,
@@ -191,9 +193,6 @@ in
   meta ? { },
 
   doCheck ? true,
-
-  # Allow passing in a custom stdenv to buildPython*
-  stdenv ? python.stdenv,
 
   ...
 }@attrs:

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -45,21 +45,42 @@ let
       override = lib.mirrorFunctionArgs f.override (fdrv: makeOverridablePythonPackage (f.override fdrv));
     };
 
+  overrideStdenvCompat =
+    f:
+    lib.setFunctionArgs (
+      args:
+      if !(lib.isFunction args) && (args ? stdenv) then
+        # TODO: warn that `args ? stdenv` is deprecated (once in-tree usage is migrated)
+        f.override { stdenv = args.stdenv; } args
+      else
+        f args
+    ) (removeAttrs (lib.functionArgs f) [ "stdenv" ])
+    // {
+      # Intentionally drop the effect of overrideStdenvCompat when calling `buildPython*.override`.
+      inherit (f) override;
+    };
+
   mkPythonDerivation =
     if python.isPy3k then ./mk-python-derivation.nix else ./python2/mk-python-derivation.nix;
 
   buildPythonPackage = makeOverridablePythonPackage (
-    callPackage mkPythonDerivation {
-      inherit namePrefix; # We want Python libraries to be named like e.g. "python3.6-${name}"
-      inherit toPythonModule; # Libraries provide modules
-    }
+    overrideStdenvCompat (
+      callPackage mkPythonDerivation {
+        inherit namePrefix; # We want Python libraries to be named like e.g. "python3.6-${name}"
+        inherit toPythonModule; # Libraries provide modules
+        inherit (python) stdenv;
+      }
+    )
   );
 
   buildPythonApplication = makeOverridablePythonPackage (
-    callPackage mkPythonDerivation {
-      namePrefix = ""; # Python applications should not have any prefix
-      toPythonModule = x: x; # Application does not provide modules.
-    }
+    overrideStdenvCompat (
+      callPackage mkPythonDerivation {
+        namePrefix = ""; # Python applications should not have any prefix
+        toPythonModule = x: x; # Application does not provide modules.
+        inherit (python) stdenv;
+      }
+    )
   );
 
   # Check whether a derivation provides a Python module.

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -50,8 +50,10 @@ let
     lib.setFunctionArgs (
       args:
       if !(lib.isFunction args) && (args ? stdenv) then
-        # TODO: warn that `args ? stdenv` is deprecated (once in-tree usage is migrated)
-        f.override { stdenv = args.stdenv; } args
+        lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511) ''
+          Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
+            buildPythonPackage.override { stdenv = customStdenv; } { }
+        '' (f.override { stdenv = args.stdenv; } args)
       else
         f args
     ) (removeAttrs (lib.functionArgs f) [ "stdenv" ])

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -4,6 +4,8 @@
   lib,
   config,
   python,
+  # Allow passing in a custom stdenv to buildPython*.override
+  stdenv,
   wrapPython,
   unzip,
   ensureNewerSourcesForZipFilesHook,
@@ -101,8 +103,6 @@
 }@attrs:
 
 let
-  inherit (python) stdenv;
-
   withDistOutput = lib.elem format [
     "pyproject"
     "setuptools"

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -275,13 +275,15 @@ let
 
   stdenv' = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 in
-buildPythonPackage rec {
+let
+  # From here on, `stdenv` shall be `stdenv'`.
+  stdenv = stdenv';
+in
+buildPythonPackage.override { inherit stdenv; } rec {
   pname = "torch";
   # Don't forget to update torch-bin to the same version.
   version = "2.8.0";
   pyproject = true;
-
-  stdenv = stdenv';
 
   outputs = [
     "out" # output standard python package


### PR DESCRIPTION
## Description of changes

Now that https://github.com/NixOS/nixpkgs/pull/366593 has restored the missing `.override` to `buildPythonPackage` and `buildPythonApplication`, this allow specifying the `stdenv` used by the build helpers through `buildPython*.override` (as most build helpers do) instead of passing it directly into `buildPython*`.

The reason to move to `buildPythonPackage.override { stdenv = ...; }` from `buildPythonPackage { stdenv = ...; }` includes:

1. The `buildPython* { inherit stdenv; ...; }` will be impossible/unfeasible when taking fixed-point arguments (`buildPython* (finalAttrs: { ...; })`). `lib.extendMkDerivation` is on its way, but we need a clean ground to integrate it into `buildPython*`.

2. `stdenv` is a dependency `buildPythonPackage` would (directly or indirectly) get from `pkgs` through `callPackage`. It makes better sense to change it through the `.override` attribute provided by `callPackage`.

3. In the future, we could get rid of all the special, impassable arguments, and pass everything properly either into `stdenv.mkDerivation` or through `passthru`. This way, we only need `overrideAttrs` to override attributes, without having to defined special overriders like `overridePythonAttrs` and for each language and framework. `stdenv` could neither be passed into `stdenv.mkDerivation` or through `passthru`, since `stdenv.mkDerivaiton` will add a `stdenv` attribute to the resulting derivation.

For package definition that used to be:

```nix
{
  lib,
  stdenv,
  buildPythonPackage,
  fetchPyPi,
}:
buildPythonPackage rec {
  inherit stdenv;
  pname = "...";
  version = "...";
  src = fetchPypi {
    inherit pname source;
    hash = "...";
  };
}
```

can now become

```nix
{
  lib,
  stdenv,
  buildPythonPackage,
  fetchPyPi,
}:
buildPythonPackage.override { inherit stdenv; } rec {
  pname = "...";
  version = "...";
  src = fetchPypi {
    inherit pname source;
    hash = "...";
  };
}
```

In the future, when `buildPythonPackage` also takes fixed-point arguments, we could write:

```nix
{
  lib,
  stdenv,
  buildPythonPackage,
  fetchPyPi,
}:
buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
  pname = "...";
  version = "...";
  src = fetchPypi {
    inherit (finalAttrs) pname source;
    hash = "...";
  };
})
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~This PR depends on #366593.~~
Initial effort for #271387.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (no rebuilds other than `nixos-install-tools`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
