### PR TITLE
groff: Update site.tmac to conceal glyph usage errors

### DIFF
--- a/pkgs/tools/text/groff/site.tmac
+++ b/pkgs/tools/text/groff/site.tmac
@@ -1,13 +1,26 @@
 .
 .if n \{\
-.  \" Character translations for non-keyboard
-.  \" characters - to make them searchable
+.  \" With groff 1.23.0 "[t]he 'utf8' output device now maps the input
+.  \" characters '^' (caret, circumflex accent, or 'hat') and '~' (tilde)
+.  \" to U+02C6 (modifier letter circumflex accent) and U+02DC (small tilde),
+.  \" respectively, for consistency with groff's other output devices.
+.  \" This change is expected to expose glyph usage errors in man pages.
+.  \" See [http://git.savannah.gnu.org/cgit/groff.git/tree/PROBLEMS] for
+.  \" a recipe that will conceal these errors"
+.  \" -- https://lists.gnu.org/archive/html/groff/2023-07/msg00051.html
+.  \"
+.  \" Conceal glyph usage errors in man pages with the following
+.  \" character translations for non-keyboard characters to make them searchable.
 .  if '\*[.T]'utf8' \{\
 .    char \- \N'45'
 .    char - \N'45'
-.    char ' \N'39'
-.    char \' \N'39'
+.    char \' \[aq]
+.    char ' \[aq]
+.    char ` \[ga]
+.    char ^ \[ha]
+.    char ~ \[ti]
 .  \}
+.\}
 .
 .ds doc-default-operating-system Nixpkgs
 .ds doc-volume-operating-system Nixpkgs


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ℹ️ This PR supercedes #272363

Add character translations to site.tmac to conceal glyph usage errors in man pages.

For details see

<details><summary>the <a href='https://lists.gnu.org/archive/html/groff/2023-07/msg00051.html'>Groff 1.23.0 announcement email</a></summary>

> o The "utf8" output device now maps the input characters '^' (caret,
  circumflex accent, or "hat") and '~' (tilde) to U+02C6 (modifier
  letter circumflex accent) and U+02DC (small tilde), respectively, for
  consistency with groff's other output devices.  This change is
  expected to expose glyph usage errors in man pages.  See the
  "PROBLEMS" file for a recipe that will conceal these errors.  A better
  long-term approach is for man pages to adopt correct input practices;
  the man pages groff_man_style(7), groff_char(7), and man-pages(7)
  (subsection "Generating optimal glyphs"; from the Linux man-pages
  project) contain such instructions.  Doing so also improves man page
  typography when formatting for PDF.
  
</details>
  
<details><summary>and the mentioned<a href='http://git.savannah.gnu.org/cgit/groff.git/tree/PROBLEMS'>"PROBLEMS" file</a></summary>

> [groff 1.19.2]
>
> * When viewing man pages, some characters on my UTF-8 terminal emulator
  look funny or copy-and-paste wrong.  Why?
>
>Some Unicode Basic Latin ("ASCII") input characters are mapped to
non-Basic Latin code points in output for consistency with other output
devices, like PDF.  See groff_man_style(7) and groff_char(7) for correct
input conventions and background.  If you use the correct groff special
character escape sequences to input them, you will get correct output no
matter what device the input is formatted for.
>
>However, many man pages are written in ignorance of the correct special
characters to obtain the desired glyphs.  You can conceal these errors
by adding the following to your site-local man(7) configuration.  The
file is called "man.local"; its installation directory depends on how
groff was configured when it was built.
>
>--- start ---
.if '\*[.T]'utf8' \{\
.  char ' \[aq]
.  char - \-
.  char ^ \[ha]
.  char ` \[ga]
.  char ~ \[ti]
.\}
--- end ---
>
>You may also wish to do the same for "mdoc.local".
>
>In man pages (only), groff maps the minus sign special character '\-' to
the Basic Latin hyphen-minus (U+002D) because man pages require this
glyph and there is no historically established *roff input character,
ordinary or special, for obtaining it when a hyphen and minus sign are
both separately available.  To obtain a true minus sign, use the special
character escape sequences '\(mi' or '\[mi]'.

</details>

Approach of other distributions to address this:

* [Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/groff/-/blob/e474b541a32fc905b4f748de0313acfb8b98c081/site.tmac#L17-26)
* [Debian](https://salsa.debian.org/debian/groff/blob/d5394c68d70e6c5199b01d2522e094c8fd52e64e/debian/mandoc.local#L3-17)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
