### PR TITLE
gitlab: 16.5.1 -> 16.5.3

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "16.5.1",
-  "repo_hash": "sha256-7vKdCFDgtXSTlYV9nfLuQ+LZCaGDLU9zp97rob4dj2A=",
-  "yarn_hash": "1df7lf2grxpfjy1vgwsxw9n310jgjb64vqcxn2a7wzgh0svr1yyf",
+  "version": "16.5.3",
+  "repo_hash": "sha256-0Tewet9A0+0wDcMWVhXMGx1zr/R2WN46h+pEP3pEkac=",
+  "yarn_hash": "03ryyk7dw7s8yjdx9wdrvllaydb0w5an06agkwf5npgr6x1bz3yv",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v16.5.1-ee",
+  "rev": "v16.5.3-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "16.5.1",
-    "GITLAB_PAGES_VERSION": "16.5.1",
+    "GITALY_SERVER_VERSION": "16.5.3",
+    "GITLAB_PAGES_VERSION": "16.5.3",
     "GITLAB_SHELL_VERSION": "14.29.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "4.4.0",
-    "GITLAB_WORKHORSE_VERSION": "16.5.1"
+    "GITLAB_WORKHORSE_VERSION": "16.5.3"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "16.5.1";
+  version = "16.5.3";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -18,7 +18,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-LrkFSsWIPqiEXUV5OyYkB2XUbCMXjbpcCmTacR33vOQ=";
+      hash = "sha256-lGwRGU24pyBypQRTvGRYaAmkVbPLaw+fSeAXJ1pyQaA=";
     };
 
     vendorHash = "sha256-QLt/12P6OLpLqCINROLmzhoRpLGrB9WzME7FzhIcb0Q=";

--- a/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "gitlab-container-registry";
-  version = "3.85.0";
+  version = "3.86.2";
   rev = "v${version}-gitlab";
 
   # nixpkgs-update: no auto update
@@ -10,10 +10,10 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "container-registry";
     inherit rev;
-    sha256 = "sha256-F20f1qDsI+moBAL+Tpx5AALgOi0vTH7hZ5RIvRMwY1s=";
+    sha256 = "sha256-hZhlSZ/crwzc8KEkbMGY9zAYVbMT9p4y7Wm3B+F+iPU=";
   };
 
-  vendorHash = "sha256-JWuSJD2Mi0om9vA6+mYbArfr2lmGlRua6IM0DhDzSBk=";
+  vendorHash = "sha256-3iBMn1kA/GZC/7FEFLd1/e7+mSsCOAo+zQo3dVpTHw4=";
 
   patches = [
     ./Disable-inmemory-storage-driver-test.patch

--- a/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
@@ -2,14 +2,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "16.5.1";
+  version = "16.5.3";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-1fcsliorkl118MyUnZ3yrQjwLBQGsNBBA4dIEFHBJAI=";
+    hash = "sha256-eE+QuzqNm3zA0le8MWR3Kbc+/kQtKIrSd9sTmVYaNbQ=";
   };
 
   vendorHash = "sha256-YG+ERETxp0BPh/V4820pMXTXu9YcodRhzme6qZJBC9Q=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "16.5.1";
+  version = "16.5.3";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION
## Description of changes
- Fixes CVE-2023-3443
- Fixes CVE-2023-3949
- Fixes CVE-2023-3964
- Fixes CVE-2023-4317
- Fixes CVE-2023-4658
- Fixes CVE-2023-4912
- Fixes CVE-2023-5226
- Fixes CVE-2023-5995
- Fixes CVE-2023-6033
- Fixes CVE-2023-6396
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
