### PR TITLE
elixir: rename erlangPackage option to erlang

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -8,11 +8,11 @@
 , curl
 , bash
 , debugInfo ? false
-}:
+} @ inputs:
 
 { baseName ? "elixir"
 , version
-, erlangPackage ? erlang
+, erlang ? inputs.erlang
 , minimumOTPVersion
 , sha256 ? null
 , rev ? "v${version}"
@@ -24,7 +24,7 @@ let
   inherit (lib) getVersion versionAtLeast optional concatStringsSep;
 
 in
-assert versionAtLeast (getVersion erlangPackage) minimumOTPVersion;
+assert versionAtLeast (getVersion erlang) minimumOTPVersion;
 
 stdenv.mkDerivation ({
   pname = "${baseName}";
@@ -32,7 +32,7 @@ stdenv.mkDerivation ({
   inherit src version debugInfo;
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ erlangPackage ];
+  buildInputs = [ erlang ];
 
   LANG = "C.UTF-8";
   LC_TYPE = "C.UTF-8";


### PR DESCRIPTION
## Description of changes

Noticed the new changes of elixir generic builder, and I think there is some inconsistency in the code here. 

In beam modules related code, we are using `elixir` / `erlang` instead of `elixirPackage` / `erlangPackage`. So, I think that renaming `erlangPackage` option to `erlang` would be better. 

> Considering that this part of the code was just modified yesterday, there hasn't been any compatibility handling done here.

@happysalada @jozuas what do you think?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
