### PR TITLE
build-support/fetchpijul: Add cacert dependency, set impureEnvVars, and enable strictDeps

### DIFF
--- a/pkgs/build-support/fetchpijul/default.nix
+++ b/pkgs/build-support/fetchpijul/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, pijul }:
+{ lib, stdenvNoCC, pijul, cacert }:
 
 lib.makeOverridable (
 { url
@@ -17,7 +17,7 @@ if change != null && state != null then
 else
   stdenvNoCC.mkDerivation {
     inherit name;
-    nativeBuildInputs = [ pijul ];
+    nativeBuildInputs = [ pijul cacert ];
 
     dontUnpack = true;
     dontConfigure = true;
@@ -52,5 +52,7 @@ else
       lib.fakeSha256;
 
     inherit url change state channel;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
   }
 )

--- a/pkgs/build-support/fetchpijul/default.nix
+++ b/pkgs/build-support/fetchpijul/default.nix
@@ -18,6 +18,7 @@ else
   stdenvNoCC.mkDerivation {
     inherit name;
     nativeBuildInputs = [ pijul cacert ];
+    strictDeps = true;
 
     dontUnpack = true;
     dontConfigure = true;


### PR DESCRIPTION
## Description of changes
Closes #270252
We now properly set `SSL_CERT_FILE` and the proxy variables. I also added `strictDeps = true` so that pijul doesn't need to be fetched when using sources obtained with `fetchpijul`.

cc @2xsaiko

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
