### PR TITLE
taler: fix determinism of `taler-exchange.src`

### DIFF
--- a/pkgs/applications/networking/taler/default.nix
+++ b/pkgs/applications/networking/taler/default.nix
@@ -9,22 +9,25 @@ let
   taler-wallet-core = fetchgit {
     url = "https://git.taler.net/wallet-core.git";
     rev = "v${version}";
-    sha256 = "sha256-uwbgIzSjLN+KQCY134VfnCuBEtvCO3a6mEw++HoZDHs=";
+    sha256 = "sha256-oL8vi8gxPjKxRpioMs0GLvkzlTkrm1kyvhsXOgrtvVQ=";
   };
-in rec {
-  taler-exchange = stdenv.mkDerivation rec {
+
+  taler-exchange = stdenv.mkDerivation {
     pname = "taler-exchange";
     inherit version;
 
     src = fetchgit {
       url = "https://git.taler.net/exchange.git";
       rev = "v${version}";
-      # REMOVEME: this should only be a problem for specifically v0.9.3
-      # When fetching submodules without deep clone we get the following error:
-      # "Server does not allow request for unadvertised object"
-      deepClone = true;
       fetchSubmodules = true;
-      sha256 = "sha256-txWwW5vqTblNgVIXdDkpNNZOXpY0udMaz4Wog1GobzE=";
+      sha256 = "sha256-NgDZF6LNeJI4ZuXEwoRdFG6g0S9xNTVhszzlfAnzVOs=";
+
+      # When fetching submodules without the .git folder we get the following error:
+      # "Server does not allow request for unadvertised object"
+      leaveDotGit = true;
+      postFetch = ''
+        rm -rf $out/.git
+      '';
     };
 
     nativeBuildInputs = [
@@ -76,7 +79,7 @@ in rec {
     };
   };
 
-  taler-merchant = stdenv.mkDerivation rec {
+  taler-merchant = stdenv.mkDerivation {
     pname = "taler-merchant";
     inherit version;
 
@@ -133,4 +136,6 @@ in rec {
       platforms = platforms.linux;
     };
   };
+in {
+  inherit taler-exchange taler-merchant;
 }


### PR DESCRIPTION
## Description of changes

We need `.git` for fetching submodules for `taler-exchange`, so we can delete `.git` in the `postFetch` as a workaround for #8567 and #100498

Replaces #272373

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
