### PR TITLE
modemmanager: 1.20.6 -> 1.22.0, libmbim: 1.28.4 -> 1.30.0, libqmi: 1.32.4 -> 1.34.0

### DIFF
--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitLab
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -19,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libmbim";
-  version = "1.28.4";
+  version = "1.30.0";
 
   outputs = [ "out" "dev" ]
     ++ lib.optionals withDocs [ "man" ];
@@ -29,26 +28,8 @@ stdenv.mkDerivation rec {
     owner = "mobile-broadband";
     repo = "libmbim";
     rev = version;
-    hash = "sha256-aaYjvJ2OMTzkUyqWCyHdmsKJ3VGqBmKQzb1DWK/1cPU=";
+    hash = "sha256-sHTpu9WeMZroT+1I18ObEHWSzcyj/Relyz8UNe+WawI=";
   };
-
-  patches = [
-    # Intel Mutual Authentication - FCC lock. Part of 1.30, backported to
-    # openSUSE and Fedora and ChromeOS.
-    # https://src.fedoraproject.org/rpms/libmbim/blob/rawhide/f/libmbim.spec
-    (fetchpatch {
-      url = "https://cgit.freedesktop.org/libmbim/libmbim/patch/?id=910db9cb2b6fde303d3b4720890cf6dc6fc00880";
-      hash = "sha256-412sXdWb8WsSexe1scI/C57dwENgNWoREGO1GxSF4hs=";
-    })
-
-    # Intel Tools. Allows tracing various commands. Part of 1.30, backported to
-    # openSUSE, Fedora and ChromeOS.
-    # https://src.fedoraproject.org/rpms/libmbim/blob/rawhide/f/libmbim.spec
-    (fetchpatch {
-      url = "https://cgit.freedesktop.org/libmbim/libmbim/patch/?id=8a6dec6ed11931601e605c9537da9904b3be5bc0";
-      hash = "sha256-tU4zkUl5aZJE+g/qbnWprUHe/PmZvqVKB9qecSaUBhk=";
-    })
-  ];
 
   mesonFlags = [
     "-Dudevdir=${placeholder "out"}/lib/udev"

--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libqmi";
-  version = "1.32.4";
+  version = "1.34.0";
 
   outputs = [ "out" "dev" ]
     ++ lib.optional withIntrospection "devdoc";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     owner = "mobile-broadband";
     repo = "libqmi";
     rev = version;
-    hash = "sha256-cczGvoD+2+G6uiAt0Iv1BO4/FqzO9bkqhFsEwOfp7qw=";
+    hash = "sha256-l9ev9ZOWicVNZ/Wj//KNd3NHcefIrLVriqJhEpwWvtQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -23,14 +23,14 @@
 
 stdenv.mkDerivation rec {
   pname = "modemmanager";
-  version = "1.20.6";
+  version = "1.22.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mobile-broadband";
     repo = "ModemManager";
     rev = version;
-    hash = "sha256-/A4WTsUQVeZDi5ei6qBvqoWYLKdRcZaYZU8/qWOPrvM=";
+    hash = "sha256-/D9b2rCCUhpDCUfSNAWR65+3EyUywzFdH1R17eSKRDo=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes
Closes #260700

https://gitlab.freedesktop.org/mobile-broadband/libmbim/-/compare/1.28.4...1.30.0
https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/compare/1.32.4...1.34.0
https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/compare/1.20.6...1.22.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
