### PR TITLE
datadog-agent: Remove self from maintainers

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -118,7 +118,7 @@ in buildGoModule rec {
     '';
     homepage    = "https://www.datadoghq.com";
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ thoughtpolice domenkozar rvl viraptor ];
+    maintainers = with maintainers; [ thoughtpolice domenkozar viraptor ];
     # never built on aarch64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin && stdenv.isAarch64;
   };

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
@@ -4,7 +4,7 @@ datadog-agent.overrideAttrs (attrs: {
   meta = with lib;
     attrs.meta // {
       description = "Live process collector for the DataDog Agent v7";
-      maintainers = with maintainers; [ domenkozar rvl ];
+      maintainers = with maintainers; [ domenkozar ];
     };
   subPackages = [ "cmd/process-agent" ];
   postInstall = null;


### PR DESCRIPTION
I no longer use this package and am unable to help maintain it.
