### PR TITLE
home-assistant-custom-components.miele: init at 0.1.19

### DIFF
--- a/pkgs/development/python-modules/pymiele/default.nix
+++ b/pkgs/development/python-modules/pymiele/default.nix
@@ -4,6 +4,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,10 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
     aiohttp
     async-timeout
   ];

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -2,5 +2,6 @@
 }:
 
 {
+  miele = callPackage ./miele {};
   prometheus_sensor = callPackage ./prometheus_sensor {};
 }

--- a/pkgs/servers/home-assistant/custom-components/miele/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/miele/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  flatdict,
+  pymiele,
+}:
+buildHomeAssistantComponent rec {
+  owner = "astrandb";
+  domain = "miele";
+  version = "0.1.19";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = domain;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-od7DV10/rkIw9eFMsTRw4bMmhQo9BAmw2rCbKKySeIk=";
+  };
+
+  propagatedBuildInputs = [
+    flatdict
+    pymiele
+  ];
+
+  # Makefile only used for bumping the version
+  dontBuild = true;
+
+  meta = with lib; {
+    changelog = "https://github.com/astrandb/miele/releases/tag/v${version}";
+    description = "A modern integration for Miele devices in Home Assistant";
+    homepage = "https://github.com/astrandb/miele";
+    maintainers = with maintainers; [jamiemagee];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

- Fixes a missing dependency on `setuptools` missed as part of #272316 
- Adds the [`miele` custom home assistant component][1]

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[1]: https://github.com/astrandb/miele
