### PR TITLE
aws-azure-login: Link Puppeteer to Chromium

### DIFF
--- a/pkgs/by-name/aw/aws-azure-login/package.nix
+++ b/pkgs/by-name/aw/aws-azure-login/package.nix
@@ -1,5 +1,7 @@
 { lib
+, callPackage
 , stdenv
+, chromium
 , fetchFromGitHub
 , fetchYarnDeps
 , makeWrapper
@@ -7,24 +9,23 @@
 , prefetch-yarn-deps
 , yarn
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "aws-azure-login";
   version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "aws-azure-login";
     repo = "aws-azure-login";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-PvPnqaKD98h3dCjEOwF+Uc86xCJzn2b9XNHHn13h/2Y=";
   };
 
   offlineCache = fetchYarnDeps {
-    yarnLock = "${src}/yarn.lock";
+    yarnLock = "${finalAttrs.src}/yarn.lock";
     hash = "sha256-SXQPRzF6b1FJl5HkyXNm3kGoNSDXux+0RYXBX93mOts=";
   };
 
-  nativeBuildInputs  = [
+  nativeBuildInputs = [
     makeWrapper
     nodejs
     prefetch-yarn-deps
@@ -60,10 +61,15 @@ stdenv.mkDerivation rec {
     cp -r . "$out/lib/node_modules/aws-azure-login"
 
     makeWrapper "${nodejs}/bin/node" "$out/bin/aws-azure-login" \
-      --add-flags "$out/lib/node_modules/aws-azure-login/lib/index.js"
+      --add-flags "$out/lib/node_modules/aws-azure-login/lib/index.js" \
+      --set PUPPETEER_EXECUTABLE_PATH "${lib.getExe chromium}"
 
     runHook postInstall
   '';
+
+  passthru.tests.aws-azure-login = callPackage ./tests.nix {
+    package = finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Use Azure AD SSO to log into the AWS via CLI";
@@ -73,4 +79,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ l0b0 ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/aw/aws-azure-login/package.nix
+++ b/pkgs/by-name/aw/aws-azure-login/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/aws-azure-login/aws-azure-login";
     license = lib.licenses.mit;
     mainProgram = "aws-azure-login";
-    maintainers = with lib.maintainers; [ yurrriq ];
+    maintainers = with lib.maintainers; [ l0b0 ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/aw/aws-azure-login/tests.nix
+++ b/pkgs/by-name/aw/aws-azure-login/tests.nix
@@ -1,0 +1,24 @@
+{ lib
+, runCommand
+, package
+}:
+  runCommand "${package.pname}-tests"
+    {
+      HOME = "/tmp/home";
+    } ''
+    mkdir -p "''${HOME}/.aws"
+    cat > "''${HOME}/.aws/config" <<'EOF'
+    [profile my-profile]
+    azure_tenant_id=3f03e308-ada1-45f7-9cc3-ab777eaba2d3
+    azure_app_id_uri=4fbf61f5-7302-42e5-9585-b18ad0e4649d
+    azure_default_username=user@example.org
+    azure_default_role_arn=
+    azure_default_duration_hours=1
+    azure_default_remember_me=false
+    EOF
+
+    ! ${lib.getExe package} --profile=my-profile 2> stderr
+    [[ "$(cat stderr)" == 'Unable to recognize page state! A screenshot has been dumped to aws-azure-login-unrecognized-state.png. If this problem persists, try running with --mode=gui or --mode=debug' ]]
+
+    touch $out
+  ''


### PR DESCRIPTION
## Description of changes

Closes #272544, avoiding the following runtime error:

> Error: Could not find expected browser (chrome) locally. Run `npm install` to download the correct Chromium revision (982053).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
