### PR TITLE
caffe: fix eval when CUDNN is not available

### DIFF
--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -26,24 +26,17 @@ let
   # The default for cudatoolkit 10.1 is CUDNN 8.0.5, the last version to support CUDA 10.1.
   # However, this caffe does not build with CUDNN 8.x, so we use CUDNN 7.6.5 instead.
   # Earlier versions of cudatoolkit use pre-8.x CUDNN, so we use the default.
-  cudnn = if lib.versionOlder cudatoolkit.version "10.1"
-    then cudaPackages.cudnn
-    else cudaPackages.cudnn_7_6;
-in
+  hasCudnn =
+    if lib.versionOlder cudatoolkit.version "10.1"
+    then cudaPackages ? cudnn
+    else cudaPackages ? cudnn_7_6;
 
-assert leveldbSupport -> (leveldb != null && snappy != null);
-assert cudnnSupport -> cudaSupport;
-assert ncclSupport -> cudaSupport;
-assert pythonSupport -> (python != null && numpy != null);
-
-let
   toggle = bool: if bool then "ON" else "OFF";
 
   test_model_weights = fetchurl {
     url = "http://dl.caffe.berkeleyvision.org/bvlc_reference_caffenet.caffemodel";
     sha256 = "472d4a06035497b180636d8a82667129960371375bd10fcb6df5c6c7631f25e0";
   };
-
 in
 
 stdenv.mkDerivation rec {
@@ -74,7 +67,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost gflags glog protobuf hdf5-cpp opencv4 blas ]
                 ++ lib.optional cudaSupport cudatoolkit
-                ++ lib.optional cudnnSupport cudnn
+                ++ lib.optional (lib.versionOlder cudatoolkit.version "10.1" && hasCudnn) cudaPackages.cudnn
+                ++ lib.optional (lib.versionAtLeast cudatoolkit.version "10.1" && hasCudnn) cudaPackages.cudnn_7_6
                 ++ lib.optional lmdbSupport lmdb
                 ++ lib.optional ncclSupport nccl
                 ++ lib.optionals leveldbSupport [ leveldb snappy ]
@@ -154,7 +148,14 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://caffe.berkeleyvision.org/";
     maintainers = with maintainers; [ ];
-    broken = (pythonSupport && (python.isPy310)) || cudaSupport;
+    broken =
+      (pythonSupport && (python.isPy310))
+      || cudaSupport
+      || !(leveldbSupport -> (leveldb != null && snappy != null))
+      || !(cudnnSupport -> (hasCudnn && cudaSupport))
+      || !(ncclSupport -> cudaSupport)
+      || !(pythonSupport -> (python != null && numpy != null))
+    ;
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
   };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes an eval error for caffe caused by #256324 when `cudaSupport` is false (caffe is broken when `cudaSupport` is enabled).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
