### PR TITLE
python311Packages.diffusers: init at 0.24.0

### DIFF
--- a/pkgs/development/python-modules/diffusers/default.nix
+++ b/pkgs/development/python-modules/diffusers/default.nix
@@ -1,0 +1,153 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, writeText
+, setuptools
+, wheel
+, filelock
+, huggingface-hub
+, importlib-metadata
+, numpy
+, pillow
+, regex
+, requests
+, safetensors
+# optional dependencies
+, accelerate
+, datasets
+, flax
+, jax
+, jaxlib
+, jinja2
+, protobuf
+, tensorboard
+, torch
+# test dependencies
+, parameterized
+, pytest-timeout
+, pytest-xdist
+, pytestCheckHook
+, requests-mock
+, ruff
+, scipy
+, sentencepiece
+, torchsde
+, transformers
+}:
+
+buildPythonPackage rec {
+  pname = "diffusers";
+  version = "0.24.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "diffusers";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ccWF8hQzPhFY/kqRum2tbanI+cQiT25MmvPZN+hGadc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    filelock
+    huggingface-hub
+    importlib-metadata
+    numpy
+    pillow
+    regex
+    requests
+    safetensors
+  ];
+
+  passthru.optional-dependencies = {
+    flax = [
+      flax
+      jax
+      jaxlib
+    ];
+    torch = [
+      accelerate
+      torch
+    ];
+    training = [
+      accelerate
+      datasets
+      jinja2
+      protobuf
+      tensorboard
+    ];
+  };
+
+  pythonImportsCheck = [
+    "diffusers"
+  ];
+
+  # tests crash due to torch segmentation fault
+  doCheck = !(stdenv.isLinux && stdenv.isAarch64);
+
+  nativeCheckInputs = [
+    parameterized
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
+    requests-mock
+    ruff
+    scipy
+    sentencepiece
+    torchsde
+    transformers
+  ] ++ passthru.optional-dependencies.torch;
+
+  preCheck = let
+    # This pytest hook mocks and catches attempts at accessing the network
+    # tests that try to access the network will raise, get caught, be marked as skipped and tagged as xfailed.
+    # cf. python3Packages.shap
+    conftestSkipNetworkErrors = writeText "conftest.py" ''
+      from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
+      import urllib3
+
+      class NetworkAccessDeniedError(RuntimeError): pass
+      def deny_network_access(*a, **kw):
+        raise NetworkAccessDeniedError
+
+      urllib3.connection.HTTPSConnection._new_conn = deny_network_access
+
+      def pytest_runtest_makereport(item, call):
+        tr = orig_pytest_runtest_makereport(item, call)
+        if call.excinfo is not None and call.excinfo.type is NetworkAccessDeniedError:
+            tr.outcome = 'skipped'
+            tr.wasxfail = "reason: Requires network access."
+        return tr
+    '';
+  in ''
+    export HOME=$TMPDIR
+    cat ${conftestSkipNetworkErrors} >> tests/conftest.py
+  '';
+
+  pytestFlagsArray = [
+    "tests/"
+  ];
+
+  disabledTests = [
+    # depends on current working directory
+    "test_deprecate_stacklevel"
+    # fails due to precision of floating point numbers
+    "test_model_cpu_offload_forward_pass"
+  ];
+
+  meta = with lib; {
+    description = "State-of-the-art diffusion models for image and audio generation in PyTorch";
+    homepage = "https://github.com/huggingface/diffusers";
+    changelog = "https://github.com/huggingface/diffusers/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2829,6 +2829,8 @@ self: super: with self; {
 
   diffsync = callPackage ../development/python-modules/diffsync { };
 
+  diffusers = callPackage ../development/python-modules/diffusers { };
+
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   digi-xbee = callPackage ../development/python-modules/digi-xbee { };


### PR DESCRIPTION
## Description of changes

🤗 Diffusers: State-of-the-art diffusion models for image and audio generation in PyTorch
https://github.com/huggingface/diffusers

supersedes of https://github.com/NixOS/nixpkgs/pull/262469

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
