### PR TITLE
qmk: fixup avr CFLAGS for darwin, add smoke test

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -301,6 +301,12 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" relro bindnow"
     ''
 
+    + optionalString (libc != null && targetPlatform.isAvr) ''
+      for isa in avr5 avr3 avr4 avr6 avr25 avr31 avr35 avr51 avrxmega2 avrxmega4 avrxmega5 avrxmega6 avrxmega7 tiny-stack; do
+        echo "-L${getLib libc}/avr/lib/$isa" >> $out/nix-support/libc-cflags
+      done
+    ''
+
     + optionalString stdenv.targetPlatform.isDarwin ''
       echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/libc-ldflags
     ''

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -649,6 +649,12 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" stackprotector"
     ''
 
+    + optionalString (libc != null && targetPlatform.isAvr) ''
+      for isa in avr5 avr3 avr4 avr6 avr25 avr31 avr35 avr51 avrxmega2 avrxmega4 avrxmega5 avrxmega6 avrxmega7 tiny-stack; do
+        echo "-B${getLib libc}/avr/lib/$isa" >> $out/nix-support/libc-crt1-cflags
+      done
+    ''
+
     + optionalString stdenv.targetPlatform.isDarwin ''
         echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
     ''

--- a/pkgs/development/misc/avr/libc/default.nix
+++ b/pkgs/development/misc/avr/libc/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
 
   passthru = {
     incdir = "/avr/include";
-    libdir = "/avr/lib";
   };
 
   meta = with lib; {

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , python3
 , fetchPypi
 , pkgsCross
@@ -9,8 +10,18 @@
 , gcc-arm-embedded
 , gnumake
 , teensy-loader-cli
+, makeSetupHook
 }:
 
+let
+  setupHookDarwin = makeSetupHook {
+    name = "darwin-avr-gcc-hook";
+    substitutions = {
+      darwinSuffixSalt = stdenv.cc.suffixSalt;
+      avrSuffixSalt = pkgsCross.avr.buildPackages.gcc8.suffixSalt;
+    };
+  } ./setup-hook-darwin.sh;
+in
 python3.pkgs.buildPythonApplication rec {
   pname = "qmk";
   version = "1.1.2";
@@ -44,9 +55,10 @@ python3.pkgs.buildPythonApplication rec {
     gcc-arm-embedded
     gnumake
     pkgsCross.avr.buildPackages.binutils
-    pkgsCross.avr.buildPackages.binutils.bintools
     pkgsCross.avr.buildPackages.gcc8
     pkgsCross.avr.libcCross
+  ] ++ lib.optionals stdenv.isDarwin [
+    setupHookDarwin
   ];
 
   # no tests implemented
@@ -70,7 +82,7 @@ python3.pkgs.buildPythonApplication rec {
       - ... and many more!
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple babariviere ekleog ];
+    maintainers = with maintainers; [ bhipple babariviere ekleog emilytrau ];
     mainProgram = "qmk";
   };
 }

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -11,6 +11,7 @@
 , gnumake
 , teensy-loader-cli
 , makeSetupHook
+, callPackage
 }:
 
 let
@@ -63,6 +64,8 @@ python3.pkgs.buildPythonApplication rec {
 
   # no tests implemented
   doCheck = false;
+
+  passthru.tests.smoke-test = callPackage ./smoke-test.nix { };
 
   meta = with lib; {
     homepage = "https://github.com/qmk/qmk_cli";

--- a/pkgs/tools/misc/qmk/setup-hook-darwin.sh
+++ b/pkgs/tools/misc/qmk/setup-hook-darwin.sh
@@ -1,0 +1,34 @@
+
+fixupCFlagsForDarwin() {
+    # Because it’s getting called from a Darwin stdenv, avr-gcc will pick up on
+    # Darwin-specific flags, and it will barf and die on -iframework in
+    # particular. Strip them out, so qmk can compile its test firmware.
+    cflagsFilter='s|-F[^ ]*||g;s|-iframework [^ ]*||g;s|-isystem [^ ]*||g;s|  *| |g'
+
+    # The `CoreFoundation` reference is added by `linkSystemCoreFoundationFramework` in the
+    # Apple SDK’s setup hook. Remove that because avr-gcc will fail due to file not found.
+    ldFlagsFilter='s|/nix/store/[^-]*-apple-framework-CoreFoundation[^ ]*||g'
+
+    # `cc-wrapper.sh`` supports getting flags from a system-specific salt. While it is currently a
+    # tuple, that’s not considered a stable interface, so the derivation will provide them.
+    export NIX_CFLAGS_COMPILE_@darwinSuffixSalt@=${NIX_CFLAGS_COMPILE-}
+    export NIX_LDFLAGS_@darwinSuffixSalt@=${NIX_LDFLAGS-}
+
+    echo removing @darwinSuffixSalt@-specific flags from NIX_CFLAGS_COMPILE for @avrSuffixSalt@
+    export NIX_CFLAGS_COMPILE_@avrSuffixSalt@+="$(sed "$cflagsFilter" <<< "$NIX_CFLAGS_COMPILE")"
+    echo removing @darwinSuffixSalt@-specific flags from NIX_LDFLAGS for @avrSuffixSalt@
+    export NIX_LDFLAGS_@avrSuffixSalt@+="$(sed "$ldFlagsFilter;$cflagsFilter" <<< "$NIX_LDFLAGS")"
+
+    # Make sure the global flags aren’t accidentally influencing the platform-specific flags.
+    export NIX_CFLAGS_COMPILE=""
+    export NIX_LDFLAGS=""
+}
+
+# This is pretty hacky, but this hook _must_ run after `linkSystemCoreFoundationFramework`.
+function runFixupCFlagsForDarwinLast() {
+    preConfigureHooks+=(fixupCFlagsForDarwin)
+}
+
+if [ -z "${dontFixupCFlagsForDarwin-}" ]; then
+    postUnpackHooks+=(runFixupCFlagsForDarwinLast)
+fi

--- a/pkgs/tools/misc/qmk/smoke-test.nix
+++ b/pkgs/tools/misc/qmk/smoke-test.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmk
+}:
+
+# Ensure toolchains are capable of compiling for QMK platforms
+# Use handwired/onekey/*:default as a proxy for each MCU platform supported by QMK
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qmk-firmware-smoke-test";
+  version = "0.23.1";
+
+  src = fetchFromGitHub {
+    owner = "qmk";
+    repo = "qmk_firmware";
+    rev = finalAttrs.version;
+    hash = "sha256-qIC87D2YdI2TV5rDRc22a3M7sJMP+qs4QFMHhJXGs2M=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = [ qmk ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    qmkKeyboards=$(find keyboards/handwired/onekey -name 'info.json' | sed 's|keyboards/\(.*\)/info.json|\1:default|')
+
+    # RISC-V cross with picolibc not currently supported in nixpkgs
+    qmkDisableKeyboards=( "handwired/onekey/sipeed_longan_nano:default" )
+
+    for del in ''${qmkDisableKeyboards[@]}
+    do
+      qmkKeyboards=("''${qmkKeyboards[@]/$del}")
+    done
+    echo "building qmk keyboards"
+    echo "$qmkKeyboards"
+
+    export MAKEFLAGS="SKIP_VERSION=1"
+    qmk mass-compile -j ''${NIX_BUILD_CORES:-0} $qmkKeyboards || touch .failed
+    # Generate the step summary markdown
+    ./util/ci/generate_failure_markdown.sh || true
+    # Exit with failure if the compilation stage failed
+    [ ! -f .failed ] || exit 1
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/qmk_firmware/firmware
+    find . \( \
+      -name '*.bin' \
+      -or -name '*.hex' \
+      -or -name '*.uf2' \
+      -or -name 'failed.*' \) \
+      -exec install -m444 {} $out/share/qmk_firmware/firmware/ \;
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Open-source keyboard firmware for Atmel AVR and Arm USB families";
+    homepage = "https://qmk.fm";
+    license = with licenses; [ gpl2Only gpl3Only bsd3 ];
+    platforms = platforms.unix;
+    inherit (qmk.meta) maintainers;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Gets avr platforms to work and test that each QMK platform successfully compiles. I had to partially revert #220442 once the smoke test could reveal the changes weren't completely compatible with some avr platforms I didn't test. Tested that the firmware flashes and works with a Pro Micro (`atmega32u4`).

Continues from #271919
Resolves #270986

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
