### PR TITLE
maubot: wrapper generation typo

### DIFF
--- a/pkgs/tools/networking/maubot/wrapper.nix
+++ b/pkgs/tools/networking/maubot/wrapper.nix
@@ -39,7 +39,7 @@ let wrapper = { pythonPackages ? (_: [ ]), plugins ? (_: [ ]), baseConfig ? null
             if builtins.isNull (baseConfig.server.override_resource_path or null)
             then "${unwrapped}/${python3.sitePackages}/maubot/management/frontend/build"
             else baseConfig.server.override_resource_path;
-        })})} $out/${python3.sitePackages}/maubot/example-config.yaml
+        })} $out/${python3.sitePackages}/maubot/example-config.yaml
         rm -rf $out/bin
       ''}
       mkdir -p $out/bin


### PR DESCRIPTION
## Description of changes

The plugin wrapper script seems to be generating invalid code when the module is invoked. 

For example:
```
  services.maubot = {
    enable = true;
    plugins = config.services.maubot.package.plugins.allOfficialPlugins;
    settings = {
<snip>
    };
  };
```
This fails on my system with
``` 
nix log '/nix/store/n4s92jlf7lsk78k961578sgyflfhym0l-maubot-with-plugins-0.4.2.drv^*'
/nix/store/dh5xj3wxhgcsw07c0lymrkv549qkc4nl-xyz.maubot.gitlab-0.2.1/nix-support:
propagated-build-inputs: /nix/store/9l3iwp472dgg296hrb287ka1l54bk4ij-python3.11-maubot-0.4.2/nix-support/propagated-build-inputs
/nix/store/jphjhav5va5xlfznm34by7d9fjqmljnn-xyz.maubot.reminder-0.2.2/nix-support:
propagated-build-inputs: /nix/store/9l3iwp472dgg296hrb287ka1l54bk4ij-python3.11-maubot-0.4.2/nix-support/propagated-build-inputs
/nix/store/40p33zfq5wb7aqf79dsrcf91i8d8cfhz-xyz.maubot.rss-0.3.2/nix-support:
propagated-build-inputs: /nix/store/9l3iwp472dgg296hrb287ka1l54bk4ij-python3.11-maubot-0.4.2/nix-support/propagated-build-inputs
/nix/store/hlj5vxp6h225ijvhhl845qwsrh7l6j4q-xyz.maubot.satwcomic-1.0.0/nix-support:
propagated-build-inputs: /nix/store/9l3iwp472dgg296hrb287ka1l54bk4ij-python3.11-maubot-0.4.2/nix-support/propagated-build-inputs
/nix/store/xlhp4vh70l4jpdig9ap1h9rxi3mjvq73-xyz.maubot.tex-0.1.0/nix-support:
propagated-build-inputs: /nix/store/9l3iwp472dgg296hrb287ka1l54bk4ij-python3.11-maubot-0.4.2/nix-support/propagated-build-inputs
/nix/store/qsyl4lbv83lr5pcnp84r50k39j664x8y-xyz.maubot.xkcd-1.2.0/nix-support:
propagated-build-inputs: /nix/store/9l3iwp472dgg296hrb287ka1l54bk4ij-python3.11-maubot-0.4.2/nix-support/propagated-build-inputs
/build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 8: syntax error near unexpected token `)'
```
and this is line 8:
```
substituteAll /nix/store/1qlwba4i8kn3lvwgd7cy4sjxgpw3xwnl-example-config.yaml)} $out/lib/python3.11/site-packages/maubot/example-config.yaml
```
I pulled the extra braces and parens and it's working now for me.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
