### PR TITLE
buildPythonPackage: Add support for running tests in a separate derivation

### DIFF
--- a/pkgs/development/python-modules/muscima/default.nix
+++ b/pkgs/development/python-modules/muscima/default.nix
@@ -34,12 +34,18 @@ buildPythonPackage {
     matplotlib
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  separateChecks = true;
 
-  disabledTestPaths = [
-    # They hard-code the path to the dataset and expect you to edit the test to update it to your value
-    "test/test_dataset.py"
-  ];
+  checkArgs = {
+    nativeCheckInputs = [
+      pytestCheckHook
+    ];
+
+    disabledTestPaths = [
+      # They hard-code the path to the dataset and expect you to edit the test to update it to your value
+      "test/test_dataset.py"
+    ];
+  };
 
   meta = with lib; {
     description = "Tools for working with the MUSCIMA++ dataset of handwritten music notation";


### PR DESCRIPTION
## Description of changes
Introduces a new argument to `buildPythonPackage` called `separateChecks`.

A `passthru.tests.python` attribute is added where the tests are run separately from building the package.

By removing check inputs from the main derivation we can drastically reduce build closures & reduce issues with circular dependencies.
For more motivations see the related tracking issue.

This work is a part of #272178.

### Implications

With tests no longer running in the same derivation as the build it can be harder to find issues early.

OTOH debug cycles can be cut shorter as you don't need to wait for a package rebuild to find out that a test failed because it lacked networking access.
With tests running separately I expect iteration cycles to be quicker, once the new workflow has been adopted.

`passthru.tests` is evaluated by OfBorg. Checks for nixpkgs contributions should be fine.
It's possible we may want to add another Hydra attrset so it can find tests, or make Hydra smart enough to explore `passthru.tests`.

In this PR only one derivation has been converted as a PoC. Locally I have converted many more and also found some issues.
This seems to work out fine for most pure Python packages, but Pandas was problematic. I think that particular issue is because of a bug in pytest that I will take a closer look at.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
