### PR TITLE
python311Packages.habluetooth: init at 0.5.1, python311Packages.bluetooth-data-tools: 1.15.0 -> 1.17.0 

### DIFF
--- a/pkgs/development/python-modules/bluetooth-data-tools/default.nix
+++ b/pkgs/development/python-modules/bluetooth-data-tools/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "bluetooth-data-tools";
-  version = "1.15.0";
+  version = "1.17.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.9";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-8Gbw2vXqKvWo30QKExrmH7lUkZBg7zd3o2xWEqGxSBM=";
+    hash = "sha256-CJyTWNBtBk3YpoaiL1/P+aUE4ttthQDTdDuKBYEXrBg=";
   };
 
   # The project can build both an optimized cython version and an unoptimized

--- a/pkgs/development/python-modules/habluetooth/default.nix
+++ b/pkgs/development/python-modules/habluetooth/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, poetry-core
+, setuptools
+, wheel
+, bleak
+, pytestCheckHook
+, bleak-retry-connector
+, bluetooth-adapters
+, bluetooth-auto-recovery
+, bluetooth-data-tools
+, home-assistant-bluetooth
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "habluetooth";
+  version = "0.5.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Bluetooth-Devices";
+    repo = "habluetooth";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-olR900l/xJug5DeXb8CR0vQBzjzegdiCLCp6AIQu7Tg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov=habluetooth --cov-report=term-missing:skip-covered" ""
+  '';
+
+  nativeBuildInputs = [
+    cython
+    poetry-core
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    bleak
+    bleak-retry-connector
+    bluetooth-adapters
+    bluetooth-auto-recovery
+    bluetooth-data-tools
+    home-assistant-bluetooth
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "habluetooth"
+  ];
+
+  meta = with lib; {
+    description = "Library for high availability Bluetooth";
+    homepage = "https://github.com/Bluetooth-Devices/habluetooth";
+    changelog = "https://github.com/Bluetooth-Devices/habluetooth/blob/${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4951,6 +4951,8 @@ self: super: with self; {
 
   habanero = callPackage ../development/python-modules/habanero { };
 
+  habluetooth = callPackage ../development/python-modules/habluetooth { };
+
   habitipy = callPackage ../development/python-modules/habitipy { };
 
   hachoir = callPackage ../development/python-modules/hachoir { };


### PR DESCRIPTION
## Description of changes

Library for high availability Bluetooth

https://github.com/Bluetooth-Devices/habluetooth

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
