### PR TITLE
default-gcc-version: 12 -> 13 if stdenv.isAarch64

### DIFF
--- a/pkgs/development/compilers/gcc/patches/13/ICE-PR110280.patch
+++ b/pkgs/development/compilers/gcc/patches/13/ICE-PR110280.patch
@@ -1,0 +1,60 @@
+From f4029de35fb1b293a4fd586574b1b4b73ddf7880 Mon Sep 17 00:00:00 2001
+From: Prathamesh Kulkarni <prathamesh.kulkarni@linaro.org>
+Date: Wed, 26 Jul 2023 22:36:26 +0530
+Subject: [PATCH] [aarch64/match.pd] Fix ICE observed in PR110280.
+
+gcc/ChangeLog:
+	PR tree-optimization/110280
+	* match.pd (vec_perm_expr(v, v, mask) -> v): Explicitly build vector
+	using build_vector_from_val with the element of input operand, and
+	mask's type if operand and mask's types don't match.
+
+gcc/testsuite/ChangeLog:
+	PR tree-optimization/110280
+	* gcc.target/aarch64/sve/pr110280.c: New test.
+
+(cherry picked from commit 85d8e0d8d5342ec8b4e6a54e22741c30b33c6f04)
+---
+ gcc/match.pd                                    |  9 ++++++++-
+ gcc/testsuite/gcc.target/aarch64/sve/pr110280.c | 12 ++++++++++++
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/testsuite/gcc.target/aarch64/sve/pr110280.c
+
+diff --git a/gcc/match.pd b/gcc/match.pd
+index 9118244825054..c3bb4fbc0a7a2 100644
+--- a/gcc/match.pd
++++ b/gcc/match.pd
+@@ -8292,7 +8292,14 @@ and,
+ 
+ (simplify
+  (vec_perm vec_same_elem_p@0 @0 @1)
+- @0)
++ (if (types_match (type, TREE_TYPE (@0)))
++  @0
++  (with
++   {
++     tree elem = uniform_vector_p (@0);
++   }
++   (if (elem)
++    { build_vector_from_val (type, elem); }))))
+ 
+ /* Push VEC_PERM earlier if that may help FMA perception (PR101895).  */
+ (simplify
+diff --git a/gcc/testsuite/gcc.target/aarch64/sve/pr110280.c b/gcc/testsuite/gcc.target/aarch64/sve/pr110280.c
+new file mode 100644
+index 0000000000000..d3279f383629f
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/aarch64/sve/pr110280.c
+@@ -0,0 +1,12 @@
++/* { dg-do compile } */
++/* { dg-options "-O3 -fdump-tree-optimized" } */
++
++#include "arm_sve.h"
++
++svuint32_t l()
++{
++  _Alignas(16) const unsigned int lanes[4] = {0, 0, 0, 0};
++  return svld1rq_u32(svptrue_b8(), lanes);
++}
++
++/* { dg-final { scan-tree-dump-not "VEC_PERM_EXPR" "optimized" } } */

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -74,6 +74,7 @@ in
 ++ optional langFortran (if atLeast12 then ./gcc-12-gfortran-driving.patch else ./gfortran-driving.patch)
 ++ optional atLeast7 ./ppc-musl.patch
 ++ optional is12 ./12/lambda-ICE-PR109241.patch # backport ICE fix on ccache code
+++ optional is13 ./13/ICE-PR110280.patch # backport ICE fix on const_unop
 ++ optional (atLeast9 && langD) ./libphobos.patch
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15831,7 +15831,6 @@ with pkgs;
   default-gcc-version =
     if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then 6
     else if stdenv.buildPlatform.isDarwin  then 12  # unable to test
-    else if stdenv.buildPlatform.isAarch64 then 12  # unable to test
     else 13;
   gcc = pkgs.${"gcc${toString default-gcc-version}"};
   gccFun = callPackage ../development/compilers/gcc;


### PR DESCRIPTION
## Description of changes

`default-gcc-version` was bumped in #268097 on x86_64-linux, on i686-linux, on armv7l-linux, on powerpc64le-linux, on riscv64-linux...

But not on aarch64-linux??

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
