### PR TITLE
aws-encryption-sdk-cli: fix build, pin urllib3

### DIFF
--- a/pkgs/tools/admin/aws-encryption-sdk-cli/default.nix
+++ b/pkgs/tools/admin/aws-encryption-sdk-cli/default.nix
@@ -1,12 +1,29 @@
 { lib
-, python3Packages
+, python3
 , fetchPypi
 , nix-update-script
 , testers
 , aws-encryption-sdk-cli
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  localPython = python3.override {
+    self = localPython;
+    packageOverrides = final: prev: {
+      urllib3 = prev.urllib3.overridePythonAttrs (prev: rec {
+        pyproject = true;
+        version = "1.26.18";
+        nativeBuildInputs = with final; [ setuptools ];
+        src = prev.src.override {
+          inherit version;
+          hash = "sha256-+OzBu6VmdBNFfFKauVW/jGe0XbeZ0VkGYmFxnjKFgKA=";
+        };
+      });
+    };
+  };
+in
+
+localPython.pkgs.buildPythonApplication rec {
   pname = "aws-encryption-sdk-cli";
   version = "4.1.0";
 
@@ -15,15 +32,16 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-OCbt0OkDVfpzUIogbsKzaPAle2L6l6N3cmZoS2hEaSM=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with localPython.pkgs; [
     attrs
     aws-encryption-sdk
     base64io
+    urllib3
   ];
 
   doCheck = true;
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = with localPython.pkgs; [
     mock
     pytest-mock
     pytestCheckHook


### PR DESCRIPTION
## Description of changes

fix build by pining urllib3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
