### PR TITLE
normaliz: init at 3.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19979,6 +19979,12 @@
     github = "yanganto";
     githubId = 10803111;
   };
+  yannickulrich = {
+    email = "yannick.ulrich@proton.me";
+    github = "yannickulrich";
+    githubId = 749922;
+    name = "Yannick Ulrich";
+  };
   yannip = {
     email = "yPapandreou7@gmail.com";
     github = "YanniPapandreou";

--- a/pkgs/by-name/no/normaliz/package.nix
+++ b/pkgs/by-name/no/normaliz/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gmpxx
+, flint
+, arb
+, nauty
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "normaliz";
+  version = "3.10.1";
+
+  src = fetchFromGitHub {
+    owner = "normaliz";
+    repo = "normaliz";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-nnSauTlS5R6wbaoGxR6HFacFYm5r4DAhoP9IVe4ajdc=";
+  };
+
+  buildInputs = [
+    gmpxx
+    flint
+    arb
+    nauty
+  ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://www.normaliz.uni-osnabrueck.de/";
+    description = "An open source tool for computations in affine monoids, vector configurations, lattice polytopes, and rational cones";
+    maintainers = with maintainers; [ yannickulrich ];
+    platforms = with platforms; unix ++ windows;
+    license = licenses.gpl3Plus;
+    mainProgram = "normaliz";
+  };
+})


### PR DESCRIPTION
## Description of changes

[Normaliz](https://www.normaliz.uni-osnabrueck.de/) is an open source tool for computations in affine monoids, vector configurations, lattice polytopes, and rational cones. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
