### PR TITLE
maintainer-list: fix data published without consent

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6739,6 +6739,10 @@
   gm6k = {
     email = "nix@quidecco.pl";
     name = "Isidor Zeuner";
+    /*
+this record is complete as per the documentation:
+https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix#L7
+    */
   };
   gmemstr = {
     email = "git@gmem.ca";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6738,8 +6738,6 @@
   };
   gm6k = {
     email = "nix@quidecco.pl";
-    github = "zeuner";
-    githubId = 2545850;
     name = "Isidor Zeuner";
   };
   gmemstr = {


### PR DESCRIPTION
## Description of changes

Publishing personal data requires consent in many jurisdictions. This is known and led to an appropriate hint (https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix#L52). Apparently, there was still data published without consent: https://github.com/NixOS/nixpkgs/pull/272199. It was labeled a "data scheme breakage", which is obviously untrue since the file explicitly states that all fields apart from `name` are optional, and only _one_ out of `email`, `matrix` or `githubId` must be given (see https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix#L7).

Please merge this soon and squash the related commit history so the data published without authorization cannot be retrieved from the history.

## Things done



- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
