### PR TITLE
renoise: 3.3.2 → 3.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18897,7 +18897,7 @@
   };
   uakci = {
     name = "uakci";
-    email = "uakci@uakci.pl";
+    email = "git@uakci.space";
     github = "uakci";
     githubId = 6961268;
   };

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -1,5 +1,18 @@
-{ lib, stdenv, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsa-lib
-, mpg123, releasePath ? null }:
+{ lib
+, stdenv
+, alsa-lib
+, fetchurl
+, libjack2
+, libX11
+, libXcursor
+, libXext
+, libXinerama
+, libXrandr
+, libXtst
+, mpg123
+, pipewire
+, releasePath ? null
+}:
 
 # To use the full release version:
 # 1) Sign into https://backstage.renoise.com and download the release version to some stable location.
@@ -7,28 +20,44 @@
 # Note: Renoise creates an individual build for each license which screws somewhat with the
 # use of functions like requireFile as the hash will be different for every user.
 let
-  urlVersion = lib.replaceStrings [ "." ] [ "_" ];
-in
+  platforms = {
+    x86_64-linux = {
+      archSuffix = "x86_64";
+      hash = "sha256-Etz6NaeLMysSkcQGC3g+IqUy9QrONCrbkyej63uLflo=";
+    };
+    aarch64-linux = {
+      archSuffix = "arm64";
+      hash = "sha256-PVpgxhJU8RY6QepydqImQnisWBjbrsuW4j49Xot3C6Y=";
+    };
+  };
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "renoise";
-  version = "3.3.2";
+  version = "3.4.3";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-        if releasePath == null then
-        fetchurl {
-          urls = [
-              "https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_Linux.tar.gz"
-              "https://web.archive.org/web/https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_Linux.tar.gz"
-          ];
-          sha256 = "0d9pnrvs93d4bwbfqxwyr3lg3k6gnzmp81m95gglzwdzczxkw38k";
-        }
-        else
-          releasePath
-    else throw "Platform is not supported. Use installation native to your platform https://www.renoise.com/";
+  src = if releasePath != null then
+    releasePath
+  else
+    let
+      platform = platforms.${stdenv.system};
+      urlVersion = lib.replaceStrings [ "." ] [ "_" ] version;
+    in fetchurl {
+      url =
+        "https://files.renoise.com/demo/Renoise_${urlVersion}_Demo_Linux_${platform.archSuffix}.tar.gz";
+      hash = platform.hash;
+    };
 
-  buildInputs = [ alsa-lib libjack2 libX11 libXcursor libXext libXrandr ];
+  buildInputs = [
+    alsa-lib
+    libjack2
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    libXtst
+    pipewire
+  ];
 
   installPhase = ''
     cp -r Resources $out
@@ -79,7 +108,8 @@ stdenv.mkDerivation rec {
     homepage = "https://www.renoise.com/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ uakci ];
+    platforms = lib.attrNames platforms;
+    mainProgram = "renoise";
   };
 }


### PR DESCRIPTION
## Description of changes

It appears that the archive.org links for the older versions of renoise have vanished, breaking the package. I’ve updated the package to point to the newest version while also refurbishing the Nix expression responsible for fetching the right files from files.renoise.com and/or archive.org.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - (Other platforms do not apply; package is confined to x86_64-linux.)
- For non-Linux: Is sandboxing enabled in `nix.conf`?
  - [x] `sandbox = true`
- [ ] ~~Tested compilation of all packages that depend on this change using `nixpkgs-review`~~ (Couldn’t get it to work. With this said, `NIXPKGS_ALLOW_UNFREE=1 nix --impure build .#renoise` works fine.)
- [x] Tested basic functionality of `./result/bin/renoise`

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
