### PR TITLE
xstow: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/misc/xstow/default.nix
+++ b/pkgs/tools/misc/xstow/default.nix
@@ -1,11 +1,20 @@
-{ stdenv, lib, fetchurl, ncurses, autoreconfHook }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, ncurses
+, autoreconfHook
+}:
+
 stdenv.mkDerivation rec {
   pname = "xstow";
-  version = "1.1.0";
+  version = "1.1.1";
 
-  src = fetchurl {
-    url = "http://downloads.sourceforge.net/sourceforge/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-wXQ5XSmogAt1torfarrqIU4nBYj69MGM/HBYqeIE+dw=";
+  src = fetchFromGitHub {
+    owner = "majorkingleo";
+    repo = "xstow";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-c89+thw5N3Cgl1Ww+W7c3YsyhNJMLlreedvdWJFY3WY=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -23,11 +32,11 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A replacement of GNU Stow written in C++";
-    homepage = "https://xstow.sourceforge.net";
+    homepage = "https://github.com/majorkingleo/xstow";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ nzbr ];
+    broken = stdenv.isDarwin;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/xstow/default.nix
+++ b/pkgs/tools/misc/xstow/default.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/majorkingleo/xstow";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ nzbr ];
-    broken = stdenv.isDarwin;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

The project moved [to GitHub](https://github.com/majorkingleo/xstow) and had some changes to the build process. There have been no changes to the functionality of xstow.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
