### PR TITLE
tests.nixpkgs-check-by-name: Implement gradual empty arg check migration

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/README.md
@@ -81,6 +81,10 @@ Tests are declared in [`./tests`](./tests) as subdirectories imitating Nixpkgs w
   allowing the simulation of package overrides to the real [`pkgs/top-level/all-packages.nix`](../../top-level/all-packages.nix`).
   The default is an empty overlay.
 
+- `base` (optional):
+  Contains another subdirectory imitating Nixpkgs with potentially any of the above structures.
+  This will be used as the `--base` argument, allowing tests of gradual transitions.
+
 - `expected` (optional):
   A file containing the expected standard output.
   The default is expecting an empty standard output.

--- a/pkgs/test/nixpkgs-check-by-name/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/README.md
@@ -19,7 +19,7 @@ These checks are performed by this tool:
 
 ### File structure checks
 - `pkgs/by-name` must only contain subdirectories of the form `${shard}/${name}`, called _package directories_.
-- The `name`'s of package directories must be unique when lowercased
+- The `name`'s of package directories must be unique when lowercased.
 - `name` is a string only consisting of the ASCII characters `a-z`, `A-Z`, `0-9`, `-` or `_`.
 - `shard` is the lowercased first two letters of `name`, expressed in Nix: `shard = toLower (substring 0 2 name)`.
 - Each package directory must contain a `package.nix` file and may contain arbitrary other files.
@@ -28,8 +28,8 @@ These checks are performed by this tool:
 - Each package directory must not refer to files outside itself using symlinks or Nix path expressions.
 
 ### Nix evaluation checks
-- `pkgs.${name}` is defined as `callPackage pkgs/by-name/${shard}/${name}/package.nix args` for some `args`.
-- `pkgs.lib.isDerivation pkgs.${name}` is `true`.
+- For each package directory, the `pkgs.${name}` attribute must be defined as `callPackage pkgs/by-name/${shard}/${name}/package.nix args` for some `args`.
+- For each package directory, `pkgs.lib.isDerivation pkgs.${name}` must be `true`.
 
 ### Ratchet checks
 
@@ -41,7 +41,8 @@ Ratchets should be removed eventually once the pattern is not used anymore.
 
 The current ratchets are:
 
-- If `pkgs.${name}` is not auto-called from `pkgs/by-name`, the `args` in its `callPackage` must not be empty,
+- New manual definitions of `pkgs.${name}` (e.g. in `pkgs/top-level/all-packages.nix`) with `args = { }`
+  (see [nix evaluation checks](#nix-evaluation-checks)) must not be introduced.
 
 ## Development
 

--- a/pkgs/test/nixpkgs-check-by-name/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/README.md
@@ -4,28 +4,14 @@ This directory implements a program to check the [validity](#validity-checks) of
 It is being used by [this GitHub Actions workflow](../../../.github/workflows/check-by-name.yml).
 This is part of the implementation of [RFC 140](https://github.com/NixOS/rfcs/pull/140).
 
-## API
+## Interface
 
-This API may be changed over time if the CI workflow making use of it is adjusted to deal with the change appropriately.
+The interface of the tool is shown with `--help`:
+```
+cargo run -- --help
+```
 
-- Command line: `nixpkgs-check-by-name [--base <BASE_NIXPKGS>] <NIXPKGS>`
-- Arguments:
-  - `<NIXPKGS>`:
-    The path to the Nixpkgs to check.
-    For PRs, this should be set to a checkout of the PR branch.
-  - `<BASE_NIXPKGS>`:
-    The path to the Nixpkgs to use as the [ratchet check](#ratchet-checks) base.
-    For PRs, this should be set to a checkout of the PRs base branch.
-
-    If not specified, no ratchet checks will be performed.
-    However, this flag will become required once CI uses it.
-- Exit code:
-  - `0`: If the [validation](#validity-checks) is successful
-  - `1`: If the [validation](#validity-checks) is not successful
-  - `2`: If an unexpected I/O error occurs
-- Standard error:
-  - Informative messages
-  - Detected problems if validation is not successful
+The interface may be changed over time only if the CI workflow making use of it is adjusted to deal with the change appropriately.
 
 ## Validity checks
 

--- a/pkgs/test/nixpkgs-check-by-name/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/README.md
@@ -10,8 +10,13 @@ This API may be changed over time if the CI workflow making use of it is adjuste
 
 - Command line: `nixpkgs-check-by-name [--base <BASE_NIXPKGS>] <NIXPKGS>`
 - Arguments:
-  - `<BASE_NIXPKGS>`: The path to the Nixpkgs to check against
-  - `<NIXPKGS>`: The path to the Nixpkgs to check
+  - `<NIXPKGS>`: The path to the Nixpkgs to check.
+  - `<BASE_NIXPKGS>`: The path to the Nixpkgs to use as the base to compare `<NIXPKGS>` against.
+    This allows the strictness of checks to increase over time by only preventing _new_ violations from being introduced,
+    while allowing violations that already existed.
+
+    If not specified, all violations of stricter checks are allowed.
+    However, this flag will become required once CI passes it.
 - Exit code:
   - `0`: If the [validation](#validity-checks) is successful
   - `1`: If the [validation](#validity-checks) is not successful

--- a/pkgs/test/nixpkgs-check-by-name/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/README.md
@@ -8,16 +8,10 @@ This is part of the implementation of [RFC 140](https://github.com/NixOS/rfcs/pu
 
 This API may be changed over time if the CI workflow making use of it is adjusted to deal with the change appropriately.
 
-- Command line: `nixpkgs-check-by-name <NIXPKGS>`
+- Command line: `nixpkgs-check-by-name [--base <BASE_NIXPKGS>] <NIXPKGS>`
 - Arguments:
+  - `<BASE_NIXPKGS>`: The path to the Nixpkgs to check against
   - `<NIXPKGS>`: The path to the Nixpkgs to check
-  - `--version <VERSION>`: The version of the checks to perform.
-
-    Possible values:
-    - `v0` (default)
-    - `v1`
-
-    See [validation](#validity-checks) for the differences.
 - Exit code:
   - `0`: If the [validation](#validity-checks) is successful
   - `1`: If the [validation](#validity-checks) is not successful
@@ -42,7 +36,8 @@ These checks are performed by this tool:
 
 ### Nix evaluation checks
 - `pkgs.${name}` is defined as `callPackage pkgs/by-name/${shard}/${name}/package.nix args` for some `args`.
-  - **Only after --version v1**: If `pkgs.${name}` is not auto-called from `pkgs/by-name`, `args` must not be empty
+  - If `pkgs.${name}` is not auto-called from `pkgs/by-name`, `args` must not be empty,
+    with the exception that if `BASE_NIXPKGS` also has a definition for the same package with empty `args`, it's allowed
 - `pkgs.lib.isDerivation pkgs.${name}` is `true`.
 
 ## Development

--- a/pkgs/test/nixpkgs-check-by-name/src/eval.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/eval.rs
@@ -41,7 +41,7 @@ enum AttributeVariant {
 pub fn check_values(
     nixpkgs_path: &Path,
     package_names: Vec<String>,
-    eval_accessible_paths: Vec<&Path>,
+    eval_accessible_paths: &Vec<&Path>,
 ) -> validation::Result<version::Nixpkgs> {
     // Write the list of packages we need to check into a temporary JSON file.
     // This can then get read by the Nix evaluation.

--- a/pkgs/test/nixpkgs-check-by-name/src/eval.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/eval.rs
@@ -41,7 +41,7 @@ enum AttributeVariant {
 pub fn check_values(
     nixpkgs_path: &Path,
     package_names: Vec<String>,
-    eval_accessible_paths: &Vec<&Path>,
+    eval_accessible_paths: &[&Path],
 ) -> validation::Result<version::Nixpkgs> {
     // Write the list of packages we need to check into a temporary JSON file.
     // This can then get read by the Nix evaluation.
@@ -110,11 +110,11 @@ pub fn check_values(
         ))?;
 
     Ok(
-        validation::sequence(package_names.iter().map(|package_name| {
-            let relative_package_file = structure::relative_file_for_package(package_name);
+        validation::sequence(package_names.into_iter().map(|package_name| {
+            let relative_package_file = structure::relative_file_for_package(&package_name);
             let absolute_package_file = nixpkgs_path.join(&relative_package_file);
 
-            if let Some(attribute_info) = actual_files.get(package_name) {
+            if let Some(attribute_info) = actual_files.get(&package_name) {
                 let check_result = if !attribute_info.is_derivation {
                     NixpkgsProblem::NonDerivation {
                         relative_package_file: relative_package_file.clone(),

--- a/pkgs/test/nixpkgs-check-by-name/src/main.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/main.rs
@@ -86,14 +86,9 @@ pub fn check_nixpkgs<W: io::Write>(
         );
         Success(())
     } else {
-        match check_structure(&nixpkgs_path)? {
-            Failure(errors) => Failure(errors),
-            Success(package_names) =>
+        check_structure(&nixpkgs_path)?.result_map(|package_names|
             // Only if we could successfully parse the structure, we do the evaluation checks
-            {
-                eval::check_values(version, &nixpkgs_path, package_names, eval_accessible_paths)?
-            }
-        }
+            eval::check_values(version, &nixpkgs_path, package_names, eval_accessible_paths))?
     };
 
     match check_result {

--- a/pkgs/test/nixpkgs-check-by-name/src/main.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/main.rs
@@ -17,8 +17,20 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 /// Program to check the validity of pkgs/by-name
+///
+/// This CLI interface may be changed over time if the CI workflow making use of
+/// it is adjusted to deal with the change appropriately.
+///
+/// Exit code:
+/// - `0`: If the validation is successful
+/// - `1`: If the validation is not successful
+/// - `2`: If an unexpected I/O error occurs
+///
+/// Standard error:
+/// - Informative messages
+/// - Detected problems if validation is not successful
 #[derive(Parser, Debug)]
-#[command(about)]
+#[command(about, verbatim_doc_comment)]
 pub struct Args {
     /// Path to the main Nixpkgs to check.
     /// For PRs, this should be set to a checkout of the PR branch.

--- a/pkgs/test/nixpkgs-check-by-name/src/main.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/main.rs
@@ -212,10 +212,17 @@ mod tests {
     fn test_nixpkgs(name: &str, path: &Path, expected_errors: &str) -> anyhow::Result<()> {
         let extra_nix_path = Path::new("tests/mock-nixpkgs.nix");
 
+        let base_path = path.join("base");
+        let base_nixpkgs = if base_path.exists() {
+            Some(base_path.as_path())
+        } else {
+            None
+        };
+
         // We don't want coloring to mess up the tests
         let writer = temp_env::with_var("NO_COLOR", Some("1"), || -> anyhow::Result<_> {
             let mut writer = vec![];
-            process(None, &path, &vec![&extra_nix_path], &mut writer)
+            process(base_nixpkgs, &path, &vec![&extra_nix_path], &mut writer)
                 .context(format!("Failed test case {name}"))?;
             Ok(writer)
         })?;

--- a/pkgs/test/nixpkgs-check-by-name/src/main.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/main.rs
@@ -75,14 +75,16 @@ pub fn process<W: io::Write>(
     let main_result = check_nixpkgs(main_nixpkgs, eval_accessible_paths)?;
     let check_result = main_result.result_map(|nixpkgs_version| {
         if let Some(base) = base_nixpkgs {
-            check_nixpkgs(base, eval_accessible_paths)?.result_map(|base_nixpkgs_version| {
-                Ok(Nixpkgs::compare(base_nixpkgs_version, nixpkgs_version))
-            })
+            check_nixpkgs(base, eval_accessible_paths, error_writer)?.result_map(
+                |base_nixpkgs_version| {
+                    Ok(Nixpkgs::compare(
+                        Some(base_nixpkgs_version),
+                        nixpkgs_version,
+                    ))
+                },
+            )
         } else {
-            Ok(Nixpkgs::compare(
-                version::Nixpkgs::default(),
-                nixpkgs_version,
-            ))
+            Ok(Nixpkgs::compare(None, nixpkgs_version))
         }
     })?;
 

--- a/pkgs/test/nixpkgs-check-by-name/src/validation.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/validation.rs
@@ -58,6 +58,15 @@ impl<A> Validation<A> {
             Success(value) => Success(f(value)),
         }
     }
+
+    /// Map a `Validation<A>` to a `Result<B>` by applying a function `A -> Result<B>`
+    /// only if there is a `Success` value
+    pub fn result_map<B>(self, f: impl FnOnce(A) -> Result<B>) -> Result<B> {
+        match self {
+            Failure(err) => Ok(Failure(err)),
+            Success(value) => f(value),
+        }
+    }
 }
 
 impl Validation<()> {

--- a/pkgs/test/nixpkgs-check-by-name/src/version.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/version.rs
@@ -16,6 +16,8 @@ impl Nixpkgs {
     /// Compares two Nixpkgs versions against each other, returning validation errors only if the
     /// `from` version satisfied the stricter checks, while the `to` version doesn't satisfy them
     /// anymore.
+    /// This enables a gradual transition from weaker to stricter checks, by only allowing PRs to
+    /// increase strictness.
     pub fn compare(optional_from: Option<Self>, to: Self) -> Validation<()> {
         validation::sequence_(
             // We only loop over the current attributes,

--- a/pkgs/test/nixpkgs-check-by-name/src/version.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/version.rs
@@ -1,0 +1,71 @@
+use crate::nixpkgs_problem::NixpkgsProblem;
+use crate::structure;
+use crate::validation::{self, Validation, Validation::Success};
+use std::collections::HashMap;
+
+/// The check version conformity of a Nixpkgs path:
+/// When the strictness of the check increases, this structure should be extended to distinguish
+/// between parts that are still valid, and ones that aren't valid anymore.
+#[derive(Default)]
+pub struct Nixpkgs {
+    /// The package attributes tracked in `pkgs/by-name`
+    pub attributes: HashMap<String, Attribute>,
+}
+
+impl Nixpkgs {
+    /// Compares two Nixpkgs versions against each other, returning validation errors only if the
+    /// `from` version satisfied the stricter checks, while the `to` version doesn't satisfy them
+    /// anymore.
+    pub fn compare(empty_non_auto_called_from: &EmptyNonAutoCalled, to: Self) -> Validation<()> {
+        validation::sequence_(
+            // We only loop over the current attributes,
+            // we don't need to check ones that were removed
+            to.attributes.into_iter().map(|(name, attr_to)| {
+                Attribute::compare(&name, empty_non_auto_called_from, &attr_to)
+            }),
+        )
+    }
+}
+
+/// The check version conformity of an attribute defined by `pkgs/by-name`
+pub struct Attribute {
+    pub empty_non_auto_called: EmptyNonAutoCalled,
+}
+
+impl Attribute {
+    pub fn compare(
+        name: &str,
+        empty_non_auto_called_from: &EmptyNonAutoCalled,
+        to: &Self,
+    ) -> Validation<()> {
+        EmptyNonAutoCalled::compare(name, empty_non_auto_called_from, &to.empty_non_auto_called)
+    }
+}
+
+/// Whether an attribute conforms to the new strictness check that
+/// `callPackage ... {}` is not allowed anymore in `all-package.nix`
+#[derive(PartialEq, PartialOrd)]
+pub enum EmptyNonAutoCalled {
+    /// The attribute is not valid anymore with the new check
+    Invalid,
+    /// The attribute is still valid with the new check
+    Valid,
+}
+
+impl EmptyNonAutoCalled {
+    fn compare(
+        name: &str,
+        empty_non_auto_called_from: &EmptyNonAutoCalled,
+        to: &Self,
+    ) -> Validation<()> {
+        if to >= empty_non_auto_called_from {
+            Success(())
+        } else {
+            NixpkgsProblem::WrongCallPackage {
+                relative_package_file: structure::relative_file_for_package(name),
+                package_name: name.to_owned(),
+            }
+            .into()
+        }
+    }
+}

--- a/pkgs/test/nixpkgs-check-by-name/tests/no-by-name/expected
+++ b/pkgs/test/nixpkgs-check-by-name/tests/no-by-name/expected
@@ -1,0 +1,1 @@
+Given Nixpkgs path does not contain a pkgs/by-name subdirectory, no check necessary.

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/all-packages.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/all-packages.nix
@@ -1,0 +1,3 @@
+self: super: {
+  nonDerivation = self.callPackage ./pkgs/by-name/no/nonDerivation/package.nix { };
+}

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/base/all-packages.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/base/all-packages.nix
@@ -1,0 +1,3 @@
+self: super: {
+  nonDerivation = self.callPackage ./pkgs/by-name/no/nonDerivation/package.nix { };
+}

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/base/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/base/default.nix
@@ -1,0 +1,1 @@
+import ../../mock-nixpkgs.nix { root = ./.; }

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/base/pkgs/by-name/no/nonDerivation/package.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/base/pkgs/by-name/no/nonDerivation/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/default.nix
@@ -1,0 +1,1 @@
+import ../mock-nixpkgs.nix { root = ./.; }

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/pkgs/by-name/no/nonDerivation/package.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg-gradual/pkgs/by-name/no/nonDerivation/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg/base/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg/base/default.nix
@@ -1,0 +1,1 @@
+import ../../mock-nixpkgs.nix { root = ./.; }

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg/base/pkgs/by-name/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-empty-arg/base/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+(this is just here so the directory can get tracked by git)

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-no-call-package/all-packages.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-no-call-package/all-packages.nix
@@ -1,3 +1,3 @@
 self: super: {
-  nonDerivation = null;
+  nonDerivation = self.someDrv;
 }

--- a/pkgs/test/nixpkgs-check-by-name/tests/override-no-file/all-packages.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/override-no-file/all-packages.nix
@@ -1,3 +1,3 @@
 self: super: {
-  nonDerivation = self.callPackage ({ }: { }) { };
+  nonDerivation = self.callPackage ({ someDrv }: someDrv) { };
 }


### PR DESCRIPTION
## Context

This is part of the plan to migrate all packages to `pkgs/by-name` as detailed in https://github.com/NixOS/nixpkgs/issues/258650.

In https://github.com/NixOS/nixpkgs/pull/256792 I implemented support for the `nixpkgs-check-by-name` tool to complain when there's an unnecessary definition in `all-packages.nix` with an empty second argument like

```nix
foo = ../by-name/fo/foo/package.nix { };
```

However this was never enabled in CI with `--version v1`.
While at least in master there's no package where this applies, this is a perfect test case to make sure the tool can increase strictness over time without causing master breakages, as further detailed in https://github.com/NixOS/nixpkgs/issues/256788.

After thinking about it for too long, I realised that this is actually pretty easy to do after the changes in https://github.com/NixOS/nixpkgs/pull/261939 and https://github.com/NixOS/nixpkgs/pull/257735.

## Changes

- The `--version` flag is removed again, it was never used in CI, and it's not part of the public interface, so this is fine
- The `--base <NIXPKGS>` flag is introduced, allowing the tool to check against granular regressions. For the empty argument check this means that existing empty arguments can stay, but new ones can't be introduced.

## Example

If the base Nixpkgs has
```nix
# all-packages.nix
{
  foo = callPackage ../by-name/fo/foo/package.nix {
    withGui = true;
  };
}
```

And the main Nixpkgs has
```nix
# all-packages.nix
{
  foo = callPackage ../by-name/fo/foo/package.nix { };
}
```

Then the check fails because of the empty argument check.

But if you go the other way, the check succeeds!

## Implications

While this isn't very useful for the empty argument check specifically, the same approach can be used to also ensure that all new packages using `callPackage` use `pkgs/by-name`.

This means that we can have incremental (and automated!) PRs to do the migration, without worrying about the base branch always introducing new violations!

## Things done

- [x] Tidy code
- [x] Updated documentation
- [x] Added tests

## Follow-up PR

Once the new tooling version propagates to the nixos-unstable channel, update CI to pass the `--base` flag.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
