### PR TITLE
buildNimPackage: allow overriding nim package args

### DIFF
--- a/doc/languages-frameworks/nim.section.md
+++ b/doc/languages-frameworks/nim.section.md
@@ -50,7 +50,20 @@ $ nix build -f . ttop.src
 $ nix run -f . nim_lk ./result | jq --sort-keys > pkgs/by-name/tt/ttop/lock.json
 ```
 
-## Lockfile dependency overrides {#nimoverrides}
+## Overriding Nim packages {#nim-overrides}
+
+The `buildNimPackage` function generates flags and additional build dependencies from the `lockFile` parameter passed to `buildNimPackage`. Using [`overrideAttrs`](#sec-pkg-overrideAttrs) on the final package will apply after this has already been generated, so this can't be used to override the `lockFile` in a package built with `buildNimPackage`. To be able to override parameters before flags and build dependencies are generated from the `lockFile`, use `overrideNimAttrs` instead with the same syntax as `overrideAttrs`:
+
+```nix
+pkgs.nitter.overrideNimAttrs {
+  # using a different source which has different dependencies from the standard package
+  src = pkgs.fetchFromGithub { /* … */ };
+  # new lock file generated from the source
+  lockFile = ./custom-lock.json;
+}
+```
+
+## Lockfile dependency overrides {#nim-lock-overrides}
 
 The `buildNimPackage` function matches the libraries specified by `lockFile` to attrset of override functions that are then applied to the package derivation.
 The default overrides are maintained as the top-level `nimOverrides` attrset at `pkgs/top-level/nim-overrides.nix`.
@@ -81,7 +94,7 @@ The annotations in the `nim-overrides.nix` set are functions that take three arg
 - finalAttrs: the final attrset passed by `buildNimPackage` to `stdenv.mkDerivation`.
 - prevAttrs: the attrset produced by initial arguments to `buildNimPackage` and any preceding lockfile overlays.
 
-### Overriding an Nim library override {#nimoverrides-overrides}
+### Overriding an Nim library override {#nim-lock-overrides-overrides}
 
 The `nimOverrides` attrset makes it possible to modify overrides in a few different ways.
 


### PR DESCRIPTION
## Description of changes

Without this, it's impossible to override the lockFile as the default overrideAttrs is applied after the composition in `buildNimPackage` has read the lock file and generated the nim flags from it.

My concrete use case here is `nitter` which I'm overriding to build from a not yet merged branch. This branch introduces new dependencies so with #268685 I need to specify a new lock file for this. This is currently impossible since the composition in https://github.com/NixOS/nixpkgs/blob/24b542cfe2253e030b9c812c2f2947c07cf4330b/pkgs/development/compilers/nim/build-nim-package.nix#L68 will generate nim flags from the lock file before we have any chance to override the lock file using the `overrideAttrs` function from `stdenv.mkDerivation`. With this change, Nim packages' lock files can be overridden using `overrideNimAttrs` before the composition is applied.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
