### PR TITLE
ibm-sw-tpm2: add Darwin support

### DIFF
--- a/pkgs/tools/security/ibm-sw-tpm2/default.nix
+++ b/pkgs/tools/security/ibm-sw-tpm2/default.nix
@@ -4,7 +4,12 @@
 , fetchpatch
 , openssl
 }:
-
+let
+  makefile =
+    if stdenv.isDarwin
+    then "makefile.mac"
+    else "makefile";
+in
 stdenv.mkDerivation rec {
   pname = "ibm-sw-tpm2";
   version = "1682";
@@ -30,12 +35,14 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "src";
 
+  inherit makefile;
+
   prePatch = ''
     # Fix hardcoded path to GCC.
-    substituteInPlace makefile --replace /usr/bin/gcc "${stdenv.cc}/bin/cc"
+    substituteInPlace ${makefile} --replace /usr/bin/gcc "${stdenv.cc}/bin/cc"
 
     # Remove problematic default CFLAGS.
-    substituteInPlace makefile \
+    substituteInPlace ${makefile} \
       --replace -Werror "" \
       --replace -O0 "" \
       --replace -ggdb ""
@@ -49,7 +56,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "IBM's Software TPM 2.0, an implementation of the TCG TPM 2.0 specification";
     homepage = "https://sourceforge.net/projects/ibmswtpm2/";
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ delroth ];
     license = licenses.bsd3;
   };


### PR DESCRIPTION
## Description of changes

The upstream sources ship with a dedicated Makefile for macOS. This commit conditionally uses the macOS makefile if build on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
