### PR TITLE
Introduce devtools 3.1.3 bsdmake

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -323,4 +323,16 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     # TODO(matthewbauer):
     # To be removed, once I figure out how to build a newer Security version.
     Security        = applePackage "Security/boot.nix" "osx-10.9.5"      "sha256-7qr0IamjCXCobIJ6V9KtvbMBkJDfRCy4C5eqpHJlQLI=" {};
+
+    # To enable splitting up the SDK bump into reviewable chunks before
+    # switching to it wholesale.
+    "10.13.6" = let applePackageMapping = namePath: version: sdkName: sha256:
+                      applePackage' ( { }."${namePath}"
+                                      or namePath
+                                    )
+                                    version
+                                    sdkName
+                                    sha256;
+                 in import ./macos-10.13.6.nix
+                      { applePackage' = applePackageMapping; };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -334,5 +334,10 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
                                      # rather than previous versions.
                       { }."${namePath}" or namePath;
                  in import ./macos-10.13.6.nix
-                      { applePackage' = applePackageMapping; };
+                      { applePackage' = applePackageMapping; }
+                 // { bsdmake = applePackageMapping
+                        "bsdmake" "24" "developer-tools-313"
+                        "sha256-CW8zP5QZMhWTGp+rhrm8oHE/vSLsRlv1VRAGe1OUDmI="
+                        {};
+                    };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -221,13 +221,16 @@ let
   macosPackages_11_0_1 = import ./macos-11.0.1.nix { inherit applePackage'; };
   developerToolsPackages_11_3_1 = import ./developer-tools-11.3.1.nix { inherit applePackage'; };
 
-  applePackage' = namePath: version: sdkName: sha256:
+  applePackage'' = extra: namePath: version: sdkName: sha256:
     let
       pname = builtins.head (lib.splitString "/" namePath);
       appleDerivation' = stdenv: appleDerivation'' stdenv pname version sdkName sha256;
       appleDerivation = appleDerivation' stdenv;
-      callPackage = self.newScope { inherit appleDerivation' appleDerivation; };
+      callPackage = self.newScope
+        ({ inherit appleDerivation' appleDerivation; } // extra);
     in callPackage (./. + "/${namePath}");
+
+  applePackage' = applePackage'' {};
 
   applePackage = namePath: sdkName: sha256: let
     pname = builtins.head (lib.splitString "/" namePath);
@@ -326,13 +329,10 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
 
     # To enable splitting up the SDK bump into reviewable chunks before
     # switching to it wholesale.
-    "10.13.6" = let applePackageMapping = namePath: version: sdkName: sha256:
-                      applePackage' ( { }."${namePath}"
-                                      or namePath
-                                    )
-                                    version
-                                    sdkName
-                                    sha256;
+    "10.13.6" = let applePackageMapping = namePath: applePackage''
+                      self."10.13.6" # Have packages depend on each other
+                                     # rather than previous versions.
+                      { }."${namePath}" or namePath;
                  in import ./macos-10.13.6.nix
                       { applePackage' = applePackageMapping; };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/macos-10.13.6.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/macos-10.13.6.nix
@@ -1,0 +1,48 @@
+# Generated using:  ./generate-sdk-packages.sh macos 10.13.6
+
+{ applePackage' }:
+
+{
+CommonCrypto = applePackage' "CommonCrypto" "60118.50.1" "macos-10.13.6" "1sjqa60zhchh0y5rbn9a2cbs07rw3hyvk3xqf44h48c4xpididdf" {};
+Csu = applePackage' "Csu" "85" "macos-10.13.6" "1ipas2j3250lykbppnlbpp4a2dayh413x06m51qy2m840fqvz9l7" {};
+ICU = applePackage' "ICU" "59180.0.1" "macos-10.13.6" "0c51440nfbp4fawvyzzikk7qjjcx2yvjrjghg6dqb4sy6bnb000s" {};
+Libc = applePackage' "Libc" "1244.50.9" "macos-10.13.6" "1y4r1bgs54y5ni31nwpx2n38sv1rx1g3izmjpzy6rbg21vb0jsbq" {};
+Libinfo = applePackage' "Libinfo" "517.30.1" "macos-10.13.6" "1jk9rp3sm3ij9avbkryaq9cv355dg9sf9q9wbl5l5jhgyf4azn6v" {};
+Libnotify = applePackage' "Libnotify" "172" "macos-10.13.6" "0xpqqa88nfnsccpd2imfwqa75cbga4m3l1z68sbxa5a3b5qrs2ap" {};
+Librpcsvc = applePackage' "Librpcsvc" "26" "macos-10.13.6" "0wf6srbw28664wa0dckldbhrl9ydg70fms06rj6i7mvlrz1ccxk0" {};
+Libsystem = applePackage' "Libsystem" "1252.50.4" "macos-10.13.6" "0nd5smcbakqpx1288qhsn0lglgs4klw3sp4q25gvvp1zf423k4c2" {};
+PowerManagement = applePackage' "PowerManagement" "703.71.1" "macos-10.13.6" "1naf1wfc8cakaifi9c5gf7g5wzdhppwcygybr2isr4jrp3chzzgx" {};
+Security = applePackage' "Security" "58286.70.7" "macos-10.13.6" "1xmh33z9glrcak15dqf5bnmnlyklfy069kc42dms02hxhx7c6jx0" {};
+adv_cmds = applePackage' "adv_cmds" "172" "macos-10.13.6" "1kxxwa5ix5fkncxl631skg42x2q3j9fpp8j68q5m5fwmm159dxax" {};
+architecture = applePackage' "architecture" "268" "macos-10.13.6" "0ln1byjjmsbvs6vbz6rszx1bj7mdxky7bj0i950hqf563qrrwhki" {};
+basic_cmds = applePackage' "basic_cmds" "55" "macos-10.13.6" "1913pzk376zfap2fwmrb233rkn4h4l2c65nd7s8ixvrz1r7cz0q5" {};
+bootstrap_cmds = applePackage' "bootstrap_cmds" "98" "macos-10.13.6" "18jwla9i4c94zdxddwzfrg7xmjh4kjc6q5gg0jbx0sjk7qx1mzsp" {};
+configd = applePackage' "configd" "963.50.8" "macos-10.13.6" "18bfmylqpff3f2davs1g5a9ciawigysrx9pjvrzcrc4b751aqimn" {};
+copyfile = applePackage' "copyfile" "146.50.5" "macos-10.13.6" "04hf4k04c1xzglnq2xjn091r57wy1xcqghb31b8hch58vdi704n2" {};
+diskdev_cmds = applePackage' "diskdev_cmds" "593" "macos-10.13.6" "0x635rfqnk2z3ncd79spskpk2xikwn1rc2qw28yf1169krqs2zsm" {};
+dtrace = applePackage' "dtrace" "262.50.12" "macos-10.13.6" "0f51hb5m2rx1nxk2wimdkg5d1z946r3g6r5kwv96sclhk1k9dd0q" {};
+dyld = applePackage' "dyld" "551.4" "macos-10.13.6" "1ckfar82r2p6zk2836h8jrpv4i82fm8dcqq9n9kjaqda4rfnv8k4" {};
+eap8021x = applePackage' "eap8021x" "264.50.5" "macos-10.13.6" "1129zmk4a9pzmi2bcfi43ngv34znnb4xiwxv8xdm6r7ixhd7h9v5" {};
+file_cmds = applePackage' "file_cmds" "272" "macos-10.13.6" "1h5kk4awv4sflqjkc2vzv8sj7pnzw6c7csh0jag54d4anciz4560" {};
+hfs = applePackage' "hfs" "407.50.6" "macos-10.13.6" "16q21q1s29b1gwqbzv807bgx2m514d934w9qwvc6dhg893kqj35f" {};
+libauto = applePackage' "libauto" "187" "macos-10.13.6" "1k7wb5283mll2gqf2a7frf66hykhnazwlxy3sncpd2nqyb77jjrz" {};
+libclosure = applePackage' "libclosure" "67" "macos-10.13.6" "1l7s19lnr05b2pmn5scrafp759d20dr8h050a1hihwbwz6hg0yk9" {};
+libdispatch = applePackage' "libdispatch" "913.60.2" "macos-10.13.6" "0hdg6jmx7rwqgnhby8d6hn5xvrfi0r1dk7mysp62x1m1xcfqd25z" {};
+libiconv = applePackage' "libiconv" "51.50.1" "macos-10.13.6" "0mp2ixkvda7d10q740rqxfghag36s60yiid93zgblg8nwjbjaa70" {};
+libmalloc = applePackage' "libmalloc" "140.50.6" "macos-10.13.6" "125gqbkhrghkm41hj3pjdxksgj4yxmlpg407g6hnphzgin5ixzhk" {};
+libplatform = applePackage' "libplatform" "161.50.1" "macos-10.13.6" "0pwaib4l0kngq36r43zkmw3rcvsvyj88phfgvqn0krxlq4f722lx" {};
+libpthread = applePackage' "libpthread" "301.50.1" "macos-10.13.6" "04swggjnysp6wbhfkzdwh3cafklzpmmp5r5mc8gnicbnqqh5n2hl" {};
+libresolv = applePackage' "libresolv" "65" "macos-10.13.6" "1grdd9ywzjl78mgv53l3ymsw194j8mvmx9azfj7m93dzpm9r73jj" {};
+libunwind = applePackage' "libunwind" "35.3" "macos-10.13.6" "1qdad3x35mn907fhxqqmbr4w1q4fvzzdwvnnvlgad67zsffjqb88" {};
+libutil = applePackage' "libutil" "51.20.1" "macos-10.13.6" "0r8zfpqmw5bllysz0s27w22sf2wrvskffbx332zrkmsklangycrs" {};
+mDNSResponder = applePackage' "mDNSResponder" "878.70.2" "macos-10.13.6" "0glgv8735pjmihzyssqq5313zsh9b9higb0dsnd6mwkfq7zvbdky" {};
+network_cmds = applePackage' "network_cmds" "543.50.4" "macos-10.13.6" "1zxiy7syy06qzlr4zzii5hmni4hna9337hricp2dqhiy04z4nvsq" {};
+objc4 = applePackage' "objc4" "723" "macos-10.13.6" "18chzg9ykmby6qrn6w4h2sjys6n8rf7v69lwinqzhhjy7cvylyww" {};
+ppp = applePackage' "ppp" "847" "macos-10.13.6" "1hr7p7h3kqfckm6laxifcvp52hwcs95kycavqbq2pikk4rq27vv3" {};
+removefile = applePackage' "removefile" "45" "macos-10.13.6" "1lwb50kciq9j20cr1pdsspyg6cpnai95jmsnndn7cph6p7dn94sj" {};
+shell_cmds = applePackage' "shell_cmds" "203" "macos-10.13.6" "00c001sq5npqmnac0x2z3v8fi8h5l3i2i8rjdpz1mb5k863i5x1k" {};
+system_cmds = applePackage' "system_cmds" "790.50.6" "macos-10.13.6" "0fc9hahfgsqa63s8ppbikx44qv3dsrr5lvz2pxk65mjrym208zmg" {};
+text_cmds = applePackage' "text_cmds" "99" "macos-10.13.6" "070gff2mq5nr848556kgvarp38rmhqxryxbymbgc6lkjnr9rn9r9" {};
+top = applePackage' "top" "111.20.1" "macos-10.13.6" "0qgr8ggf40pyq8bwrgf8p3fd5hf96p3nqfqj7zmilny46wkkhlay" {};
+xnu = applePackage' "xnu" "4570.71.2" "macos-10.13.6" "052sbbd3j0ngns9c2cg7jh8xwjrg1khlbj1vgn8ija767r6ciqmr" {};
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Current source releases get this from version 3.2.6 of the Developer Tools. However, this seems arbitrary since they were available as recent as version 4.2 and as early as version 3.1.3.

My rationale for picking the oldest available source is if we introduced it as early as that version we wouldn't have needed to ever bump it. It's also a more honest representation of how old the sources we depend on are.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
