### PR TITLE
hyprland: 0.32.3 -> 0.33.1

### DIFF
--- a/nixos/modules/programs/hyprland.nix
+++ b/nixos/modules/programs/hyprland.nix
@@ -30,7 +30,6 @@ in
       readOnly = true;
       default = cfg.package.override {
         enableXWayland = cfg.xwayland.enable;
-        enableNvidiaPatches = cfg.enableNvidiaPatches;
       };
       defaultText = literalExpression
         "`programs.hyprland.package` with applied configuration";
@@ -42,8 +41,6 @@ in
     portalPackage = mkPackageOption pkgs "xdg-desktop-portal-hyprland" { };
 
     xwayland.enable = mkEnableOption (mdDoc "XWayland") // { default = true; };
-
-    enableNvidiaPatches = mkEnableOption (mdDoc "patching wlroots for better Nvidia support");
   };
 
   config = mkIf cfg.enable {
@@ -73,9 +70,13 @@ in
       [ "programs" "hyprland" "xwayland" "hidpi" ]
       "XWayland patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland"
     )
-    (mkRenamedOptionModule
-      [ "programs" "hyprland" "nvidiaPatches" ]
+    (mkRemovedOptionModule
       [ "programs" "hyprland" "enableNvidiaPatches" ]
+      "Nvidia patches are no longer needed"
+    )
+    (mkRemovedOptionModule
+      [ "programs" "hyprland" "nvidiaPatches" ]
+      "Nvidia patches are no longer needed"
     )
   ];
 }

--- a/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
@@ -28,7 +28,6 @@
 , xcbutilwm
 , xwayland
 , debug ? false
-, enableNvidiaPatches ? false
 , enableXWayland ? true
 , legacyRenderer ? false
 , withSystemd ? true
@@ -36,18 +35,20 @@
   # deprecated flags
 , nvidiaPatches ? false
 , hidpiXWayland ? false
+, enableNvidiaPatches ? false
 }:
-assert lib.assertMsg (!nvidiaPatches) "The option `nvidiaPatches` has been renamed `enableNvidiaPatches`";
+assert lib.assertMsg (!nvidiaPatches) "The option `nvidiaPatches` has been removed.";
+assert lib.assertMsg (!enableNvidiaPatches) "The option `enableNvidiaPatches` has been removed.";
 assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been removed. Please refer https://wiki.hyprland.org/Configuring/XWayland";
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + lib.optionalString debug "-debug";
-  version = "0.32.3";
+  version = "0.33.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-8PP26+ybmScq5WpFd2JPqUDzG2VggYOvD6/rzY9/CJ4=";
+    hash = "sha256-p7el5oQZPy9l1zyIrlHu6nA4BAu59eLoSqBjhkw2jaw=";
   };
 
   patches = [
@@ -99,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
       wayland-protocols
       pango
       pciutils
-      (wlroots.override { inherit enableNvidiaPatches; })
+      wlroots
     ]
     ++ lib.optionals stdenv.hostPlatform.isMusl [ libexecinfo ]
     ++ lib.optionals enableXWayland [ libxcb xcbutilwm xwayland ]

--- a/pkgs/applications/window-managers/hyprwm/hyprland/wlroots.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/wlroots.nix
@@ -1,39 +1,9 @@
 { fetchFromGitLab
-, hyprland
 , wlroots
-, lib
 , libdisplay-info
 , libliftoff
 , hwdata
-, enableNvidiaPatches ? false
 }:
-let
-  libdisplay-info-new = libdisplay-info.overrideAttrs (old: {
-    version = "0.1.1+date=2023-03-02";
-    src = fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "emersion";
-      repo = old.pname;
-      rev = "147d6611a64a6ab04611b923e30efacaca6fc678";
-      sha256 = "sha256-/q79o13Zvu7x02SBGu0W5yQznQ+p7ltZ9L6cMW5t/o4=";
-    };
-  });
-
-  libliftoff-new = libliftoff.overrideAttrs (old: {
-    version = "0.5.0-dev";
-    src = fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "emersion";
-      repo = old.pname;
-      rev = "d98ae243280074b0ba44bff92215ae8d785658c0";
-      sha256 = "sha256-DjwlS8rXE7srs7A8+tHqXyUsFGtucYSeq6X0T/pVOc8=";
-    };
-
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error=sign-conversion"
-    ];
-  });
-in
 wlroots.overrideAttrs
   (old: {
     version = "0.17.0-dev";
@@ -42,29 +12,15 @@ wlroots.overrideAttrs
       domain = "gitlab.freedesktop.org";
       owner = "wlroots";
       repo = "wlroots";
-      rev = "5de9e1a99d6642c2d09d589aa37ff0a8945dcee1";
-      hash = "sha256-HXu98PyBMKEWLqiTb8viuLDznud/SdkdJsx5A5CWx7I=";
+      rev = "5d639394f3e83b01596dcd166a44a9a1a2583350";
+      hash = "sha256-7kvyoA91etzVEl9mkA/EJfB6z/PltxX7Xc4gcr7/xlo=";
     };
 
-    pname =
-      old.pname
-      + "-hyprland"
-      + lib.optionalString enableNvidiaPatches "-nvidia";
-
-    patches =
-      (old.patches or [ ])
-      ++ (lib.optionals enableNvidiaPatches [
-        "${hyprland.src}/nix/patches/wlroots-nvidia.patch"
-      ]);
-
-    # don't need old.postPatch for hwdata's path in wlroots 0.16
-    postPatch = lib.optionalString enableNvidiaPatches ''
-      substituteInPlace render/gles2/renderer.c --replace "glFlush();" "glFinish();"
-    '';
+    pname = "${old.pname}-hyprland";
 
     buildInputs = old.buildInputs ++ [
       hwdata
-      libdisplay-info-new
-      libliftoff-new
+      libdisplay-info
+      libliftoff
     ];
   })


### PR DESCRIPTION
## Description of changes

- hyprland: 0.32.3 -> 0.33.1
- nixos/hyprland: remove enableNvidiaPatches option

Hyprland no longer requires patching to work on Nvidia, so the options have been
removed both from the package and the module, and have been replaced with
appropriate assertions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)  (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
