### PR TITLE
reaction: init at 1.3.0

### DIFF
--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitLab,
+}:
+let
+  version = "1.3.0";
+in buildGoModule {
+  inherit version;
+  pname = "reaction";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "ppom";
+    repo = "reaction";
+    rev = "v${version}";
+    sha256 = "sha256-hlrso4dCGwn5/jOEPvjrK0RgctB4a70UhQkF+cv6NMc=";
+  };
+
+  vendorHash = "sha256-THUIoWFzkqaTofwH4clBgsmtUlLS9WIB2xjqW7vkhpg=";
+
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.commit=unknown"
+  ];
+
+  postBuild = ''
+    gcc helpers_c/ip46tables.c -o ip46tables
+    gcc helpers_c/nft46.c -o nft46
+  '';
+
+  postInstall = ''
+    cp ip46tables nft46 $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Scan logs and take action: an alternative to fail2ban";
+    homepage = "https://framagit.org/ppom/reaction";
+    changelog = "https://framagit.org/ppom/reaction/-/releases/v${version}";
+    license = licenses.agpl3Plus;
+    mainProgram = "reaction";
+    maintainers = with maintainers; [ppom];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

reaction is a daemon that scans program outputs for repeated patterns, and takes action.
A common usage is to scan ssh and webserver logs, and to ban hosts that cause multiple authentication errors.

It is an alternative to fail2ban with a cleaner and lighter configuration, along with overall better performance.

- https://framagit.org/ppom/reaction/
- https://blog.ppom.me/en-reaction/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
