### PR TITLE
open62541: 1.3.8 -> 1.3.9

### DIFF
--- a/pkgs/development/libraries/open62541/default.nix
+++ b/pkgs/development/libraries/open62541/default.nix
@@ -33,13 +33,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open62541";
-  version = "1.3.8";
+  version = "1.3.9";
 
   src = fetchFromGitHub {
     owner = "open62541";
     repo = "open62541";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-koifSynnJX9IuwX8HUT1TzHoKgJfweNGAVlqUx7nEc4=";
+    hash = "sha256-FnLMR54xjIyYRqwCnvMJsNgsVwH7hVAixCNGhfIZPiw=";
     fetchSubmodules = true;
   };
 
@@ -92,16 +92,15 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelChecking = false;
 
   preCheck = let
-    disabledTests =
-      lib.optionals withPubSub [
-        # "Cannot set socket option IP_ADD_MEMBERSHIP"
-        "pubsub_publish"
-        "check_pubsub_get_state"
-        "check_pubsub_publish_rt_levels"
-        "check_pubsub_subscribe_config_freeze"
-        "check_pubsub_subscribe_rt_levels"
-        "check_pubsub_multiple_subscribe_rt_levels"
-      ];
+    disabledTests = lib.optionals withPubSub [
+      # "Cannot set socket option IP_ADD_MEMBERSHIP"
+      "pubsub_publish"
+      "check_pubsub_get_state"
+      "check_pubsub_publish_rt_levels"
+      "check_pubsub_subscribe_config_freeze"
+      "check_pubsub_subscribe_rt_levels"
+      "check_pubsub_multiple_subscribe_rt_levels"
+    ];
     regex = "^(${builtins.concatStringsSep "|" disabledTests})\$";
   in lib.optionalString (disabledTests != []) ''
     checkFlagsArray+=(ARGS="-E ${lib.escapeRegex regex}")


### PR DESCRIPTION

## Description of changes

A very small patch release with just 2 small fixes:

* [Changelog](https://github.com/open62541/open62541/releases/tag/v1.3.9)
* [Comparison with the previous release](https://github.com/open62541/open62541/compare/v1.3.8...v1.3.9)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>open62541</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
