### PR TITLE
maturinBuildHook: use dist dir relative to cargoRoot; python312Packages.pendulum: init at 3.0.0b1

### DIFF
--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -25,7 +25,7 @@ maturinBuildHook() {
 
     # Move the wheel to dist/ so that regular Python tooling can find it.
     mkdir -p dist
-    mv target/wheels/*.whl dist/
+    mv ${cargoRoot:+$cargoRoot/}target/wheels/*.whl dist/
 
     # These are python build hooks and may depend on ./dist
     runHook postBuild

--- a/pkgs/development/python-modules/pendulum/3.nix
+++ b/pkgs/development/python-modules/pendulum/3.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, isPyPy
+
+# build-system
+, poetry-core
+, rustPlatform
+
+# dependencies
+, backports-zoneinfo
+, importlib-resources
+, python-dateutil
+, time-machine
+, tzdata
+
+# tests
+, pytestCheckHook
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "pendulum";
+  version = "3.0.0b1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sdispater";
+    repo = "pendulum";
+    rev = "refs/tags/${version}";
+    hash = "sha256-11W22RpoYUcL9Nya32HRX4Jdo4L9XP2Zftevc+7eFzw=";
+  };
+
+  cargoRoot = "rust";
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    sourceRoot = "source/rust";
+    name = "${pname}-${version}";
+    hash = "sha256-qyyPR4a+IHrRSZzOZaW+DXGpOTyFcEVu/+Mt5QlQFqw=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    rustPlatform.maturinBuildHook
+    rustPlatform.cargoSetupHook
+  ];
+
+  propagatedBuildInputs = [
+    python-dateutil
+    tzdata
+  ] ++ lib.optional (!isPyPy) [
+    time-machine
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    backports-zoneinfo
+    importlib-resources
+  ];
+
+  pythonImportsCheck = [
+    "pendulum"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytz
+  ];
+
+  disabledTestPaths = [
+    "tests/benchmarks"
+  ];
+
+  meta = with lib; {
+    description = "Python datetimes made easy";
+    homepage = "https://github.com/sdispater/pendulum";
+    changelog = "https://github.com/sdispater/pendulum/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -36,7 +36,6 @@ buildPythonPackage {
   # thus the `sed` command
   # Make sure to check that the right substitutions are made when updating the package
   preBuild = ''
-    cd py-polars
     #sed -i 's/version = "0.18.0"/version = "${version}"/g' Cargo.lock
   '';
 
@@ -46,7 +45,7 @@ buildPythonPackage {
       "jsonpath_lib-0.3.0" = "sha256-NKszYpDGG8VxfZSMbsTlzcMGFHBOUeFojNw4P2wM3qk=";
     };
   };
-  cargoRoot = "py-polars";
+  sourceRoot = "source/py-polars";
 
   # Revisit this whenever package or Rust is upgraded
   RUSTC_BOOTSTRAP = 1;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9002,7 +9002,10 @@ self: super: with self; {
 
   pem = callPackage ../development/python-modules/pem { };
 
-  pendulum = callPackage ../development/python-modules/pendulum { };
+  pendulum = if pythonAtLeast "3.12" then
+    callPackage ../development/python-modules/pendulum/3.nix { }
+  else
+    callPackage ../development/python-modules/pendulum { };
 
   pep440 = callPackage ../development/python-modules/pep440 { };
 


### PR DESCRIPTION
## Description of changes

Need feedback if the change to the maturinBuildHook makes sense like that.

The problem I hit when introducing pendulum was, that `Cargo.{lock,toml}` are in the `rust/` subdirectory, so I set `cargoPath` in the derivation and `sourceRoot` in the fetcher.

This resulted in the project building, but moving the final wheel failed, because it tried to move it from `target/` instead of `rust/target`.

After a bit of testing, this seems to break `python311Packages.polars`. I can check up on that later.

cc @danieldk @blaggacao 

Closes: #246882

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
