### PR TITLE
googlefonts.*: init at unstable-2023-07-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8145,6 +8145,14 @@
     githubId = 2588851;
     name = "Jan Solanti";
   };
+  janw4ld = {
+    github = "janw4ld";
+    githubId = 109631006;
+    keys = [{
+      fingerprint = "FDFE 3083 DB28 0948 6A90  9A75 1674 A3D6 104B 2892";
+    }];
+    name = "ورد";
+  };
   jappie = {
     email = "jappieklooster@hotmail.com";
     github = "jappeace";

--- a/pkgs/data/fonts/googlefonts/default.nix
+++ b/pkgs/data/fonts/googlefonts/default.nix
@@ -1,0 +1,201 @@
+{
+  stdenvNoCC
+, lib
+, fetchFromGitHub
+, symlinkJoin
+}: let
+  version = "unstable-2023-07-22";
+
+  arimoSpec = {
+    name = "arimo";
+    rev = "302dc85954f887248b4ad442b0966e4ead1c1cf9";
+    hash = "sha256-Z9CVdiWPHla7ybkNXx2z7xr+jvv5SCeo2dU7U8K9IMs=";
+    longDescription = "A free font metric-compatible with Arial.";
+    license = lib.licenses.asl20;
+  };
+
+  tinosSpec = {
+    name = "tinos";
+    rev = "ba5282d4706054e82332d3863ac96e069b34f032";
+    hash = "sha256-vxPFAoMGkL9WReFRyUUFxQ18KyAuzGzkOKOQ6On8zlo=";
+    longDescription = "A free font metric-compatible with Times New Roman.";
+  };
+
+  cousineSpec = {
+    name = "cousine";
+    rev = "134dfbb9d26045ab76936f9cb9d169ef6ff743f0";
+    hash = "sha256-01ShGv3poLMI+DvpS0DFSuvhWYppC8pTvjQD28hQ4xk=";
+    longDescription = "A free font metric-compatible with Courier New.";
+  };
+
+  carlitoSpec = {
+    name = "carlito";
+    rev = "3a810cab78ebd6e2e4eed42af9e8453c4f9b850a";
+    hash = "sha256-U4TvZZ7n7dr1/14oZkF1Eo96ZcdWIDWron70um77w+E=";
+    longDescription = "A free font metric-compatible with Calibri.";
+  };
+
+  roboto-flexSpec = {
+    name = "roboto-flex";
+    rev = "739e06dc46ebb14cddd88b9768a6c1504d4677f6";
+    hash = "sha256-/FdsA+Qvx9oGUdk/XurZJNARJkvDX6LgjBU40wAllL8=";
+    longDescription = "Roboto Flex is a variable font version of Roboto," +
+      " Google's signature font family. It is a sans serif typeface" +
+      " intended to work well in user interfaces.";
+  };
+
+  open-sansSpec = {
+    name = "open-sans";
+    repo = "opensans";
+    rev = "52bd0a97bdc86a8e913600d6f748a90d870c3e7c";
+    hash = "sha256-yiJsvH0Ocdjjj5MvXHe7E/R0jfAIbAti5c3Z/QmWu5k=";
+    longDescription = ''
+      Variable font originally designed by Steve Matteson of Ascender
+      Hebrew by Yanek Iontef
+      Weight expansion by Micah Stupak
+      Help and advice from Meir Sadan and Marc Foley
+    '';
+  };
+
+  oswaldSpec = {
+    name = "oswald";
+    repo = "oswaldfont";
+    rev = "6e65651c229e897dc55fb8d17097ee7f75b2769b";
+    hash = "sha256-4RNJLaOzcIjPGUVnImK5Ngoi5+XKuQaqZy0S4uUCKGM=";
+    longDescription = "Oswald is a reworking of the classic gothic typeface" +
+      " style historically represented by designs such as 'Franklyn Gothic'" +
+      " , 'Alternate Gothic', 'News Gothic' and more. The characters of" +
+      " Oswald have been re-drawn and reformed to better fit the pixel grid" +
+      " of standard digital screens. Oswald is designed to be used freely" +
+      " across the internet by web browsers on desktop computers, laptops" +
+      " and mobile devices.";
+  };
+
+  michromaSpec = {
+    name = "michroma";
+    repo = "michroma-font";
+    rev = "07893d1b85a537a6ed4b96fdb091bee45eabe65f";
+    hash = "sha256-EGe2VnlPmwQ2P49iqUbnc7n5jsPKYGuOVfOLBH97A2Y=";
+    longDescription = "Michroma is a reworking and remodelling of the" +
+      " rounded-square sans genre that is closely associated with a 1960s" +
+      " feeling of the future. This is due to the popularity of " +
+      " Microgramma, designed by Aldo Novarese and Alessandro Buttiin in" +
+      " 1952, which pioneered the style; and the most famous typeface " +
+      " family of the genre that came 10 years later in Novarese's Eurostile.";
+  };
+
+  nunitoSpec = {
+    name = "nunito";
+    rev = "43d16f963c5c341c10efa0bfe7a82aa1bea8a938";
+    hash = "sha256-9Ap+WaUd5chxS4cJbT86aTopKOvNpNsFawnx1h5HwDw=";
+    longDescription = "Nunito is a well balanced Sans Serif with rounded" +
+      " terminals. Nunito has been designed mainly to be used as a display" +
+      " font but is useable as a text font too. Nunito has been designed to" +
+      " be used freely across the internet by web browsers on desktop" +
+      " computers, laptops and mobile devices.";
+  };
+
+  mkFont = (font: let inherit ({
+      # defaults that are overridden with `font` attributes
+      inherit (font) name;  # `name` is the only required attr
+      repo = name;
+      longDescription = "A Google font.";
+      license = lib.licenses.ofl;
+      rev = "main";
+      hash = "";
+    } // font) name repo longDescription license rev hash;
+    in stdenvNoCC.mkDerivation {
+      inherit version;
+      pname = "googlefonts." + name;
+
+      src = fetchFromGitHub {
+        inherit repo rev hash;
+        owner = "googlefonts";
+        sparseCheckout = [ "/fonts/" ];
+      } + "/fonts/";
+
+      dontBuild = true;
+      dontConfigure = true;
+      installPhase = ''
+        set -e ; shopt -u nullglob
+
+        local out_font=$out/share/fonts/googlefonts/
+
+        if [ -d ttf/variable_ttf ]; then
+          f=ttf/variable_ttf/
+        elif [ -d variable ]; then
+          f=variable/
+        elif [ -d vf  ]; then
+          f=vf/
+        elif [ -d otf ]; then
+          f=otf/
+        elif [ -d ttf ]; then
+          f=ttf/
+        elif ls *.ttf || ls *.otf ; then
+          f=./
+        else
+          echo "no precompiled fonts found"
+          exit 1
+        fi
+
+        echo "Installing ${name} from $f"
+
+        if [ -d "$f"unhinted/variable_ttf ]; then
+          install -m444 -Dt $out_font "$f"unhinted/variable_ttf/*.ttf
+        elif [ -d "$f"unhinted/otf ]; then
+          install -m444 -Dt $out_font "$f"unhinted/otf/*.otf
+        elif [ -d "$f"unhinted/ttf ]; then
+          install -m444 -Dt $out_font "$f"unhinted/ttf/*.ttf
+        elif ls "$f"*.ttf &>/dev/null; then
+          install -m444 -Dt $out_font "$f"*.ttf
+        elif ls "$f"*.otf &>/dev/null; then
+          install -m444 -Dt $out_font "$f"*.otf
+        else
+          echo "no fonts found in $f"
+          exit 1
+        fi || {
+          echo "something went very wrong, probably a bug in the script."
+          exit 1
+        }
+      '';
+
+      meta = with lib; {
+        inherit longDescription license;
+        description = "A free font created or forked by Google";
+        homepage = "https://github.com/googlefonts";
+        platforms = platforms.all;
+        maintainers = [ maintainers.janw4ld ];
+      };
+    });
+
+  mkFontPack = { fontList, name, description }: with lib; let
+      getMetaAttr = attr: (map (f: f.meta."${attr}") fontList);
+      foldl1 = fn: l: foldl fn (head l) (tail l);
+    in (symlinkJoin {
+      name = "googlefonts.${name}-${version}";
+      paths = fontList;
+    }).overrideAttrs {
+      meta = {
+        inherit description;
+        license =  unique (getMetaAttr "license");
+        platforms = foldl1 intersectLists (getMetaAttr "platforms");
+        maintainers = unique (concatLists (getMetaAttr "maintainers"));
+      };
+    };
+in rec {
+  croscorePack = mkFontPack {
+    name = "croscorePack";
+    description =  "A pack of fonts metric-compatible with Arial," +
+      " Times New Roman, Courier New and Calibri";
+    fontList = [ arimo tinos cousine carlito ];
+  };
+  arimo = mkFont arimoSpec;
+  tinos = mkFont tinosSpec;
+  cousine = mkFont cousineSpec;
+  carlito = mkFont carlitoSpec;
+  roboto-flex = mkFont roboto-flexSpec;
+  open-sans = mkFont open-sansSpec;
+  oswald = mkFont oswaldSpec;
+  michroma = mkFont michromaSpec;
+  nunito = mkFont nunitoSpec;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8797,6 +8797,8 @@ with pkgs;
 
   google-fonts = callPackage ../data/fonts/google-fonts { };
 
+  googlefonts = recurseIntoAttrs (callPackage ../data/fonts/googlefonts { });
+
   google-clasp = callPackage ../development/tools/google-clasp { };
 
   google-compute-engine = with python38.pkgs; toPythonApplication google-compute-engine;


### PR DESCRIPTION
@emilytrau I'm not sure how the previous branch got corrupted tbh, but I've recreated the PR and applied your suggestion.

## Description of changes

Added a collection of Google Fonts built from github:googlefonts/* repos. This was created to package the croscore fonts (issue https://github.com/NixOS/nixpkgs/issues/238047) without having to fetch the entire github:google/fonts repo using the google-fonts package.
If having a parent attrset containing the derivations isn't okay, I'll drop the separate font derivations and create one "croscore" package instead.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
