### PR TITLE
tree-sitter-grammar: ensure enough space when updating id of shared lib on Darwin

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -23,8 +23,13 @@ stdenv.mkDerivation ({
 
   nativeBuildInputs = lib.optionals generate [ nodejs tree-sitter ];
 
-  CFLAGS = [ "-Isrc" "-O2" ];
-  CXXFLAGS = [ "-Isrc" "-O2" ];
+  env = {
+    CFLAGS = toString [ "-Isrc" "-O2" ];
+    CXXFLAGS = toString [ "-Isrc" "-O2" ];
+  } // lib.optionalAttrs stdenv.isDarwin {
+    # Ensure that there is enough space to update the install names of the output on Darwin.
+    NIX_LDFLAGS = "-headerpad_max_install_names";
+  };
 
   stripDebugList = [ "parser" ];
 


### PR DESCRIPTION
This PR is trying to fix the error when updating install names on Darwin:
```
error: install_name_tool: changing install names or rpaths can't be redone for: [...]
(the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
```

This technique is also used by:
+ [ghostscript](https://github.com/plastic-forks/nixpkgs/blob/702e789054ce561091666756ab57522f33e505a6/pkgs/misc/ghostscript/default.nix#L128)
+ [lpsolve](https://github.com/plastic-forks/nixpkgs/blob/702e789054ce561091666756ab57522f33e505a6/pkgs/applications/science/math/lp_solve/default.nix#L28)
+ [suitesparse](https://github.com/plastic-forks/nixpkgs/blob/702e789054ce561091666756ab57522f33e505a6/pkgs/development/libraries/science/math/suitesparse/default.nix#L66)
+ ...

It should be safe to add it. I have tested on x86_64-darwin.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
