### PR TITLE
Update androidStudioPackages.stable and androidStudioPackages.canary

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -18,8 +18,8 @@ let
     sha256Hash = "sha256-jOqTAHYAk8j9+Ir01TLBsp20u7/iBKV8T/joZLITDs4=";
   };
   latestVersion = {
-    version = "2023.2.1.14"; # "Android Studio Iguana | 2023.2.1 Canary 14"
-    sha256Hash = "sha256-8szERftch1JWJ66BclJBq5DZcH1Xf1cyVj08WknLoS8=";
+    version = "2023.2.1.17"; # "Android Studio Iguana | 2023.2.1 Canary 17"
+    sha256Hash = "sha256-RG1N06psRaRrC/57Trb23K0Iezp2VBViBRqJRHLssMI=";
   };
 in {
   # Attributes are named by their corresponding release channels

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -10,8 +10,8 @@ let
     inherit tiling_wm;
   };
   stableVersion = {
-    version = "2022.3.1.20"; # "Android Studio Giraffe (2022.3.1) Patch 2"
-    sha256Hash = "sha256-IkxOt6DI4cBPUOztEBNJV0DHGruJjVdJ0skxcue+rdg=";
+    version = "2023.1.1.26"; # "Android Studio Hedgehog | 2023.1.1"
+    sha256Hash = "sha256-l36KmFVBT31BFX8L4OEPt0DEK9M392PV2Ws+BZeAZj0=";
   };
   betaVersion = {
     version = "2023.1.1.25"; # "Android Studio Hedgehog | 2023.1.1 RC 3"


### PR DESCRIPTION
## Description of changes
Android Studio Hedgehog has been released to stable recently and is required for some projects to work properly (e.g. if your project is using the #GRADLE_LOCAL_JAVA_HOME macro it won't work with the old stable version). This PR fixes this by updating the stable version. It also updates the canary version. There hasn't been a new beta release yet, so there is no update to be made there.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
