### PR TITLE
cudaPackages.nccl-tests: support building with CUDA < 11.4 with cudatoolkit

### DIFF
--- a/pkgs/development/libraries/science/math/nccl/tests.nix
+++ b/pkgs/development/libraries/science/math/nccl/tests.nix
@@ -1,69 +1,84 @@
-{ backendStdenv
-, config
-, cuda_cccl
-, cuda_cudart
-, cuda_nvcc
-, cudaVersion
-, fetchFromGitHub
-, gitUpdater
-, lib
-, mpi
-, mpiSupport ? false
-, nccl
-, which
+# NOTE: Though NCCL tests is called within the cudaPackages package set, we avoid passing in
+# the names of dependencies from that package set directly to avoid evaluation errors
+# in the case redistributable packages are not available.
+{
+  config,
+  cudaPackages,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  mpi,
+  mpiSupport ? false,
+  which,
 }:
-
-backendStdenv.mkDerivation (finalAttrs: {
-
-  pname = "nccl-tests";
-  version = "2.13.8";
-
-  src = fetchFromGitHub {
-    owner = "NVIDIA";
-    repo = finalAttrs.pname;
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-dxLoflsTHDBnZRTzoXdm30OyKpLlRa73b784YWALBHg=";
-  };
-
-  strictDeps = true;
-
-  nativeBuildInputs = [
-    cuda_nvcc
-    which
-  ];
-
-  buildInputs = [
+let
+  inherit (cudaPackages)
+    backendStdenv
+    cuda_cccl
     cuda_cudart
+    cuda_nvcc
+    cudatoolkit
+    cudaVersion
     nccl
-  ] ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [
-    cuda_cccl.dev # <nv/target>
-  ] ++ lib.optional mpiSupport mpi;
+    ;
+in
+backendStdenv.mkDerivation (
+  finalAttrs: {
 
-  makeFlags = [
-    "CUDA_HOME=${cuda_nvcc}"
-    "NCCL_HOME=${nccl}"
-  ] ++ lib.optionals mpiSupport [
-    "MPI=1"
-  ];
+    pname = "nccl-tests";
+    version = "2.13.8";
 
-  enableParallelBuilding = true;
+    src = fetchFromGitHub {
+      owner = "NVIDIA";
+      repo = finalAttrs.pname;
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-dxLoflsTHDBnZRTzoXdm30OyKpLlRa73b784YWALBHg=";
+    };
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -r build/* $out/bin/
-  '';
+    strictDeps = true;
 
-  passthru.updateScript = gitUpdater {
-    inherit (finalAttrs) pname version;
-    rev-prefix = "v";
-  };
+    nativeBuildInputs =
+      [which]
+      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
+      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [cuda_nvcc];
 
-  meta = with lib; {
-    description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations";
-    homepage = "https://github.com/NVIDIA/nccl-tests";
-    platforms = platforms.linux;
-    license = licenses.bsd3;
-    broken = !config.cudaSupport || (mpiSupport && mpi == null);
-    maintainers = with maintainers; [ jmillerpdt ] ++ teams.cuda.members;
-  };
-})
+    buildInputs =
+      [nccl]
+      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
+      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
+        cuda_nvcc.dev # crt/host_config.h
+        cuda_cudart
+      ]
+      ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [
+        cuda_cccl.dev # <nv/target>
+      ]
+      ++ lib.optionals mpiSupport [mpi];
+
+    makeFlags =
+      ["NCCL_HOME=${nccl}"]
+      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") ["CUDA_HOME=${cudatoolkit}"]
+      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") ["CUDA_HOME=${cuda_nvcc}"]
+      ++ lib.optionals mpiSupport ["MPI=1"];
+
+    enableParallelBuilding = true;
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp -r build/* $out/bin/
+    '';
+
+    passthru.updateScript = gitUpdater {
+      inherit (finalAttrs) pname version;
+      rev-prefix = "v";
+    };
+
+    meta = with lib; {
+      description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations";
+      homepage = "https://github.com/NVIDIA/nccl-tests";
+      platforms = platforms.linux;
+      license = licenses.bsd3;
+      broken = !config.cudaSupport || (mpiSupport && mpi == null);
+      maintainers = with maintainers; [jmillerpdt] ++ teams.cuda.members;
+    };
+  }
+)


### PR DESCRIPTION
> [!Note]
> This PR was formatted with Reformatted with https://github.com/piegamesde/nixfmt/commit/21ef16e7fe9011ecd77ba05fa5873287e4c0d2a4.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Allows building `nccl-tests` with CUDA < 11.4 by adding support for `cudatoolkit` back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
