### PR TITLE
ocamlPackages.conduit: 6.2.0 → 6.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -9,8 +9,6 @@ buildDunePackage {
     src
     ;
 
-  duneVersion = "3";
-
   buildInputs = [ ppx_sexp_conv ppx_here ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -5,14 +5,13 @@
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "6.2.0";
+  version = "6.2.1";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-${version}.tbz";
-    sha256 = "sha256-PtRAsO3aGyEt12K9skgx85TcoFmF3RtKxPlFgdFFI5Q=";
+    hash = "sha256-WdXntiQ3vkibC3nOEf+QrATvOcaD5M78qFh6/cL1W7s=";
   };
 
   propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri ppx_sexp_conv ];

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -6,7 +6,6 @@
 buildDunePackage {
   pname = "conduit-lwt-unix";
   inherit (conduit-lwt) version src;
-  duneVersion = "3";
 
   buildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -3,7 +3,6 @@
 buildDunePackage {
   pname = "conduit-lwt";
   inherit (conduit) version src;
-  duneVersion = "3";
 
   buildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/conduit/mirage.nix
+++ b/pkgs/development/ocaml-modules/conduit/mirage.nix
@@ -1,5 +1,4 @@
 { buildDunePackage, conduit-lwt
-, fetchpatch
 , ppx_sexp_conv, sexplib, uri, cstruct, mirage-flow
 , mirage-flow-combinators, mirage-random, mirage-time, mirage-clock
 , dns-client-mirage, vchan, xenstore, tls, tls-mirage, ipaddr, ipaddr-sexp
@@ -10,12 +9,6 @@ buildDunePackage {
   pname = "conduit-mirage";
 
   inherit (conduit-lwt) version src;
-
-  # Compatibility with tls ≥ 0.17
-  patches = fetchpatch {
-    url = "https://github.com/mirage/ocaml-conduit/commit/403b4cec528dae71aded311215868a35c11dad7e.patch";
-    hash = "sha256-R/iuLf2PSrx8mLKLueMA3+zr9sB8dX/3evjUbfQECBk=";
-  };
 
   nativeBuildInputs = [ ppx_sexp_conv ];
 


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/mirage/ocaml-conduit/v6.2.1/CHANGES.md

cc maintainer @alexfmpe.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
