### PR TITLE
plasma5Packages.polonium: init at 0.6.0

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/addons/polonium.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/polonium.nix
@@ -1,0 +1,51 @@
+{ lib
+, fetchFromGitHub
+, buildNpmPackage
+, plasma-framework
+}:
+
+# how to update:
+# 1. check out the tag for the version in question
+# 2. run `prefetch-npm-deps package-lock.json`
+# 3. update npmDepsHash with the output of the previous step
+
+buildNpmPackage rec {
+  pname = "polonium";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "zeroxoneafour";
+    repo = pname;
+    rev = "v" + version;
+    hash = "sha256-fZgNOcOq+owmqtplwnxeOIQpWmrga/WitCNCj89O5XA=";
+  };
+
+  npmDepsHash = "sha256-25AtM1FweWIbFot+HUMSPYTu47/0eKNpRWSlBEL0yKk=";
+
+  dontConfigure = true;
+
+  # the installer does a bunch of stuff that fails in our sandbox, so just build here and then we
+  # manually do the install
+  buildFlags = [ "res" "src" ];
+
+  nativeBuildInputs = [ plasma-framework ];
+
+  dontNpmBuild = true;
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    plasmapkg2 --install pkg --packageroot $out/share/kwin/scripts
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Auto-tiler that uses KWin 5.27+ tiling functionality";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit (plasma-framework.meta) platforms;
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -49,7 +49,7 @@ let
     mirror = "mirror://kde";
   };
 
-  qtStdenv = libsForQt5.callPackage ({ stdenv }: stdenv) {};
+  qtStdenv = libsForQt5.callPackage ({ stdenv }: stdenv) { };
 
   packages = self:
     let
@@ -96,7 +96,7 @@ let
 
             defaultSetupHook = if hasBin && hasDev then propagateBin else null;
             setupHook = args.setupHook or defaultSetupHook;
-            nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ libsForQt5.wrapQtAppsHook ];
+            nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ libsForQt5.wrapQtAppsHook ];
 
             meta =
               let meta = args.meta or { }; in
@@ -183,6 +183,7 @@ let
         kzones = callPackage ./3rdparty/kwin/scripts/kzones.nix { };
         lightly = callPackage ./3rdparty/lightly { };
         parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };
+        polonium = callPackage ./3rdparty/addons/polonium.nix { };
       };
 
     } // lib.optionalAttrs config.allowAliases {


### PR DESCRIPTION
## Description of changes

polonium is a new auto-tiler for kwin that works with kwin 5.27+ and should replace bismuth, kwin-autotiler et al.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
