### PR TITLE
[Release 23.05] vaultwarden: Add VW_VERSION env to fix version detection

### DIFF
--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -11,6 +11,10 @@ rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
   version = "1.28.1";
 
+  # the build step requires this env variable to figure out the version
+  # if this is unset, the server will respond with "null" as version, which crashes newer mobile clients
+  VW_VERSION = version;
+
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = pname;


### PR DESCRIPTION
At build time, vaultwarden looks at the VW_VERSION env variable to embed it's own version string. When this is unset, it still compiles, but responds with "null" as version info under `/api/config`, which leads to issues like https://github.com/dani-garcia/vaultwarden/discussions/3996, where the (mobile) clients crash, or https://github.com/NixOS/nixpkgs/issues/216409

Under Nix, this variable is unset, so this commit properly forces it.

Note that this only affects vaultwarden <1.30, as present in NixOS 23.05. With the newer versions, the version is hardcoded:
https://github.com/dani-garcia/vaultwarden/commit/cb4b683dcd51eff4508bcf50e34d657b8d2225d4#diff-0c15871c114078d2cdd4a58dc463a77a055ab8ae4ef41583685afcc4aa062e45R202
Therefore this fix is only applicable to NixOS 23.05

## Description of changes

vaultwarden: set VW_VERSION 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

