### PR TITLE
WIP: Python no runtime deps at build time

### DIFF
--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -85,8 +85,7 @@ llvmPackages.stdenv.mkDerivation rec {
     # Should appear BEFORE lit, since lit passes through python rather
     # than the python environment we make.
     kleePython
-    (lit.override { python = kleePython; })
-  ];
+  ] ++ python3.pkgs.requiredPythonModules python3.pkgs.lit;
 
   cmakeBuildType = if debug then "Debug" else if !debug && includeDebugInfo then "RelWithDebInfo" else "MinSizeRel";
 

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -251,7 +251,10 @@ in {
   sphinxHook = callPackage ({ makePythonHook, installShellFiles }:
     makePythonHook {
       name = "python${python.pythonVersion}-sphinx-hook";
-      propagatedBuildInputs = [ pythonOnBuildForHost.pkgs.sphinx installShellFiles ];
+      propagatedBuildInputs = [
+        pythonOnBuildForHost.pkgs.sphinx
+        installShellFiles
+      ] ++ (pythonOnBuildForHost.pkgs.requiredPythonModules [ pythonOnBuildForHost.pkgs.sphinx ]);
       substitutions = {
         sphinxBuild = "${pythonOnBuildForHost.pkgs.sphinx}/bin/sphinx-build";
       };

--- a/pkgs/development/interpreters/python/link.py
+++ b/pkgs/development/interpreters/python/link.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from functools import wraps
+from textwrap import dedent
+import os.path
+import stat
+import os
+import sys
+
+
+src = sys.argv[1]
+dst = sys.argv[2]
+
+
+def write_bin_wrapper(bin_name):
+    """Write a bin wrapper with NIX_PYTHONPATH set"""
+    src_bin = os.path.join(src, "bin", bin_name)
+    dst_bin = os.path.join(dst, "bin", bin_name)
+
+    # TODO: Non-executable files
+
+    script = "#!/usr/bin/env bash" + dedent("""
+    export NIX_PYTHONPATH="%s"
+    exec %s "$@"
+    """ % (os.environ["PYTHONPATH"], src_bin))
+
+    with open(dst_bin, "w") as fd:
+        fd.write(script)
+
+        mode = os.fstat(fd.fileno()).st_mode
+        mode |= stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        os.fchmod(fd.fileno(), stat.S_IMODE(mode))
+
+
+@wraps(os.mkdir)
+def mkdir(*args, **kwargs):
+    """Wraps os.mkdir but doesn't fail on existing file"""
+    try:
+        os.mkdir(*args, **kwargs)
+    except FileExistsError:
+        pass
+
+
+def symlink_tree(src: str, dst: str):
+    mkdir(dst)
+
+    for root, dirs, files in os.walk(src):
+        dst_dir = os.path.join(dst, root.removeprefix(src).removeprefix(os.path.sep))
+        mkdir(dst_dir)
+
+        for dir in dirs:
+            mkdir(os.path.join(dst_dir, dir))
+        for filename in files:
+            os.symlink(os.path.join(root, filename), os.path.join(dst_dir, filename))
+
+
+if __name__ == "__main__":
+    # If the store path is a simple file no special handling can be done.
+    st = os.lstat(src)
+    if not stat.S_ISDIR(st.st_mode):
+        os.symlink(src, dst)
+        exit(0)
+
+    os.mkdir(dst)
+
+    for filename in os.listdir(src):
+        src_file = os.path.join(src, filename)
+        dst_file = os.path.join(dst, filename)
+
+        # Wrap bin's in a wrapper that sets NIX_PYTHONPATH.
+        if filename == "bin":
+            os.mkdir(dst_file)
+            for bin_name in os.listdir(src_file):
+                write_bin_wrapper(bin_name)
+            continue
+
+        st = os.lstat(src_file)
+        if stat.S_ISDIR(st.st_mode):
+            symlink_tree(src_file, dst_file)
+            continue
+
+        # For all other files we place a symlink to the original Python derivation.
+        os.symlink(src_file, dst_file)

--- a/pkgs/development/interpreters/python/with-packages.nix
+++ b/pkgs/development/interpreters/python/with-packages.nix
@@ -1,3 +1,9 @@
 { buildEnv, pythonPackages }:
 
-f: let packages = f pythonPackages; in buildEnv.override { extraLibs = packages; }
+f: let
+  packages = f pythonPackages;
+in
+buildEnv.override {
+  # Compute required dependencies recursively.
+  extraLibs = packages ++ pythonPackages.requiredPythonModules packages;
+}

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -60,7 +60,7 @@ python3.pkgs.buildPythonApplication rec {
     dblatex
   ];
 
-  pythonPath = with python3.pkgs; [
+  pythonPath = with python3.pkgs; requiredPythonModules [
     pygments # Needed for https://gitlab.gnome.org/GNOME/gtk-doc/blob/GTK_DOC_1_32/meson.build#L42
     lxml
   ];

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -51,6 +51,9 @@ in
   '' + lib.optionalString withDebugLogLevel ''
     # if debugging
     substituteInPlace inputremapper/logger.py --replace "logger.setLevel(logging.INFO)"  "logger.setLevel(logging.DEBUG)"
+  '' + ''
+    # set revision for --version output
+    echo "COMMIT_HASH = '${src.rev}'" > inputremapper/commit_hash.py
   '';
 
   doCheck = withDoCheck;
@@ -144,14 +147,4 @@ in
     maintainers = with maintainers; [ LunNova ];
     mainProgram = "input-remapper-gtk";
   };
-}).overrideAttrs (final: prev: {
-  # Set in an override as buildPythonApplication doesn't yet support
-  # the `final:` arg yet from #119942 'overlay style overridable recursive attributes'
-  # this ensures the rev matches the input src's rev after overriding
-  # See https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/7 for more
-  # discussion
-  postPatch = prev.postPatch or "" + ''
-    # set revision for --version output
-    echo "COMMIT_HASH = '${final.src.rev}'" > inputremapper/commit_hash.py
-  '';
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4966,10 +4966,7 @@ with pkgs;
   dvc = with python3.pkgs; toPythonApplication dvc;
 
   dvc-with-remotes = dvc.override {
-    enableGoogle = true;
-    enableAWS = true;
-    enableAzure = true;
-    enableSSH = true;
+    optional-dependencies = [ "gs" "s3" "azure" "ssh" ];
   };
 
   dynamic-colors = callPackage ../tools/misc/dynamic-colors { };


### PR DESCRIPTION
## Description of changes
Removes dependency propagation from `buildPythonPackage` when a runtime dependency is passed via `dependencies`.

Please don't actually review the code yet. This a a very WIP, very draft PoC & should be considered a demo for #272178.
This also includes the commits from #271597.
Only the commits prefixed with WIP: are a part of this.

### `python3Packages.foo`
Depending on a Python package like this will break:
``` nix
stdenv.mkDerivation {
  propagatedBuildInputs = [ python3Packages.requests ];
}
```

You will instead need to:
``` nix
stdenv.mkDerivation {
  propagatedBuildInputs = python3Packages.requiredPythonModules [ python3Packages.requests ];
}
```

This is because dependencies are no longer build-time propagated, so the full dependency graph calculation needs to happen in the Nix evaluator.

### `python3Packages.buildPythonPackage` vs `python3Packages.buildPythonApplication`
- `buildPythonPackage` is for building a Python package without dependency propagation
- `buildPythonApplication` is for building application bundles. This internally calls `buildPythonPackage`, and also creates a wrapper derivation that takes care of calling `requiredPythonModules`.

All Python applications which has runnable binaries now needs to either be:
- Created using `buildPythonApplication`
- Converted from a Python module using `toPythonApplication`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
