### PR TITLE
jshon: fix build on aarch64-darwin

### DIFF
--- a/pkgs/development/tools/parsing/jshon/default.nix
+++ b/pkgs/development/tools/parsing/jshon/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ jansson ];
 
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=strict-prototypes";
+
   patches = [
     (fetchpatch {
       # https://github.com/keenerd/jshon/pull/62


### PR DESCRIPTION
## Description of changes

Fix `jshon` build on aarch64-darwin. Note, that this is currently broken in 23.11 as well, so likely should be backported

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
jshon> unpacking sources
jshon> unpacking source archive /nix/store/6qrdq6xjpycpwjj39xxww6gzg9biqifl-source
jshon> source root is source
jshon> patching sources
jshon> applying patch /nix/store/65ychbjyrl6md08s2zskzfn7cgwl4bnn-96b4e9dbf578be7b31f29740b608aa7b34df3318.patch
jshon> patching file jshon.c
jshon> updateAutotoolsGnuConfigScriptsPhase
jshon> configuring
jshon> no configure script, doing nothing
jshon> building
jshon> build flags: SHELL=/nix/store/x1xxsh1gp6y389hyl40a0i74dkxiprl7-bash-5.2-p15/bin/bash
jshon> clang -std=c99 -Wall -pedantic -Wextra -Werror    -c -o jshon.o jshon.c
jshon> jshon.c:189:25: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
jshon> json_t** stack_safe_peek()
jshon>                         ^
jshon>                          void
jshon> jshon.c:222:23: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
jshon> mapping* map_safe_peek()
jshon>                       ^
jshon>                        void
jshon> jshon.c:229:13: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
jshon> void MAPPUSH()
jshon>             ^
jshon>              void
jshon> jshon.c:251:13: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
jshon> void MAPNEXT()
jshon>             ^
jshon>              void
jshon> jshon.c:276:12: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
jshon> void MAPPOP()
jshon>            ^
jshon>             void
jshon> jshon.c:846:15: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
jshon> void debug_map()
jshon>               ^
jshon>                void
jshon> 6 errors generated.
jshon> make: *** [<builtin>: jshon.o] Error 1
```


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
