### PR TITLE
graplang: init at 1.46

### DIFF
--- a/pkgs/by-name/gr/graplang/package.nix
+++ b/pkgs/by-name/gr/graplang/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchurl
+, flex
+, bison
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "graplang";
+  version = "1.46";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchurl {
+    url = "https://www.lunabase.org/~faber/Vault/software/grap/grap-${finalAttrs.version}.tar.gz";
+    hash = "sha512-7n+jLANU/x+wGrpjwYAnf45fQ5M91SwraiCbvUKe6XhWtilhGoT2yTlLkPlTihETTkizLyssW5gj5gbwNHaooA==";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+
+  meta = with lib; {
+    description = "Language for typesetting graphs";
+    longDescription = ''
+      Grap is an Expressive language for describing graphs and incorporating
+      them in typeset documents.  It is implemented as a preprocessor to
+      Kernigan's pic language for describing languages, so any system that can
+      use pic can use grap. For sure, TeX and groff can use it.
+    '';
+    homepage = "https://www.lunabase.org/~faber/Vault/software/grap/";
+    changelog = "https://github.com/snorerot13/grap/blob/master/CHANGES";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ afh ];
+    mainProgram = "grap";
+  };
+})


### PR DESCRIPTION
This is an implementation of Grap the language for describing graphs as first implemented by Brian Kernighan and Jon Bentley at Bell Labs.

The output of grap can further be processed with pic and groff or TeX.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
