### PR TITLE
python311Packages.jupyterhub: not broken on aarch64

### DIFF
--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -207,6 +207,6 @@ buildPythonPackage rec {
     license = licenses.bsd3;
     maintainers = teams.jupyter.members;
     # darwin: E   OSError: dlopen(/nix/store/43zml0mlr17r5jsagxr00xxx91hz9lky-openpam-20170430/lib/libpam.so, 6): image not found
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

Jupyterhub has been marked as broken on aarch64 in [afbb0f](https://github.com/NixOS/nixpkgs/commit/afbb0f6ff4a6df918d1f0dc37dd2d4b97cf2881e) by [this PR](https://github.com/NixOS/nixpkgs/pull/173671) but now seems to work on ARM systems.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested the `services.jupyterhub` module.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
