### PR TITLE
cloud-provider-aws: init at 1.28.11

### DIFF
--- a/pkgs/by-name/cl/cloud-provider-aws/package.nix
+++ b/pkgs/by-name/cl/cloud-provider-aws/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+  ...
+}:
+buildGoModule rec {
+  pname = "cloud-provider-aws";
+  version = "1.28.11";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes";
+    repo = "cloud-provider-aws";
+    tag = "v${version}";
+    hash = "sha256-wsbhJLkJyenc59wwCy+M0cpRqarO7UxLFS6dy6FDY/A=";
+  };
+
+  subPackages = [
+    "cmd/aws-cloud-controller-manager"
+    "cmd/ecr-credential-provider"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s -w -X k8s.io/component-base/version.gitVersion=v${version} -X main.gitVersion=v${version}"
+  ];
+
+  vendorHash = "sha256-ZZ28dx5QZLU4bOOgno0bfsFooa7fR/laIomjEKShKLQ=";
+
+  doCheck = false;
+
+  meta = {
+    description = "Kubernetes tools for AWS services, such as ECR Credential Provider or EBS CSI Driver";
+    homepage = "https://github.com/kubernetes/cloud-provider-aws/";
+    changelog = "https://github.com/kubernetes/cloud-provider-aws/blob/${src.rev}/docs/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ fangpen ];
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add new package `cloud-provider-aws`:

https://github.com/kubernetes/cloud-provider-aws

That package comes with a command line tool `ecr-credential-provider` for AWS ECR docker image registry authentication if you are running a Kubernetes cluster yourself and need to pull images from there:

https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/#configure-a-kubelet-credential-provider

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
