### PR TITLE
hareThirdParty.hare-png: init at unstable-2023-09-09

### DIFF
--- a/pkgs/development/hare-third-party/hare-png/default.nix
+++ b/pkgs/development/hare-third-party/hare-png/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, hare, hareThirdParty, fetchFromSourcehut }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-png";
+  version = "unstable-2023-09-09";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-png";
+    rev = "9deb848ae691d784c5cc7949153cfa04c67f90b6";
+    hash = "sha256-Q7xylsLVd/sp57kv6WzC7QHGN1xOsm7YEsYCbY/zi1Q=";
+  };
+
+  nativeBuildInputs = [ hare ];
+  propagatedBuildInputs = [ hareThirdParty.hare-compress ];
+
+  makeFlags = [
+    "PREFIX=${builtins.placeholder "out"}"
+    "HARECACHE=.harecache"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~sircmpwn/hare-png/";
+    description = "PNG implementation for Hare";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ starzation ];
+
+    inherit (hare.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -9,4 +9,5 @@ in
   hare-ev = callPackage ../development/hare-third-party/hare-ev { };
   hare-json = callPackage ../development/hare-third-party/hare-json { };
   hare-toml = callPackage ../development/hare-third-party/hare-toml { };
+  hare-png = callPackage ../development/hare-third-party/hare-png { };
 })


### PR DESCRIPTION
## Description of changes

[hare-png](https://git.sr.ht/~sircmpwn/hare-png) package provides an implementation of the PNG image format.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
