### PR TITLE
mpvScripts: make into a scope

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -1,6 +1,6 @@
 { lib
-, callPackage
 , config
+, newScope
 , runCommand
 }:
 
@@ -56,33 +56,34 @@ let
     ]; }; });
 in
 
-lib.recurseIntoAttrs
-  (lib.mapAttrs addTests (rec {
-    inherit (callPackage ./mpv.nix { inherit buildLua; })
+lib.recurseIntoAttrs (lib.makeScope newScope (self:
+  let inherit (self) callPackage;
+  in lib.mapAttrs addTests {
+    inherit (callPackage ./mpv.nix { })
       acompressor autocrop autodeint autoload;
-    inherit (callPackage ./occivink.nix { inherit buildLua; })
+    inherit (callPackage ./occivink.nix { })
       blacklistExtensions seekTo;
 
     buildLua = callPackage ./buildLua.nix { };
-    chapterskip = callPackage ./chapterskip.nix { inherit buildLua; };
-    convert = callPackage ./convert.nix { inherit buildLua; };
-    cutter = callPackage ./cutter.nix { inherit buildLua; };
+    chapterskip = callPackage ./chapterskip.nix { };
+    convert = callPackage ./convert.nix { };
+    cutter = callPackage ./cutter.nix { };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
-    mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { inherit buildLua; };
-    mpv-webm = callPackage ./mpv-webm.nix { inherit buildLua; };
-    mpvacious = callPackage ./mpvacious.nix { inherit buildLua; };
-    quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
-    simple-mpv-webui = callPackage ./simple-mpv-webui.nix { inherit buildLua; };
+    mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
+    mpv-webm = callPackage ./mpv-webm.nix { };
+    mpvacious = callPackage ./mpvacious.nix { };
+    quality-menu = callPackage ./quality-menu.nix { };
+    simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };
-    sponsorblock-minimal = callPackage ./sponsorblock-minimal.nix { inherit buildLua; };
-    thumbfast = callPackage ./thumbfast.nix { inherit buildLua; };
-    thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };
-    uosc = callPackage ./uosc.nix { inherit buildLua; };
-    visualizer = callPackage ./visualizer.nix { inherit buildLua; };
+    sponsorblock-minimal = callPackage ./sponsorblock-minimal.nix { };
+    thumbfast = callPackage ./thumbfast.nix { };
+    thumbnail = callPackage ./thumbnail.nix { };
+    uosc = callPackage ./uosc.nix { };
+    visualizer = callPackage ./visualizer.nix { };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
-  }))
+  }
   // lib.optionalAttrs config.allowAliases {
   youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
-}
+  }))

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -54,10 +54,9 @@ let
         '';
       })
     ]; }; });
-in
 
-lib.recurseIntoAttrs (lib.makeScope newScope (self:
-  let inherit (self) callPackage;
+  scope = self: let
+    inherit (self) callPackage;
   in lib.mapAttrs addTests {
     inherit (callPackage ./mpv.nix { })
       acompressor autocrop autodeint autoload;
@@ -83,7 +82,15 @@ lib.recurseIntoAttrs (lib.makeScope newScope (self:
     visualizer = callPackage ./visualizer.nix { };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
-  }
-  // lib.optionalAttrs config.allowAliases {
-  youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
-  }))
+  };
+
+  aliases = lib.optionalAttrs config.allowAliases {
+    youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
+  };
+in
+
+with lib; pipe scope [
+  (makeScope newScope)
+  (attrsets.unionOfDisjoint aliases)
+  recurseIntoAttrs
+]

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -58,6 +58,11 @@ in
 
 lib.recurseIntoAttrs
   (lib.mapAttrs addTests ({
+    inherit (callPackage ./mpv.nix { inherit buildLua; })
+      acompressor autocrop autodeint autoload;
+    inherit (callPackage ./occivink.nix { inherit buildLua; })
+      blacklistExtensions seekTo;
+
     chapterskip = callPackage ./chapterskip.nix { inherit buildLua; };
     convert = callPackage ./convert.nix { inherit buildLua; };
     cutter = callPackage ./cutter.nix { inherit buildLua; };
@@ -76,9 +81,7 @@ lib.recurseIntoAttrs
     visualizer = callPackage ./visualizer.nix { inherit buildLua; };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
-  }
-  // (callPackage ./mpv.nix      { inherit buildLua; })
-  // (callPackage ./occivink.nix { inherit buildLua; })))
+  }))
   // lib.optionalAttrs config.allowAliases {
   youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
 }

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -84,13 +84,15 @@ let
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
   };
 
-  aliases = lib.optionalAttrs config.allowAliases {
+  aliases = {
     youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
   };
 in
 
 with lib; pipe scope [
   (makeScope newScope)
-  (attrsets.unionOfDisjoint aliases)
+  (self:
+    assert builtins.intersectAttrs self aliases == {};
+    self // optionalAttrs config.allowAliases aliases)
   recurseIntoAttrs
 ]


### PR DESCRIPTION
## Description of changes

- make `mpvScripts` into a scope, simplifying imports in `default.nix`
- expose `mpvScripts.buildLua` to nixpkgs users

This PR is **blocked on #273155**, as it includes its changes (to avoid a merge conflict)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages with `nixpkgs-review`
- [x] Checked there was no change in derivations' outputs
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
