### PR TITLE
espresso: init at 2.4

### DIFF
--- a/pkgs/by-name/es/espresso/package.nix
+++ b/pkgs/by-name/es/espresso/package.nix
@@ -1,0 +1,40 @@
+{ lib, fetchFromGitHub, cmake, stdenv, nix-update-script }:
+stdenv.mkDerivation rec {
+  pname = "espresso";
+  version = "2.4";
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = "espresso";
+    rev = "v${version}";
+    hash = "sha256-z5By57VbmIt4sgRgvECnLbZklnDDWUA6fyvWVyXUzsI=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+
+  outputs = [ "out" "man" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib;{
+    description = "Multi-valued PLA minimization";
+    # from manual
+    longDescription = ''
+      Espresso takes as input a two-level representation of a
+      two-valued (or multiple-valued) Boolean function, and produces a
+      minimal equivalent representation.  The algorithms used are new and
+      represent an advance in both speed and optimality of solution in
+      heuristic Boolean minimization.
+    '';
+    homepage = "https://github.com/chipsalliance/espresso";
+    maintainers = with maintainers;[ pineapplehunter ];
+    mainProgram = "espresso";
+    platforms = lib.platforms.all;
+
+    # The license is not provided in the GitHub repo,
+    # so until there's an update on the license, it is marked as unfree.
+    # See: https://github.com/chipsalliance/espresso/issues/4
+    license = licenses.unfree;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Added espresso as a new package

The license is set ro unfree, since the source on github does not provide a licence. See: https://github.com/chipsalliance/espresso/issues/4

cc: @sequencer 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
