### PR TITLE
python311Packages.scancode-toolkit: 32.0.6 -> 32.0.8

### DIFF
--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -16,7 +16,6 @@
 , extractcode-libarchive
 , fasteners
 , fetchPypi
-, fetchpatch
 , fingerprints
 , ftfy
 , gemfileparser2
@@ -48,12 +47,12 @@
 , pythonOlder
 , requests
 , saneyaml
+, setuptools
 , spdx-tools
 , text-unidecode
 , toml
 , typecode
 , typecode-libmagic
-, typing
 , urlpy
 , xmltodict
 , zipp
@@ -61,16 +60,21 @@
 
 buildPythonPackage rec {
   pname = "scancode-toolkit";
-  version = "32.0.6";
+  version = "32.0.8";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-suqk7LOnZgSJGlaHq81LDOSCHZWdsJOUbma6MEpHxSM=";
+    hash = "sha256-W6Ev1MV8cZU4bauAfmuZsBzMJKz7xpw8siO3Afn5mc8=";
   };
 
   dontConfigure = true;
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     attrs
@@ -126,32 +130,11 @@ buildPythonPackage rec {
     xmltodict
   ] ++ lib.optionals (pythonOlder "3.9") [
     zipp
-  ] ++ lib.optionals (pythonOlder "3.7") [
-    typing
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
   ];
-
-  patches = [
-    (fetchpatch {
-      name = "${pname}-allow-stable-spdx-tools.patch";
-      url = "https://github.com/nexB/scancode-toolkit/commit/d89ab6584d3df6b7eb1d1394559e9d967d6db6ae.patch";
-      includes = [ "src/*" ];
-      hash = "sha256-AU3vJlOxmCy3yvkupVaAVxAKxJI3ymXEk+A5DWSkfOM=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pdfminer.six >= 20200101" "pdfminer.six" \
-      --replace "pluggy >= 0.12.0, < 1.0" "pluggy" \
-      --replace "pygmars >= 0.7.0" "pygmars" \
-      --replace "license_expression >= 21.6.14" "license_expression" \
-      --replace "intbitset >= 2.3.0,  < 3.0" "intbitset" \
-      --replace "spdx_tools == 0.7.0a3" "spdx_tools"
-  '';
 
   # Importing scancode needs a writeable home, and preCheck happens in between
   # pythonImportsCheckPhase and pytestCheckPhase.
@@ -163,7 +146,13 @@ buildPythonPackage rec {
     "scancode"
   ];
 
-  # takes a long time and doesn't appear to do anything
+  disabledTestPaths = [
+    # Tests are outdated
+    "src/formattedcode/output_spdx.py"
+    "src/scancode/cli.py"
+  ];
+
+  # Takes a long time and doesn't appear to do anything
   dontStrip = true;
 
   meta = with lib; {


### PR DESCRIPTION
Changelog: https://github.com/nexB/scancode-toolkit/blob/v32.0.8/CHANGELOG.rst

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
