### PR TITLE
arduino-ide: Init at 2.2.1

### DIFF
--- a/pkgs/by-name/ar/arduino-ide/package.nix
+++ b/pkgs/by-name/ar/arduino-ide/package.nix
@@ -1,0 +1,38 @@
+{ appimageTools
+, fetchurl
+, lib
+}:
+
+let
+  pname = "arduino-ide";
+  version = "2.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/arduino/arduino-ide/releases/download/${version}/arduino-ide_${version}_Linux_64bit.AppImage";
+    hash = "sha256-77uS/3ean3dWG/vDHG+ry238hiJlYub7H03f15eJu+I=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mv $out/bin/{${pname}-${version},${pname}}
+
+    install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications/
+    install -Dm444 ${appimageContents}/${pname}.png -t $out/share/pixmaps/
+  '';
+
+  extraPkgs = pkgs: with pkgs; [ libsecret ];
+
+  meta = with lib; {
+    description = "Open-source electronics prototyping platform";
+    homepage = "https://www.arduino.cc/en/software";
+    changelog = "https://github.com/arduino/arduino-ide/releases/tag/${version}";
+    license = licenses.agpl3Only;
+    mainProgram = "arduino-ide";
+    maintainers = with maintainers; [ clerie ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is the [new Arduino IDE](https://github.com/arduino/arduino-ide) based on [Theia IDE](https://theia-ide.org/).

The [old Arduino IDE](https://github.com/arduino/Arduino) is already packaged as `arduino` in nixpkgs, but upstream is unmaintained since two years.

I'm not really sure what the state between the two IDEs are, but it seems like both are still a thing, so I think we should keep both around for a while too. Therefore I took the upstream name `arduino-ide` as the package name for the new package.

I packaged it from the AppImage off GitHub as building it from source just looks very painful.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
