### PR TITLE
vulkan-loader, pkg-config: Fix MinGWW64 Builds

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ vulkan-headers ]
-    ++ lib.optionals (!stdenv.isDarwin) [ libX11 libxcb libXrandr wayland ];
+    ++ lib.optionals stdenv.isLinux [ libX11 libxcb libXrandr wayland ];
 
   cmakeFlags = [ "-DCMAKE_INSTALL_INCLUDEDIR=${vulkan-headers}/include" ]
     ++ lib.optional stdenv.isDarwin "-DSYSCONFDIR=${moltenvk}/share"
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "LunarG Vulkan loader";
     homepage    = "https://www.lunarg.com";
-    platforms   = platforms.unix;
+    platforms   = platforms.unix ++ platforms.windows;
     license     = licenses.asl20;
     maintainers = [ maintainers.ralith ];
     broken = (version != vulkan-headers.version);

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -35,8 +35,12 @@ stdenv.mkDerivation rec {
          "ac_cv_func_posix_getgrgid_r=yes"
        ];
 
-  # Silence "incompatible integer to pointer conversion passing 'gsize'" when building with Clang.
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
+  env.NIX_CFLAGS_COMPILE = builtins.toString (
+    # Silence "incompatible integer to pointer conversion passing 'gsize'" when building with Clang.
+    lib.optionals stdenv.cc.isClang ["-Wno-int-conversion"] ++
+    # Silence fprintf format errors when building for Windows.
+    lib.optionals stdenv.hostPlatform.isWindows ["-Wno-error=format"]
+  );
 
   enableParallelBuilding = true;
   doCheck = true;

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -35,11 +35,11 @@ stdenv.mkDerivation rec {
          "ac_cv_func_posix_getgrgid_r=yes"
        ];
 
-  env.NIX_CFLAGS_COMPILE = builtins.toString (
+  env.NIX_CFLAGS_COMPILE = toString (
     # Silence "incompatible integer to pointer conversion passing 'gsize'" when building with Clang.
-    lib.optionals stdenv.cc.isClang ["-Wno-int-conversion"] ++
+    lib.optionals stdenv.cc.isClang ["-Wno-int-conversion"]
     # Silence fprintf format errors when building for Windows.
-    lib.optionals stdenv.hostPlatform.isWindows ["-Wno-error=format"]
+    ++ lib.optionals stdenv.hostPlatform.isWindows ["-Wno-error=format"]
   );
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes

- Fixed MinGWW64 builds of pkg-config and vulkan-loader by making minor changes to the respective derivations.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-linux.pkgsCross.mingwW64
  - [x] aarch64-linux.pkgsCross.mingwW64
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
