### PR TITLE
python3.pkgs.ariadne: remove opentracing dependency

### DIFF
--- a/pkgs/development/python-modules/ariadne/default.nix
+++ b/pkgs/development/python-modules/ariadne/default.nix
@@ -4,7 +4,6 @@
 , hatchling
 , freezegun
 , graphql-core
-, opentracing
 , pytest-asyncio
 , pytest-mock
 , pytestCheckHook
@@ -28,6 +27,9 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     hash = "sha256-v3CaLMTo/zbNEoE3K+aWnFTCgLetcnN7vOU/sFqLq2k=";
   };
+  patches = [
+    ./remove-opentracing.patch
+  ];
 
   nativeBuildInputs = [
     hatchling
@@ -41,7 +43,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     freezegun
-    opentracing
     pytest-asyncio
     pytest-mock
     pytestCheckHook
@@ -58,12 +59,18 @@ buildPythonPackage rec {
     "test_attempt_parse_request_missing_content_type_raises_bad_request_error"
     "test_attempt_parse_non_json_request_raises_bad_request_error"
     "test_attempt_parse_non_json_request_body_raises_bad_request_error"
+    # opentracing
+    "test_query_is_executed_for_multipart_form_request_with_file"
+    "test_query_is_executed_for_multipart_request_with_large_file_with_tracing"
   ];
 
   disabledTestPaths = [
     # missing graphql-sync-dataloader test dep
     "tests/test_dataloaders.py"
     "tests/wsgi/test_configuration.py"
+    # both include opentracing module, which has been removed from nixpkgs
+    "tests/tracing/test_opentracing.py"
+    "tests/tracing/test_opentelemetry.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/ariadne/remove-opentracing.patch
+++ b/pkgs/development/python-modules/ariadne/remove-opentracing.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/asgi/conftest.py b/tests/asgi/conftest.py
+index a703466..223586e 100644
+--- a/tests/asgi/conftest.py
++++ b/tests/asgi/conftest.py
+@@ -8,7 +8,6 @@ from ariadne.asgi.handlers import (
+     GraphQLTransportWSHandler,
+     GraphQLWSHandler,
+ )
+-from ariadne.contrib.tracing.opentracing import opentracing_extension
+ 
+ 
+ @pytest.fixture


### PR DESCRIPTION
opentracing is no longer developed and does not work with python 3.11

Fixes the build of python3.pkgs.ariadne

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
