### PR TITLE
sonobuoy: 0.56.14 -> 0.57.1

### DIFF
--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
 # SHA of ${version} for the tool's help output. Unfortunately this is needed in build flags.
-let rev = "bd5465d6b2b2b92b517f4c6074008d22338ff509";
+let rev = "6dffe7abf704a808b85f57c9f773ea23b1175b47";
 in
 buildGoModule rec {
   pname = "sonobuoy";
-  version = "0.56.14"; # Do not forget to update `rev` above
+  version = "0.56.17"; # Do not forget to update `rev` above
 
   ldflags =
     let t = "github.com/vmware-tanzu/sonobuoy";
@@ -20,10 +20,10 @@ buildGoModule rec {
     owner = "vmware-tanzu";
     repo = "sonobuoy";
     rev = "v${version}";
-    sha256 = "sha256-YiVCdAdwdK9PcQ6VQQNAjLQq2X54vJmZfbHRjV2d8VQ=";
+    hash = "sha256-m+kUd5q53X9hlr97SAPzkuOQQDoaJzLQPSIqwAzSCHk=";
   };
 
-  vendorHash = "sha256-Fqxkyl9AKZ7H4QSp2V/yztpeXHt57+LjpzzGtOPndX0=";
+  vendorHash = "sha256-f/Qv+j58oisaOs4HJQh7rIslds6Ic2w3DJB+nHdIgFo=";
 
   subPackages = [ "." ];
 

--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
 # SHA of ${version} for the tool's help output. Unfortunately this is needed in build flags.
-let rev = "6dffe7abf704a808b85f57c9f773ea23b1175b47";
+let rev = "6f9e27f1795f10475c9f6f5decdff692e1e228da";
 in
 buildGoModule rec {
   pname = "sonobuoy";
-  version = "0.56.17"; # Do not forget to update `rev` above
+  version = "0.57.1"; # Do not forget to update `rev` above
 
   ldflags =
     let t = "github.com/vmware-tanzu/sonobuoy";
@@ -20,10 +20,10 @@ buildGoModule rec {
     owner = "vmware-tanzu";
     repo = "sonobuoy";
     rev = "v${version}";
-    hash = "sha256-m+kUd5q53X9hlr97SAPzkuOQQDoaJzLQPSIqwAzSCHk=";
+    hash = "sha256-e9C5ZwKqT3Fiko2HqrIpONVvjhT8KBBO7rQc3BJhl+A=";
   };
 
-  vendorHash = "sha256-f/Qv+j58oisaOs4HJQh7rIslds6Ic2w3DJB+nHdIgFo=";
+  vendorHash = "sha256-HE53eIEyhOI9ksEx1EKmv/txaTa7KDrNUMEVRMi4Wuo=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
## Description of changes

https://github.com/vmware-tanzu/sonobuoy/compare/v0.56.14...v0.56.17
https://github.com/vmware-tanzu/sonobuoy/compare/v0.56.17...v0.57.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
