### PR TITLE
memtree: unstable-2023-11-04 → 2023-11-22

### DIFF
--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -18,6 +18,7 @@ python3Packages.buildPythonApplication {
 
   nativeBuildInputs = with python3Packages; [
     poetry-core
+    pytestCheckHook
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -29,12 +30,7 @@ python3Packages.buildPythonApplication {
     pytest
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    python -m pytest -v
-    runHook postCheck
-  '';
-
+  pytestFlagsArray = [ "-v" ];
   pythonImportChecks = [ "memtree" ];
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "memtree";
-  version = "unstable-2023-11-04";
+  version = "unstable-2023-11-22";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nbraud";
     repo = "memtree";
-    rev = "093caeef26ee944b5bf4408710f63494e442b5ff";
-    hash = "sha256-j4LqWy7DxeV7pjwnCfpkHwug4p48kux6BM6oDJmvuUo=";
+    rev = "edc09d91dcd72f175d6adc1d08b261dd95cc4fbf";
+    hash = "sha256-YLZm0wjkjaTw/lHY5k4cqPXCgINe+49SGPLZq+eRdI4=";
   };
 
   nativeBuildInputs = with python3Packages; [

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -41,6 +41,7 @@ python3Packages.buildPythonApplication {
     description = "Render cgroups tree annotated by memory usage";
     homepage = "https://github.com/nbraud/memtree";
     maintainers = with maintainers; [ nicoo ];
+    mainProgram = "memtree";
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

- Update `memtree` from unstable-2023-11-04 to 2023-11-22;
- Replace its custom `checkPhase` with `pytestCheckHook`;
- Add the `mainProgram` metadata field.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
