### PR TITLE
ocamlPackages.kappa-{agents,binaries,library,server}: init at 4.1-unstable-2023-11-30

### DIFF
--- a/pkgs/development/ocaml-modules/kappa-agents/default.nix
+++ b/pkgs/development/ocaml-modules/kappa-agents/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildDunePackage
+, num
+, re
+, yojson
+, lwt
+, fmt
+, logs
+, kappa-library
+, atdgen-runtime
+, atdgen
+}:
+
+buildDunePackage {
+  pname = "kappa-agents";
+  inherit (kappa-library) version src;
+
+  nativeBuildInputs = [
+    atdgen
+  ];
+
+  propagatedBuildInputs = [
+    num
+    re
+    yojson
+    lwt
+    fmt
+    logs
+    kappa-library
+    atdgen-runtime
+  ];
+
+  meta = {
+    description = "Backends for an interactive use of the Kappa tool suite";
+    homepage = "https://kappalanguage.org/";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ wegank ];
+  };
+}

--- a/pkgs/development/ocaml-modules/kappa-binaries/default.nix
+++ b/pkgs/development/ocaml-modules/kappa-binaries/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildDunePackage
+, num
+, re
+, yojson
+, lwt
+, fmt
+, logs
+, kappa-library
+}:
+
+buildDunePackage {
+  pname = "kappa-binaries";
+  inherit (kappa-library) version src;
+
+  propagatedBuildInputs = [
+    num
+    re
+    yojson
+    lwt
+    fmt
+    logs
+    kappa-library
+  ];
+
+  meta = {
+    description = "Command line interfaces of the Kappa tool suite";
+    homepage = "https://kappalanguage.org/";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ wegank ];
+  };
+}

--- a/pkgs/development/ocaml-modules/kappa-library/default.nix
+++ b/pkgs/development/ocaml-modules/kappa-library/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+, num
+, re
+, yojson
+, lwt
+, stdlib-shims
+, fmt
+, logs
+, result
+, camlp-streams
+}:
+
+buildDunePackage {
+  pname = "kappa-library";
+  version = "4.1-unstable-2023-11-30";
+
+  src = fetchFromGitHub {
+    owner = "Kappa-Dev";
+    repo = "KappaTools";
+    rev = "e01791c5487be46e5912150e57375e4b83391a1e";
+    hash = "sha256-DINok0LviwO7UMhjjq9c0KGv9mdlpsbzivij2imOoxI=";
+  };
+
+  propagatedBuildInputs = [
+    num
+    re
+    yojson
+    lwt
+    stdlib-shims
+    fmt
+    logs
+    result
+    camlp-streams
+  ];
+
+  meta = {
+    description = "Public internals of the Kappa tool suite";
+    homepage = "https://kappalanguage.org/";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ wegank ];
+  };
+}

--- a/pkgs/development/ocaml-modules/kappa-server/default.nix
+++ b/pkgs/development/ocaml-modules/kappa-server/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildDunePackage
+, num
+, re
+, yojson
+, lwt
+, fmt
+, logs
+, kappa-binaries
+, kappa-agents
+, cohttp-lwt-unix
+, atdgen-runtime
+, atdgen
+}:
+
+buildDunePackage {
+  pname = "kappa-server";
+  inherit (kappa-binaries) version src;
+
+  nativeBuildInputs = [
+    atdgen
+  ];
+
+  propagatedBuildInputs = [
+    num
+    re
+    yojson
+    lwt
+    fmt
+    logs
+    kappa-binaries
+    kappa-agents
+    cohttp-lwt-unix
+    atdgen-runtime
+  ];
+
+  meta = {
+    description = "HTTP server to query the Kappa tool suite";
+    homepage = "https://kappalanguage.org/";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ wegank ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -884,6 +884,8 @@ let
 
     kafka_lwt = callPackage ../development/ocaml-modules/kafka/lwt.nix { };
 
+    kappa-agents = callPackage ../development/ocaml-modules/kappa-agents { };
+
     kappa-library = callPackage ../development/ocaml-modules/kappa-library { };
 
     kcas = callPackage ../development/ocaml-modules/kcas { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -890,6 +890,8 @@ let
 
     kappa-library = callPackage ../development/ocaml-modules/kappa-library { };
 
+    kappa-server = callPackage ../development/ocaml-modules/kappa-server { };
+
     kcas = callPackage ../development/ocaml-modules/kcas { };
 
     ke = callPackage ../development/ocaml-modules/ke { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -886,6 +886,8 @@ let
 
     kappa-agents = callPackage ../development/ocaml-modules/kappa-agents { };
 
+    kappa-binaries = callPackage ../development/ocaml-modules/kappa-binaries { };
+
     kappa-library = callPackage ../development/ocaml-modules/kappa-library { };
 
     kcas = callPackage ../development/ocaml-modules/kcas { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -884,6 +884,8 @@ let
 
     kafka_lwt = callPackage ../development/ocaml-modules/kafka/lwt.nix { };
 
+    kappa-library = callPackage ../development/ocaml-modules/kappa-library { };
+
     kcas = callPackage ../development/ocaml-modules/kcas { };
 
     ke = callPackage ../development/ocaml-modules/ke { };


### PR DESCRIPTION
## Description of changes

https://kappalanguage.org

https://opam.ocaml.org/packages/kappa-binaries/

Note that the 4.1 release only supports OCaml < 4.12, hence the unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
