### PR TITLE
Revert "electron_25: eol"

### DIFF
--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -40,7 +40,7 @@ let
       ++ optionals (versionAtLeast version "11.0.0") [ "aarch64-darwin" ]
       ++ optionals (versionOlder version "19.0.0") [ "i686-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    knownVulnerabilities = optional (versionOlder version "26.0.0") "Electron version ${version} is EOL";
+    knownVulnerabilities = optional (versionOlder version "25.0.0") "Electron version ${version} is EOL";
   };
 
   fetcher = vers: tag: hash: fetchurl {

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -169,6 +169,8 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
     enable_widevine = false;
     use_perfetto_client_library = false;
     enable_check_raw_ptr_fields = false;
+  } // lib.optionalAttrs (lib.versionOlder info.version "26")  {
+    use_gnome_keyring = false;
   } // lib.optionalAttrs (lib.versionAtLeast info.version "27")  {
     override_electron_version = info.version;
   };

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2626,5 +2626,825 @@
         },
         "chromium_npm_hash": "sha256-5cjqpYB45nw2gop54VP+tL7/0w63nQGfQ4x6a6KS7XQ=",
         "electron_yarn_hash": "05wkb1m0yjbai4153y49kwr1v2lj14fg75aqlvmmrhf3bxp9lg5g"
+    },
+    "25": {
+        "deps": {
+            "src/electron": {
+                "fetcher": "fetchFromGitHub",
+                "hash": "sha256-Yo/ZvOLOPIktV5gzZK80LKVZb3xMXrzGkdQw9u4djoI=",
+                "owner": "electron",
+                "repo": "electron",
+                "rev": "v25.9.1"
+            },
+            "src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-nh8LrBKsfW6K/scG1GPUyp/tYiXOxZkmjtuTyAXC4zI=",
+                "url": "https://chromium.googlesource.com/chromium/src.git",
+                "rev": "114.0.5735.289",
+                "postFetch": "rm -r $out/third_party/blink/web_tests; rm -r $out/third_party/hunspell/tests; rm -r $out/content/test/data; rm -r $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; "
+            },
+            "src/buildtools/clang_format/script": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-IL6ReGM6+urkXfGYe1BBOv+0XgCZv5i3Lib1q9COhig=",
+                "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git",
+                "rev": "f97059df7f8b205064625cdb5f97b56668a125ef"
+            },
+            "src/buildtools/third_party/libc++/trunk": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-i/FGU9F7HlGJJuwoFMV4V05pf4pvsqNxrPBN223YjZQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
+                "rev": "bff81b702ff4b7f74b1c0ed02a4bcf6c2744a90b"
+            },
+            "src/buildtools/third_party/libc++abi/trunk": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Zka8AHFtHA4AC/Pbzc3pVqz/k2GYZYc8CeP1IXxGBUM=",
+                "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
+                "rev": "307bd163607c315d46103ebe1d68aab44bf93986"
+            },
+            "src/buildtools/third_party/libunwind/trunk": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-u6FMD83JBBusQuWU7Hx5HREvLIFWUA4iN4If8poaHbE=",
+                "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
+                "rev": "2795322d57001de8125cfdf18cef804acff69e35"
+            },
+            "src/chrome/test/data/perf/canvas_bench": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-svOuyBGKloBLM11xLlWCDsB4PpRjdKTBdW2UEW4JQjM=",
+                "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
+                "rev": "a7b40ea5ae0239517d78845a5fc9b12976bfc732"
+            },
+            "src/chrome/test/data/perf/frame_rate/content": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-t4kcuvH0rkPBkcdiMsoNQaRwU09eU+oSvyHDiAHrKXo=",
+                "url": "https://chromium.googlesource.com/chromium/frame_rate/content.git",
+                "rev": "c10272c88463efeef6bb19c9ec07c42bc8fe22b9"
+            },
+            "src/chrome/test/data/xr/webvr_info": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-BsAPwc4oEWri0TlqhyxqFNqKdfgVSrB0vQyISmYY4eg=",
+                "url": "https://chromium.googlesource.com/external/github.com/toji/webvr.info.git",
+                "rev": "c58ae99b9ff9e2aa4c524633519570bf33536248"
+            },
+            "src/docs/website": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-0rI5HUWxfNU0mrWJ4ndzL1gnn4E67UVPFpqkEpQjgW0=",
+                "url": "https://chromium.googlesource.com/website.git",
+                "rev": "40cfbbdee67c7010ae103011fe5797858e692a79"
+            },
+            "src/media/cdm/api": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-6J6aSYW0or99VAgMNJJOdJqMJspoG7w1HxDN50MV5bw=",
+                "url": "https://chromium.googlesource.com/chromium/cdm.git",
+                "rev": "fef0b5aa1bd31efb88dfab804bdbe614f3d54f28"
+            },
+            "src/net/third_party/quiche/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-dUSUlZR7svBw35TX/ywZaa1Ko/yTeV/gE+GudhX981E=",
+                "url": "https://quiche.googlesource.com/quiche.git",
+                "rev": "02c69dd28eef7ef2618782e8d54d53c14ae64382"
+            },
+            "src/third_party/angle": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-EpR25A5wDGnhK9EI2eSx8OsLtA4YvtDREi6x8ZfIVsM=",
+                "url": "https://chromium.googlesource.com/angle/angle.git",
+                "rev": "ce590bee825a18785f86d096f2c7be06428ccf88"
+            },
+            "src/third_party/angle/third_party/glmark2/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-L7+zWM0qn8WFhmON7DGvarTsN1YHt1sn5+hazTOZrrk=",
+                "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
+                "rev": "ca8de51fedb70bace5351c6b002eb952c747e889"
+            },
+            "src/third_party/angle/third_party/rapidjson/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-btUl1a/B0sXwf/+hyvCvVJjWqIkXfVYCpHm3TeBuOxk=",
+                "url": "https://chromium.googlesource.com/external/github.com/Tencent/rapidjson",
+                "rev": "781a4e667d84aeedbeb8184b7b62425ea66ec59f"
+            },
+            "src/third_party/angle/third_party/VK-GL-CTS/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-XcaAnz36QOg+A5XcyGg0Z9dLFjsDSUa0GzZpEuQYMTg=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
+                "rev": "e3b9db9ad121f46b7943d0152a25d5ee9afaa13c"
+            },
+            "src/third_party/content_analysis_sdk/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-p4N3zAUoM/ApBlYvLsCcH9QLArz7T4+miDGVuTbrZEc=",
+                "url": "https://chromium.googlesource.com/external/github.com/chromium/content_analysis_sdk.git",
+                "rev": "b8744f00646d175057f0be7443c7c72a311b5381"
+            },
+            "src/third_party/dav1d/libdav1d": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-FivzwqCvlY89q2znGvfNks+hje/iUFHcKPb19FyAZhM=",
+                "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
+                "rev": "d426d1c91075b9c552b12dd052af1cd0368f05a2"
+            },
+            "src/third_party/dawn": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-HoLI1IlG+ThNERz6xr1doIzNhPWNcZabiyPEn15kvoM=",
+                "url": "https://dawn.googlesource.com/dawn.git",
+                "rev": "bf86a1c8d463d7b9a556b10a80d17990d413831c"
+            },
+            "src/third_party/dawn/third_party/glfw": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-TwAPRjQxIz3J+zbNxzCp5Tek7MwisxdekMpY5QGsKyg=",
+                "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
+                "rev": "62e175ef9fae75335575964c845a302447c012c7"
+            },
+            "src/third_party/dawn/third_party/webgpu-cts": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-+FRGgJSs7sVEZ6B6PZPxmXvmsKtt/sC/ZAjw+NdOwPQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
+                "rev": "c7d833badcd37dc46a999ebeebbbde1368ff15b5"
+            },
+            "src/third_party/highway/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-kNb9UVcFq2BIf9nftUgN8ciFFCzRCou/sLwVf08jf3E=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/highway.git",
+                "rev": "8f20644eca693cfb74aa795b0006b6779c370e7a"
+            },
+            "src/third_party/google_benchmark/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-h2ryAQAuHI54Cni88L85e7Np4KATGVTRdDcmUvCNeWc=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/benchmark.git",
+                "rev": "b177433f3ee2513b1075140c723d73ab8901790f"
+            },
+            "src/third_party/boringssl/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-oeV7oMNpPbQyi5RiRJm/KAVmO7JZ1QRdYoNgFXh7Snc=",
+                "url": "https://boringssl.googlesource.com/boringssl.git",
+                "rev": "4b6d950d8921d6dd5365de0797fcc97302b9561b"
+            },
+            "src/third_party/breakpad/breakpad": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-+3Y4jCpcZ/++1Etpu/ZNuJvtTEX/Xn4HNfmx4nzcTtA=",
+                "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
+                "rev": "bfde407de559c10d6cef861b3873ff287c24e761"
+            },
+            "src/third_party/cast_core/public/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-pyjxQQYnsASHV2SxwZeIqkZJSpTrqyGg7Uee/GRp9VU=",
+                "url": "https://chromium.googlesource.com/cast_core/public",
+                "rev": "e42ef68aa05ac0c163805f60b9b19284f3c2dee3"
+            },
+            "src/third_party/catapult": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-vK7rlGshfzPzaEdAxlP5vQ4USR/fC3BzPCh/rn0aAf4=",
+                "url": "https://chromium.googlesource.com/catapult.git",
+                "rev": "cae7ec667dee9f5c012b54ee9ffee94eb7beda14"
+            },
+            "src/third_party/ced/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-ySG74Rj2i2c/PltEgHVEDq+N8yd9gZmxNktc56zIUiY=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
+                "rev": "ba412eaaacd3186085babcd901679a48863c7dd5"
+            },
+            "src/third_party/cld_3/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-C3MOMBUy9jgkT9BAi/Fgm2UH4cxRuwSBEcRl3hzM2Ss=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/cld_3.git",
+                "rev": "b48dc46512566f5a2d41118c8c1116c4f96dc661"
+            },
+            "src/third_party/colorama/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-6ZTdPYSHdQOLYMSnE+Tp7PgsVTs3U2awGu9Qb4Rg/tk=",
+                "url": "https://chromium.googlesource.com/external/colorama.git",
+                "rev": "3de9f013df4b470069d03d250224062e8cf15c49"
+            },
+            "src/third_party/cpuinfo/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-ZXsJVhqyeH/9dN0/1Cq0TCjmzwmsePX9YyuuaI9+puI=",
+                "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
+                "rev": "beb46ca0319882f262e682dd596880c92830687f"
+            },
+            "src/third_party/crc32c/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-urg0bmnfMfHagLPELp4WrNCz1gBZ6DFOWpDue1KsMtc=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
+                "rev": "fa5ade41ee480003d9c5af6f43567ba22e4e17e6"
+            },
+            "src/third_party/cros_system_api": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-0tnidX0O+jn1xbJMuSPsGPqwZBCKmfjWZY3aQdjM1gE=",
+                "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
+                "rev": "73d6b816cacd86b886b4cc1e60f12ac1960f1d90"
+            },
+            "src/third_party/crossbench": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-IM81ppJX/ib//P2ESbQXMSL+BiOSVKbdXZdcMsq4xn0=",
+                "url": "https://chromium.googlesource.com/crossbench.git",
+                "rev": "cdc33384bfa900dfec28e6cf7b5f22cd7ff2c92f"
+            },
+            "src/third_party/depot_tools": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-7jPow77ejToE55KvQ7/eO0alMdMHcypfSyPceFAbZkw=",
+                "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
+                "rev": "6e714e6dfe62110c95fafed4bdeb365a69c6a77e"
+            },
+            "src/third_party/devtools-frontend/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-jDE3eGkpcJYE5lt/dpIpKa6me3ZZnfY/9boL/YBnHoc=",
+                "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
+                "rev": "3f60fe50e4790d1154659b9628e811bbcdf1aa4f"
+            },
+            "src/third_party/dom_distiller_js/dist": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-yuEBD2XQlV3FGI/i7lTmJbCqzeBiuG1Qow8wvsppGJw=",
+                "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
+                "rev": "199de96b345ada7c6e7e6ba3d2fa7a6911b8767d"
+            },
+            "src/third_party/eigen3/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Jf8sFjSMuXeiXm53srR2HahbBXszLOawdYk5H1UrK4c=",
+                "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
+                "rev": "554fe02ae3f3fbc2fd320c26a522f1e59b2d6342"
+            },
+            "src/third_party/farmhash/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-5n58VEUxa/K//jAfZqG4cXyfxrp50ogWDNYcgiXVHdc=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
+                "rev": "816a4ae622e964763ca0862d9dbd19324a1eaf45"
+            },
+            "src/third_party/ffmpeg": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-UjrZJBtOQiiqxtLb8x24axord3OFvyCcRcgDwiYE/jw=",
+                "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
+                "rev": "8d21d41d8bec5c0b266ee305d1a708dc5c23b594"
+            },
+            "src/third_party/flac": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-gvTFPNOlBfozptaH7lTb9iD/09AmpdT3kCl9ClszjEs=",
+                "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
+                "rev": "689da3a7ed50af7448c3f1961d1791c7c1d9c85c"
+            },
+            "src/third_party/flatbuffers/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-OQ8E+i30WRz/lPJmVDiF7+TPo4gZVu2Of9loxz3tswI=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/flatbuffers.git",
+                "rev": "a56f9ec50e908362e20254fcef28e62a2f148d91"
+            },
+            "src/third_party/fontconfig/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-0R+FEhtGXFiQWHEPRrJqaBW1JVfCojYI4NPDvYMBhoU=",
+                "url": "https://chromium.googlesource.com/external/fontconfig.git",
+                "rev": "06929a556fdc39c8fe12965b69070c8df520a33e"
+            },
+            "src/third_party/fp16/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-m2d9bqZoGWzuUPGkd29MsrdscnJRtuIkLIMp3fMmtRY=",
+                "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git",
+                "rev": "0a92994d729ff76a58f692d3028ca1b64b145d91"
+            },
+            "src/third_party/gemmlowp/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-O5wD8wxgis0qYMaY+xZ21GBDVQFphMRvInCOswS6inA=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/gemmlowp.git",
+                "rev": "13d57703abca3005d97b19df1f2db731607a7dc2"
+            },
+            "src/third_party/grpc/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-64JEVCx/PCM0dvv7kAQvSjLc0QbRAZVBDzwD/FAV6T8=",
+                "url": "https://chromium.googlesource.com/external/github.com/grpc/grpc.git",
+                "rev": "822dab21d9995c5cf942476b35ca12a1aa9d2737"
+            },
+            "src/third_party/freetype/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-qJBw5ocv4+2Xx8bU47QK8sw9Sl636iI+16cbaSNatHU=",
+                "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
+                "rev": "0a3836c97d5e84d6721ac0fd2839e8ae1b7be8d9"
+            },
+            "src/third_party/freetype-testing/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-2aHPchIK5Oce5+XxdXVCC+8EM6i0XT0rFbjSIVa2L1A=",
+                "url": "https://chromium.googlesource.com/external/github.com/freetype/freetype2-testing.git",
+                "rev": "7a69b1a2b028476f840ab7d4a2ffdfe4eb2c389f"
+            },
+            "src/third_party/fxdiv/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-LjX5kivfHbqCIA5pF9qUvswG1gjOFo3CMpX0VR+Cn38=",
+                "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
+                "rev": "63058eff77e11aa15bf531df5dd34395ec3017c8"
+            },
+            "src/third_party/harfbuzz-ng/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-WaR7U7PeHIffa+ZG85QG7pii/dLOI4+23xK0/hUf1ok=",
+                "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
+                "rev": "2175f5d050743317c563ec9414e0f83a47f7fbc4"
+            },
+            "src/third_party/emoji-segmenter/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-oT9mAKoKnrsFsBAeTRfPOXM76HRQQabFAlPpfKUGFhs=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git",
+                "rev": "9ba6d25d0d9313569665d4a9d2b34f0f39f9a50e"
+            },
+            "src/third_party/ots/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-kiUXrXsaGOzPkKh0dVmU1I13WHt0Stzj7QLMqHN9FbU=",
+                "url": "https://chromium.googlesource.com/external/github.com/khaledhosny/ots.git",
+                "rev": "46bea9879127d0ff1c6601b078e2ce98e83fcd33"
+            },
+            "src/third_party/libgav1/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-DY2BBK+bH1lGZNEl3rMDsPb7Z52YMIQy/3N0achugE0=",
+                "url": "https://chromium.googlesource.com/codecs/libgav1.git",
+                "rev": "cd53f7c0d6a1c005e38874d143c8876d375bae70"
+            },
+            "src/third_party/googletest/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-VYRjcM3dDY2FarviXyFMgSkXCqKfWXwtGAj2Msgm7zg=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git",
+                "rev": "af29db7ec28d6df1c7f0f745186884091e602e07"
+            },
+            "src/third_party/hunspell_dictionaries": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-67mvpJRFFa9eMfyqFMURlbxOaTJBICnk+gl0b0mEHl8=",
+                "url": "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git",
+                "rev": "41cdffd71c9948f63c7ad36e1fb0ff519aa7a37e"
+            },
+            "src/third_party/icu": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-47Xxb5IFbRmdO3oADjn13fm7aIYFXh2R4YVZIJAy22U=",
+                "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
+                "rev": "d8daa943f64cd5dd2a55e9baf2e655ab4bfa5ae9"
+            },
+            "src/third_party/jsoncpp/source": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-bSLNcoYBz3QCt5VuTR056V9mU2PmBuYBa0W6hFg2m8Q=",
+                "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
+                "rev": "42e892d96e47b1f6e29844cc705e148ec4856448"
+            },
+            "src/third_party/leveldatabase/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-TTX2FrmcWsgqrh4uzqMyGnnnG51cVC2ILfdLxD65MLY=",
+                "url": "https://chromium.googlesource.com/external/leveldb.git",
+                "rev": "068d5ee1a3ac40dabd00d211d5013af44be55bea"
+            },
+            "src/third_party/libFuzzer/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-HG3KHhKQnr4hdnUK/2QhcxRdNxh38fhU54JKKzqZaio=",
+                "url": "https://chromium.googlesource.com/chromium/llvm-project/compiler-rt/lib/fuzzer.git",
+                "rev": "debe7d2d1982e540fbd6bd78604bf001753f9e74"
+            },
+            "src/third_party/centipede/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-yFZOn/Ga+D/b/1TwuOZdO/H4/GuX/HRB18rgYg7+rmE=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/centipede.git",
+                "rev": "a5a9071410e6e8134855b88461d0eb2c77d48cdd"
+            },
+            "src/third_party/libaddressinput/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-xvUUQSPrvqUp5DI9AqlRTWurwDW087c6v4RvI+4sfOQ=",
+                "url": "https://chromium.googlesource.com/external/libaddressinput.git",
+                "rev": "e8712e415627f22d0b00ebee8db99547077f39bd"
+            },
+            "src/third_party/libaom/source/libaom": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-j8b0xM7hHNqYIeUQjf+c7LyzcfZVJx64Xqo9gIRtsYU=",
+                "url": "https://aomedia.googlesource.com/aom.git",
+                "rev": "5a0903824082f41123e8365b5b99ddb6ced8971c"
+            },
+            "src/third_party/libavif/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-3Oe8ouucu2eHpXov3WchwKQIqjhzuSFfNZ7ChEkQiTE=",
+                "url": "https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git",
+                "rev": "1af8cea3d1b3a05ecbcb0e39d99a7f0183e6ce13"
+            },
+            "src/third_party/nearby/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-GfxGDSh2qkjIGgXgwH0xWAnjswOmGEVaXlci+tZS53g=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
+                "rev": "37000006c224476104276bf74038d60967593814"
+            },
+            "src/third_party/securemessage/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-GS4ccnuiqxMs/LVYAtvSlVAYFp4a5GoZsxcriTX3k78=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/securemessage.git",
+                "rev": "fa07beb12babc3b25e0c5b1f38c16aa8cb6b8f84"
+            },
+            "src/third_party/ukey2/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-aaLs6ZS+CdBlCJ6ZhsmdAPFxiBIij6oufsDcNeRSV1E=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/ukey2.git",
+                "rev": "0275885d8e6038c39b8a8ca55e75d1d4d1727f47"
+            },
+            "src/third_party/cros-components/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-HgBDDfYvxYtHPfWlAs4aFCzDyhdcWnSP9nvCl8/UDfU=",
+                "url": "https://chromium.googlesource.com/external/google3/cros_components.git",
+                "rev": "0971e0c09f748dd476089b0e5136fe0b84e0bb4c"
+            },
+            "src/third_party/libdrm/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-ML89TBKDPHOd0YOVBmvLac+tyqgA5khDFK5vq4CCru8=",
+                "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git",
+                "rev": "b9ca37b3134861048986b75896c0915cbf2e97f9"
+            },
+            "src/third_party/expat/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-FXTDGAK03jc2wvazhRKqtsFRKZUYS/9HLpZNp4JfZJI=",
+                "url": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git",
+                "rev": "441f98d02deafd9b090aea568282b28f66a50e36"
+            },
+            "src/third_party/libipp/libipp": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-gxU92lHLd6uxO8T3QWhZIK0hGy97cki705DV0VimCPY=",
+                "url": "https://chromium.googlesource.com/chromiumos/platform2/libipp.git",
+                "rev": "2209bb84a8e122dab7c02fe66cc61a7b42873d7f"
+            },
+            "src/third_party/libjpeg_turbo": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-QnXMR9qqRiYfV1sUJvKVvLQ9A022lYKbsrI9HOU9LCs=",
+                "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git",
+                "rev": "aa4075f116e4312537d0d3e9dbd5e31096539f94"
+            },
+            "src/third_party/liblouis/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-EI/uaHXe0NlqdEw764q0SjerThYEVLRogUlmrsZwXnY=",
+                "url": "https://chromium.googlesource.com/external/liblouis-github.git",
+                "rev": "9700847afb92cb35969bdfcbbfbbb74b9c7b3376"
+            },
+            "src/third_party/libphonenumber/dist": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-3hSnTFTD3KAdbyxfKg12qbIYTmw6YlTCH64gMP/HUJo=",
+                "url": "https://chromium.googlesource.com/external/libphonenumber.git",
+                "rev": "140dfeb81b753388e8a672900fb7a971e9a0d362"
+            },
+            "src/third_party/libprotobuf-mutator/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-ZyPweW+V5foxFQwjjMLkaRUo+FNV+kEDGIH/4oRV614=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git",
+                "rev": "a304ec48dcf15d942607032151f7e9ee504b5dcf"
+            },
+            "src/third_party/libsrtp": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-pfLFh2JGk/g0ZZxBKTaYW9/PBpkCm0rtJeyNePUMTTc=",
+                "url": "https://chromium.googlesource.com/chromium/deps/libsrtp.git",
+                "rev": "5b7c744eb8310250ccc534f3f86a2015b3887a0a"
+            },
+            "src/third_party/libsync/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Mkl6C1LxF3RYLwYbxiSfoQPt8QKFwQWj/Ati2sNJ32E=",
+                "url": "https://chromium.googlesource.com/aosp/platform/system/core/libsync.git",
+                "rev": "f4f4387b6bf2387efbcfd1453af4892e8982faf6"
+            },
+            "src/third_party/libvpx/source/libvpx": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-hIXEvCqbeMShGL1hCpJAMPbpuVfFM6Z4z5DPR3kfwb4=",
+                "url": "https://chromium.googlesource.com/webm/libvpx.git",
+                "rev": "27171320f5e36f7b18071bfa1d9616863ca1b4e8"
+            },
+            "src/third_party/libwebm/source": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-u/5nkJed0DzdhR5OLL2kIhZhOnrbyzL1Kx37vV/jcEo=",
+                "url": "https://chromium.googlesource.com/webm/libwebm.git",
+                "rev": "e4fbea0c9751ae8aa86629b197a28d8276a2b0da"
+            },
+            "src/third_party/libwebp/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-zBMivj2tF5AWC+E/rHHEtxBel0i1YwGGBus+4h3PCYY=",
+                "url": "https://chromium.googlesource.com/webm/libwebp.git",
+                "rev": "fd7b5d48464475408d32d2611bdb6947d4246b97"
+            },
+            "src/third_party/libyuv": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-LLmTW05GxoXgNkLRHp3e6gb7glMgJo1moc6lPLVHk6w=",
+                "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
+                "rev": "77c2121f7e6b8e694d6e908bbbe9be24214097da"
+            },
+            "src/third_party/lss": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-hE8uZf9Fst66qJkoVYChiB8G41ie+k9M4X0W+5JUSdw=",
+                "url": "https://chromium.googlesource.com/linux-syscall-support.git",
+                "rev": "ce877209e11aa69dcfffbd53ef90ea1d07136521"
+            },
+            "src/third_party/material_color_utilities/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Cv1TjvOcswhp60LXblrLwY5jrudqKuDUqs1c//x49YE=",
+                "url": "https://chromium.googlesource.com/external/github.com/material-foundation/material-color-utilities.git",
+                "rev": "bd6537fb1c4aa2164d97f96e78a9c826e360a0ed"
+            },
+            "src/third_party/minigbm/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-9HwvjTETerbQ7YKXH9kUB2eWa8PxGWMAJfx1jAluhrs=",
+                "url": "https://chromium.googlesource.com/chromiumos/platform/minigbm.git",
+                "rev": "3018207f4d89395cc271278fb9a6558b660885f5"
+            },
+            "src/third_party/nasm": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-L+b3X3vsfpY6FSlIK/AHhxhmq2cXd50vND6uT6yn8Qs=",
+                "url": "https://chromium.googlesource.com/chromium/deps/nasm.git",
+                "rev": "7fc833e889d1afda72c06220e5bed8fb43b2e5ce"
+            },
+            "src/third_party/neon_2_sse/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-299ZptvdTmCnIuVVBkrpf5ZTxKPwgcGUob81tEI91F0=",
+                "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git",
+                "rev": "a15b489e1222b2087007546b4912e21293ea86ff"
+            },
+            "src/third_party/openh264/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-J7Eqe2QevZh1xfap19W8AVCcwfRu7ztknnbKFJUAH1c=",
+                "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264",
+                "rev": "09a4f3ec842a8932341b195c5b01e141c8a16eb7"
+            },
+            "src/third_party/openscreen/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-MSJbCxYEJmhUrBUobKBgUhPV5yMhxxtKgU4NE2h9mFs=",
+                "url": "https://chromium.googlesource.com/openscreen",
+                "rev": "0964c1e903264ae2c388fc0eda3309c22b46e1a2"
+            },
+            "src/third_party/openscreen/src/third_party/tinycbor/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-fMKBFUSKmODQyg4hKIa1hwnEKIV6WBbY1Gb8DOSnaHA=",
+                "url": "https://chromium.googlesource.com/external/github.com/intel/tinycbor.git",
+                "rev": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7"
+            },
+            "src/third_party/pdfium": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-3FXPYcZZtfwzlkkakKczjoYbDURBA/QDCVdOn+98864=",
+                "url": "https://pdfium.googlesource.com/pdfium.git",
+                "rev": "9505810f66cc3dde86c30d072de53ca6fc8a45de"
+            },
+            "src/third_party/perfetto": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-AJWzQUYiml374LUZyku0ZTEM+lXAKsjc1YbsLfCfMGo=",
+                "url": "https://android.googlesource.com/platform/external/perfetto.git",
+                "rev": "f2da6df2f144e41e1c1428f11e8b388eaf8a2209"
+            },
+            "src/third_party/pthreadpool/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Pfvievhma1rOpbLdSrIX4KaZyRpdvrnjRzzPYl3fDQo=",
+                "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/pthreadpool.git",
+                "rev": "1787867f6183f056420e532eec640cba25efafea"
+            },
+            "src/third_party/pyelftools": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-I/7p3IEvfP/gkes4kx18PvWwhAKilQKb67GXoW4zFB4=",
+                "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git",
+                "rev": "19b3e610c86fcadb837d252c794cb5e8008826ae"
+            },
+            "src/third_party/quic_trace/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Nf9ZDLcE1JunhbpEMHhrY2ROnbgrvVZoRkPwWq1DU0g=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/quic-trace.git",
+                "rev": "caa0a6eaba816ecb737f9a70782b7c80b8ac8dbc"
+            },
+            "src/third_party/pywebsocket3/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-WEqqu2/7fLqcf/2/IcD7/FewRSZ6jTgVlVBvnihthYQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/pywebsocket3.git",
+                "rev": "50602a14f1b6da17e0b619833a13addc6ea78bc2"
+            },
+            "src/third_party/re2/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-9dMTr5VuQfteKK/xIqZUqLnGu26ZYlFUfZTZNgzKUN4=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/re2.git",
+                "rev": "11073deb73b3d01018308863c0bcdfd0d51d3e70"
+            },
+            "src/third_party/ruy/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Sv2rfq3ghddpcJHn7Z2FTXpwKdzgJOiSGu6HhV6nXIQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git",
+                "rev": "363f252289fb7a1fba1703d99196524698cb884d"
+            },
+            "src/third_party/skia": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-7kD6XLaeriWGXM69rCcqPoAkX0NAFOFhFX/SBm710cA=",
+                "url": "https://skia.googlesource.com/skia.git",
+                "rev": "ea1a1635fcf5b1f68b59cd3f8649a0abfab65cfd"
+            },
+            "src/third_party/smhasher/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-RyC//me08hwGXRrWcK8GZ1uhIkBq4FByA7fHCVDsniw=",
+                "url": "https://chromium.googlesource.com/external/smhasher.git",
+                "rev": "e87738e57558e0ec472b2fc3a643b838e5b6e88f"
+            },
+            "src/third_party/snappy/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-5fV6NfO8vmqK+iCwpLtE2YjYOzjsshctauyjNIOxrH0=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/snappy.git",
+                "rev": "c9f9edf6d75bb065fa47468bf035e051a57bec7c"
+            },
+            "src/third_party/sqlite/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-MO4fd5ROy8vtUeGYeWaMT6uO/zYUruPCPjHnZT9elcI=",
+                "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git",
+                "rev": "f6752b7ed1fe3cc1491c0c47ec5804ee2bd0e59b"
+            },
+            "src/third_party/swiftshader": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-H2A42dNT1DgRknyL3lzHlWbxURskjTqzvqd097w4Tho=",
+                "url": "https://swiftshader.googlesource.com/SwiftShader.git",
+                "rev": "23e97b79fb9193bf88e79c16c6a577c680edb2d6"
+            },
+            "src/third_party/text-fragments-polyfill/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-4rW2u1cQAF4iPWHAt1FvVXIpz2pmI901rEPks/w/iFA=",
+                "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git",
+                "rev": "c036420683f672d685e27415de0a5f5e85bdc23f"
+            },
+            "src/third_party/tflite/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-TdBBSPfUCIst1G6BixqcOx9dQiN6f1wmSRS9Gjh4K1U=",
+                "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
+                "rev": "ab14323eaf8522fa608fe047d99249bc844c47cd"
+            },
+            "src/third_party/vulkan-deps": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-4Mwtu/Qmz0wAm8YCWYq9ogzKLg7nEwgka3+OFI/s+fs=",
+                "url": "https://chromium.googlesource.com/vulkan-deps",
+                "rev": "a52479099cf2862650df9dbc12e2e202e345901e"
+            },
+            "src/third_party/vulkan-deps/glslang/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-UOJ4O1zRbW0qxj2oxSKSdvOwZOD907Q0flXxQjYavuQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
+                "rev": "9c7fd1a33e5cecbe465e1cd70170167d5e40d398"
+            },
+            "src/third_party/vulkan-deps/spirv-cross/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-UmzXWpjwGgLijP+BumSK1OW+8OrtWjBXgIt4vzI8ZvQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
+                "rev": "fc9bee27f445644635e83ef111ef54944bb6e3af"
+            },
+            "src/third_party/vulkan-deps/spirv-headers/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-a7OjEH3WczZa8VFvPGGh/J+8nmtYDf0eSUuxU20XSJI=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
+                "rev": "cfbe4feef20c3c0628712c2792624f0221e378ac"
+            },
+            "src/third_party/vulkan-deps/spirv-tools/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-UfcBkLIDSEgKyEz11Tsf3FIM+R6ZboWmDVKR1xu6q6o=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
+                "rev": "25ad5e19f193429b737433d5f6151062ddbc1680"
+            },
+            "src/third_party/vulkan-deps/vulkan-headers/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-bilEf59jBDgl5WUgOZpRSMkp33C/rssj37rdvHaxRGU=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
+                "rev": "8a397558c4d2a4bf9e64e900c45a7e65664c32b2"
+            },
+            "src/third_party/vulkan-deps/vulkan-loader/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-gLNrvpBDnKOr03e5TKxMUVCQ70fI27x3MSLVjMkw2d8=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
+                "rev": "f035e57c171ce9009f2c47b5488a66c653843501"
+            },
+            "src/third_party/vulkan-deps/vulkan-tools/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-VEBPgOGdrzQoIYU7BTioa6m/OH1TUGXGaF7FH5B/h2M=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
+                "rev": "df10a2759b4b60d59b735882217a749d8e5be660"
+            },
+            "src/third_party/vulkan-deps/vulkan-validation-layers/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-JqLhqdqKX2n0ifLfS7ymOL2kcelUjdmsLKqmkqPwTQU=",
+                "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
+                "rev": "3d530f6921f7a9defa297eec25fcef77c9b96282"
+            },
+            "src/third_party/vulkan_memory_allocator": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-rARuPHa/gEAOTM8/Fnob0bU0Jv+UKLiwe3o0UGWYlME=",
+                "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
+                "rev": "ebe84bec02c041d28f902da0214bf442743fc907"
+            },
+            "src/third_party/wayland/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-fcZtJP/8Ck+9WyPvt3AhogwPae5+gAxdIaEMp7eSr44=",
+                "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git",
+                "rev": "c7473676b8abc682e820546287044cee3bca9147"
+            },
+            "src/third_party/wayland-protocols/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-3QK+ZN6IFUFkDxySSoQwP1J3JnTlD7JPaUk6Tr/d/k4=",
+                "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git",
+                "rev": "4624cfaaf563cd7be5e2e2087c8de6d3a48ea867"
+            },
+            "src/third_party/wayland-protocols/kde": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-Dmcp/2ms/k7NxPPmPkp0YNfM9z2Es1ZO0uX10bc7N2Y=",
+                "url": "https://chromium.googlesource.com/external/github.com/KDE/plasma-wayland-protocols.git",
+                "rev": "0b07950714b3a36c9b9f71fc025fc7783e82926e"
+            },
+            "src/third_party/wayland-protocols/gtk": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-75XNnLkF5Lt1LMRGT+T61k0/mLa3kkynfN+QWvZ0LiQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/GNOME/gtk.git",
+                "rev": "40ebed3a03aef096addc0af09fec4ec529d882a0"
+            },
+            "src/third_party/webdriver/pylib": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-WIqWXIKVgElgg8P8laLAlUrgwodGdeVcwohZxnPKedw=",
+                "url": "https://chromium.googlesource.com/external/github.com/SeleniumHQ/selenium/py.git",
+                "rev": "fc5e7e70c098bfb189a9a74746809ad3c5c34e04"
+            },
+            "src/third_party/webgl/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-BRF0/WxbwxTby1o+zFHU42s7xYJUmcsgfu4DFX97jRU=",
+                "url": "https://chromium.googlesource.com/external/khronosgroup/webgl.git",
+                "rev": "d1b65aa5a88f6efd900604dfcda840154e9f16e2"
+            },
+            "src/third_party/webgpu-cts/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-pSwkkIcfrWP6NKNFtHlyq2Z7zYqbKU6V/GXMqH6rYBs=",
+                "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
+                "rev": "7d2d22292ce5af280c8c5849ed7f0679d7ab70e9"
+            },
+            "src/third_party/webrtc": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-J/XEHY4y9j4bg0+ORkDydVOvtncPLMN/9cy073lpMOM=",
+                "url": "https://webrtc.googlesource.com/src.git",
+                "rev": "151be743d4c83671565f9c1eada3f4a0b2e44dea"
+            },
+            "src/third_party/wuffs/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-HP8Vf1C9DuA9H+busf3lFoF9SsYqviLKv0l73CxmNEI=",
+                "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
+                "rev": "fe9d08f2b6e80af691bfb1a718e144c49a1b9eba"
+            },
+            "src/third_party/weston/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-EKl6oIM8Vml9wtSIb9ExFIuuJohbU/rsG3JVS5thaUU=",
+                "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git",
+                "rev": "420cfd00f2de91de74bd9d4d8348e43c582d29f0"
+            },
+            "src/third_party/xdg-utils": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-t3uV9JkkQQIwmezzSoEdTMLSizZdLQB7eLKTRQGH4kQ=",
+                "url": "https://chromium.googlesource.com/chromium/deps/xdg-utils.git",
+                "rev": "d80274d5869b17b8c9067a1022e4416ee7ed5e0d"
+            },
+            "src/third_party/xnnpack/src": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-vsn3lrog5affus0qxc4TK2Z/tdd/E6hBYeUQRWoDZPQ=",
+                "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
+                "rev": "b9d4073a6913891ce9cbd8965c8d506075d2a45a"
+            },
+            "src/tools/page_cycler/acid3": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-+7Ynz7k/dWdd4Wo7Rjzvc8GY9gTsjzjG3GdNsuDKszY=",
+                "url": "https://chromium.googlesource.com/chromium/deps/acid3.git",
+                "rev": "6be0a66a1ebd7ebc5abc1b2f405a945f6d871521"
+            },
+            "src/v8": {
+                "fetcher": "fetchFromGitiles",
+                "hash": "sha256-pmam8TVqtxmfc0V1gy2R1jhW+dF2ybzeKbGZKAbJveY=",
+                "url": "https://chromium.googlesource.com/v8/v8.git",
+                "rev": "978934af4a291282d994fc184d5dc03a82deb5df"
+            },
+            "src/third_party/nan": {
+                "fetcher": "fetchFromGitHub",
+                "hash": "sha256-tur5CExvwuSmwqBwH9o8OZWzDuifRybjEb+4/tm6exk=",
+                "owner": "nodejs",
+                "repo": "nan",
+                "rev": "16fa32231e2ccd89d2804b3f765319128b20c4ac"
+            },
+            "src/third_party/electron_node": {
+                "fetcher": "fetchFromGitHub",
+                "hash": "sha256-XBm+WYXQ8DM1HU6NFciGSfkbHDXPbTyg0gScQCbbpQU=",
+                "owner": "nodejs",
+                "repo": "node",
+                "rev": "v18.15.0"
+            },
+            "src/third_party/squirrel.mac": {
+                "fetcher": "fetchFromGitHub",
+                "hash": "sha256-4GfKQg0u3c9GI+jl3ixESNqWXQJKRMi+00QT0s2Shqw=",
+                "owner": "Squirrel",
+                "repo": "Squirrel.Mac",
+                "rev": "0e5d146ba13101a1302d59ea6e6e0b3cace4ae38"
+            },
+            "src/third_party/squirrel.mac/vendor/ReactiveObjC": {
+                "fetcher": "fetchFromGitHub",
+                "hash": "sha256-/MCqC1oFe3N9TsmfVLgl+deR6qHU6ZFQQjudb9zB5Mo=",
+                "owner": "ReactiveCocoa",
+                "repo": "ReactiveObjC",
+                "rev": "74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76"
+            },
+            "src/third_party/squirrel.mac/vendor/Mantle": {
+                "fetcher": "fetchFromGitHub",
+                "hash": "sha256-ogFkMJybf2Ue606ojXJu6Gy5aXSi1bSKm60qcTAIaPk=",
+                "owner": "Mantle",
+                "repo": "Mantle",
+                "rev": "78d3966b3c331292ea29ec38661b25df0a245948"
+            }
+        },
+        "version": "25.9.1",
+        "modules": "116",
+        "chrome": "114.0.5735.289",
+        "node": "18.15.0",
+        "chromium": {
+            "version": "114.0.5735.289",
+            "deps": {
+                "gn": {
+                    "version": "2023-04-19",
+                    "url": "https://gn.googlesource.com/gn",
+                    "rev": "5a004f9427a050c6c393c07ddb85cba8ff3849fa",
+                    "hash": "sha256-U0rinjJAToVh4zCBd/9I3O4McxW88b7Bp6ibmmqCuQc="
+                }
+            }
+        },
+        "chromium_npm_hash": "sha256-WFkyT1V4jNkWUyyHF68yEe50GhdlNZJBXuQvVVGPk6A=",
+        "electron_yarn_hash": "0fq44b91ha1lbgakwfz16z0g10y66c7m8gvlkg1ci81rzjrj0qpz"
     }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18479,7 +18479,7 @@ with pkgs;
   electron_22 = electron_22-bin;
   electron_23 = electron_23-bin;
   electron_24 = electron_24-bin;
-  electron_25 = electron_25-bin;
+  electron_25 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_25 then electron-source.electron_25 else electron_25-bin;
   electron_26 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_26 then electron-source.electron_26 else electron_26-bin;
   electron_27 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_27 then electron-source.electron_27 else electron_27-bin;
   electron_28 = electron-source.electron_28;


### PR DESCRIPTION
This reverts commit 9652f98da0717bbd5a8e1166196e13dd9f7b25b6.

## Description of changes

Currently testing locally. This revives the electron desktop application. @dotlambda 

Also see this thread https://github.com/NixOS/nixpkgs/pull/271677#discussion_r1417189161

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
