### PR TITLE
ccid: 1.5.2 -> 1.5.4

### DIFF
--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchurl, pcsclite, pkg-config, libusb1, perl }:
+{ lib
+, stdenv
+, fetchurl
+, pcsclite
+, pkg-config
+, libusb1
+, perl
+, gitUpdater
+}:
 
 stdenv.mkDerivation rec {
   pname = "ccid";
@@ -24,6 +32,10 @@ stdenv.mkDerivation rec {
   # The resulting shared object ends up outside of the default paths which are
   # usually getting stripped.
   stripDebugList = ["pcsc"];
+
+  passthru.updateScript = gitUpdater {
+    url = "https://salsa.debian.org/rousseau/CCID.git";
+  };
 
   meta = with lib; {
     description = "ccid drivers for pcsclite";

--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     description = "PC/SC driver for USB CCID smart card readers";
     homepage = "https://ccid.apdu.fr/";
     license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.anthonyroussel ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -38,9 +38,9 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "ccid drivers for pcsclite";
+    description = "PC/SC driver for USB CCID smart card readers";
     homepage = "https://ccid.apdu.fr/";
-    license = licenses.gpl2Plus;
+    license = licenses.lgpl21Plus;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -1,20 +1,22 @@
 { lib
 , stdenv
 , fetchurl
+, flex
 , pcsclite
 , pkg-config
 , libusb1
 , perl
+, zlib
 , gitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "ccid";
-  version = "1.5.2";
+  version = "1.5.4";
 
   src = fetchurl {
     url = "https://ccid.apdu.fr/files/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-E5NEh+b4tI9pmhbTZ8x6GvejyodN5yGsbpYzvrhuchk=";
+    hash = "sha256-boMq3Bcuzc/e4rVvMxRGhIgsvpctr/GTjnqcc6ZPiL8=";
   };
 
   postPatch = ''
@@ -22,12 +24,36 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Makefile.in --replace /bin/echo echo
   '';
 
-  preConfigure = ''
-    configureFlagsArray+=("--enable-usbdropdir=$out/pcsc/drivers")
-  '';
+  configureFlags = [
+    "--enable-twinserial"
+    "--enable-serialconfdir=${placeholder "out"}/etc/reader.conf.d"
+    "--enable-ccidtwindir=${placeholder "out"}/pcsc/drivers/serial"
+    "--enable-usbdropdir=${placeholder "out"}/pcsc/drivers"
+  ];
 
-  nativeBuildInputs = [ pkg-config perl ];
-  buildInputs = [ pcsclite libusb1 ];
+  # error: call to undeclared function 'InterruptRead';
+  # ISO C99 and later do not support implicit function declarations
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
+  nativeBuildInputs = [
+    flex
+    pkg-config
+    perl
+  ];
+
+  buildInputs = [
+    pcsclite
+    libusb1
+    zlib
+  ];
+
+  postInstall = ''
+    install -Dm 0444 -t $out/lib/udev/rules.d src/92_pcscd_ccid.rules
+    substituteInPlace $out/lib/udev/rules.d/92_pcscd_ccid.rules \
+      --replace "/usr/sbin/pcscd" "${pcsclite}/bin/pcscd"
+  '';
 
   # The resulting shared object ends up outside of the default paths which are
   # usually getting stripped.


### PR DESCRIPTION
## Description of changes

https://salsa.debian.org/rousseau/CCID/-/compare/1.5.2...1.5.4

* Added passthru.updateScript
* Updated meta.license and meta.description
* Updated configureFlags to install reader.conf.d configuration file, udev rule, and build twinserial driver

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
