### PR TITLE
decent-sampler: init at 1.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -388,6 +388,12 @@
       fingerprint = "CE85 54F7 B9BC AC0D D648  5661 AB5F C04C 3C94 443F";
     }];
   };
+  adam248 = {
+    email = "adamjbutler091@gmail.com";
+    github = "adam248";
+    githubId = 85082674;
+    name = "Adam J. Butler";
+  };
   adamcstephens = {
     email = "happy.plan4249@valkor.net";
     matrix = "@adam:valkor.net";

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -9,7 +9,7 @@
 , }:
 
 let
-  pname = "decent-sampler-unwrapped";
+  pname = "decent-sampler";
   version = "1.9.4";
 
   decent-sampler = stdenv.mkDerivation {
@@ -31,8 +31,7 @@ let
 in
 
 buildFHSEnv {
-    inherit version;
-  name = "decent-sampler";
+    inherit pname version;
 
   targetPkgs = pkgs: [
     decent-sampler

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -18,7 +18,9 @@ let
     src = fetchzip {
       # dropbox link: https://www.dropbox.com/sh/dwyry6xpy5uut07/AABBJ84bjTTSQWzXGG5TOQpfa\
 
-      url = "https://archive.org/download/decent-sampler-linux-static-download-mirror/Decent_Sampler-${version}-Linux-Static-x86_64.tar.gz";
+      # there is a strange conflict between 1.9.8 url and 1.9.4
+      # but 1.9.4 downloads 1.9.8 version anyway...
+      url = "https://archive.org/download/decent-sampler-linux-static-download-mirror/Decent_Sampler-1.9.4-Linux-Static-x86_64.tar.gz";
       sha256 = "sha256-O/0R70tZOmSGgth6nzt4zPiJr1P8890uzk8PiQGnC6M=";
     };
 

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "decent-sampler";
-  version = "1.9.4";
+  version = "1.9.8";
 
   decent-sampler = stdenv.mkDerivation {
     inherit pname version;
@@ -31,7 +31,7 @@ let
 in
 
 buildFHSEnv {
-    inherit pname version;
+  inherit pname version;
 
   targetPkgs = pkgs: [
     decent-sampler

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchzip
+, buildFHSEnv
+, alsa-lib
+, freetype
+, nghttp2
+, xorg
+, }:
+
+let
+  name = "decent-sampler";
+  version = "1.9.4";
+
+  decent-sampler = stdenv.mkDerivation {
+    inherit name version;
+
+    src = fetchzip {
+      # dropbox link: https://www.dropbox.com/sh/dwyry6xpy5uut07/AABBJ84bjTTSQWzXGG5TOQpfa\
+
+      url = "https://archive.org/download/decent-sampler-linux-static-download-mirror/Decent_Sampler-${version}-Linux-Static-x86_64.tar.gz";
+      sha256 = "sha256-O/0R70tZOmSGgth6nzt4zPiJr1P8890uzk8PiQGnC6M=";
+    };
+
+    installPhase = ''
+      mkdir -p $out/bin
+      install -m755 "DecentSampler" "$out/bin/decent-sampler"
+    '';
+
+  };
+in
+
+buildFHSEnv {
+  inherit name version;
+
+  targetPkgs = pkgs: [
+    decent-sampler
+    alsa-lib
+    freetype
+    nghttp2
+    xorg.libX11
+  ];
+
+  runScript = "decent-sampler";
+
+  meta = with lib; {
+    description = "An audio sample player";
+    longDescription = ''
+        Decent Sampler is an audio sample player.
+        Allowing you to play sample libraries in the DecentSampler format
+        (files with extensions: dspreset and dslibrary).
+        It claims to be free but we currently cannot find any license
+        that it is released under.
+    '';
+    homepage = "https://www.decentsamples.com/product/decent-sampler-plugin/";
+    license = licenses.unlicense;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ adam248 ];
+  };
+}
+

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "decent-sampler";
-  version = "1.9.8";
+  version = "1.9.4";
 
   decent-sampler = stdenv.mkDerivation {
     inherit pname version;
@@ -18,9 +18,7 @@ let
     src = fetchzip {
       # dropbox link: https://www.dropbox.com/sh/dwyry6xpy5uut07/AABBJ84bjTTSQWzXGG5TOQpfa\
 
-      # there is a strange conflict between 1.9.8 url and 1.9.4
-      # but 1.9.4 downloads 1.9.8 version anyway...
-      url = "https://archive.org/download/decent-sampler-linux-static-download-mirror/Decent_Sampler-1.9.4-Linux-Static-x86_64.tar.gz";
+      url = "https://archive.org/download/decent-sampler-linux-static-download-mirror/Decent_Sampler-${version}-Linux-Static-x86_64.tar.gz";
       sha256 = "sha256-O/0R70tZOmSGgth6nzt4zPiJr1P8890uzk8PiQGnC6M=";
     };
 

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -31,6 +31,7 @@ let
 in
 
 buildFHSEnv {
+    inherit version;
   name = "decent-sampler";
 
   targetPkgs = pkgs: [

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -34,8 +34,8 @@ buildFHSEnv {
   inherit pname version;
 
   targetPkgs = pkgs: [
-    decent-sampler
     alsa-lib
+    decent-sampler
     freetype
     nghttp2
     xorg.libX11

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -28,6 +28,11 @@ let
     '';
 
   };
+
+  libs = with xorg; [
+    libX11
+  ];
+
 in
 
 buildFHSEnv {
@@ -38,8 +43,7 @@ buildFHSEnv {
     decent-sampler
     freetype
     nghttp2
-    xorg.libX11
-  ];
+  ] ++ libs;
 
   runScript = "decent-sampler";
 

--- a/pkgs/by-name/ds/decent-sampler/package.nix
+++ b/pkgs/by-name/ds/decent-sampler/package.nix
@@ -9,11 +9,11 @@
 , }:
 
 let
-  name = "decent-sampler";
+  pname = "decent-sampler-unwrapped";
   version = "1.9.4";
 
   decent-sampler = stdenv.mkDerivation {
-    inherit name version;
+    inherit pname version;
 
     src = fetchzip {
       # dropbox link: https://www.dropbox.com/sh/dwyry6xpy5uut07/AABBJ84bjTTSQWzXGG5TOQpfa\
@@ -31,7 +31,7 @@ let
 in
 
 buildFHSEnv {
-  inherit name version;
+  name = "decent-sampler";
 
   targetPkgs = pkgs: [
     decent-sampler


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Decent Sampler

https://www.decentsamples.com/product/decent-sampler-plugin/

Resolving Issue: https://github.com/NixOS/nixpkgs/issues/238499

This is my very first contribution to `nixpkgs` and I have tried to make it as simple as possible.
I have read as much as I can about how to do this correctly but if I missed something please let me know.
Thanks

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
