### PR TITLE
rocmPackages_5: pin stdenv to GCC 12

### DIFF
--- a/pkgs/development/rocm-modules/5/default.nix
+++ b/pkgs/development/rocm-modules/5/default.nix
@@ -1,4 +1,5 @@
-{ callPackage
+{ gcc12Stdenv # FIXME: Try removing this with a new ROCm release https://github.com/NixOS/nixpkgs/issues/271943
+, callPackage
 , recurseIntoAttrs
 , symlinkJoin
 , fetchFromGitHub
@@ -73,10 +74,11 @@ in rec {
   # Broken, too many errors
   rdc = callPackage ./rdc {
     inherit rocmUpdateScript rocm-smi rocm-runtime;
+    stdenv = gcc12Stdenv;
     # stdenv = llvm.rocmClangStdenv;
   };
 
-  rocm-docs-core = python3Packages.callPackage ./rocm-docs-core { };
+  rocm-docs-core = python3Packages.callPackage ./rocm-docs-core { stdenv = gcc12Stdenv; };
 
   ## ROCm-Developer-Tools ##
   hip-common = callPackage ./hip-common {
@@ -107,17 +109,20 @@ in rec {
   rocprofiler = callPackage ./rocprofiler {
     inherit rocmUpdateScript clr rocm-core rocm-thunk rocm-device-libs roctracer rocdbgapi rocm-smi hsa-amd-aqlprofile-bin;
     inherit (llvm) clang;
+    stdenv = gcc12Stdenv;
   };
 
   # Needs GCC
   roctracer = callPackage ./roctracer {
     inherit rocmUpdateScript rocm-device-libs rocm-runtime clr;
+    stdenv = gcc12Stdenv;
   };
 
   # Needs GCC
   rocgdb = callPackage ./rocgdb {
     inherit rocmUpdateScript;
     elfutils = elfutils.override { enableDebuginfod = true; };
+    stdenv = gcc12Stdenv;
   };
 
   rocdbgapi = callPackage ./rocdbgapi {

--- a/pkgs/development/rocm-modules/5/llvm/default.nix
+++ b/pkgs/development/rocm-modules/5/llvm/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ # stdenv FIXME: Try changing back to this with a new ROCm release https://github.com/NixOS/nixpkgs/issues/271943
+  gcc12Stdenv
 , callPackage
 , rocmUpdateScript
 , wrapBintoolsWith
@@ -12,18 +13,18 @@
 let
   ## Stage 1 ##
   # Projects
-  llvm = callPackage ./stage-1/llvm.nix { inherit rocmUpdateScript; };
-  clang-unwrapped = callPackage ./stage-1/clang-unwrapped.nix { inherit rocmUpdateScript llvm; };
-  lld = callPackage ./stage-1/lld.nix { inherit rocmUpdateScript llvm; };
+  llvm = callPackage ./stage-1/llvm.nix { inherit rocmUpdateScript; stdenv = gcc12Stdenv; };
+  clang-unwrapped = callPackage ./stage-1/clang-unwrapped.nix { inherit rocmUpdateScript llvm; stdenv = gcc12Stdenv; };
+  lld = callPackage ./stage-1/lld.nix { inherit rocmUpdateScript llvm; stdenv = gcc12Stdenv; };
 
   # Runtimes
-  runtimes = callPackage ./stage-1/runtimes.nix { inherit rocmUpdateScript llvm; };
+  runtimes = callPackage ./stage-1/runtimes.nix { inherit rocmUpdateScript llvm; stdenv = gcc12Stdenv; };
 
   ## Stage 2 ##
   # Helpers
   bintools-unwrapped = callPackage ./stage-2/bintools-unwrapped.nix { inherit llvm lld; };
   bintools = wrapBintoolsWith { bintools = bintools-unwrapped; };
-  rStdenv = callPackage ./stage-2/rstdenv.nix { inherit llvm clang-unwrapped lld runtimes bintools; };
+  rStdenv = callPackage ./stage-2/rstdenv.nix { inherit llvm clang-unwrapped lld runtimes bintools; stdenv = gcc12Stdenv; };
 in rec {
   inherit
   llvm
@@ -40,8 +41,8 @@ in rec {
 
   ## Stage 3 ##
   # Helpers
-  clang = callPackage ./stage-3/clang.nix { inherit llvm lld clang-unwrapped bintools libc libunwind libcxxabi libcxx compiler-rt; };
-  rocmClangStdenv = overrideCC stdenv clang;
+  clang = callPackage ./stage-3/clang.nix { inherit llvm lld clang-unwrapped bintools libc libunwind libcxxabi libcxx compiler-rt; stdenv = gcc12Stdenv; };
+  rocmClangStdenv = overrideCC gcc12Stdenv clang;
 
   # Projects
   clang-tools-extra = callPackage ./stage-3/clang-tools-extra.nix { inherit rocmUpdateScript llvm clang-unwrapped; stdenv = rocmClangStdenv; };

--- a/pkgs/development/rocm-modules/5/llvm/stage-1/clang-unwrapped.nix
+++ b/pkgs/development/rocm-modules/5/llvm/stage-1/clang-unwrapped.nix
@@ -1,10 +1,11 @@
-{ callPackage
+{ stdenv
+, callPackage
 , rocmUpdateScript
 , llvm
 }:
 
 callPackage ../base.nix rec {
-  inherit rocmUpdateScript;
+  inherit stdenv rocmUpdateScript;
   targetName = "clang-unwrapped";
   targetDir = "clang";
   extraBuildInputs = [ llvm ];

--- a/pkgs/development/rocm-modules/5/llvm/stage-1/lld.nix
+++ b/pkgs/development/rocm-modules/5/llvm/stage-1/lld.nix
@@ -1,10 +1,11 @@
-{ callPackage
+{ stdenv
+, callPackage
 , rocmUpdateScript
 , llvm
 }:
 
 callPackage ../base.nix rec {
-  inherit rocmUpdateScript;
+  inherit stdenv rocmUpdateScript;
   buildMan = false; # No man pages to build
   targetName = "lld";
   targetDir = targetName;

--- a/pkgs/development/rocm-modules/5/llvm/stage-1/llvm.nix
+++ b/pkgs/development/rocm-modules/5/llvm/stage-1/llvm.nix
@@ -4,7 +4,7 @@
 }:
 
 callPackage ../base.nix {
-  inherit rocmUpdateScript;
+  inherit stdenv rocmUpdateScript;
   requiredSystemFeatures = [ "big-parallel" ];
   isBroken = stdenv.isAarch64; # https://github.com/RadeonOpenCompute/ROCm/issues/1831#issuecomment-1278205344
 }

--- a/pkgs/development/rocm-modules/5/llvm/stage-1/runtimes.nix
+++ b/pkgs/development/rocm-modules/5/llvm/stage-1/runtimes.nix
@@ -1,11 +1,12 @@
 { lib
+, stdenv
 , callPackage
 , rocmUpdateScript
 , llvm
 }:
 
 callPackage ../base.nix rec {
-  inherit rocmUpdateScript;
+  inherit stdenv rocmUpdateScript;
   buildDocs = false;
   buildMan = false;
   buildTests = false;


### PR DESCRIPTION
## Description of changes
Lazy fix for the linked issue that I have not tested, as I do not have much time currently.
Only merge once #268097 is merged.

There is a lot more I can do here, there was a ``rocmPackages`` rework I was working on, ~~which I think I accidentally just killed with this branch~~ thankfully github is smart (https://github.com/Madouura/nixpkgs/tree/dev/rocm-rework). Oh well. Any further improvements/nitpicks should go to that, this is just a quick fix.

Fixes: #271943
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
