### PR TITLE
emacsPackages.lspce: unstable-2023-10-30 -> unstable-2023-12-01

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/default.nix
@@ -9,13 +9,13 @@
 }:
 
 let
-  version = "unstable-2023-10-30";
+  version = "unstable-2023-12-01";
 
   src = fetchFromGitHub {
     owner = "zbelial";
     repo = "lspce";
-    rev = "34c59787bcdbf414c92d9b3bf0a0f5306cb98d64";
-    hash = "sha256-kUHGdeJo2zXA410FqXGclgXmgWrll30Zv8fSprcmnIo=";
+    rev = "1958b6fcdfb6288aa17fa42360315d6c4aa85991";
+    hash = "sha256-HUIRm1z6xNJWgX7ykujzniBrOTh76D3dJHrm0LR3nuQ=";
   };
 
   meta = {
@@ -30,17 +30,19 @@ let
     inherit version src meta;
     pname = "lspce-module";
 
-    cargoHash = "sha256-eqSromwJrFhtJWedDVJivfbKpAtSFEtuCP098qOxFgI=";
+    cargoHash = "sha256-qMLwdZwqrK7bPXL1bIbOqM7xQPpeiO8FDoje0CEJeXQ=";
 
     checkFlags = [
       # flaky test
       "--skip=msg::tests::serialize_request_with_null_params"
     ];
 
-    postFixup = ''
+    postInstall = ''
+      mkdir -p $out/share/emacs/site-lisp
       for f in $out/lib/*; do
-        mv $f $out/lib/lspce-module.''${f##*.}
+        mv $f $out/share/emacs/site-lisp/lspce-module.''${f##*.}
       done
+      rmdir $out/lib
     '';
   };
 in
@@ -48,25 +50,16 @@ trivialBuild rec {
   inherit version src meta;
   pname = "lspce";
 
-  preBuild = ''
-    ln -s ${lspce-module}/lib/lspce-module* .
-
-    # Fix byte-compilation
-    substituteInPlace lspce-util.el \
-      --replace "(require 'yasnippet)" "(require 'yasnippet)(require 'url-util)"
-    substituteInPlace lspce-calltree.el \
-      --replace "(require 'compile)" "(require 'compile)(require 'cl-lib)"
-  '';
-
   buildInputs = propagatedUserEnvPkgs;
 
   propagatedUserEnvPkgs = [
     f
     markdown-mode
     yasnippet
+    lspce-module
   ];
 
-  postInstall = ''
-    install lspce-module* $LISPDIR
-  '';
+  passthru = {
+    inherit lspce-module;
+  };
 }


### PR DESCRIPTION
Diff: https://github.com/zbelial/lspce/compare/34c59787bcdbf414c92d9b3bf0a0f5306cb98d64...1958b6fcdfb6288aa17fa42360315d6c4aa85991

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
