### PR TITLE
python311Packages.pytype: init at 2023.11.29; 

### DIFF
--- a/pkgs/development/python-modules/pycnite/default.nix
+++ b/pkgs/development/python-modules/pycnite/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "pycnite";
+  version = "2023.10.11";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-rYYWmCvuzDnyCQmZqo/gsESx9nM+w5SEy14JALPIiqE=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  meta = {
+    homepage = "https://github.com/google/pycnite";
+    description = "A collection of utilities for working with compiled Python bytecode";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ jfvillablanca ];
+  };
+}

--- a/pkgs/development/python-modules/pytype/default.nix
+++ b/pkgs/development/python-modules/pytype/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+
+, ninja
+, pybind11
+, setuptools
+, wheel
+
+, attrs
+, importlab
+, jinja2
+, libcst
+, networkx
+, pydot
+, pylint
+, tabulate
+, toml
+, typing-extensions
+, pycnite
+}:
+
+buildPythonPackage rec {
+  pname = "pytype";
+  version = "2023.11.29";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "pytype";
+    rev = version;
+    hash = "sha256-+lXgY9Z8zeMuuVaFAmgxC4pTtGLxiPN+pPikn6JCNL8=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    ninja
+    pybind11
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    attrs
+    importlab
+    jinja2
+    libcst
+    networkx
+    ninja
+    pybind11
+    pycnite
+    pydot
+    pylint
+    tabulate
+    toml
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "pytype" ];
+
+  meta = {
+    homepage = "https://github.com/google/pytype";
+    description = "A static type analyzer for Python code";
+    changelog = "https://github.com/google/pytype/blob/${src.rev}/CHANGELOG";
+    license = with lib.licenses; [ asl20 mit ];
+    maintainers = with lib.maintainers; [ jfvillablanca ];
+    mainProgram = "pytype";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12409,6 +12409,8 @@ with pkgs;
 
   pylint = with python3Packages; toPythonApplication pylint;
 
+  pytype = with python3Packages; toPythonApplication pytype;
+
   pympress = callPackage ../applications/office/pympress { };
 
   pyocd = with python3Packages; toPythonApplication pyocd;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11871,6 +11871,8 @@ self: super: with self; {
 
   pytweening = callPackage ../development/python-modules/pytweening { };
 
+  pytype = callPackage ../development/python-modules/pytype { };
+
   pytz = callPackage ../development/python-modules/pytz { };
 
   pytz-deprecation-shim = callPackage ../development/python-modules/pytz-deprecation-shim { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9290,6 +9290,8 @@ self: super: with self; {
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
+  pycnite = callPackage ../development/python-modules/pycnite { };
+
   pycomposefile = callPackage ../development/python-modules/pycomposefile { };
   pycontrol4 = callPackage ../development/python-modules/pycontrol4 { };
 


### PR DESCRIPTION
## Description of changes
Resolves https://github.com/NixOS/nixpkgs/issues/272786

This includes `python311Packages.pycnite: init at 2023.10.11` since it's a dependency not in nixpkgs yet.

This builds fine, however, there's a runtime error:
`No module named ninja` when running `pytype` on a python file.
I believe it's because the `ninja` in `propagatedBuildInputs` is the ninja package, not the application

Any hints on how to resolve this?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
