### PR TITLE
python311Packages.fhir-py: init at 1.4.2

### DIFF
--- a/pkgs/development/python-modules/fhir-py/default.nix
+++ b/pkgs/development/python-modules/fhir-py/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, flit-core
+, aiohttp
+, pytz
+, requests
+, pytestCheckHook
+, pytest-asyncio
+, responses
+}:
+
+buildPythonPackage rec {
+  pname = "fhir-py";
+  version = "1.4.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "beda-software";
+    repo = "fhir-py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-kYqoRso1ypN5novRxMMzz1h2NGNybbw5lK4+HErG79I=";
+  };
+
+  preBuild = ''
+    substituteInPlace pyproject.toml  \
+      --replace "--cov=fhirpy" ""  \
+      --replace "--cov-report=xml" ""
+  '';
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    pytz
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    responses
+  ];
+
+  # sync/async test cases require docker-compose to set up services, so disable:
+  disabledTestPaths = [ "tests/test_lib_sync.py" ];
+  disabledTests = [ "TestLibAsyncCase" ];
+
+  pythonImportsCheck = [ "fhirpy" ];
+
+  meta = with lib; {
+    description = "Async/sync API for FHIR resources";
+    homepage = "https://github.com/beda-software/fhir-py";
+    changelog = "https://github.com/beda-software/fhir-py/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3930,6 +3930,8 @@ self: super: with self; {
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
+  fhir-py = callPackage ../development/python-modules/fhir-py { };
+
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };
 
   fido2 = callPackage ../development/python-modules/fido2 { };


### PR DESCRIPTION
## Description of changes

Add fhir-py, a FHIR client API for medical informatics.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [NA] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
