### PR TITLE
buildPythonPackage: Reimplement `format = "setuptools"` in terms of `format = "pyproject"`

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pyproject-setuptools-legacy-hook-patch.py
+++ b/pkgs/development/interpreters/python/hooks/pyproject-setuptools-legacy-hook-patch.py
@@ -1,0 +1,40 @@
+# Patch pyproject.toml to use setuptools in legacy mode as a PEP-517 builder.
+#
+# https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour
+
+import sys; sys.path.append("@tomlkit@")
+import tomlkit
+
+
+BUILD_BACKEND = "setuptools.build_meta:__legacy__"
+
+
+if __name__ == "__main__":
+    # If package has no pyproject.toml fallback behaviour is already in effect.
+    try:
+        with open("pyproject.toml") as fd:
+            pyproject = tomlkit.load(fd)
+    except FileNotFoundError:
+        exit(0)
+
+    # If package has no build-system legacy fallback behaviour is already in effect.
+    try:
+        build_system = pyproject["build-system"]
+    except KeyError:
+        exit(0)
+
+    # Some packages (like skia-pathops) defines build-system.requires but not build-system.build-backend.
+    # This signifies that it's building using the setuptools legacy builder, but with additional requirements like cython.
+    # Skia-pathops in particular parses pyproject.toml at build time to check it's minimum cython version, meaning that
+    # it's unsafe simply always apply this patching, so we only do so when strictly necessary.
+    try:
+        if build_system["build-backend"] == BUILD_BACKEND:
+            exit(0)
+    except KeyError:
+        exit(0)
+
+    build_system["requires"] = ["setuptools>=40.8.0", "wheel"]
+    build_system["build-backend"] = BUILD_BACKEND
+
+    with open("pyproject.toml", "w") as fd:
+        tomlkit.dump(pyproject, fd)

--- a/pkgs/development/interpreters/python/hooks/pyproject-setuptools-legacy-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pyproject-setuptools-legacy-hook.sh
@@ -1,0 +1,28 @@
+pyprojectSetuptoolsLegacyFlagsHook() {
+    echo "Executing pyprojectSetuptoolsLegacyFlagsHook"
+
+    if [ -n "$setupPyGlobalFlags" ]; then
+        for f in $setupPyGlobalFlags; do
+            pypaBuildFlags+=" --config-setting=--global-option=$f"
+        done
+    fi
+
+    if [ -n "$setupPyBuildFlags" ]; then
+        for f in $setupPyBuildFlags; do
+            pypaBuildFlags+=" --config-setting=--build-option=$f"
+        done
+    fi
+}
+
+pyprojectSetuptoolsLegacyPatchHook() {
+    echo "Executing setuptoolsPyprojectLegacyPatchHook"
+
+    if ! test -f pyproject.toml; then
+        return
+    fi
+
+    @pythonInterpreter@ @patchScript@
+}
+
+postPatchHooks+=(pyprojectSetuptoolsLegacyPatchHook)
+preConfigureHooks+=(pyprojectSetuptoolsLegacyFlagsHook)

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -11,8 +11,10 @@
 , namePrefix
 , update-python-libraries
 , setuptools
+, wheel
 , pypaBuildHook
 , pypaInstallHook
+, pyprojectSetuptoolsLegacyHook
 , pythonCatchConflictsHook
 , pythonImportsCheckHook
 , pythonNamespacesHook
@@ -21,7 +23,6 @@
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
 , pythonRuntimeDepsCheckHook
-, setuptoolsBuildHook
 , setuptoolsCheckHook
 , wheelUnpackHook
 , eggUnpackHook
@@ -259,9 +260,11 @@ let
       pythonRemoveBinBytecodeHook
     ] ++ optionals (hasSuffix "zip" (attrs.src.name or "")) [
       unzip
-    ] ++ optionals (format' == "setuptools") [
-      setuptoolsBuildHook
-    ] ++ optionals (format' == "pyproject") [(
+    ] ++ lib.optionals (format' == "setuptools") [
+      pyprojectSetuptoolsLegacyHook
+      setuptools
+      wheel
+    ] ++ lib.optionals (format' == "pyproject" || format' == "setuptools") [(
       if isBootstrapPackage then
         pypaBuildHook.override {
           inherit (python.pythonOnBuildForHost.pkgs.bootstrap) build;


### PR DESCRIPTION
## Description of changes

This change reimplements the behaviour of `format = "setuptools"` to use `pypaBuildHook`, allowing us to deprecate `setuptoolsBuildHook`.

To accomplish compatibility with the any unchanged expressions `pyprojectSetuptoolsLegacyHook` was created.

The hook is responsible for three things:
- Remaps `setupPyGlobalFlags` to `pypaBuildFlags`
- Remaps `setupPyBuildFlags` to `pypaBuildFlags`
- Patches `pyproject.toml` to opt out of the build-system declared and to use setuptools's legacy backend instead. 
  Tools such as Flit and older versions of Poetry generates setup.py files for backwards compatibility with older pre PEP-517 tooling. Such behaviour causes issues when we're building in PEP-517 mode, because `build` will try to import the defined build backend which was never added as a build input when `format = "setuptools"` was set. 
  When `format = "setuptools"` is passed to `buildPythonPackage` it will forcibly use setuptools PEP-517 legacy backend.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


cc @FRidh @mweinelt @jonringer @tjni
cc @figsoda 

See related issues:
- https://github.com/NixOS/nixpkgs/issues/253154