### PR TITLE
tests.trivial-builders.references: provide passthru attributes and override interface on non-Linux platforms

### DIFF
--- a/pkgs/build-support/trivial-builders/test/default.nix
+++ b/pkgs/build-support/trivial-builders/test/default.nix
@@ -11,27 +11,47 @@
 
 */
 
-{ callPackage, lib, stdenv }:
+{ callPackage, lib, stdenv, tests }:
 let
   inherit (lib) recurseIntoAttrs;
   references = callPackage ./references {};
+  # To override the `samples` for all other test cases, pass the new
+  # `samples` to `references.override` in Nixpkgs overlays.
+  final-references = tests.trivial-builders.references;
 in
 recurseIntoAttrs {
   concat = callPackage ./concat-test.nix {};
   linkFarm = callPackage ./link-farm.nix {};
   overriding = callPackage ../test-overriding.nix {};
-  # VM test not supported beyond linux yet
+  # VM test not supported beyond linux yet, while non-Linux users can
+  # still run the test by executing `references.testScriptBin`, and
+  # access passthru attributes like `samples`, the way Linux users do.
+  # Use `references.override` to override these attributes.
   references =
-    if stdenv.hostPlatform.isLinux
-    then references
-    else {};
+    if stdenv.hostPlatform.isLinux then
+      references
+    else
+      lib.makeOverridable (lib.mirrorFunctionArgs references.override (referenceArgs:
+      let
+        references-overridden = references.override referenceArgs;
+      in
+      {
+        inherit (references-overridden)
+          samples
+          references
+          directReferences
+          testScriptBin
+        ;
+        meta = { inherit (references-overridden.meta) maintainers; };
+      }
+      )) { };
   writeCBin = callPackage ./writeCBin.nix {};
   writeShellApplication = callPackage ./writeShellApplication.nix {};
   writeScriptBin = callPackage ./writeScriptBin.nix {};
   writeShellScript = callPackage ./write-shell-script.nix {};
   writeShellScriptBin = callPackage ./writeShellScriptBin.nix {};
   writeStringReferencesToFile = callPackage ./writeStringReferencesToFile.nix {
-    inherit (references) samples;
+    inherit (final-references) samples;
   };
   writeTextFile = callPackage ./write-text-file.nix {};
 }


### PR DESCRIPTION
## Description of changes

NixOS VM Tests are not supported outside Linux so far, and we leave tests.trivial-builders.references = { } for non-Linux systems to please the CI.

If applied, non-Linux users will be able to run `testScriptBin` and access `passthru` attributes and override interface of `test.trivial-builders.references` the way Linux users do.

Status: waiting for #178717. It brings several renames and one extra test cases that depends on `samples`.

Cc: @roberth

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
