### PR TITLE
python3.pkgs.pymyob: init at 1.2.24

### DIFF
--- a/pkgs/development/python-modules/pymyob/default.nix
+++ b/pkgs/development/python-modules/pymyob/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, requests
+, requests-oauthlib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pymyob";
+  version = "1.2.24";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "uptick";
+    repo = pname;
+    rev = version;
+    hash = "sha256-+ltztCm3eGYB5Fn7AQNkB2RRFxOJGcewfDj9djetF9s=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    requests
+    requests-oauthlib
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "myob" ];
+
+  meta = with lib; {
+    description = "A Python API around MYOB's AccountRight API";
+    homepage = "https://github.com/uptick/pymyob";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10678,6 +10678,8 @@ self: super: with self; {
 
   python-myq = callPackage ../development/python-modules/python-myq { };
 
+  pymyob = callPackage ../development/python-modules/pymyob { };
+
   pymysensors = callPackage ../development/python-modules/pymysensors { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };


### PR DESCRIPTION
# python3.pkgs.pymyob: init at 1.2.24

```
python3.pkgs.pymyob: init at 1.2.24
```

## Build info of packages affected directly
### python3.pkgs.pymyob

<details><summary>content of python3.pkgs.pymyob.dist</summary>

```
/nix/store/xb1a6pag9bysrmz27ij74vfjilsh8knh-python3.11-pymyob-1.2.24-dist
└── pymyob-1.2.24-py3-none-any.whl

0 directories, 1 file
```
</details>

<details><summary>content of python3.pkgs.pymyob.out</summary>

```
/nix/store/gbnx3fd42clj1mnzwc67g23k6m2f7spm-python3.11-pymyob-1.2.24
├── lib
│   └── python3.11
│       └── site-packages
│           ├── myob
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── __init__.cpython-311.opt-1.pyc
│           │   │   ├── __init__.cpython-311.pyc
│           │   │   ├── api.cpython-311.opt-1.pyc
│           │   │   ├── api.cpython-311.pyc
│           │   │   ├── constants.cpython-311.opt-1.pyc
│           │   │   ├── constants.cpython-311.pyc
│           │   │   ├── credentials.cpython-311.opt-1.pyc
│           │   │   ├── credentials.cpython-311.pyc
│           │   │   ├── endpoints.cpython-311.opt-1.pyc
│           │   │   ├── endpoints.cpython-311.pyc
│           │   │   ├── exceptions.cpython-311.opt-1.pyc
│           │   │   ├── exceptions.cpython-311.pyc
│           │   │   ├── managers.cpython-311.opt-1.pyc
│           │   │   ├── managers.cpython-311.pyc
│           │   │   ├── utils.cpython-311.opt-1.pyc
│           │   │   └── utils.cpython-311.pyc
│           │   ├── api.py
│           │   ├── constants.py
│           │   ├── credentials.py
│           │   ├── endpoints.py
│           │   ├── exceptions.py
│           │   ├── managers.py
│           │   └── utils.py
│           └── pymyob-1.2.24.dist-info
│               ├── LICENSE
│               ├── METADATA
│               ├── RECORD
│               ├── WHEEL
│               └── top_level.txt
└── nix-support
    └── propagated-build-inputs

7 directories, 30 files
```
</details>

<details><summary>build log of python3.pkgs.pymyob</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
Sourcing pytest-check-hook
Using pytestCheckPhase
Removing setuptoolsCheckPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/63knij6p621wv3ylhbs726qwp38dmwb6-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tests/test_managers.py
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Executing setuptoolsBuildPhase
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/myob
copying myob/api.py -> build/lib/myob
copying myob/__init__.py -> build/lib/myob
copying myob/managers.py -> build/lib/myob
copying myob/constants.py -> build/lib/myob
copying myob/exceptions.py -> build/lib/myob
copying myob/utils.py -> build/lib/myob
copying myob/credentials.py -> build/lib/myob
copying myob/endpoints.py -> build/lib/myob
/nix/store/y8yq448xka665bqyd5gvdhajqdbsnyys-python3.11-setuptools-68.2.2/lib/python3.11/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/api.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/__init__.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/managers.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/constants.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/exceptions.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/utils.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/credentials.py -> build/bdist.linux-x86_64/wheel/myob
copying build/lib/myob/endpoints.py -> build/bdist.linux-x86_64/wheel/myob
running install_egg_info
running egg_info
creating pymyob.egg-info
writing pymyob.egg-info/PKG-INFO
writing dependency_links to pymyob.egg-info/dependency_links.txt
writing requirements to pymyob.egg-info/requires.txt
writing top-level names to pymyob.egg-info/top_level.txt
writing manifest file 'pymyob.egg-info/SOURCES.txt'
reading manifest file 'pymyob.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'pymyob.egg-info/SOURCES.txt'
Copying pymyob.egg-info to build/bdist.linux-x86_64/wheel/pymyob-1.2.24-py3.11.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/pymyob-1.2.24.dist-info/WHEEL
creating 'dist/pymyob-1.2.24-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'myob/__init__.py'
adding 'myob/api.py'
adding 'myob/constants.py'
adding 'myob/credentials.py'
adding 'myob/endpoints.py'
adding 'myob/exceptions.py'
adding 'myob/managers.py'
adding 'myob/utils.py'
adding 'pymyob-1.2.24.dist-info/LICENSE'
adding 'pymyob-1.2.24.dist-info/METADATA'
adding 'pymyob-1.2.24.dist-info/WHEEL'
adding 'pymyob-1.2.24.dist-info/top_level.txt'
adding 'pymyob-1.2.24.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Finished executing setuptoolsBuildPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
Executing pypaInstallPhase
Successfully installed pymyob-1.2.24-py3-none-any.whl
Finished executing pypaInstallPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/gbnx3fd42clj1mnzwc67g23k6m2f7spm-python3.11-pymyob-1.2.24
checking for references to /build/ in /nix/store/gbnx3fd42clj1mnzwc67g23k6m2f7spm-python3.11-pymyob-1.2.24...
patching script interpreter paths in /nix/store/gbnx3fd42clj1mnzwc67g23k6m2f7spm-python3.11-pymyob-1.2.24
stripping (with command strip and flags -S -p) in  /nix/store/gbnx3fd42clj1mnzwc67g23k6m2f7spm-python3.11-pymyob-1.2.24/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/xb1a6pag9bysrmz27ij74vfjilsh8knh-python3.11-pymyob-1.2.24-dist
checking for references to /build/ in /nix/store/xb1a6pag9bysrmz27ij74vfjilsh8knh-python3.11-pymyob-1.2.24-dist...
patching script interpreter paths in /nix/store/xb1a6pag9bysrmz27ij74vfjilsh8knh-python3.11-pymyob-1.2.24-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
@nix { "action": "setPhase", "phase": "installCheckPhase" }
running install tests
no Makefile or custom installCheckPhase, doing nothing
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: myob
@nix { "action": "setPhase", "phase": "pytestCheckPhase" }
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /build/source
collecting ... 
collected 30 items                                                             

tests/test_endpoints.py ......................                           [ 73%]
tests/test_managers.py ........                                          [100%]

============================== 30 passed in 0.60s ==============================
Finished executing pytestCheckPhase
@nix { "action": "setPhase", "phase": "pytestcachePhase" }
pytestcachePhase
@nix { "action": "setPhase", "phase": "pytestRemoveBytecodePhase" }
pytestRemoveBytecodePhase
```
</details>
