### PR TITLE
mpvScripts.cutter: unstable-2021-02-03 → 2023-11-09

### DIFF
--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -1,6 +1,6 @@
-{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper }:
+{ lib, buildLua, fetchFromGitHub, makeWrapper }:
 
-stdenvNoCC.mkDerivation {
+buildLua {
   pname = "video-cutter";
   version = "unstable-2021-02-03";
 
@@ -10,9 +10,6 @@ stdenvNoCC.mkDerivation {
     rev = "718d6ce9356e63fdd47208ec44f575a212b9068a";
     sha256 = "sha256-ramID1DPl0UqEzevpqdYKb9aaW3CAy3Dy9CPb/oJ4eY=";
   };
-
-  dontBuild = true;
-  dontCheck = true;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -27,15 +24,14 @@ stdenvNoCC.mkDerivation {
       --replace '~/.config/mpv/scripts' "''${XDG_CONFIG_HOME:-~/.config}/mpv/cutter"
   '';
 
-  installPhase = ''
-    install -Dm755 c_concat.sh $out/share/mpv/scripts/c_concat.sh
-    install cutter.lua $out/share/mpv/scripts/cutter.lua
+  passthru.scriptName = "cutter.lua";
+  extraScripts = [ "c_concat.sh" ];
 
+  postInstall = ''
+    chmod 0755 $out/share/mpv/scripts/c_concat.sh
     wrapProgram $out/share/mpv/scripts/c_concat.sh \
       --run "mkdir -p ~/.config/mpv/cutter/"
   '';
-
-  passthru.scriptName = "cutter.lua";
 
   meta = with lib; {
     description = "Cut videos and concat them automatically";

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -2,13 +2,13 @@
 
 buildLua {
   pname = "video-cutter";
-  version = "unstable-2021-02-03";
+  version = "unstable-2023-11-09";
 
   src = fetchFromGitHub {
     owner = "rushmj";
     repo = "mpv-video-cutter";
-    rev = "718d6ce9356e63fdd47208ec44f575a212b9068a";
-    sha256 = "sha256-ramID1DPl0UqEzevpqdYKb9aaW3CAy3Dy9CPb/oJ4eY=";
+    rev = "01a0396c075d5f8bbd1de5b571e6231f8899ab65";
+    sha256 = "sha256-veoRFzUCRH8TrvR7x+WWoycpDyxqrJZ/bnp61dVc0pE=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -36,8 +36,7 @@ buildLua {
   meta = with lib; {
     description = "Cut videos and concat them automatically";
     homepage = "https://github.com/rushmj/mpv-video-cutter";
-    # repo doesn't have a license
-    license = licenses.unfree;
+    license = licenses.mit;
     maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -12,6 +12,7 @@ in lib.recurseIntoAttrs
     autoload = callPackage ./autoload.nix { };
     chapterskip = callPackage ./chapterskip.nix { inherit buildLua; };
     convert = callPackage ./convert.nix { inherit buildLua; };
+    cutter = callPackage ./cutter.nix { inherit buildLua; };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { inherit buildLua; };
@@ -26,7 +27,6 @@ in lib.recurseIntoAttrs
     visualizer = callPackage ./visualizer.nix { };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
-    cutter = callPackage ./cutter.nix { };
   }
   // (callPackage ./occivink.nix { inherit buildLua; }))
   // lib.optionalAttrs config.allowAliases {


### PR DESCRIPTION
## Description of changes

`mpvScripts.cutter`:
- simplify with `buildLua`
- update from unstable-2021-02-03 to 2023-11-09
  - resolve conflict with default shortcuts
  - license under MIT terms

cc @legendofmiracles


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
