### PR TITLE
cudatoolkit: Replace vendored Qt plugins with symlinks

### DIFF
--- a/pkgs/development/cuda-modules/cudatoolkit/default.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/default.nix
@@ -258,12 +258,27 @@ backendStdenv.mkDerivation rec {
         rm $out/host-linux-x64/libstdc++.so*
       ''}
         ${
-          lib.optionalString (lib.versionAtLeast version "11.8")
+          lib.optionalString (lib.versionAtLeast version "11.8" && lib.versionOlder version "12")
             # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/.......-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
             # we only ship libtiff.so.6, so let's use qt plugins built by Nix.
             # TODO: don't copy, come up with a symlink-based "merge"
             ''
               rsync ${lib.getLib qt6Packages.qtimageformats}/lib/qt-6/plugins/ $out/host-linux-x64/Plugins/ -aP
+            ''
+        }
+        ${
+          lib.optionalString (lib.versionAtLeast version "12")
+            # Use Qt plugins built by Nix.
+            ''
+              for qtlib in $out/host-linux-x64/Plugins/*/libq*.so; do
+                qtdir=$(basename $(dirname $qtlib))
+                filename=$(basename $qtlib)
+                for qtpkgdir in ${lib.concatMapStringsSep " " (x: qt6Packages.${x}) ["qtbase" "qtimageformats" "qtsvg" "qtwayland"]}; do
+                  if [ -e $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename ]; then
+                    ln -snf $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename $qtlib
+                  fi
+                done
+              done
             ''
         }
 
@@ -336,6 +351,20 @@ backendStdenv.mkDerivation rec {
       wrapProgram "$out/bin/$b" \
         --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
     done
+    ${
+      lib.optionalString (lib.versionAtLeast version "12")
+        # Check we don't have any lurking vendored qt libraries that weren't
+        # replaced during installPhase
+        ''
+          qtlibfiles=$(find $out -name "libq*.so" -type f)
+          if [ ! -z "$qtlibfiles" ]; then
+            echo "Found unexpected vendored Qt library files in $out" >&2
+            echo $qtlibfiles >&2
+            echo "These should be replaced with symlinks in installPhase" >&2
+            exit 1
+          fi
+        ''
+    }
   '';
 
   # cuda-gdb doesn't run correctly when not using sandboxing, so


### PR DESCRIPTION
This resolves crashes in nsys-ui

## Description of changes

Although we remove most of the vendored Qt libraries in cudatoolkit (and use patchelf to ensure the Nix versions are picked up), there are still quite a lot of Qt plugin libraries that remain. These appear to be causing the `nsys-ui` crashes reported in #232458 due to binary compatibility issues. 

Fixes #232458

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
