### PR TITLE
cudaPackages.cudatoolkit: fix the setupCudaHook not being propagated correctly

### DIFF
--- a/pkgs/development/cuda-modules/cudatoolkit/default.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/default.nix
@@ -80,7 +80,7 @@ backendStdenv.mkDerivation rec {
     ]
     ++ lib.optionals (lib.versionOlder version "11") [libsForQt5.wrapQtAppsHook]
     ++ lib.optionals (lib.versionAtLeast version "11.8") [qt6Packages.wrapQtAppsHook];
-  depsTargetTargetPropagated = [setupCudaHook];
+  propagatedBuildInputs = [setupCudaHook];
   buildInputs =
     lib.optionals (lib.versionOlder version "11") [
       libsForQt5.qt5.qtwebengine

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -8,7 +8,7 @@
 , mpfr
 , config
 , enableCuda ? config.cudaSupport
-, cudatoolkit
+, cudaPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -25,7 +25,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-  ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  ] ++ lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
+  ] ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+  ];
 
   # Use compatible indexing for lapack and blas used
   buildInputs = assert (blas.isILP64 == lapack.isILP64); [
@@ -34,7 +38,12 @@ stdenv.mkDerivation rec {
     gfortran.cc.lib
     gmp
     mpfr
-  ] ++ lib.optional enableCuda cudatoolkit;
+  ] ++ lib.optionals enableCuda [
+    cudaPackages.cuda_cudart.dev
+    cudaPackages.cuda_cudart.lib
+    cudaPackages.libcublas.dev
+    cudaPackages.libcublas.lib
+  ];
 
   preConfigure = ''
     # Mongoose and GraphBLAS are packaged separately
@@ -49,9 +58,9 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals blas.isILP64 [
     "CFLAGS=-DBLAS64"
   ] ++ lib.optionals enableCuda [
-    "CUDA_PATH=${cudatoolkit}"
-    "CUDART_LIB=${cudatoolkit.lib}/lib/libcudart.so"
-    "CUBLAS_LIB=${cudatoolkit}/lib/libcublas.so"
+    "CUDA_PATH=${cudaPackages.cuda_nvcc}"
+    "CUDART_LIB=${cudaPackages.cuda_cudart.lib}/lib/libcudart.so"
+    "CUBLAS_LIB=${cudaPackages.libcublas.lib}/lib/libcublas.so"
   ] ++ lib.optionals stdenv.isDarwin [
     # Unless these are set, the build will attempt to use `Accelerate` on darwin, see:
     # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v5.13.0/SuiteSparse_config/SuiteSparse_config.mk#L368


### PR DESCRIPTION
## Description of changes

Missed in https://github.com/NixOS/nixpkgs/pull/271078. Here's an example of a related error: https://hercules-ci.com/accounts/github/SomeoneSerge/derivations/%2Fnix%2Fstore%2F064plchffmjm075mhb0m3s00q3977hpl-suitesparse-5.13.0.drv/log?via-job=0a87e961-e83f-43e5-89fd-0fa01863101b
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
