### PR TITLE
qt6.qtmultimedia: Enable ffmpeg/VAAPI backend

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -53,3 +53,5 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - The `hardware.pulseaudio` module now sets permission of pulse user home directory to 755 when running in "systemWide" mode. It fixes [issue 114399](https://github.com/NixOS/nixpkgs/issues/114399).
 
+- QtMultimedia has changed its default backend to `QT_MEDIA_BACKEND=ffmpeg` (previously `gstreamer` on Linux or `darwin` on MacOS).
+  The previous native backends remain available but are now minimally maintained. Refer to [upstream documentation](https://doc.qt.io/qt-6/qtmultimedia-index.html#ffmpeg-as-the-default-backend) for further details about each platform.

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -13,8 +13,10 @@
 , gst-plugins-good
 , gst-libav
 , gst-vaapi
+, ffmpeg_6
 , libpulseaudio
 , wayland
+, libXrandr
 , elfutils
 , libunwind
 , orc
@@ -24,8 +26,8 @@
 qtModule {
   pname = "qtmultimedia";
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libunwind orc ]
-    ++ lib.optionals stdenv.isLinux [ libpulseaudio elfutils alsa-lib wayland ];
+  buildInputs = [ libunwind orc ffmpeg_6 ]
+    ++ lib.optionals stdenv.isLinux [ libpulseaudio elfutils alsa-lib wayland libXrandr ];
   propagatedBuildInputs = [ qtbase qtdeclarative qtsvg qtshadertools qtquick3d ]
     ++ lib.optionals stdenv.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]
     ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -3,6 +3,7 @@
 , stdenv
 , qtbase
 , qtdeclarative
+, qtquick3d
 , qtshadertools
 , qtsvg
 , pkg-config
@@ -25,7 +26,7 @@ qtModule {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libunwind orc ]
     ++ lib.optionals stdenv.isLinux [ libpulseaudio elfutils alsa-lib wayland ];
-  propagatedBuildInputs = [ qtbase qtdeclarative qtsvg qtshadertools ]
+  propagatedBuildInputs = [ qtbase qtdeclarative qtsvg qtshadertools qtquick3d ]
     ++ lib.optionals stdenv.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]
     ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];
 

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -14,6 +14,7 @@
 , gst-libav
 , gst-vaapi
 , ffmpeg_6
+, libva
 , libpulseaudio
 , wayland
 , libXrandr
@@ -27,7 +28,7 @@ qtModule {
   pname = "qtmultimedia";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libunwind orc ffmpeg_6 ]
-    ++ lib.optionals stdenv.isLinux [ libpulseaudio elfutils alsa-lib wayland libXrandr ];
+    ++ lib.optionals stdenv.isLinux [ libpulseaudio elfutils alsa-lib wayland libXrandr libva ];
   propagatedBuildInputs = [ qtbase qtdeclarative qtsvg qtshadertools qtquick3d ]
     ++ lib.optionals stdenv.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]
     ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -33,6 +33,8 @@ qtModule {
     ++ lib.optionals stdenv.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]
     ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];
 
+  cmakeFlags = [ "-DENABLE_DYNAMIC_RESOLVE_VAAPI_SYMBOLS=0" ];
+
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin
     "-include AudioToolbox/AudioToolbox.h";
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin


### PR DESCRIPTION
## Description of changes

Enable new QtMultimedia plugins to match upstream recommendations/defaults for Qt6.6
- Spatial Audio (Quick3D)
 https://doc.qt.io/qt-6.5/qtquick3d-audio-qmlmodule.html
- ffmpeg
  https://doc.qt.io/qt-6.5/qtmultimedia-index.html#ffmpeg-as-the-default-backend
- vaapi acceleration

See also https://github.com/NixOS/nixpkgs/pull/194167 (closed unmerged) which had started to make similar changes back in Qt 6.4; I presume it was rejected/abandoned because at that point these new backends were still technology previews and not enabled by default in the upstream releases either. Now they are the recommended defaults.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

--

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
