### PR TITLE
uptrace: init at 1.6.0-rc.3

### DIFF
--- a/pkgs/servers/monitoring/uptrace/common.nix
+++ b/pkgs/servers/monitoring/uptrace/common.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub }: rec {
+  name = "uptrace";
+  version = "1.6.0-rc.3";
+
+  src = (fetchFromGitHub {
+    owner = name;
+    repo = name;
+    rev = "v${version}";
+    hash = "sha256-f9Mu/DhcfuZwY4xtdc09zYwHOUoKlPrZckFr7p3b4m8=";
+    fetchSubmodules = true;
+  }).overrideAttrs (_: {
+    GIT_CONFIG_COUNT = 1;
+    GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+    GIT_CONFIG_VALUE_0 = "git@github.com:";
+  });
+
+  pnpmHash = "sha256-x46wV/hbwC8YRQKJZVJ22Mec/6z7Av93jLMTjzntLZg=";
+  vendorHash = "sha256-/3GYxVrJ7F3AN2lGtyh/DZo71R3hd0s3ALm1NTRnStM=";
+
+  meta = with lib; {
+    homepage = "https://uptrace.dev/";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ fionera ];
+  };
+}

--- a/pkgs/servers/monitoring/uptrace/default.nix
+++ b/pkgs/servers/monitoring/uptrace/default.nix
@@ -1,0 +1,29 @@
+{ callPackage, buildGoModule, fetchFromGitHub, lib }:
+let
+  common = callPackage ./common.nix { };
+  frontend = callPackage ./frontend.nix { };
+in
+buildGoModule {
+  pname = common.name;
+
+  inherit (common) src version vendorHash;
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    cp -R ${frontend}/ vue/dist
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/uptrace/uptrace/pkg/internal/version.Version=${common.version}"
+  ];
+
+  subPackages = [
+    "cmd/uptrace"
+  ];
+
+  meta = common.meta // {
+    description = "Open source APM: OpenTelemetry traces, metrics, and logs";
+  };
+}

--- a/pkgs/servers/monitoring/uptrace/frontend.nix
+++ b/pkgs/servers/monitoring/uptrace/frontend.nix
@@ -1,0 +1,78 @@
+{ stdenvNoCC, callPackage, nodejs, jq, moreutils, nodePackages, cacert }:
+let
+  common = callPackage ./common.nix { };
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "${common.name}-frontend";
+  inherit (common) src version;
+
+  sourceRoot = "source/vue";
+
+  pnpm-deps = stdenvNoCC.mkDerivation {
+    pname = "${pname}-pnpm-deps";
+    inherit (common) src version;
+
+    sourceRoot = "source/vue";
+
+    nativeBuildInputs = [
+      jq
+      moreutils
+      nodePackages.pnpm
+      cacert
+    ];
+
+    installPhase = ''
+      export HOME=$(mktemp -d)
+      pnpm config set store-dir $out
+      pnpm install --ignore-scripts
+
+      # Remove timestamp and sort the json files
+      rm -rf $out/v3/tmp
+      for f in $(find $out -name "*.json"); do
+        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
+        jq --sort-keys . $f | sponge $f
+      done
+    '';
+
+    dontFixup = true;
+    outputHashMode = "recursive";
+    outputHash = common.pnpmHash;
+  };
+
+
+  nativeBuildInputs = [
+    nodePackages.pnpm
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    pnpm config set store-dir ${pnpm-deps}
+    pnpm install --ignore-scripts --offline
+    chmod -R +w node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm rebuild
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -R ../vue/dist $out
+
+    runHook postInstall
+  '';
+
+  meta = common.meta // {
+    description = "Uptrace frontend";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14787,6 +14787,8 @@ with pkgs;
 
   uptime-kuma = callPackage ../servers/monitoring/uptime-kuma { };
 
+  uptrace = callPackage ../servers/monitoring/uptrace { };
+
   vul = callPackage ../applications/misc/vul { };
 
   xar = callPackage ../tools/compression/xar { };


### PR DESCRIPTION
## Description of changes
Uptrace is an [open source APM](https://uptrace.dev/get/open-source-apm.html) that supports distributed tracing, metrics, and logs. You can use it to monitor applications and troubleshoot issues.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
