### PR TITLE
ocamlPackages.gsl: 1.24.3 → 1.25.0

### DIFF
--- a/pkgs/development/ocaml-modules/gsl/default.nix
+++ b/pkgs/development/ocaml-modules/gsl/default.nix
@@ -1,11 +1,8 @@
-{ lib, stdenv, ocaml, fetchFromGitHub, fetchpatch, buildDunePackage, pkg-config, gsl, darwin, dune-configurator }:
-
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
-  "gsl is not available for OCaml ${ocaml.version}"
+{ lib, stdenv, fetchFromGitHub, buildDunePackage, pkg-config, gsl, darwin, dune-configurator }:
 
 buildDunePackage rec {
   pname = "gsl";
-  version = "1.24.3";
+  version = "1.25.0";
 
   minimalOCamlVersion = "4.12";
 
@@ -13,31 +10,8 @@ buildDunePackage rec {
     owner = "mmottl";
     repo = "gsl-ocaml";
     rev = version;
-    hash = "sha256-I+u7lFEredt8ZLiba8x904eTgSUdZq82/e82B+/GIlo=";
+    hash = "sha256-vxXv0ZcToXmdYu5k0aLdV3seNn3Y6Sgg+8dpy3Iw68I=";
   };
-
-  patches = [
-    # Switched to Dune lang 2.7
-    (fetchpatch {
-      url = "https://github.com/mmottl/gsl-ocaml/commit/be0f6933f16fea6d6fb2e39178816974be4c3724.patch";
-      sha256 = "sha256-G/4JT8XPYw+oNJEwJ9zRdUBwtNUHL+T8/htCb3qfuT8=";
-    })
-    # Fix dune rules
-    (fetchpatch {
-      url = "https://github.com/mmottl/gsl-ocaml/commit/0b38a22d9813de27eab5caafafeabd945f298b5e.patch";
-      sha256 = "sha256-S6OUDase2kR7V6fizaev5huqEAIM5QOkx3n18rj4y3w=";
-    })
-    # Updated opam file
-    (fetchpatch {
-      url = "https://github.com/mmottl/gsl-ocaml/commit/b749455b76501c9e3623e05d659565eab7292602.patch";
-      sha256 = "sha256-/GACjI3cRCApyGyk1kQp0rB/Hae8DIR9zs6q9KiS1ZQ=";
-    })
-    # Used new OCaml 4.12 C-macros
-    (fetchpatch {
-      url = "https://github.com/mmottl/gsl-ocaml/commit/cca79ea56a7ee83a4c67b432decdaef3de8c9d30.patch";
-      sha256 = "sha256-bsIKkvj9W8oAYSvP6ZfbqSgt5fSirc780O08WBhVRmI=";
-    })
-  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator gsl ];

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,4 +1,5 @@
 { lib
+, ocaml
 , buildDunePackage
 , fetchFromGitHub
 , ppx_deriving
@@ -14,6 +15,9 @@
 , printbox-text
 }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "phylogenetics is not compatible with OCaml ${ocaml.version}"
+
 buildDunePackage rec {
   pname = "phylogenetics";
   version = "unstable-2022-05-06";
@@ -26,7 +30,6 @@ buildDunePackage rec {
   };
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   nativeCheckInputs = [ bppsuite ];
   checkInputs = [ alcotest ];


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/mmottl/gsl-ocaml/1.25.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
