### PR TITLE
[23.05] mbedtls: add patches for CVE-2023-45199 & CVE-2023-43615, mbedtls_2: 2.28.3 -> 2.28.5

### DIFF
--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "2.28.4";
-  hash = "sha256-88Lnj9NgS5PWg2hydvb9cwi6s6BG3UMvkUH2Ny1jmtE=";
+  version = "2.28.5";
+  hash = "sha256-Gl4UQMSvAwYbOi2b/AUMz+zgkOl1o0UA2VveF/3ek8o=";
 }

--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "2.28.3";
-  hash = "sha256-w5bJErCNRZLE8rHcuZlK3bOqel97gPPMKH2cPGUR6Zw=";
+  version = "2.28.4";
+  hash = "sha256-88Lnj9NgS5PWg2hydvb9cwi6s6BG3UMvkUH2Ny1jmtE=";
 }

--- a/pkgs/development/libraries/mbedtls/3.4.0-CVE-2023-45199.patch
+++ b/pkgs/development/libraries/mbedtls/3.4.0-CVE-2023-45199.patch
@@ -1,0 +1,78 @@
+Based on upstream 130938a80403647dc22a3e15ca442a500248647b, alterations
+mostly due to ecdh_psa_peerkey being renamed xxdh_psa_peerkey upstream
+
+--- a/library/ssl_tls12_client.c
++++ b/library/ssl_tls12_client.c
+@@ -1714,7 +1714,7 @@ static int ssl_parse_server_ecdh_params(mbedtls_ssl_context *ssl,
+                                         unsigned char *end)
+ {
+     uint16_t tls_id;
+-    uint8_t ecpoint_len;
++    size_t ecpoint_len;
+     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+     psa_ecc_family_t ec_psa_family = 0;
+     size_t ec_bits = 0;
+@@ -2039,7 +2039,7 @@ static int ssl_get_ecdh_params_from_cert(mbedtls_ssl_context *ssl)
+     ret = mbedtls_ecp_point_write_binary(&peer_key->grp, &peer_key->Q,
+                                          MBEDTLS_ECP_PF_UNCOMPRESSED, &olen,
+                                          ssl->handshake->ecdh_psa_peerkey,
+-                                         MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH);
++                                         sizeof(ssl->handshake->ecdh_psa_peerkey));
+ 
+     if (ret != 0) {
+         MBEDTLS_SSL_DEBUG_RET(1, ("mbedtls_ecp_point_write_binary"), ret);
+--- a/library/ssl_tls12_server.c
++++ b/library/ssl_tls12_server.c
+@@ -3667,22 +3667,32 @@ static int ssl_parse_client_key_exchange(mbedtls_ssl_context *ssl)
+         psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+         mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+ 
+-        MBEDTLS_SSL_DEBUG_MSG(1, ("Read the peer's public key."));
++        MBEDTLS_SSL_DEBUG_MSG(3, ("Read the peer's public key."));
+ 
+         /*
+          * We must have at least two bytes (1 for length, at least 1 for data)
+          */
+         if (buf_len < 2) {
+-            MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid buffer length"));
+-            return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
++            MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid buffer length: %" MBEDTLS_PRINTF_SIZET,
++                                      buf_len));
++            return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+         }
+ 
+         if (data_len < 1 || data_len > buf_len) {
+-            MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid data length"));
+-            return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
++            MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid data length: %" MBEDTLS_PRINTF_SIZET
++                                      " > %" MBEDTLS_PRINTF_SIZET,
++                                      data_len, buf_len));
++            return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+         }
+ 
+         /* Store peer's ECDH public key. */
++        if (data_len > sizeof(handshake->ecdh_psa_peerkey)) {
++            MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid public key length: %" MBEDTLS_PRINTF_SIZET
++                                      " > %" MBEDTLS_PRINTF_SIZET,
++                                      data_len,
++                                      sizeof(handshake->ecdh_psa_peerkey)));
++            return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
++        }
+         memcpy(handshake->ecdh_psa_peerkey, p, data_len);
+         handshake->ecdh_psa_peerkey_len = data_len;
+ 
+--- a/library/ssl_tls13_generic.c
++++ b/library/ssl_tls13_generic.c
+@@ -1447,6 +1447,12 @@ int mbedtls_ssl_tls13_read_public_ecdhe_share(mbedtls_ssl_context *ssl,
+     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, peerkey_len);
+ 
+     /* Store peer's ECDH public key. */
++    if (peerkey_len > sizeof(handshake->ecdh_psa_peerkey)) {
++        MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid public key length: %u > %" MBEDTLS_PRINTF_SIZET,
++                                  (unsigned) peerkey_len,
++                                  sizeof(handshake->ecdh_psa_peerkey)));
++        return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
++    }
+     memcpy(handshake->ecdh_psa_peerkey, p, peerkey_len);
+     handshake->ecdh_psa_peerkey_len = peerkey_len;
+ 

--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -1,6 +1,14 @@
-{ callPackage }:
+{ callPackage, fetchpatch }:
 
 callPackage ./generic.nix {
   version = "3.4.0";
   hash = "sha256-1YA4hp/VEjph5k0qJqhhH4nBbTP3Qu2pl7WpuvPkVfg=";
+  patches = [
+    ./3.4.0-CVE-2023-45199.patch
+    (fetchpatch {
+      name = "CVE-2023-43615.patch";
+      url = "https://github.com/Mbed-TLS/mbedtls/commit/faf0b8604ac49456b0cff7a34ad27485ca145cce.patch";
+      hash = "sha256-GFx+7TmhthRbwBnTgTdNhokftsGwIY7cQGhxKf3WZcE=";
+    })
+  ];
 }

--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -3,6 +3,7 @@
 , version
 , hash
 , fetchFromGitHub
+, patches ? []
 
 , cmake
 , ninja
@@ -14,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "mbedtls";
-  inherit version;
+  inherit version patches;
 
   src = fetchFromGitHub {
     owner = "Mbed-TLS";


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-43615
https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2023-10-1/

https://nvd.nist.gov/vuln/detail/CVE-2023-45199
https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2023-10-2/

For `mbedtls_2` these are resolved by 2.28.5.

For `mbedtls` (3.x) these would be resolved by 3.5.0, but that brings in a _lot_ of other changes, so I located the patches instead. Suggest reading the descriptions of the issues linked and compare the descriptions to confirm I've found the right patches (I also worked backwards from the additions to the changelog for additional proof)

`nixpkgs-review` happy for me, macos 12 x86_64, nixos x86_64. `pkgsi686Linux`, `pkgsStatic`, `pkgsMusl`, `pkgsCross.aarch64-multiplatform` variants of `mbedtls` and `mbedtls_2` build successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
