### PR TITLE
utf8cpp: 3.2.5 -> 4.0.3

### DIFF
--- a/pkgs/development/libraries/utf8cpp/default.nix
+++ b/pkgs/development/libraries/utf8cpp/default.nix
@@ -2,25 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "utf8cpp";
-  version = "3.2.5";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "nemtrif";
     repo = "utfcpp";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-cWiGggn2GP25K/8eopvnFPq6iwcBteNI3i9Lo1Sr+ig=";
+    hash = "sha256-oUr476HMBYzX64x28Kcudw0B1BVqLUPVVdRzRe82AOc=";
   };
 
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-  ];
-
   nativeBuildInputs = [ cmake ];
-
-  # Tests fail on darwin, probably due to a bug in the test framework:
-  # https://github.com/nemtrif/utfcpp/issues/84
-  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     homepage = "https://github.com/nemtrif/utfcpp";

--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -15,7 +15,8 @@ let
   mkAntlr = {
     version, sourceSha256, jarSha256,
     extraCppBuildInputs ? [],
-    extraCppCmakeFlags ? []
+    extraCppCmakeFlags ? [],
+    extraPatches ? [ ]
   }: rec {
     source = fetchFromGitHub {
       owner = "antlr";
@@ -81,7 +82,8 @@ let
         pname = "antlr-runtime-cpp";
         inherit version;
         src = source;
-        sourceRoot = "${source.name}/runtime/Cpp";
+
+        patches = extraPatches;
 
         outputs = [ "out" "dev" "doc" ];
 
@@ -89,6 +91,8 @@ let
         buildInputs =
           lib.optional stdenv.isDarwin CoreFoundation ++
           extraCppBuildInputs;
+
+        cmakeDir = "../runtime/Cpp";
 
         cmakeFlags = extraCppCmakeFlags;
 
@@ -162,6 +166,12 @@ in {
     jarSha256 = "0dnz2x54kigc58bxnynjhmr5iq49f938vj6p50gdir1xdna41kdg";
     extraCppBuildInputs = [ utf8cpp ]
       ++ lib.optional stdenv.isLinux libuuid;
+    extraCppCmakeFlags = [
+      "-DCMAKE_CXX_FLAGS='-I${lib.getDev utf8cpp}/include/utf8cpp'"
+    ];
+    extraPatches = [
+      ./utf8cpp.patch
+    ];
   }).antlr;
 
   antlr4_8 = (mkAntlr {

--- a/pkgs/development/tools/parsing/antlr/utf8cpp.patch
+++ b/pkgs/development/tools/parsing/antlr/utf8cpp.patch
@@ -1,0 +1,15 @@
+diff --git a/runtime/Cpp/runtime/CMakeLists.txt b/runtime/Cpp/runtime/CMakeLists.txt
+index c8b16c6cf..e8da7960d 100644
+--- a/runtime/Cpp/runtime/CMakeLists.txt
++++ b/runtime/Cpp/runtime/CMakeLists.txt
+@@ -40,8 +40,8 @@ find_package(utf8cpp QUIET)
+ set(INSTALL_utf8cpp FALSE)
+ 
+ if (utf8cpp_FOUND)
+-  target_link_libraries(antlr4_shared utf8cpp)
+-  target_link_libraries(antlr4_static utf8cpp)
++  target_link_libraries(antlr4_shared utf8cpp::utf8cpp)
++  target_link_libraries(antlr4_static utf8cpp::utf8cpp)
+ else()
+ 
+   # older utf8cpp doesn't define the package above

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -26,7 +26,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-sLNO4vkmlirsqJmCV9YWpyNnIiigU1KMls7rOgWgSmQ=";
   };
-  sourceRoot = "${src.name}/desktop_version";
+
+  patches = [
+    ./utf8cpp.patch
+  ];
+
   dataZip = fetchurl {
     url = "https://thelettervsixtim.es/makeandplay/data.zip";
     name = "data.zip";
@@ -51,7 +55,12 @@ stdenv.mkDerivation rec {
   # Help CMake find SDL_mixer.h
   env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2_mixer}/include/SDL2";
 
-  cmakeFlags = [ "-DBUNDLE_DEPENDENCIES=OFF" ] ++ lib.optional makeAndPlay "-DMAKEANDPLAY=ON";
+  cmakeDir = "../desktop_version";
+
+  cmakeFlags = [
+    "-DBUNDLE_DEPENDENCIES=OFF"
+    "-DCMAKE_CXX_FLAGS='-I${lib.getDev utf8cpp}/include/utf8cpp'"
+  ] ++ lib.optional makeAndPlay "-DMAKEANDPLAY=ON";
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/games/vvvvvv/utf8cpp.patch
+++ b/pkgs/games/vvvvvv/utf8cpp.patch
@@ -1,0 +1,13 @@
+diff --git a/desktop_version/CMakeLists.txt b/desktop_version/CMakeLists.txt
+index 7405c122..68ba40e3 100644
+--- a/desktop_version/CMakeLists.txt
++++ b/desktop_version/CMakeLists.txt
+@@ -296,7 +296,7 @@ if(BUNDLE_DEPENDENCIES)
+ else()
+ 	find_package(utf8cpp CONFIG)
+ 
+-	target_link_libraries(VVVVVV physfs tinyxml2 utf8cpp lodepng-static)
++	target_link_libraries(VVVVVV physfs tinyxml2 utf8cpp::utf8cpp lodepng-static)
+ endif()
+ 
+ # SDL2 Dependency (Detection pulled from FAudio)


### PR DESCRIPTION
## Description of changes

Closes #269374
Closes #262908

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
