### PR TITLE
cryptomator: Add secret service and appindicator

### DIFF
--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -1,16 +1,19 @@
 { lib, stdenv, fetchFromGitHub
 , autoPatchelfHook
 , fuse3
-, maven, jdk, makeShellWrapper, glib, wrapGAppsHook
+, maven, jdk21, makeShellWrapper, glib, wrapGAppsHook
+, libayatana-appindicator
 }:
 
 
 let
+  jdk = jdk21 .override (lib.optionalAttrs stdenv.isLinux {
+    enableJavaFX = true;
+  });
   mavenJdk = maven.override {
-    jdk = jdk;
+    inherit jdk;
   };
 in
-assert stdenv.isLinux; # better than `called with unexpected argument 'enableJavaFX'`
 mavenJdk.buildMavenPackage rec {
   pname = "cryptomator";
   version = "1.11.0";
@@ -22,14 +25,13 @@ mavenJdk.buildMavenPackage rec {
     hash = "sha256-NMNlDEUpwKUywzhXhxlNX7NiE+6wOov2Yt8nTfbKTNI=";
   };
 
-  mvnParameters = "-Dmaven.test.skip=true";
-  mvnHash = "sha256-jIHMUj7ZQFu4XAvWUywj4f0PbmLHGtU5VRG0ZuKm3mA=";
+  mvnParameters = "-Dmaven.test.skip=true -Plinux";
+  mvnHash = "sha256-cmwU9k7TRRJ07bT1EmY3pIBkvvqmFyE7WJeVL7VFDyc=";
 
   preBuild = ''
     VERSION=${version}
     SEMVER_STR=${version}
   '';
-
 
   # This is based on the instructins in https://github.com/cryptomator/cryptomator/blob/develop/dist/linux/appimage/build.sh
   installPhase = ''
@@ -38,8 +40,9 @@ mavenJdk.buildMavenPackage rec {
     cp target/libs/* $out/share/cryptomator/libs/
     cp target/mods/* target/cryptomator-*.jar $out/share/cryptomator/mods/
 
-    makeShellWrapper ${jdk}/bin/java $out/bin/cryptomator \
+    makeShellWrapper ${jdk}/bin/java $out/bin/${pname} \
       --add-flags "--enable-preview" \
+      --add-flags "--enable-native-access=org.cryptomator.jfuse.linux.amd64,org.purejava.appindicator" \
       --add-flags "--class-path '$out/share/cryptomator/libs/*'" \
       --add-flags "--module-path '$out/share/cryptomator/mods'" \
       --add-flags "-Dfile.encoding='utf-8'" \
@@ -49,17 +52,17 @@ mavenJdk.buildMavenPackage rec {
       --add-flags "-Dcryptomator.p12Path='@{userhome}/.config/Cryptomator/key.p12'" \
       --add-flags "-Dcryptomator.ipcSocketPath='@{userhome}/.config/Cryptomator/ipc.socket'" \
       --add-flags "-Dcryptomator.mountPointsDir='@{userhome}/.local/share/Cryptomator/mnt'" \
-      --add-flags "-Dcryptomator.showTrayIcon=false" \
-      --add-flags "-Dcryptomator.buildNumber='nix'" \
+      --add-flags "-Dcryptomator.showTrayIcon=true" \
+      --add-flags "-Dcryptomator.buildNumber='nix-${src.rev}'" \
       --add-flags "-Dcryptomator.appVersion='${version}'" \
-      --add-flags "-Djdk.gtk.version=3" \
+      --add-flags "-Djava.net.useSystemProxies=true" \
       --add-flags "-Xss20m" \
       --add-flags "-Xmx512m" \
-      --add-flags "-Djavafx.embed.singleThread=true " \
-      --add-flags "-Dawt.useSystemAAFontSettings=on" \
+      --add-flags "-Dcryptomator.disableUpdateCheck=true" \
+      --add-flags "-Dcryptomator.integrationsLinux.trayIconsDir='$out/share/icons/hicolor/symbolic/apps'" \
       --add-flags "--module org.cryptomator.desktop/org.cryptomator.launcher.Cryptomator" \
       --prefix PATH : "$out/share/cryptomator/libs/:${lib.makeBinPath [ jdk glib ]}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fuse3 ]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fuse3 libayatana-appindicator ]}" \
       --set JAVA_HOME "${jdk.home}"
 
     # install desktop entry and icons
@@ -80,7 +83,7 @@ mavenJdk.buildMavenPackage rec {
     wrapGAppsHook
     jdk
   ];
-  buildInputs = [ fuse3 jdk glib ];
+  buildInputs = [ fuse3 jdk glib libayatana-appindicator ];
 
   meta = with lib; {
     description = "Free client-side encryption for your cloud files";

--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -1,19 +1,17 @@
 { lib, stdenv, fetchFromGitHub
 , autoPatchelfHook
 , fuse3
-, maven, jdk21, makeShellWrapper, glib, wrapGAppsHook
+, maven, jdk, makeShellWrapper, glib, wrapGAppsHook
 , libayatana-appindicator
 }:
 
 
 let
-  jdk = jdk21 .override (lib.optionalAttrs stdenv.isLinux {
-    enableJavaFX = true;
-  });
   mavenJdk = maven.override {
-    inherit jdk;
+    jdk = jdk;
   };
 in
+assert stdenv.isLinux; # better than `called with unexpected argument 'enableJavaFX'`
 mavenJdk.buildMavenPackage rec {
   pname = "cryptomator";
   version = "1.11.0";


### PR DESCRIPTION
## Description of changes

Adding:
- secret service integration (save secrets in keyring)
- appindicator
- Native jfuse
- Adapting parameters from cryptomator build

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
