### PR TITLE
signal-desktop: Adds support for `aarch64-linux`

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,12 +1,17 @@
-{ callPackage }: builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
-  signal-desktop = {
+{ callPackage, stdenv }: builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
+  signal-desktop = rec {
     dir = "Signal";
     version = "6.40.0";
+    version-aarch64 = "6.40.0";
+    url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
+    url-aarch64 = "https://github.com/0mniteck/Signal-Desktop-Mobian/raw/${version-aarch64}/builds/release/signal-desktop_${version-aarch64}_arm64.deb";
     hash = "sha256-vyXHlycPSyEyv938IKzGM6pdERHHerx2CLY/U+WMrH4=";
+    hash-aarch64 = "sha256-3Pi0c+CGcJR1M4ll51m+B5PmGIcIjjlc0qa9b8rkMeU=";
   };
-  signal-desktop-beta = {
+  signal-desktop-beta = rec {
     dir = "Signal Beta";
     version = "6.40.0-beta.2";
     hash = "sha256-pfedkxbZ25DFgz+/N7ZEb9LwKrHuoMM+Zi+Tc21QPsg=";
+    url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop-beta/signal-desktop-beta_${version}_amd64.deb";
   };
 }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
@@ -1,7 +1,11 @@
 { pname
 , dir
 , version
+, version-aarch64 ? ""
 , hash
+, hash-aarch64 ? ""
+, url
+, url-aarch64 ? ""
 , stdenv
 , lib
 , fetchurl
@@ -51,8 +55,15 @@
 , wayland
 }:
 
-stdenv.mkDerivation rec {
-  inherit pname version; # Please backport all updates to the stable channel.
+let
+  inherit (stdenv) targetPlatform;
+  ARCH = if targetPlatform.isAarch64 then "arm64" else "x64";
+  final-version = if targetPlatform.isAarch64 then version-aarch64 else version;
+in stdenv.mkDerivation rec {
+  inherit pname;
+  version = final-version;
+
+  # Please backport all updates to the stable channel.
   # All releases have a limited lifetime and "expire" 90 days after the release.
   # When releases "expire" the application becomes unusable until an update is
   # applied. The expiration date for the current release can be extracted with:
@@ -61,8 +72,8 @@ stdenv.mkDerivation rec {
   # few additional steps and might not be the best idea.)
 
   src = fetchurl {
-    url = "https://updates.signal.org/desktop/apt/pool/s/${pname}/${pname}_${version}_amd64.deb";
-    inherit hash;
+    url = if targetPlatform.isAarch64 then url-aarch64 else url;
+    hash = if targetPlatform.isAarch64 then hash-aarch64 else hash;
   };
 
   nativeBuildInputs = [
@@ -163,7 +174,7 @@ stdenv.mkDerivation rec {
       ${if pname == "signal-desktop" then "--replace \"bin/signal-desktop\" \"bin/signal-desktop --use-tray-icon\"" else ""}
 
     autoPatchelf --no-recurse -- "$out/lib/${dir}/"
-    patchelf --add-needed ${libpulseaudio}/lib/libpulse.so "$out/lib/${dir}/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-x64.node"
+    patchelf --add-needed ${libpulseaudio}/lib/libpulse.so "$out/lib/${dir}/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-${ARCH}.node"
   '';
 
   # Tests if the application launches and waits for "Link your phone to Signal Desktop":
@@ -176,11 +187,11 @@ stdenv.mkDerivation rec {
       "Signal Android" or "Signal iOS" app.
     '';
     homepage = "https://signal.org/";
-    changelog = "https://github.com/signalapp/Signal-Desktop/releases/tag/v${version}";
+    changelog = "https://github.com/signalapp/Signal-Desktop/releases/tag/v${final-version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ mic92 equirosa urandom ];
+    maintainers = with lib.maintainers; [ mic92 equirosa urandom bkchr ];
     mainProgram = pname;
-    platforms = [ "x86_64-linux" ];
+    platforms = if builtins.stringLength version-aarch64 > 0 then [ "x86_64-linux" "aarch64-linux" ] else [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }


### PR DESCRIPTION
## Description of changes

This adds support for `signal-desktop` on `aarch64-linux`. This is achieved by leveraging a community deb package that builds it for `aarch64`. A future version may switches to a full custom build of the package, so that we don't need to use any debs at all.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
