### PR TITLE
nixos/sshServe: use bash as default shell for nix-ssh user

### DIFF
--- a/nixos/modules/services/misc/nix-ssh-serve.nix
+++ b/nixos/modules/services/misc/nix-ssh-serve.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 let cfg = config.nix.sshServe;
@@ -46,7 +46,7 @@ in {
       description = "Nix SSH store user";
       isSystemUser = true;
       group = "nix-ssh";
-      useDefaultShell = true;
+      shell = pkgs.bashInteractive;
     };
     users.groups.nix-ssh = {};
 


### PR DESCRIPTION
## Description of changes
Using the user-set default shell (which is intended for non-system users) for the nix-ssh user can lead to unpredictable behavior, such as `fish` complaining about the unwritable home directory on every connection. Bash is guaranteed to be available and work as expected, so explicitly use it instead.

Current issue, when `users.defaultUserShell = pkgs.fish;`:
```sh
> nix store ping --store 'ssh-ng://nix-ssh@host?ssh-key=nix-builder.key'
Store URL: ssh-ng://nix-ssh@host
error: can not save history
warning-path: Unable to locate data directory derived from $HOME: '/var/empty/.local/share/fish'.
warning-path: The error was 'Operation not permitted'.
warning-path: Please set $HOME to a directory where you have write access.

error: can not save universal variables or functions
warning-path: Unable to locate config directory derived from $HOME: '/var/empty/.config/fish'.
warning-path: The error was 'Operation not permitted'.
warning-path: Please set $HOME to a directory where you have write access.

Version: 2.18.1
Trusted: 1
```
Store operations don't completely fail, but do spam useless errors like this.

When only setting `users.users."nix-ssh".useDefaultShell = false;`:
```sh
> nix store ping --store 'ssh-ng://nix-ssh@host?ssh-key=nix-builder.key'
Store URL: ssh-ng://nix-ssh@host
error: cannot open connection to remote store 'ssh-ng://nix-ssh@host': error: protocol mismatch, got 'This account is currently not available.'
```

Setting `users.users."nix-ssh".shell = pkgs.bashInteractive;`:
```sh
> nix store ping --store 'ssh-ng://nix-ssh@host?ssh-key=nix-builder.key'
Store URL: ssh-ng://nix-ssh@host
Version: 2.18.1
Trusted: 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).