### PR TITLE
nixos/locale: Mention tzselect in docs and generated config

### DIFF
--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -23,11 +23,13 @@ in
         type = timezone;
         example = "America/New_York";
         description = lib.mdDoc ''
-          The time zone used when displaying times and dates. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
-          for a comprehensive list of possible values for this setting.
+          The time zone used when displaying times and dates.
+          Run {command}`tzselect` to interactively select a timezone for a value of this option.
+          Alternatively see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
+          for a comprehensive list of possible values for this option.
 
           If null, the timezone will default to UTC and can be set imperatively
-          using timedatectl.
+          using {command}`timedatectl`.
         '';
       };
 

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -151,7 +151,7 @@ in
         # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
         # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.
 
-        # Set your time zone.
+        # Set your time zone, run `tzselect` to interactively select a value for this option.
         # time.timeZone = "Europe/Amsterdam";
 
         # Configure network proxy if necessary


### PR DESCRIPTION
## Description of changes

One of the easiest ways to select the timezone, `tzselect`, wasn't mentioned in the docs before:

```nix
$ tzselect
Please identify a location so that time zone rules can be set correctly.
Please select a continent, ocean, "coord", or "TZ".
 1) Africa
 2) Americas
 3) Antarctica
 4) Asia
 5) Atlantic Ocean
 6) Australia
 7) Europe
 8) Indian Ocean
 9) Pacific Ocean
10) coord - I want to use geographical coordinates.
11) TZ - I want to specify the timezone using the Posix TZ format.
#? 7
Please select a country whose clocks agree with yours.
 1) Åland Islands	 18) Greece		   35) Norway
 2) Albania		 19) Guernsey		   36) Poland
 3) Andorra		 20) Hungary		   37) Portugal
 4) Austria		 21) Ireland		   38) Romania
 5) Belarus		 22) Isle of Man	   39) Russia
 6) Belgium		 23) Italy		   40) San Marino
 7) Bosnia & Herzegovina  24) Jersey		   41) Serbia
 8) Britain (UK)	 25) Latvia		   42) Slovakia
 9) Bulgaria		 26) Liechtenstein	   43) Slovenia
10) Croatia		 27) Lithuania		   44) Spain
11) Czech Republic	 28) Luxembourg	   45) Svalbard & Jan Mayen
12) Denmark		 29) Malta		   46) Sweden
13) Estonia		 30) Moldova		   47) Switzerland
14) Finland		 31) Monaco		   48) Turkey
15) France		 32) Montenegro	   49) Ukraine
16) Germany		 33) Netherlands	   50) Vatican City
17) Gibraltar		 34) North Macedonia
#? 47

The following information has been given:

	Switzerland
	Büsingen

Therefore TZ='Europe/Zurich' will be used.
Selected time is now:	Tue Dec  5 15:24:52 CET 2023.
Universal Time is now:	Tue Dec  5 14:24:52 UTC 2023.
Is the above information OK?
1) Yes
2) No
#? 1

You can make this change permanent for yourself by appending the line
	TZ='Europe/Zurich'; export TZ
to the file '.profile' in your home directory; then log out and log in again.

Here is that TZ value again, this time on standard output so that you
can use the /run/current-system/sw/bin/tzselect command in shell scripts:
Europe/Zurich
```

It's not great how it says to set it in `.profile`, but the NixOS docs should be obvious that it should be set to `time.timeZone`.

## Things done

- [x] Ran `nix-build nixos/tests/installer.nix -A simple` successfully

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
