### PR TITLE
nixos/guix: fix user activation script

### DIFF
--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -265,7 +265,7 @@ in
         linkProfileToPath = acc: profile: location: let
           guixProfile = "${cfg.stateDir}/guix/profiles/per-user/\${USER}/${profile}";
           in acc + ''
-            [ -d "${guixProfile}" ] && ln -sf "${guixProfile}" "${location}"
+            [ -d "${guixProfile}" ] && [ -L "${location}" ] || ln -sf "${guixProfile}" "${location}"
           '';
 
         activationScript = lib.foldlAttrs linkProfileToPath "" guixUserProfiles;


### PR DESCRIPTION
## Description of changes

Can't believe I missed this but better to fix this now than later. This should fix errors for linking different profiles once they're setup properly like what is shown with the following error.

```Console
❯ bash -x /nix/store/v65pmjnz507rbrqaxkh3l25x2d039vkn-unit-script-nixos-activation-start/bin/nixos-activation-start
+ set -e
+ unset PATH
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/sbin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/bin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/sbin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/bin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/sbin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/bin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/sbin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/bin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/sbin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/bin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/sbin:/nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1/bin:/nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/sbin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/bin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/sbin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/bin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/sbin:/nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1/bin:/nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1/sbin:/nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10/bin:/nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10/sbin
+ for i in /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3 /nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11 /nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0 /nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27 /nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin /nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1 /nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10 /nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin
+ PATH=:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/sbin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/sbin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/sbin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/bin:/nix/store/gwsk1v8pkyd8ds1gpjhv6wl95rcxfpwd-getent-glibc-2.38-27/sbin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/bin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/sbin:/nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1/bin:/nix/store/9gp61969lhj6flfyrbhfxmf4mgnxlbcf-shadow-4.14.1/sbin:/nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10/bin:/nix/store/5xjkyf24mb3pk3xkglxzqyww601d1lgk-net-tools-2.10/sbin:/nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin/bin:/nix/store/wijccjzl2g8knym08ixzbhqp06p8d2ck-util-linux-2.39.2-bin/sbin
+ _status=0
+ trap '_status=1 _localstatus=$?' ERR
+ _localstatus=0
+ XDG_CONFIG_HOME=/home/foo-dogsquared/.config
+ '[' -d /var/guix/profiles/per-user/foo-dogsquared/current-guix ']'
+ ln -sf /var/guix/profiles/per-user/foo-dogsquared/current-guix /home/foo-dogsquared/.config/guix/current
ln: failed to create symbolic link '/home/foo-dogsquared/.config/guix/current/current-guix': Read-only file system
++ _status=1
++ _localstatus=1
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
