### PR TITLE
adrgen: 0.4.0-beta -> 0.4.1-beta

### DIFF
--- a/pkgs/tools/misc/adrgen/default.nix
+++ b/pkgs/tools/misc/adrgen/default.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , testers
 , adrgen
+, installShellFiles
 }:
 
 buildGoModule rec {
@@ -17,6 +18,9 @@ buildGoModule rec {
     hash = "sha256-9EiJe5shhwbjLIvUQMUTSGTgCA+r3RdkLkPRPoWvZ3g=";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
+
+
   vendorHash = "sha256-RXwwv3Q/kQ6FondpiUm5XZogAVK2aaVmKu4hfr+AnAM=";
 
   ldflags = [ "-s" "-w" ];
@@ -26,6 +30,13 @@ buildGoModule rec {
     command = "adrgen version";
     version = "v${version}";
   };
+
+  postInstall = ''
+    installShellCompletion --cmd adrgen \
+      --bash <($out/bin/adrgen completion bash) \
+      --fish <($out/bin/adrgen completion fish) \
+      --zsh <($out/bin/adrgen completion zsh)
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/asiermarques/adrgen";

--- a/pkgs/tools/misc/adrgen/default.nix
+++ b/pkgs/tools/misc/adrgen/default.nix
@@ -8,25 +8,18 @@
 
 buildGoModule rec {
   pname = "adrgen";
-  version = "0.4.0-beta";
+  version = "0.4.1-beta";
 
   src = fetchFromGitHub {
     owner = "asiermarques";
     repo = "adrgen";
     rev = "v${version}";
-    hash = "sha256-2ZE/orsfwL59Io09c4yfXt2enVmpSM/QHlUMgyd9RYQ=";
+    hash = "sha256-9EiJe5shhwbjLIvUQMUTSGTgCA+r3RdkLkPRPoWvZ3g=";
   };
 
-  patches = [
-    # https://github.com/asiermarques/adrgen/pull/14
-    (fetchpatch {
-      name = "update-x-sys-for-go-1.18-on-aarch64-darwin.patch";
-      url = "https://github.com/asiermarques/adrgen/commit/485dc383106467d1029ee6d92c9bcbc3c2281626.patch";
-      hash = "sha256-38ktHrRgW5ysQmafvFthNtkZ6nnM61z4yEA7wUGmWb4=";
-    })
-  ];
-
   vendorHash = "sha256-RXwwv3Q/kQ6FondpiUm5XZogAVK2aaVmKu4hfr+AnAM=";
+
+  ldflags = [ "-s" "-w" ];
 
   passthru.tests.version = testers.testVersion {
     package = adrgen;


### PR DESCRIPTION
## Description of changes

Update adrgen to remove necessity for macos patch 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

cc @ivarmedi 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
