### PR TITLE
ocamlPackages.gluten: 0.3.0 → 0.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/gluten/default.nix
+++ b/pkgs/development/ocaml-modules/gluten/default.nix
@@ -3,25 +3,22 @@
 , faraday
 , fetchurl
 , lib
-, ke
 }:
 
 buildDunePackage rec {
   pname = "gluten";
-  version = "0.3.0";
+  version = "0.5.0";
 
   src = fetchurl {
     url = "https://github.com/anmonteiro/gluten/releases/download/${version}/gluten-${version}.tbz";
-    hash = "sha256-9jctX3G/nQJTGJ7ClSBEiXwxeu0GcT9N+EmPfLuSFOU=";
+    hash = "sha256-mGKbbQSPMOumUCtxrAdoBt5y2RrkAf58spkUymTYhYM=";
   };
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     bigstringaf
     faraday
-    ke
   ];
 
   doCheck = false; # No tests

--- a/pkgs/development/ocaml-modules/gluten/eio.nix
+++ b/pkgs/development/ocaml-modules/gluten/eio.nix
@@ -1,0 +1,12 @@
+{ lib, buildDunePackage, gluten, eio }:
+
+buildDunePackage {
+  pname = "gluten-eio";
+  inherit (gluten) src version;
+
+  propagatedBuildInputs = [ gluten eio ];
+
+  meta = gluten.meta // {
+    description = "EIO runtime for gluten";
+  };
+}

--- a/pkgs/development/ocaml-modules/gluten/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/gluten/lwt-unix.nix
@@ -9,8 +9,6 @@ buildDunePackage rec {
   pname = "gluten-lwt-unix";
   inherit (gluten) doCheck meta src version;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     faraday-lwt-unix
     gluten-lwt

--- a/pkgs/development/ocaml-modules/gluten/lwt.nix
+++ b/pkgs/development/ocaml-modules/gluten/lwt.nix
@@ -7,8 +7,6 @@ buildDunePackage rec {
   pname = "gluten-lwt";
   inherit (gluten) doCheck meta src version;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     gluten
     lwt

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -593,6 +593,7 @@ let
     github-unix = callPackage ../development/ocaml-modules/github/unix.nix {  };
 
     gluten = callPackage ../development/ocaml-modules/gluten { };
+    gluten-eio = callPackage ../development/ocaml-modules/gluten/eio.nix { };
     gluten-lwt = callPackage ../development/ocaml-modules/gluten/lwt.nix { };
     gluten-lwt-unix = callPackage ../development/ocaml-modules/gluten/lwt-unix.nix { };
 


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/anmonteiro/gluten/0.5.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
