### PR TITLE
buildcatrust: use pep517 builder

### DIFF
--- a/pkgs/development/python-modules/buildcatrust/default.nix
+++ b/pkgs/development/python-modules/buildcatrust/default.nix
@@ -1,27 +1,37 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, flit-core
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "buildcatrust";
   version = "0.1.3";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256:0s0m0fy943dakw9cbd40h46qmrhhgrcp292kppyb34m6y27sbagy";
+    hash = "sha256:0s0m0fy943dakw9cbd40h46qmrhhgrcp292kppyb34m6y27sbagy";
   };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
   ];
+
   disabledTestPaths = [
     # Non-hermetic, needs internet access (e.g. attempts to retrieve NSS store).
     "buildcatrust/tests/test_nonhermetic.py"
   ];
 
-  pythonImportsCheck = [ "buildcatrust" "buildcatrust.cli" ];
+  pythonImportsCheck = [
+    "buildcatrust"
+    "buildcatrust.cli"
+  ];
 
   meta = with lib; {
     description = "Build SSL/TLS trust stores";


### PR DESCRIPTION
Up until now this project was build using the setup.py shim, that flit creates for tools that don't support PEP 517 yet.

```python
#!/usr/bin/env python
# setup.py generated by flit for tools that don't yet use PEP 517

from distutils.core import setup

packages = \
['buildcatrust', 'buildcatrust.tests']

package_data = \
{'': ['*'],
 'buildcatrust': ['.pytest_cache/*',
                  '.pytest_cache/v/*',
                  '.pytest_cache/v/cache/*',
                  'tools/*'],
 'buildcatrust.tests': ['.pytest_cache/*',
                        '.pytest_cache/v/*',
                        '.pytest_cache/v/cache/*',
                        'testdata/*',
                        'testdata/local/*']}

entry_points = \
{'console_scripts': ['buildcatrust = buildcatrust.cli:main']}

setup(name='buildcatrust',
      version='0.1.3',
      description='Utilities for turning one trust store into another.',
      author='Luke Granger-Brown',
      author_email='buildcatrust@lukegb.com',
      url='https://github.com/lukegb/buildcatrust',
      packages=packages,
      package_data=package_data,
      entry_points=entry_points,
     )
```

On top of that an implicit format implies setuptools and makes a call to `python setup.py install`, which is deprecated.

```
buildcatrust> Executing setuptoolsBuildPhase
buildcatrust> /nix/store/y8yq448xka665bqyd5gvdhajqdbsnyys-python3.11-setuptools-68.2.2/lib/python3.11/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
buildcatrust> !!
buildcatrust> 
buildcatrust>         ********************************************************************************
buildcatrust>         Please avoid running ``setup.py`` directly.
buildcatrust>         Instead, use pypa/build, pypa/installer or other
buildcatrust>         standards-based tools.
buildcatrust> 
buildcatrust>         See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
buildcatrust>         ********************************************************************************
buildcatrust> 
buildcatrust> !!
buildcatrust>   self.initialize_options()
buildcatrust> Finished executing setuptoolsBuildPhase
```

Added some light reformatting on top.

The commit sits on top of the merge base between master/staging, so it is cheap to test.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
