### PR TITLE
buildPython*: migrate from `buildPython* { inherit stdenv; ...; }` to `(buildPython*.override { inherit stdenv; }) { ... }`

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -542,6 +542,10 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
   with the `pipInstallHook`.
 - `unittestCheckHook` will run tests with `python -m unittest discover`. See [example usage](#using-unittestcheckhook).
 
+#### Overriding build helpers {#overriding-python-build-helpers}
+
+Like most of the build helpers provided by Nixpkgs, most Python build helpers provide a `<function>.override` attributes. It works like [<pkg>.override](#sec-pkg-override), and can be used to override the dependencies of each build helper. Specifically, the `stdenv` used by `buildPythonPackage` and `buildPythonApplication`, which defaults to `python.stdenv`, can be overridden with `buildPythonPackage.override { stdenv = customStdenv; }` and `buildPythonApplication.override { stdenv = customStdenv; }`, respectively.
+
 ## User Guide {#user-guide}
 
 ### Using Python {#using-python}

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -3406,6 +3406,9 @@
   "buildpythonpackage-parameters": [
     "index.html#buildpythonpackage-parameters"
   ],
+  "overriding-python-build-helpers": [
+    "index.html#overriding-python-build-helpers"
+  ],
   "overriding-python-packages": [
     "index.html#overriding-python-packages"
   ],

--- a/pkgs/applications/networking/browsers/webmacs/default.nix
+++ b/pkgs/applications/networking/browsers/webmacs/default.nix
@@ -7,9 +7,7 @@
   herbstluftwm,
 }:
 
-mkDerivationWith python3Packages.buildPythonApplication rec {
-  inherit stdenv;
-
+mkDerivationWith python3Packages.buildPythonApplication.override { inherit stdenv; } rec {
   pname = "webmacs";
   version = "0.8";
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -4,6 +4,8 @@
   lib,
   config,
   python,
+  # Allow passing in a custom stdenv to buildPython*.override
+  stdenv,
   wrapPython,
   unzip,
   ensureNewerSourcesForZipFilesHook,
@@ -198,9 +200,6 @@ in
   doCheck ? true,
 
   disabledTestPaths ? [ ],
-
-  # Allow passing in a custom stdenv to buildPython*
-  stdenv ? python.stdenv,
 
   ...
 }@attrs:

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -43,21 +43,41 @@ let
       override = lib.mirrorFunctionArgs f.override (fdrv: makeOverridablePythonPackage (f.override fdrv));
     };
 
+  overrideStdenvCompat =
+    f:
+    lib.setFunctionArgs (
+      args:
+      if !(lib.isFunction args) && (args ? stdenv) then
+        f.override { stdenv = args.stdenv; } args
+      else
+        f args
+    ) (removeAttrs (lib.functionArgs f) [ "stdenv" ])
+    // {
+      # Intentionally drop the effect of overrideStdenvCompat when calling `buildPython*.override`.
+      inherit (f) override;
+    };
+
   mkPythonDerivation =
     if python.isPy3k then ./mk-python-derivation.nix else ./python2/mk-python-derivation.nix;
 
   buildPythonPackage = makeOverridablePythonPackage (
-    callPackage mkPythonDerivation {
-      inherit namePrefix; # We want Python libraries to be named like e.g. "python3.6-${name}"
-      inherit toPythonModule; # Libraries provide modules
-    }
+    overrideStdenvCompat (
+      callPackage mkPythonDerivation {
+        inherit namePrefix; # We want Python libraries to be named like e.g. "python3.6-${name}"
+        inherit toPythonModule; # Libraries provide modules
+        inherit (python) stdenv;
+      }
+    )
   );
 
   buildPythonApplication = makeOverridablePythonPackage (
-    callPackage mkPythonDerivation {
-      namePrefix = ""; # Python applications should not have any prefix
-      toPythonModule = x: x; # Application does not provide modules.
-    }
+    overrideStdenvCompat (
+      callPackage mkPythonDerivation {
+        namePrefix = ""; # Python applications should not have any prefix
+        toPythonModule = x: x; # Application does not provide modules.
+        inherit (python) stdenv;
+      }
+    )
   );
 
   # Check whether a derivation provides a Python module.

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -38,7 +38,10 @@ let
         }
       else
         result
-    );
+    )
+    // lib.optionalAttrs (f ? override) {
+      override = lib.mirrorFunctionArgs f.override (fdrv: makeOverridablePythonPackage (f.override fdrv));
+    };
 
   mkPythonDerivation =
     if python.isPy3k then ./mk-python-derivation.nix else ./python2/mk-python-derivation.nix;

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -4,6 +4,8 @@
   lib,
   config,
   python,
+  # Allow passing in a custom stdenv to buildPython*.override
+  stdenv,
   wrapPython,
   unzip,
   ensureNewerSourcesForZipFilesHook,
@@ -101,8 +103,6 @@
 }@attrs:
 
 let
-  inherit (python) stdenv;
-
   withDistOutput = lib.elem format [
     "pyproject"
     "setuptools"

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -48,6 +48,8 @@ let
   pyside-tools-uic = writeShellScriptBin "pyside6-uic" ''
     exec ${qt6.qtbase}/libexec/uic -g python "$@"
   '';
+
+  stdenv = python.stdenv;
 in
 
 buildPythonPackage rec {
@@ -61,8 +63,6 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-slBJleeDi0mCVThty4NUX4M9vaCLV+E8rnp1Ab77TmE=";
   };
-
-  stdenv = python.stdenv;
 
   outputs = [ "out" ] ++ lib.optional withDocs "doc";
 

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -11,12 +11,10 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage.override { inherit stdenv; } rec {
   pname = "psutil";
   version = "6.1.1";
   pyproject = true;
-
-  inherit stdenv;
 
   disabled = pythonOlder "3.7";
 

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -27,6 +27,9 @@
   sparsehash,
 }:
 
+let
+  stdenv = python.stdenv;
+in
 buildPythonPackage rec {
   pname = "python-mapnik";
   version = "3.0.16-unstable-2024-02-22";
@@ -52,8 +55,6 @@ buildPythonPackage rec {
     # https://github.com/mapnik/python-mapnik/commit/e9f88a95a03dc081826a69da67bbec3e4cccd5eb
     ./python-mapnik_std_optional.patch
   ];
-
-  stdenv = python.stdenv;
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/sourmash/default.nix
+++ b/pkgs/development/python-modules/sourmash/default.nix
@@ -24,13 +24,11 @@ let
   stdenv' =
     if stdenv.hostPlatform.isDarwin then overrideSDK stdenv { darwinMinVersion = "10.14"; } else stdenv;
 in
-buildPythonPackage rec {
+buildPythonPackage.override { stdenv = stdenv'; } rec {
   pname = "sourmash";
   version = "4.8.12";
   pyproject = true;
   disabled = pythonOlder "3.9";
-
-  stdenv = stdenv';
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -328,8 +328,10 @@ let
         jsoncpp
         libjpeg_turbo
         libpng
-        (pybind11.overridePythonAttrs (_: {
-          inherit stdenv;
+        (pybind11.override (previousArgs: {
+          buildPythonPackage = previousArgs.buildPythonPackage.override {
+            inherit stdenv;
+          };
         }))
         snappy
         sqlite

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -45,7 +45,7 @@
   rocmSupport ? !config.cudaSupport,
   rocmPackages ? { },
   gpuTargets ? [ ],
-}@args:
+}:
 
 let
   cutlass = fetchFromGitHub {
@@ -56,12 +56,13 @@ let
   };
 in
 
-buildPythonPackage rec {
+let
+  stdenv' = if cudaSupport then cudaPackages.backendStdenv else stdenv;
+in
+buildPythonPackage.override { stdenv = stdenv'; } rec {
   pname = "vllm";
   version = "0.6.2";
   pyproject = true;
-
-  stdenv = if cudaSupport then cudaPackages.backendStdenv else args.stdenv;
 
   src = fetchFromGitHub {
     owner = "vllm-project";

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -32,7 +32,9 @@ let
   inherit (torch) cudaCapabilities cudaPackages cudaSupport;
   version = "0.0.28.post3";
 in
-buildPythonPackage {
+buildPythonPackage.override {
+  stdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
+} {
   pname = "xformers";
   inherit version;
   pyproject = true;
@@ -63,8 +65,6 @@ buildPythonPackage {
   env = lib.attrsets.optionalAttrs cudaSupport {
     TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
   };
-
-  stdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 
   buildInputs = lib.optionals cudaSupport (
     with cudaPackages;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `buildPython* { inherit stdenv; ...; }` will be impossible/unfeasible when taking fixed-point arguments (`buildPython* (finalAttrs: { ...; })`).

This PR does tree-wide migration to the `(buildPython*.override { inherit stdenv; ...; }) { ... }` style of customize stdenv specification, and print out a warning when `stdenv = ;` is passed directly into `buildPython*`.

Depends on #271762, will be shorter once that PR gets merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (No changed path aside from `nixos-install-tools`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
