### PR TITLE
home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: init at unstable-2023-12-06

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/default.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/default.nix
@@ -7,4 +7,6 @@
   mini-graph-card = callPackage ./mini-graph-card {};
 
   mini-media-player = callPackage ./mini-media-player {};
+
+  zigbee2mqtt-networkmap = callPackage ./zigbee2mqtt-networkmap { };
 }

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/default.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, fetchFromGitHub
+, fetchYarnDeps
+, mkYarnPackage
+}:
+
+mkYarnPackage rec {
+  pname = "zigbee2mqtt-networkmap";
+  version = "unstable-2023-12-06";
+
+  src = fetchFromGitHub {
+    owner = "azuwis";
+    repo = "zigbee2mqtt-networkmap";
+    rev = "d5f1002118ba5881c6bdc27cb0f67642575c414f";
+    hash = "sha256-ITqzMjom2XN7+ICDH0Z5YJWY5GNUXzaqSuEzXekhw9I=";
+  };
+
+  packageJSON = ./package.json;
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-uPhD6UQ1KI7y6bqqQF7InT9eKU9VWGf2D60Lo5Mwcf8=";
+  };
+
+  configurePhase = ''
+    cp -r $node_modules node_modules
+    chmod +w node_modules
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -v dist/zigbee2mqtt-networkmap.js $out/
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+
+  doDist = false;
+
+  passthru.entrypoint = "zigbee2mqtt-networkmap.js";
+
+  meta = with lib; {
+    description = "Home Assistant Custom Card to show Zigbee2mqtt network map";
+    homepage = "https://github.com/azuwis/zigbee2mqtt-networkmap";
+    maintainers = with maintainers; [ azuwis ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.json
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "zigbee2mqtt-networkmap",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "lint": "vue-cli-service lint"
+  },
+  "dependencies": {
+    "vue": "^3.3.4"
+  },
+  "devDependencies": {
+    "@material/mwc-button": "^0.27.0",
+    "@vue/cli-plugin-eslint": "^5.0.8",
+    "@vue/cli-service": "^5.0.8",
+    "@vue/eslint-config-standard": "^8.0.1",
+    "@babel/core": "^7.0.0",
+    "@babel/eslint-parser": "^7.0.0",
+    "eslint": "^8.42.0",
+    "eslint-plugin-vue": "^9.14.1",
+    "lodash.isequal": "^4.5.0",
+    "vue-d3-network": "^0.1.28"
+  }
+}


### PR DESCRIPTION
## Description of changes

Home Assistant Custom Card to show Zigbee2mqtt network map, homepage: https://github.com/azuwis/zigbee2mqtt-networkmap

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
