### PR TITLE
xautoclick: rename feature flags to match dominant convention

### DIFF
--- a/pkgs/development/python-modules/pymyob/default.nix
+++ b/pkgs/development/python-modules/pymyob/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, requests-oauthlib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pymyob";
+  version = "1.2.24";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "uptick";
+    repo = pname;
+    rev = version;
+    hash = "sha256-+ltztCm3eGYB5Fn7AQNkB2RRFxOJGcewfDj9djetF9s=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    requests-oauthlib
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "myob" ];
+
+  meta = with lib; {
+    description = "A Python API around MYOB's AccountRight API";
+    homepage = "https://github.com/uptick/pymyob";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10678,6 +10678,8 @@ self: super: with self; {
 
   python-myq = callPackage ../development/python-modules/python-myq { };
 
+  pymyob = callPackage ../development/python-modules/pymyob { };
+
   pymysensors = callPackage ../development/python-modules/pymysensors { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };


### PR DESCRIPTION
# xautoclick: rename feature flags to match dominant convention

```
xautoclick: rename feature flags to match dominant convention
```

## Build info of packages affected directly
### xautoclick

<details><summary>content of xautoclick.out</summary>

```
/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34
├── bin
│   ├── aautoclick
│   ├── cautoclick
│   ├── fltkautoclick
│   ├── gautoclick3
│   └── qt5autoclick
└── share
    ├── applications
    │   └── xautoclick.desktop
    ├── icons
    │   └── hicolor
    │       └── scalable
    │           └── apps
    │               └── xautoclick.svg
    └── man
        └── man1
            └── xautoclick.1.gz

9 directories, 8 files
```
</details>

<details><summary>build log of xautoclick</summary>

```
@nix { "action": "setPhase", "phase": "qtPreHook" }
qtPreHook
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/8j55dnzwz1bnqv1584imx8xs869ygaa1-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/doc/xautoclick -DCMAKE_INSTALL_INFODIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/include -DCMAKE_INSTALL_SBINDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/frxg2hvacachpkv3ywdpmfl5pl2yg5y6-gcc-wrapper-12.3.0/bin/strip -DCMAKE_RANLIB=/nix/store/frxg2hvacachpkv3ywdpmfl5pl2yg5y6-gcc-wrapper-12.3.0/bin/ranlib -DCMAKE_AR=/nix/store/frxg2hvacachpkv3ywdpmfl5pl2yg5y6-gcc-wrapper-12.3.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34  
-- The C compiler identification is GNU 12.3.0
-- The CXX compiler identification is GNU 12.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/frxg2hvacachpkv3ywdpmfl5pl2yg5y6-gcc-wrapper-12.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/frxg2hvacachpkv3ywdpmfl5pl2yg5y6-gcc-wrapper-12.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found X11: /nix/store/xrpp2qqfkkzwsc2kwf0lwgsb45qkw8vw-xorgproto-2021.5/include   
-- Looking for XOpenDisplay in /nix/store/wcqi0dshizby7qpabjv2axgyvv7x2arl-libX11-1.8.4/lib/libX11.so;/nix/store/zdhrf49df04hh209hw4m8pwbddhp5vyb-libXext-1.3.4/lib/libXext.so
-- Looking for XOpenDisplay in /nix/store/wcqi0dshizby7qpabjv2axgyvv7x2arl-libX11-1.8.4/lib/libX11.so;/nix/store/zdhrf49df04hh209hw4m8pwbddhp5vyb-libXext-1.3.4/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Found PkgConfig: /nix/store/hfh0z67fbyk5g2qn9b1n962s5gmxmkqi-pkg-config-wrapper-0.29.2/bin/pkg-config (found version "0.29.2") 
-- Checking for module 'libevdev'
--   Found libevdev, version 1.13.1
-- Found FLTK: /nix/store/pylbfpi68b9n95nb0fzdbg5i6fas0ivf-fltk-1.3.8/lib/libfltk_images.so;/nix/store/pylbfpi68b9n95nb0fzdbg5i6fas0ivf-fltk-1.3.8/lib/libfltk_forms.so;/nix/store/pylbfpi68b9n95nb0fzdbg5i6fas0ivf-fltk-1.3.8/lib/libfltk.so  
-- Checking for module 'gtk+-3.0'
--   Found gtk+-3.0, version 3.24.37
Package mount was not found in the pkg-config search path.
Perhaps you should add the directory containing `mount.pc'
to the PKG_CONFIG_PATH environment variable
Package 'mount', required by 'gio-2.0', not found
Package mount was not found in the pkg-config search path.
Perhaps you should add the directory containing `mount.pc'
to the PKG_CONFIG_PATH environment variable
Package 'mount', required by 'gio-2.0', not found
Package mount was not found in the pkg-config search path.
Perhaps you should add the directory containing `mount.pc'
to the PKG_CONFIG_PATH environment variable
Package 'mount', required by 'gio-2.0', not found
Package mount was not found in the pkg-config search path.
Perhaps you should add the directory containing `mount.pc'
to the PKG_CONFIG_PATH environment variable
Package 'mount', required by 'gio-2.0', not found
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DOCDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_INFODIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_LOCALEDIR
    CMAKE_INSTALL_MANDIR
    CMAKE_INSTALL_OLDINCLUDEDIR
    CMAKE_INSTALL_SBINDIR
    CMAKE_POLICY_DEFAULT_CMP0025


-- Build files have been written to: /build/source/build
cmake: enabled parallel building
cmake: enabled parallel installing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
build flags: -j16 SHELL=/nix/store/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash
[  2%] Building C object CMakeFiles/x11clicker.dir/x11clicker.c.o
[  5%] Building C object CMakeFiles/udevclicker.dir/udevclicker.c.o
[  7%] Linking C static library libx11clicker.a
[  7%] Built target x11clicker
[ 10%] Linking C static library libudevclicker.a
[ 10%] Built target udevclicker
[ 12%] Building C object CMakeFiles/clicker.dir/clicker.c.o
[ 15%] Linking C static library libclicker.a
[ 15%] Built target clicker
[ 25%] Building C object CMakeFiles/aautoclick.dir/main.c.o
[ 25%] Building C object CMakeFiles/aautoclick.dir/gui.c.o
[ 25%] Building C object CMakeFiles/cautoclick.dir/main.c.o
[ 38%] Building C object CMakeFiles/cautoclick.dir/osdep.c.o
[ 38%] Building C object CMakeFiles/cautoclick.dir/gui.c.o
[ 43%] Building C object CMakeFiles/aautoclick.dir/osdep.c.o
[ 48%] Building C object CMakeFiles/fltkautoclick.dir/osdep.c.o
[ 53%] Building C object CMakeFiles/aautoclick.dir/options.c.o
[ 28%] Building C object CMakeFiles/cautoclick.dir/options.c.o
[ 56%] Building C object CMakeFiles/fltkautoclick.dir/main.c.o
[ 56%] Building C object CMakeFiles/gautoclick3.dir/main.c.o
[ 56%] Building C object CMakeFiles/gautoclick3.dir/gui.c.o
[ 56%] Building C object CMakeFiles/fltkautoclick.dir/options.c.o
[ 56%] Building C object CMakeFiles/gautoclick3.dir/options.c.o
[ 56%] Building C object CMakeFiles/fltkautoclick.dir/gui.c.o
[ 56%] Automatic MOC for target qt5autoclick
[ 64%] Building C object CMakeFiles/cautoclick.dir/guicommandline.c.o
[ 64%] Building C object CMakeFiles/gautoclick3.dir/osdep.c.o
[ 64%] Building C object CMakeFiles/aautoclick.dir/guiascii.c.o
[ 66%] Building C object CMakeFiles/gautoclick3.dir/guigtk3.c.o
[ 69%] Building CXX object CMakeFiles/fltkautoclick.dir/guifltk.cpp.o
[ 71%] Linking C executable cautoclick
[ 74%] Linking C executable aautoclick
[ 74%] Built target qt5autoclick_autogen
[ 74%] Built target cautoclick
[ 79%] Building C object CMakeFiles/qt5autoclick.dir/options.c.o
[ 79%] Building C object CMakeFiles/qt5autoclick.dir/main.c.o
[ 84%] Building C object CMakeFiles/qt5autoclick.dir/gui.c.o
[ 84%] Building CXX object CMakeFiles/qt5autoclick.dir/qt5autoclick_autogen/mocs_compilation.cpp.o
[ 87%] Building C object CMakeFiles/qt5autoclick.dir/osdep.c.o
[ 89%] Building CXX object CMakeFiles/qt5autoclick.dir/clickwidget.cpp.o
[ 92%] Building CXX object CMakeFiles/qt5autoclick.dir/guiqt.cpp.o
[ 92%] Built target aautoclick
[ 94%] Linking C executable gautoclick3
[ 97%] Linking CXX executable fltkautoclick
[ 97%] Built target gautoclick3
[ 97%] Built target fltkautoclick
[100%] Linking CXX executable qt5autoclick
[100%] Built target qt5autoclick
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
glibPreInstallPhase
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
glibPreInstallPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
install flags: -j16 SHELL=/nix/store/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash gsettingsschemadir=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/gsettings-schemas/xautoclick-0.34/glib-2.0/schemas/ gsettingsschemadir=/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/gsettings-schemas/xautoclick-0.34/glib-2.0/schemas/ install
[  5%] Built target x11clicker
[ 10%] Built target udevclicker
[ 15%] Built target clicker
[ 17%] Automatic MOC for target qt5autoclick
[ 48%] Built target cautoclick
[ 48%] Built target aautoclick
[ 64%] Built target fltkautoclick
[ 79%] Built target gautoclick3
[ 79%] Built target qt5autoclick_autogen
[100%] Built target qt5autoclick
Install the project...
-- Install configuration: "Release"
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/aautoclick
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/cautoclick
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/fltkautoclick
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/gautoclick3
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/applications/xautoclick.desktop
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/icons/hicolor/scalable/apps/xautoclick.svg
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/qt5autoclick
-- Installing: /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/man/man1/xautoclick.1
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
dropIconThemeCache
@nix { "action": "setPhase", "phase": "glibPreFixupPhase" }
glibPreFixupPhase
@nix { "action": "setPhase", "phase": "glibPreFixupPhase" }
glibPreFixupPhase
@nix { "action": "setPhase", "phase": "gappsWrapperArgsHook" }
gappsWrapperArgsHook
@nix { "action": "setPhase", "phase": "qtOwnPathsHook" }
qtOwnPathsHook
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
dropIconThemeCache
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34
shrinking /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/aautoclick
shrinking /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/fltkautoclick
shrinking /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/qt5autoclick
shrinking /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/cautoclick
shrinking /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/gautoclick3
checking for references to /build/ in /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34...
gzipping man pages under /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/share/man/
patching script interpreter paths in /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34
stripping (with command strip and flags -S -p) in  /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin
Wrapping program '/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/aautoclick'
Wrapping program '/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/fltkautoclick'
Wrapping program '/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/qt5autoclick'
Wrapping program '/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/cautoclick'
Wrapping program '/nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/gautoclick3'
wrapping Qt applications in /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/sbin /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/libexec /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/Applications
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/.gautoclick3-wrapped
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/.aautoclick-wrapped
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/.cautoclick-wrapped
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/aautoclick
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/.fltkautoclick-wrapped
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/.qt5autoclick-wrapped
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/fltkautoclick
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/qt5autoclick
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/cautoclick
wrapping /nix/store/2v1a52h7z6c7j4vajrr5fril992axj6b-xautoclick-0.34/bin/gautoclick3
@nix { "action": "setPhase", "phase": "postPatchMkspecs" }
postPatchMkspecs
```
</details>
