### PR TITLE
python-qt: 3.3.0 -> 3.4.2

### DIFF
--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -4,28 +4,19 @@
 
 stdenv.mkDerivation rec {
   pname = "python-qt";
-  version = "3.3.0";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
     owner = "MeVisLab";
     repo = "pythonqt";
     rev = "v${version}";
-    hash = "sha256-zbQ6X4Q2/QChaw3GAz/aVBj2JjWEz52YuPuHbBz935k=";
+    hash = "sha256-xJYOD07ACOKtY3psmfHNSCjm6t0fr8JU9CrL0w5P5G0=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "remove-unneeded-pydebug-include.patch";
-      url = "https://github.com/MeVisLab/pythonqt/commit/a93104dea4d9c79351276ec963e931ca617625ec.patch";
-      includes = [ "src/PythonQt.cpp" ];
-      hash = "sha256-Tc4+6dIdvrda/z3Nz1s9Xz+ZWJLV2BQh8i552UynSI0=";
-    })
-  ];
 
   # https://github.com/CsoundQt/CsoundQt/blob/develop/BUILDING.md#pythonqt
   postPatch = ''
     substituteInPlace build/python.prf \
-      --replace "unix:PYTHON_VERSION=2.7" "unix:PYTHON_VERSION=${python.pythonVersion}"
+      --replace "PYTHON_VERSION=2.7" "PYTHON_VERSION=${python.pythonVersion}"
   '';
 
   hardeningDisable = [ "all" ];


### PR DESCRIPTION
`python-qt` v. 3.3.0 wasn't compatible with Python 3.11 yet (it contained include statements for header files that were removed by 3.11 [^1] and used a python tuple field that was replaced through a dedicated getter function [^2]).

These incompatibilities also break downstream builds like `csound-qt`.

Switching to version 3.4.2 also means we can remove the `remove-unneeded-pydebug-include.patch`, as it has since been merged.

[^1]: https://docs.python.org/3.11/whatsnew/3.11.html , Ctrl+f `eval.h`
[^2]: https://github.com/python/cpython/issues/94936#issuecomment-1206497729

## Description of changes

- Switched to version 3.4.2.
- Removed pydebug.h patch
- Built and ran `csound-qt` with these changes applied; rendered a simple example file.

Failing Hydra build: https://hydra.nixos.org/build/242581707
Hydra log: https://hydra.nixos.org/build/242581707/nixlog/2

Relevant log excerpt (first  error):

```
g++ -c -pipe -I/nix/store/qp5zys77biz7imbk6yy85q5pdv7qk84j-python3-3.11.6/include/python3.11 -I/nix/store/qp5zys77biz7imbk6yy85q5pdv7qk84j-python3-3.11.6/include/python3.11 -O2 -D_REENTRANT -Wall -Wextra -fPIC -DPYTHONQT_CATCH_ALL_EXCEPTIONS -DPYTHONQT_EXPORTS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I. -I. -I/nix/store/w7bnync8834h31ixcqyy5r52mkaxkv76-qtbase-5.15.11-dev/include/QtWidgets -I/nix/store/w7bnync8834h31ixcqyy5r52mkaxkv76-qtbase-5.15.11-dev/include/QtGui -I/nix/store/w7bnync8834h31ixcqyy5r52mkaxkv76-qtbase-5.15.11-dev/include/QtCore/5.15.11 -I/nix/store/w7bnync8834h31ixcqyy5r52mkaxkv76-qtbase-5.15.11-dev/include/QtCore/5.15.11/QtCore -I/nix/store/w7bnync8834h31ixcqyy5r52mkaxkv76-qtbase-5.15.11-dev/include/QtCore -I. -I/nix/store/7lwr59bpy8asiyzcgh4rj9baskcc9vq8-libglvnd-1.7.0-dev/include -I/nix/store/w7bnync8834h31ixcqyy5r52mkaxkv76-qtbase-5.15.11-dev/mkspecs/linux-g++ -o PythonQt.o PythonQt.cpp
In file included from PythonQtInstanceWrapper.h:48,
                 from PythonQt.h:48,
                 from PythonQt.cpp:42:
PythonQtClassWrapper.h:52:10: fatal error: eval.h: No such file or directory
   52 | #include "eval.h"
      |          ^~~~~~~~
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
