### PR TITLE
mpvScripts: Add generic tests to all drvs

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -14,8 +14,8 @@ let
     scriptPath = "share/mpv/scripts/${scriptName}";
     fullScriptPath = "${drv}/${scriptPath}";
 
-  in drv.override { passthru.tests = unionOfDisjoints [
-    (drv.passthru.tests or {})
+  in drv.overrideAttrs (old: { passthru = (old.passthru or {}) // { tests = unionOfDisjoints [
+    (old.passthru.tests or {})
 
     {
       scriptName-is-valid = runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
@@ -53,7 +53,7 @@ let
         fi
       '';
     })
-  ]; };
+  ]; }; });
 in
 
 lib.recurseIntoAttrs

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -7,19 +7,51 @@
 let
   buildLua = callPackage ./buildLua.nix { };
 
-  addTests = name: drv: drv.override { passthru.tests = lib.attrsets.unionOfDisjoint (drv.passthru.tests or {}) {
-    scriptName-is-valid = let
-      inherit (drv) scriptName;
-      scriptPath = "${drv}/share/mpv/scripts/${scriptName}";
-    in runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
+  inherit (lib.attrsets) filterAttrs optionalAttrs recursiveUpdate unionOfDisjoint;
+
+  addTests = name: drv: let
+    inherit (drv) scriptName;
+    scriptPath = "share/mpv/scripts/${scriptName}";
+    fullScriptPath = "${drv}/${scriptPath}";
+
+  in drv.override { passthru.tests = unionOfDisjoint (drv.passthru.tests or {}) {
+
+    scriptName-is-valid = runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
       meta.maintainers = with lib.maintainers; [ nicoo ];
       preferLocalBuild = true;
     } ''
-      if [ -e "${scriptPath}" ]; then
+      if [ -e "${fullScriptPath}" ]; then
         touch $out
       else
         echo "mpvScripts.\"${name}\" does not contain a script named \"${scriptName}\"" >&2
         exit 1
+      fi
+    '';
+
+    # TODO(nicoo): Avoid emitting the test for scripts that aren't dir-packaged
+    single-main-in-script-dir = runCommand "mpvScripts.${name}.passthru.tests.single-main-in-script-dir" {
+      meta.maintainers = with lib.maintainers; [ nicoo ];
+      preferLocalBuild = true;
+    } ''
+      die() {
+        echo "$@" >&2
+        exit 1
+      }
+
+      if ! [ -d "${fullScriptPath}" ]; then
+        echo "This script isn't dir-packaged" >&2
+        touch $out
+        exit 0
+      fi
+
+      cd "${drv}/${scriptPath}"  # so the glob expands to filenames only
+      mains=( main.* )
+      if [ "''${#mains[*]}" -eq 1 ]; then
+        touch $out
+      elif [ "''${#mains[*]}" -eq 0 ]; then
+        die "'${scriptPath}' contains no 'main.*' file"
+      else
+        die "'${scriptPath}' contains multiple 'main.*' files:" "''${mains[*]}"
       fi
     '';
   }; };
@@ -50,6 +82,6 @@ lib.recurseIntoAttrs
     cutter = callPackage ./cutter.nix { };
   }
   // (callPackage ./occivink.nix { inherit buildLua; })))
-  // lib.optionalAttrs config.allowAliases {
+  // optionalAttrs config.allowAliases {
   youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
 }

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -1,11 +1,32 @@
 { lib
 , callPackage
 , config
+, runCommand
 }:
 
-let buildLua = callPackage ./buildLua.nix { };
-in lib.recurseIntoAttrs
-  ({
+let
+  buildLua = callPackage ./buildLua.nix { };
+
+  addTests = name: drv: drv.override { passthru.tests = lib.attrsets.unionOfDisjoint (drv.passthru.tests or {}) {
+    scriptName-is-valid = let
+      inherit (drv) scriptName;
+      scriptPath = "${drv}/share/mpv/scripts/${scriptName}";
+    in runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
+      meta.maintainers = with lib.maintainers; [ nicoo ];
+      preferLocalBuild = true;
+    } ''
+      if [ -e "${scriptPath}" ]; then
+        touch $out
+      else
+        echo "mpvScripts.\"${name}\" does not contain a script named \"${scriptName}\"" >&2
+        exit 1
+      fi
+    '';
+  }; };
+in
+
+lib.recurseIntoAttrs
+  (lib.mapAttrs addTests ({
     acompressor = callPackage ./acompressor.nix { inherit buildLua; };
     autocrop = callPackage ./autocrop.nix { };
     autodeint = callPackage ./autodeint.nix { };
@@ -28,7 +49,7 @@ in lib.recurseIntoAttrs
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
     cutter = callPackage ./cutter.nix { };
   }
-  // (callPackage ./occivink.nix { inherit buildLua; }))
+  // (callPackage ./occivink.nix { inherit buildLua; })))
   // lib.optionalAttrs config.allowAliases {
   youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
 }

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -7,54 +7,53 @@
 let
   buildLua = callPackage ./buildLua.nix { };
 
-  inherit (lib.attrsets) filterAttrs optionalAttrs recursiveUpdate unionOfDisjoint;
+  unionOfDisjoints = lib.fold lib.attrsets.unionOfDisjoint {};
 
   addTests = name: drv: let
     inherit (drv) scriptName;
     scriptPath = "share/mpv/scripts/${scriptName}";
     fullScriptPath = "${drv}/${scriptPath}";
 
-  in drv.override { passthru.tests = unionOfDisjoint (drv.passthru.tests or {}) {
+  in drv.override { passthru.tests = unionOfDisjoints [
+    (drv.passthru.tests or {})
 
-    scriptName-is-valid = runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
-      meta.maintainers = with lib.maintainers; [ nicoo ];
-      preferLocalBuild = true;
-    } ''
-      if [ -e "${fullScriptPath}" ]; then
-        touch $out
-      else
-        echo "mpvScripts.\"${name}\" does not contain a script named \"${scriptName}\"" >&2
-        exit 1
-      fi
-    '';
+    {
+      scriptName-is-valid = runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
+        meta.maintainers = with lib.maintainers; [ nicoo ];
+        preferLocalBuild = true;
+      } ''
+        if [ -e "${fullScriptPath}" ]; then
+          touch $out
+        else
+          echo "mpvScripts.\"${name}\" does not contain a script named \"${scriptName}\"" >&2
+          exit 1
+        fi
+      '';
+    }
 
-    # TODO(nicoo): Avoid emitting the test for scripts that aren't dir-packaged
-    single-main-in-script-dir = runCommand "mpvScripts.${name}.passthru.tests.single-main-in-script-dir" {
-      meta.maintainers = with lib.maintainers; [ nicoo ];
-      preferLocalBuild = true;
-    } ''
-      die() {
-        echo "$@" >&2
-        exit 1
-      }
+    # can't check whether `fullScriptPath` is a directory, in pure-evaluation mode
+    (with lib; optionalAttrs (! any (s: hasSuffix s drv.passthru.scriptName) [ ".js" ".lua" ".so" ]) {
+      single-main-in-script-dir = runCommand "mpvScripts.${name}.passthru.tests.single-main-in-script-dir" {
+        meta.maintainers = with lib.maintainers; [ nicoo ];
+        preferLocalBuild = true;
+      } ''
+        die() {
+          echo "$@" >&2
+          exit 1
+        }
 
-      if ! [ -d "${fullScriptPath}" ]; then
-        echo "This script isn't dir-packaged" >&2
-        touch $out
-        exit 0
-      fi
-
-      cd "${drv}/${scriptPath}"  # so the glob expands to filenames only
-      mains=( main.* )
-      if [ "''${#mains[*]}" -eq 1 ]; then
-        touch $out
-      elif [ "''${#mains[*]}" -eq 0 ]; then
-        die "'${scriptPath}' contains no 'main.*' file"
-      else
-        die "'${scriptPath}' contains multiple 'main.*' files:" "''${mains[*]}"
-      fi
-    '';
-  }; };
+        cd "${drv}/${scriptPath}"  # so the glob expands to filenames only
+        mains=( main.* )
+        if [ "''${#mains[*]}" -eq 1 ]; then
+          touch $out
+        elif [ "''${#mains[*]}" -eq 0 ]; then
+          die "'${scriptPath}' contains no 'main.*' file"
+        else
+          die "'${scriptPath}' contains multiple 'main.*' files:" "''${mains[*]}"
+        fi
+      '';
+    })
+  ]; };
 in
 
 lib.recurseIntoAttrs
@@ -82,6 +81,6 @@ lib.recurseIntoAttrs
     cutter = callPackage ./cutter.nix { };
   }
   // (callPackage ./occivink.nix { inherit buildLua; })))
-  // optionalAttrs config.allowAliases {
+  // lib.optionalAttrs config.allowAliases {
   youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
 }

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -32,6 +32,8 @@ buildLua rec {
     runHook postInstall
   '';
 
+  passthru.scriptName = "mpvacious";
+
   meta = with lib; {
     description = "Adds mpv keybindings to create Anki cards from movies and TV shows";
     homepage = "https://github.com/Ajatt-Tools/mpvacious";

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -13,7 +13,7 @@ buildLua rec {
   };
 
   scriptPath = ".";
-  passthru.scriptName = "webui.lua";
+  passthru.scriptName = "webui";
 
   meta = with lib; {
     description = "A web based user interface with controls for the mpv mediaplayer";


### PR DESCRIPTION
## Description of changes

- `mpvScripts.buildLua`: Fix bug in `scriptName` inferrence
  `wrapMpv` expects `scriptName` to be the name of the file/directory under `share/mpv/scripts`
- Add 2 generic tests to all drvs in `mpvScripts`:
  - `scriptName-is-valid` checks that a given drv provides `share/mpv/scripts/${drv.scriptName}` as `wrapMpv` expects;
    this would have caught the bug in `buildLua`
  - `single-main-in-script-dir`: if the script is a directory (under `share/mpv/scripts`), check there is exactly one `main.*` file


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran all package tests under `mpvScripts`
  except for derivations under non-free licenses
- [x] Tested compilation of all affected packages with `nixpkgs-review`
  No rebuild needed
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  No change in the drv's outputs
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
