### PR TITLE
sauce-connect: 4.5.4 -> 4.9.1

### DIFF
--- a/pkgs/development/tools/sauce-connect/default.nix
+++ b/pkgs/development/tools/sauce-connect/default.nix
@@ -2,20 +2,24 @@
 
 stdenv.mkDerivation rec {
   pname = "sauce-connect";
-  version = "4.5.4";
+  version = "4.9.1";
 
-  src = fetchurl (
-    if stdenv.hostPlatform.system == "x86_64-linux" then {
-      url = "https://saucelabs.com/downloads/sc-${version}-linux.tar.gz";
-      sha256 = "1w8fw47q4bzpk5jfagmc0cbp69jdd6jcv2xl1gx91cbp7xd8mcbf";
-    } else if stdenv.hostPlatform.system == "i686-linux" then {
-      url = "https://saucelabs.com/downloads/sc-${version}-linux32.tar.gz";
-      sha256 = "1h9n1mzmrmlrbd0921b0sgg7m8z0w71pdb5sif6h1b9f97cp353x";
-    } else {
-      url = "https://saucelabs.com/downloads/sc-${version}-osx.zip";
-      sha256 = "0rkyd402f1n92ad3w1460j1a4m46b29nandv4z6wvg2pasyyf2lj";
-    }
-  );
+  passthru = {
+    sources = {
+      x86_64-linux = fetchurl {
+        url = "https://saucelabs.com/downloads/sc-${version}-linux.tar.gz";
+        hash = "sha256-S3vzng6b0giB6Zceaxi62pQOEHysIR/vVQmswkEZ0/M=";
+      };
+      x86_64-darwin = fetchurl {
+        url = "https://saucelabs.com/downloads/sc-${version}-osx.zip";
+        hash = "sha256-6tJayqo+p7PMz8M651ikHz6tEjGjRIffOqQBchkpW5Q=";
+      };
+      aarch64-darwin = passthru.sources.x86_64-darwin;
+    };
+  };
+
+  src = passthru.sources.${stdenv.hostPlatform.system}
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   nativeBuildInputs = [ unzip ];
 
@@ -38,7 +42,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     homepage = "https://docs.saucelabs.com/reference/sauce-connect/";
-    maintainers = with maintainers; [offline];
-    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ offline ];
+    platforms = builtins.attrNames passthru.sources;
   };
 }

--- a/pkgs/development/tools/sauce-connect/update.sh
+++ b/pkgs/development/tools/sauce-connect/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl jq
+# API documentation: https://docs.saucelabs.com/dev/api/connect/
+
+set -Eeuo pipefail
+shopt -s lastpipe
+die() {
+    echo -e "${BASH_SOURCE[0]}:${BASH_LINENO[0]}" ERROR: "$@" >&2
+    exit 1
+}
+# shellcheck disable=2154
+trap 's=$?; die "$BASH_COMMAND"; exit $s' ERR
+
+# Versions may not be updated simultaneously across all platforms, so need to figure out the latest
+# version that includes both platforms. For example, currently the latest on Linux is 4.9.2 while
+# Mac is 4.9.1.
+response=$(curl -fsSL 'https://api.us-west-1.saucelabs.com/rest/v1/public/tunnels/info/versions?all=true')
+all_versions=$(jq --exit-status --raw-output \
+    '.all_downloads | to_entries[] | select(.value | has("linux") and has("osx")) | .key' \
+    <<< "$response")
+latest_version=$(sort --version-sort <<< "$all_versions" | tail -n 1)
+for platform in x86_64-linux x86_64-darwin; do
+    update-source-version sauce-connect 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" \
+        --source-key="passthru.sources.$platform"
+    update-source-version sauce-connect "$latest_version" \
+        --source-key="passthru.sources.$platform"
+done


### PR DESCRIPTION
## Description of changes

Latest version on Linux is actually 4.9.2, but latest on Mac is 4.9.1, so only updating to 4.9.1 for consistency between the two.

Also added passthru.updateScript to keep this package up to date in the future, with associated refactoring to make that possible.

P.S. Since this package was significantly out of date, I assume it's effectively unmaintained. I'm willing to become the maintainer of it if that's helpful.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
