### PR TITLE
vscode-extensions.ms-toolsai.jupyter: 2023.2.1000411022 → 2023.11.1003402403

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-toolsai.jupyter/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-toolsai.jupyter/default.nix
@@ -4,8 +4,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "jupyter";
     publisher = "ms-toolsai";
-    version = "2023.2.1000411022";
-    sha256 = "sha256-gMK/t/rLXYN3rlHxxVeW0W/FWEP0ZCiEwzM8DY14vYg=";
+    version = "2023.11.1003402403";
+    sha256 = "sha256-CQoWy51ZncgWXLiecGDKFHMYZtiTbS2QBzTFyQFPcTg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Update `vscode-extensions.ms-toolsai.jupyter` to v2023.11.1003402403.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Will test it in the morning, leaving the PR as draft in the meanwhile.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
