### PR TITLE
nixos/kubo: fix potential panic on startup

### DIFF
--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -361,6 +361,8 @@ in
         Group = cfg.group;
         StateDirectory = "";
         ReadWritePaths = optionals (!cfg.autoMount) [ "" cfg.dataDir ];
+        # Make sure the socket units are started before ipfs.service
+        Sockets = [ "ipfs-gateway.socket" "ipfs-api.socket" ];
       } // optionalAttrs (cfg.serviceFdlimit != null) { LimitNOFILE = cfg.serviceFdlimit; };
     } // optionalAttrs (!cfg.startWhenNeeded) {
       wantedBy = [ "default.target" ];


### PR DESCRIPTION
## Description of changes
This fixes a panic of the kubo daemon which could occur under certain conditions when the daemon was starting.
It was caused by the `ipfs.service` unit not depending on the `ipfs-api.socket` and `ipfs-gateway.socket` units with `Wants=`. This allows the `ipfs.service` to be started manually or by `nixos-rebuild` without the sockets being set up before that. When that happens, the daemon won't know about these sockets and will only use what is set in `services.kubo.settings.Addresses.Gateway` and `services.kubo.settings.Addresses.API`. By default the `API` is an empty list in NixOS though. The daemon doesn't like this at all and panics on startup, see https://github.com/ipfs/kubo/issues/10056.
With this commit, starting `ipfs.service` will first set up the two sockets before starting the actual service.
Adding the `Sockets=` option implicitly adds a `Wants=` for the sockets and this is exactly what we need. See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Implicit%20Dependencies . This can be checked with `systemctl show ipfs.service`.

This should probably be upstreamed to the unit file in the Kubo repo.

The problem can be reproduced in the following way:
- Add `services.kubo.enable = true` to `/etc/nixos/configuration.nix`
- `sudo nixos-rebuild switch` (this may already fail, not sure why it's not deterministic for me)
- `sudo systemctl stop ipfs-api.socket`
- `sudo systemctl stop ipfs-gateway.socket`
- `sudo systemctl stop ipfs.service`
- `sudo systemctl start ipfs.service`

Fixes #248447.


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
