### PR TITLE
obsidian-export: init at 23.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14777,6 +14777,12 @@
     githubId = 18549627;
     name = "Proglodyte";
   };
+  programmerino = {
+    email = "davis.davalos.delosh@gmail.com";
+    github = "Programmerino";
+    githubId = 17630263;
+    name = "Davis Davalos-DeLosh";
+  };
   progval = {
     email = "progval+nix@progval.net";
     github = "progval";

--- a/pkgs/by-name/ob/obsidian-export/package.nix
+++ b/pkgs/by-name/ob/obsidian-export/package.nix
@@ -16,8 +16,10 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Rust library and CLI to export an Obsidian vault to regular Markdown";
     homepage = "https://github.com/zoni/${pname}";
+    changelog = "https://github.com/zoni/obsidian-export/blob/main/CHANGELOG.md";
     license = licenses.bsd2Patent;
     platforms = platforms.linux;
     maintainers = with maintainers; [ programmerino ];
+    mainProgram = "obsidian-export";
   };
 }

--- a/pkgs/by-name/ob/obsidian-export/package.nix
+++ b/pkgs/by-name/ob/obsidian-export/package.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "obsidian-export";
+  version = "23.12.0";
+
+  src = fetchFromGitHub {
+    owner = "zoni";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-r5G2XVV2F/Bt29gxuTZKX+KxH6RFa1hJNH3gSTi7yCU=";
+  };
+
+  cargoSha256 = "sha256-lkqoMFasHpfhmVd3dlYd/TKIBIDzqMbsxfigpeJq0w8=";
+
+  meta = with lib; {
+    description = "Rust library and CLI to export an Obsidian vault to regular Markdown";
+    homepage = "https://github.com/zoni/${pname}";
+    license = licenses.bsd2Patent;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ programmerino ];
+  };
+}


### PR DESCRIPTION
## Description of changes

* Add [obsidian-export](https://github.com/zoni/obsidian-export) @ [v23.12.0](https://github.com/zoni/obsidian-export/releases/tag/v23.12.0) (latest)
* Add myself as a maintainer

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
