### PR TITLE
xen-guest-agent: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11299,6 +11299,12 @@
     githubId = 585424;
     name = "Massimo Gengarelli";
   };
+  matdibu = {
+    email = "contact@mateidibu.dev";
+    github = "matdibu";
+    githubId = 24750154;
+    name = "Matei Dibu";
+  };
   matejc = {
     email = "cotman.matej@gmail.com";
     github = "matejc";

--- a/pkgs/tools/virtualization/xen-guest-agent/default.nix
+++ b/pkgs/tools/virtualization/xen-guest-agent/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitLab,
+  rustPlatform,
+  llvmPackages,
+  xen-light,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "xen-guest-agent";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    owner = "xen-project";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Csio24ofj+p0j/R0av/28P/KCNXhmcF+r8xGJEfoHjQ=";
+  };
+
+  cargoHash = "sha256-XWDDzSu88zCIwMuvkFjCb98DzXHvW2IP9u3EbpAMIgw=";
+
+  env = {
+    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${xen-light}/include";
+    RUSTFLAGS = "-L ${xen-light}/lib";
+  };
+
+  nativeBuildInputs = [llvmPackages.clang xen-light];
+
+  postFixup = ''
+    patchelf $out/bin/xen-guest-agent --add-rpath ${xen-light}/lib
+  '';
+
+  meta = with lib; {
+    description = "Xen agent running in Linux/BSDs (POSIX) VMs";
+    homepage = "https://gitlab.com/xen-project/xen-guest-agent";
+    license = licenses.agpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [matdibu];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15052,6 +15052,8 @@ with pkgs;
 
   xe-guest-utilities = callPackage ../tools/virtualization/xe-guest-utilities { };
 
+  xen-guest-agent = callPackage ../tools/virtualization/xen-guest-agent { };
+
   xflux = callPackage ../tools/misc/xflux { };
   xflux-gui = python3Packages.callPackage ../tools/misc/xflux/gui.nix { };
 


### PR DESCRIPTION
## Description of changes

New upstream project aimed at replacing xe-guest-utilities.

Homepage: https://gitlab.com/xen-project/xen-guest-agent

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
