### PR TITLE
auto-patchelf: add support for __structuredAttrs

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -65,12 +65,17 @@ autoPatchelf() {
         local patchelfFlagsArray=($patchelfFlags)
     fi
 
-    if [ "$autoPatchelfIgnoreMissingDeps" == "1" ]; then
-        echo "autoPatchelf: WARNING: setting 'autoPatchelfIgnoreMissingDeps" \
-             "= true;' is deprecated and will be removed in a future release." \
-             "Use 'autoPatchelfIgnoreMissingDeps = [ \"*\" ];' instead." >&2
-        ignoreMissingDepsArray=( "*" )
-    fi
+    # Check if ignoreMissingDepsArray contains "1" and if so, replace it with
+    # "*", printing a deprecation warning.
+    for dep in "${ignoreMissingDepsArray[@]}"; do
+        if [ "$dep" == "1" ]; then
+            echo "autoPatchelf: WARNING: setting 'autoPatchelfIgnoreMissingDeps" \
+                 "= true;' is deprecated and will be removed in a future release." \
+                 "Use 'autoPatchelfIgnoreMissingDeps = [ \"*\" ];' instead." >&2
+            ignoreMissingDepsArray=( "*" )
+            break
+        fi
+    done
 
     @pythonInterpreter@ @autoPatchelfScript@                            \
         ${norecurse:+--no-recurse}                                      \

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -53,7 +53,18 @@ autoPatchelf() {
         esac
     done
 
-    readarray -td' ' ignoreMissingDepsArray < <(echo -n "$autoPatchelfIgnoreMissingDeps")
+    if [ -n "$__structuredAttrs" ]; then
+        local ignoreMissingDepsArray=( "${autoPatchelfIgnoreMissingDeps[@]}" )
+        local appendRunpathsArray=( "${appendRunpaths[@]}" )
+        local runtimeDependenciesArray=( "${runtimeDependencies[@]}" )
+        local patchelfFlagsArray=( "${patchelfFlags[@]}" )
+    else
+        readarray -td' ' ignoreMissingDepsArray < <(echo -n "$autoPatchelfIgnoreMissingDeps")
+        local appendRunpathsArray=($appendRunpaths)
+        local runtimeDependenciesArray=($runtimeDependencies)
+        local patchelfFlagsArray=($patchelfFlags)
+    fi
+
     if [ "$autoPatchelfIgnoreMissingDeps" == "1" ]; then
         echo "autoPatchelf: WARNING: setting 'autoPatchelfIgnoreMissingDeps" \
              "= true;' is deprecated and will be removed in a future release." \
@@ -61,9 +72,6 @@ autoPatchelf() {
         ignoreMissingDepsArray=( "*" )
     fi
 
-    local appendRunpathsArray=($appendRunpaths)
-    local runtimeDependenciesArray=($runtimeDependencies)
-    local patchelfFlagsArray=($patchelfFlags)
     @pythonInterpreter@ @autoPatchelfScript@                            \
         ${norecurse:+--no-recurse}                                      \
         --ignore-missing "${ignoreMissingDepsArray[@]}"                 \

--- a/pkgs/test/auto-patchelf-hook/default.nix
+++ b/pkgs/test/auto-patchelf-hook/default.nix
@@ -1,0 +1,6 @@
+{ lib, callPackage }:
+
+lib.recurseIntoAttrs {
+  withStructuredAttrs = callPackage ./package.nix { __structuredAttrs = true; };
+  withoutStructuredAttrs = callPackage ./package.nix { __structuredAttrs = false; };
+}

--- a/pkgs/test/auto-patchelf-hook/package.nix
+++ b/pkgs/test/auto-patchelf-hook/package.nix
@@ -1,0 +1,96 @@
+# This is a test for autoPatchelfHook. To test it, we just need a simple binary
+# which uses the hook. We took the derivation from tonelib-jam, which sounds
+# like a good candidate with a small closure, and trimmed it down.
+
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, freetype
+, curl
+# This test checks that the behavior of autoPatchelfHook is correct whether
+# __structuredAttrs
+# (https://nixos.org/manual/nix/stable/language/advanced-attributes#adv-attr-structuredAttrs)
+# is set or not. Hence __structuredAttrs is provided as a parameter.
+, __structuredAttrs
+}:
+
+let runtimeDependencies = [
+  (lib.getLib curl)
+  "/some/dep"
+  "/some/other/dep"
+]
+# A dependency with space only works with __structuredAttrs set to true.
+++ lib.lists.optional __structuredAttrs "/some/dep with space";
+in
+
+stdenv.mkDerivation {
+  name = "auto-patchelf-test";
+
+  src = fetchurl {
+    url = "https://tonelib.net/download/221222/ToneLib-Jam-amd64.deb";
+    sha256 = "sha256-c6At2lRPngQPpE7O+VY/Hsfw+QfIb3COIuHfbqqIEuM=";
+  };
+
+  unpackCmd = ''
+    dpkg -x $curSrc source
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    mv usr $out
+  '';
+
+  buildInputs = [
+    freetype
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libGL.so.1"
+    "libasound.so.2"
+  ];
+
+  inherit runtimeDependencies;
+
+  # Additional phase performing the actual test.
+  installCheckPhase =
+    let allDeps = runtimeDependencies ++ [ (lib.getLib freetype) ];
+    in
+    ''
+      local binary="$out/bin/ToneLib-Jam"
+      local interpreter=$(patchelf --print-interpreter $binary)
+      local runpath=$(patchelf --print-rpath $binary)
+      local glibcStorePath="${stdenv.cc.libc}"
+
+      # Check that the glibc path is a prefix of the interpreter. If
+      # autoPatchelfHook ran correctly, the binary should have set the interpreter
+      # to point to the store.
+      echo "[auto-patchelf-hook-test]: Check that the interpreter is in the store"
+      test "''${interpreter#$glibcStorePath}" != "$interpreter"
+
+      readarray -td':' runpathArray < <(echo -n "$runpath")
+
+      echo "[auto-patchelf-hook-test]: Check that the runpath has the right number of entries"
+      test "''${#runpathArray[@]}" -eq ${builtins.toString (builtins.length allDeps)}
+
+      echo "[auto-patchelf-hook-test]: Check that the runpath contains the expected runtime deps"
+    ''
+    + lib.strings.concatStringsSep "\n"
+      (lib.lists.imap0
+        (i: path:
+          let iAsStr = builtins.toString i; in
+          ''
+            echo "[auto-patchelf-hook-test]: Check that entry ${iAsStr} is ${path}"
+            test "''${paths[${iAsStr}]}" = "$path"
+          '')
+        allDeps
+      );
+
+  doInstallCheck = true;
+  inherit __structuredAttrs;
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -167,4 +167,6 @@ with pkgs;
   pkgs-lib = recurseIntoAttrs (import ../pkgs-lib/tests { inherit pkgs; });
 
   nixpkgs-check-by-name = callPackage ./nixpkgs-check-by-name { };
+
+  auto-patchelf-hook = callPackage ./auto-patchelf-hook { };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As discovered in #256324, `autoPatchelf` doesn't work correctly when `__structuredAttrs` is true. This patch fixes that.

This PR is tagged with a CUDA label because it being merged allows refactoring the work-around hack in #256324 where `autoPatchelfIgnoreMissingDeps` was moved inside `env` to ensure it was not treated as an array.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
