### PR TITLE
redocly-cli: init at 1.5.0

### DIFF
--- a/pkgs/by-name/re/redocly-cli/package.nix
+++ b/pkgs/by-name/re/redocly-cli/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, makeWrapper
+}:
+
+buildNpmPackage rec {
+  pname = "redocly-cli";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "Redocly";
+    repo = "redocly-cli";
+    rev = "@redocly/cli@${version}";
+    hash = "sha256-Wi3IxPeNqD1s1Q0Pi9cCus6jCQM0noBTHIAp9HUSpZk=";
+  };
+
+  npmDepsHash = "sha256-BcjQ9z2i1YBt6lBqgkRcv29P/WZeuGjVSeVmekaFugM=";
+
+  npmBuildScript = "prepare";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    rm $out/lib/node_modules/@redocly/cli/node_modules/@redocly/{cli,openapi-core}
+    cp -R packages/cli $out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli
+    cp -R packages/core $out/lib/node_modules/@redocly/cli/node_modules/@redocly/openapi-core
+
+    mkdir $out/bin
+    makeWrapper $out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli/bin/cli.js $out/bin/redocly-cli --set REDOCLY_TELEMETRY off
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/redocly-cli --version
+    runHook postInstallCheck
+  '';
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Redocly CLI makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more.";
+    homepage = "https://github.com/Redocly/redocly-cli";
+    license = lib.licenses.mit;
+    mainProgram = "redocly-cli";
+    maintainers = with lib.maintainers; [ szlend ];
+  };
+}

--- a/pkgs/development/tools/redoc-cli/default.nix
+++ b/pkgs/development/tools/redoc-cli/default.nix
@@ -30,5 +30,7 @@ buildNpmPackage rec {
     license = lib.licenses.mit;
     mainProgram = "redoc-cli";
     maintainers = with lib.maintainers; [ veehaitch ];
+    # https://github.com/NixOS/nixpkgs/issues/272217
+    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Add redocly-cli at v1.5.0
- Mark redoc-cli as broken (this is also deprecated upstream and replaced with redoc**ly**-cli)

Given redoc-cli is broken, it makes sense to backport this to 23.11 as a replacement.

cc @veehaitch @dotlambda

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
