### PR TITLE
glfw: Fix MinGW Build

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -19,21 +19,22 @@ stdenv.mkDerivation rec {
   # Fix linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
   patches = lib.optional (!waylandSupport) ./x11.patch;
 
-  propagatedBuildInputs = [ (if stdenv.isDarwin then OpenGL else libGL) ];
+  propagatedBuildInputs =
+    lib.optionals stdenv.isDarwin [ OpenGL ]
+    ++ lib.optionals stdenv.isLinux [ libGL ];
 
   nativeBuildInputs = [ cmake ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames
     ++ lib.optional waylandSupport extra-cmake-modules;
 
   buildInputs =
-    if waylandSupport
-    then [ wayland wayland-protocols libxkbcommon ]
-    else [ libX11 libXrandr libXinerama libXcursor libXi libXext ]
-         ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa Kernel ];
+    lib.optionals stdenv.isDarwin [ Carbon Cocoa Kernel ]
+    ++ lib.optionals (stdenv.isLinux && waylandSupport) [ wayland wayland-protocols libxkbcommon ]
+    ++ lib.optionals (stdenv.isLinux && !waylandSupport) [ libX11 libXrandr libXinerama libXcursor libXi libXext ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-  ] ++ lib.optionals (!stdenv.isDarwin) [
+  ] ++ lib.optionals (!stdenv.isDarwin && !stdenv.hostPlatform.isWindows) [
     "-DCMAKE_C_FLAGS=-D_GLFW_GLX_LIBRARY='\"${lib.getLib libGL}/lib/libGL.so.1\"'"
   ] ++ lib.optionals waylandSupport [
     "-DGLFW_USE_WAYLAND=ON"
@@ -50,6 +51,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.glfw.org/";
     license = licenses.zlib;
     maintainers = with maintainers; [ marcweber twey ];
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
   };
 }


### PR DESCRIPTION
## Description of changes

- Adjust build inputs and CMake flags to support cross-compilation of GLFW from Linux to Windows (using MinGW).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-linux.pkgsCross.mingwW64
  - [x] aarch64-linux.pkgsCross.mingwW64
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@MarcWeber @Twey 
