### PR TITLE
vibrantLinux: init at 2.1.10

### DIFF
--- a/pkgs/by-name/li/libvibrant/package.nix
+++ b/pkgs/by-name/li/libvibrant/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, makeWrapper
+, libX11
+, libXrandr
+, linuxPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libvibrant";
+  version = "2100c09";
+
+  src = fetchFromGitHub {
+    owner = "libvibrant";
+    repo = "libvibrant";
+    rev = version;
+    hash = "sha256-nVODwP/PQgYBTHnSplgrkdNOLsF7N+vZ8iPL7gArVNY=";
+  };
+
+  buildInputs = [ libX11 libXrandr linuxPackages.nvidia_x11.settings.libXNVCtrl ];
+  nativeBuildInputs = [ cmake makeWrapper ];
+
+  meta = with lib; {
+    description = "A simple library to adjust color saturation of X11 outputs";
+    homepage = "https://github.com/libvibrant/libvibrant";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "vibrant-cli";
+  };
+}

--- a/pkgs/by-name/vi/vibrantlinux/package.nix
+++ b/pkgs/by-name/vi/vibrantlinux/package.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qt5
+, makeWrapper
+, libvibrant
+, libX11
+, libXrandr
+, libxcb
+, linuxPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vibrantLinux";
+  version = "2.1.10";
+
+  src = fetchFromGitHub {
+    owner = "libvibrant";
+    repo = "vibrantLinux";
+    rev = version;
+    hash = "sha256-rvJiVId6221hTrfEIvVO9HTMhaZ6KY44Bu3a5MinPHI=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ] ++ (with qt5; [
+    qmake
+    wrapQtAppsHook
+  ]);
+
+  buildInputs = [
+    libX11
+    libXrandr
+    libxcb
+    libvibrant
+    linuxPackages.nvidia_x11.settings.libXNVCtrl
+  ] ++ (with qt5; [
+    qtbase
+    qttools
+  ]);
+
+  postPatch = ''
+    substituteInPlace vibrantLinux.pro \
+      --replace '$$(PREFIX)' '$$PREFIX'
+  '';
+
+  meta = with lib; {
+    description = "A tool to automate managing your screen's saturation depending on what programs are running";
+    homepage = "https://github.com/libvibrant/vibrantLinux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ unclamped ];
+    platforms = platforms.linux;
+    mainProgram = "vibrantLinux";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [libvibrant](https://github.com/libvibrant/libvibrant), a simple library to adjust the color saturation of X11 outputs, and [vibrantLinux](https://github.com/libvibrant/vibrantLinux), a tool to automate managing your screen's saturation depending on what programs are running. Should close https://github.com/NixOS/nixpkgs/issues/179873 and close https://github.com/NixOS/nixpkgs/issues/188051

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
