### PR TITLE
rakarrack: fix segmentation fault

### DIFF
--- a/pkgs/applications/audio/rakarrack/default.nix
+++ b/pkgs/applications/audio/rakarrack/default.nix
@@ -12,7 +12,11 @@ stdenv.mkDerivation  rec {
 
   hardeningDisable = [ "format" ];
 
-  patches = [ ./fltk-path.patch ];
+  patches = [
+    ./fltk-path.patch
+    # https://sourceforge.net/p/rakarrack/git/merge-requests/2/
+    ./looper-preset.patch
+  ];
 
   buildInputs = [ alsa-lib alsa-utils fltk libjack2 libXft libXpm libjpeg
     libpng libsamplerate libsndfile zlib ];

--- a/pkgs/applications/audio/rakarrack/looper-preset.patch
+++ b/pkgs/applications/audio/rakarrack/looper-preset.patch
@@ -1,0 +1,11 @@
+diff -Naurd rakarrack-0.6.1/src/Looper.C rakarrack-0.6.1-segfault/src/Looper.C
+--- rakarrack-0.6.1/src/Looper.C	2010-10-01 01:27:55.000000000 +0000
++++ rakarrack-0.6.1-segfault/src/Looper.C	2023-12-08 21:12:31.818569726 +0000
+@@ -34,6 +34,7 @@
+   efxoutr = efxoutr_;
+ 
+   //default values
++      Ppreset = 0;
+       Pclear = 1;
+       Pplay = 0;
+       Precord = 0;


### PR DESCRIPTION
## Description of changes

Adds a patch to fix a segmentation fault: https://sourceforge.net/p/rakarrack/git/merge-requests/2/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
