### PR TITLE
lib/customisation: fix callPackage error messages

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -4,11 +4,12 @@ let
   inherit (builtins)
     intersectAttrs;
   inherit (lib)
-    functionArgs isFunction mirrorFunctionArgs isAttrs setFunctionArgs levenshteinAtMost
+    functionArgs isFunction mirrorFunctionArgs isAttrs setFunctionArgs
     optionalAttrs attrNames levenshtein filter elemAt concatStringsSep sort take length
     filterAttrs optionalString flip pathIsDirectory head pipe isDerivation listToAttrs
     mapAttrs seq flatten deepSeq warnIf isInOldestRelease extends
     ;
+  inherit (lib.strings) levenshteinAtMost;
 
 in
 rec {
@@ -198,7 +199,7 @@ rec {
         + "${loc'}${prettySuggestions (getSuggestions arg)}";
 
       # Only show the error for the first missing argument
-      error = errorForArg missingArgs.${head (attrNames missingArgs)};
+      error = errorForArg (head (attrNames missingArgs));
 
     in if missingArgs == {}
        then makeOverridable f allArgs


### PR DESCRIPTION
## Description of changes

Broken in 8d162ec7b8c87525af611f163e424ea9b09f7fa0.

Bad:

```
❯ nix-instantiate --eval --expr '(import ./. {}).callPackage ({ kaboom }: {}) {}'
error:
       … from call site

         at «string»:1:1:

            1| (import ./. {}).callPackage ({ kaboom }: {}) {}
             | ^

       … while calling 'callPackageWith'

         at /home/k900/nixpkgs/lib/customisation.nix:152:35:

          151|   */
          152|   callPackageWith = autoArgs: fn: args:
             |                                   ^
          153|     let

       … from call site

         at /home/k900/nixpkgs/lib/customisation.nix:201:15:

          200|       # Only show the error for the first missing argument
          201|       error = errorForArg missingArgs.${head (attrNames missingArgs)};
             |               ^
          202|

       … while calling 'errorForArg'

         at /home/k900/nixpkgs/lib/customisation.nix:188:21:

          187|
          188|       errorForArg = arg:
             |                     ^
          189|         let

       error: cannot coerce a Boolean to a string
```

Good:

```
❯ nix-instantiate --eval --expr '(import ./. {}).callPackage ({ kaboom }: {}) {}'
error:
       … from call site

         at «string»:1:1:

            1| (import ./. {}).callPackage ({ kaboom }: {}) {}
             | ^

       … while calling 'callPackageWith'

         at /home/k900/nixpkgs/lib/customisation.nix:153:35:

          152|   */
          153|   callPackageWith = autoArgs: fn: args:
             |                                   ^
          154|     let

       error: lib.customisation.callPackageWith: Function called without required argument "kaboom" at <unknown location>, did you mean "abook"?
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
