### PR TITLE
river-bsp-layout: init at 1.1.1

### DIFF
--- a/pkgs/by-name/ri/river-bsp-layout/package.nix
+++ b/pkgs/by-name/ri/river-bsp-layout/package.nix
@@ -1,4 +1,4 @@
-{ 
+{
   lib
   rustPlatform,
   fetchFromGitHub,

--- a/pkgs/by-name/ri/river-bsp-layout/package.nix
+++ b/pkgs/by-name/ri/river-bsp-layout/package.nix
@@ -1,0 +1,48 @@
+{ 
+  lib
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  darwin,
+  bottom,
+  testers,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "river-bsp-layout";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "areif-dev";
+    repo = pname;
+    rev = version;
+    hash = "sha256-2348939e0f23f1df61a71f139d58d1267b0de408455c4b8ea3db229421bf8631";
+  };
+
+  cargoHash = "sha256-cd1090816ed927703c0de800cef448b38662901946e6239ab3e81136e31d0fa9";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.Foundation
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = river-bsp-layout;
+  };
+
+  meta = with lib; {
+    description = "Custom River layout manager that creates a Binary Space Partition / Grid layout using river-layout-toolkit";
+    homepage = "https://github.com/areif-dev/river-bsp-layout";
+    changelog = "https://github.com/areif-dev/river-bsp-layout/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with maintainers; [ ];
+    mainProgram = "river-bsp-layout";
+  };
+}


### PR DESCRIPTION
## Description of changes

Custom River layout manager that creates a Binary Space Partition / Grid layout using river-layout-toolkit 

https://github.com/areif-dev/river-bsp-layout

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
