### PR TITLE
matlab-language-server: init at 1.1.6

### DIFF
--- a/pkgs/by-name/ma/matlab-language-server/package.nix
+++ b/pkgs/by-name/ma/matlab-language-server/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, fetchpatch
+}:
+
+buildNpmPackage {
+  pname = "matlab-language-server";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "mathworks";
+    repo = "matlab-language-server";
+    # Upstream doesn't tag commits unfortunatly, but lists versions and dates
+    # in README... See complaint at:
+    # https://github.com/mathworks/MATLAB-language-server/issues/24
+    rev = "c8c901956e3bbfbd6eab440a1b60c3fe016cf567";
+    hash = "sha256-D03gXyrvPYOMkJI2YuHfPAnWdXTz5baemykQ5j9L0rs=";
+  };
+  patches = [
+    # https://github.com/mathworks/MATLAB-language-server/pull/23
+    (fetchpatch {
+      url = "https://github.com/mathworks/MATLAB-language-server/commit/56374de620b4855529c4136539f52ab6030e2c92.patch";
+      hash = "sha256-F38ATP+eap0SnxQoib1JwIvNCFfB7g8EtXI9+iK5+HA=";
+    })
+  ];
+
+  npmDepsHash = "sha256-P3MSrwk6FVt4lK58pjwy0YOg2UZI0TG8uXjqCPudgTE=";
+
+  npmBuildScript = "package";
+
+  meta = {
+    description = "Language Server for MATLAB® code";
+    homepage = "https://github.com/mathworks/MATLAB-language-server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "matlab-language-server";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
