### PR TITLE
guile: Fix posix_spawn use on Darwin, Hurd, and other platforms

### DIFF
--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -74,6 +74,7 @@ builder rec {
 
   patches = [
     ./eai_system.patch
+    ./guile-hurd-posix-spawn.patch
   ] ++ lib.optional (coverageAnalysis != null) ./gcov-file-name.patch
   ++ lib.optional stdenv.isDarwin
     (fetchpatch {

--- a/pkgs/development/interpreters/guile/guile-hurd-posix-spawn.patch
+++ b/pkgs/development/interpreters/guile/guile-hurd-posix-spawn.patch
@@ -1,0 +1,44 @@
+Fix <https://issues.guix.gnu.org/61095>, which affects GNU/Hurd.
+
+diff --git a/libguile/posix.c b/libguile/posix.c
+index 3a8be94e4..f5fdc544c 100644
+--- a/libguile/posix.c
++++ b/libguile/posix.c
+@@ -1326,7 +1326,14 @@ static void
+ close_inherited_fds_slow (posix_spawn_file_actions_t *actions, int max_fd)
+ {
+   while (--max_fd > 2)
+-    posix_spawn_file_actions_addclose (actions, max_fd);
++    {
++      /* Adding invalid file descriptors to an 'addclose' action leads
++         to 'posix_spawn' failures on some operating systems:
++         <https://bugs.gnu.org/61095>.  Hence the extra check.  */
++      int flags = fcntl (max_fd, F_GETFD, NULL);
++      if ((flags >= 0) && ((flags & FD_CLOEXEC) == 0))
++        posix_spawn_file_actions_addclose (actions, max_fd);
++    }
+ }
+ 
+ static void
+
+Fix <https://issues.guix.gnu.org/62501>.
+
+diff --git a/test-suite/tests/posix.test b/test-suite/tests/posix.test
+index f20e04453..d5cf47cda 100644
+--- a/test-suite/tests/posix.test
++++ b/test-suite/tests/posix.test
+@@ -431,7 +431,13 @@
+       (let ((str (get-string-all (car input+output))))
+         (close-port (car input+output))
+         (waitpid pid)
+-        str)))
++
++        ;; On GNU/Hurd, the exec server prepends 'LD_ORIGIN_PATH' for
++        ;; every program: <https://bugs.gnu.org/62501>.  Strip it.
++        (if (and (string=? "GNU" (utsname:sysname (uname)))
++                 (string-prefix? "LD_ORIGIN_PATH=" str))
++            (string-drop str (+ 1 (string-index str #\newline)))
++            str))))
+ 
+   (pass-if-equal "ls /proc/self/fd"
+       "0\n1\n2\n3\n"                     ;fourth FD is for /proc/self/fd


### PR DESCRIPTION
This backports a patch from current Guile HEAD which fixes a platform-specific bug causing all subprocess spawns to fail on (at least) Darwin and GNU Hurd, and possibly other platforms as well.

Upstream patch:
<https://git.savannah.gnu.org/cgit/guix.git/plain/gnu/packages/patches/guile-hurd-posix-spawn.patch>

Note that despite the patch name and comments, other OSes than Hurd are affected as well.

Thanks to @civodul for the hint that this patch would fix the problem.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
