### PR TITLE
lib.types.boolByOr: init

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -111,6 +111,12 @@ checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*' 
 checkConfigError 'while evaluating a definition from `.*/define-enable-abort.nix' config.enable ./define-enable-abort.nix
 checkConfigError 'while evaluating the error message for definitions for .enable., which is an option that does not exist' config.enable ./define-enable-abort.nix
 
+# Check boolByOr type.
+checkConfigOutput '^false$' config.value.falseFalse ./boolByOr.nix
+checkConfigOutput '^true$' config.value.trueFalse ./boolByOr.nix
+checkConfigOutput '^true$' config.value.falseTrue ./boolByOr.nix
+checkConfigOutput '^true$' config.value.trueTrue ./boolByOr.nix
+
 checkConfigOutput '^1$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix
 checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix
 checkConfigOutput '^42$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix

--- a/lib/tests/modules/boolByOr.nix
+++ b/lib/tests/modules/boolByOr.nix
@@ -1,0 +1,14 @@
+{ lib, ... }: {
+
+  options.value = lib.mkOption {
+    type = lib.types.lazyAttrsOf lib.types.boolByOr;
+  };
+
+  config.value = {
+    falseFalse = lib.mkMerge [ false false ];
+    trueFalse = lib.mkMerge [ true false ];
+    falseTrue = lib.mkMerge [ false true ];
+    trueTrue = lib.mkMerge [ true true ];
+  };
+}
+

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -275,6 +275,22 @@ rec {
       merge = mergeEqualOption;
     };
 
+    boolByOr = mkOptionType {
+      name = "boolByOr";
+      description = "boolean (merged using or)";
+      descriptionClass = "noun";
+      check = isBool;
+      merge = loc: defs:
+        foldl'
+          (result: def:
+            # Under the assumption that .check always runs before merge, we can assume that all defs.*.value
+            # have been forced, and therefore we assume we don't introduce order-dependent strictness here
+            result || def.value
+          )
+          false
+          defs;
+    };
+
     int = mkOptionType {
       name = "int";
       description = "signed integer";

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -13,6 +13,13 @@ merging is handled.
 `types.bool`
 
 :   A boolean, its values can be `true` or `false`.
+    All definitions must have the same value, after priorities. An error is thrown in case of a conflict.
+
+`types.boolByOr`
+
+:   A boolean, its values can be `true` or `false`.
+    The result is `true` if _any_ of multiple definitions is `true`.
+    In other words, definitions are merged with the logical _OR_ operator.
 
 `types.path`
 


### PR DESCRIPTION
## Description of changes

This type is necessary to have correct merging behavior for `allowUnfreePredicate` and `allowInsecurePredicate`, as discussed in https://github.com/NixOS/nixpkgs/pull/272686#issuecomment-1845898263.

## Things done

- [x] Added tests
- [x] Wrote docs

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
