### PR TITLE
mpvScripts: Add `updateScript` to (almost) every drv

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -56,6 +56,17 @@ lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
     '';
 
     passthru = { inherit scriptName; };
-    meta.platforms = lib.platforms.all;
+    meta = {
+      platforms = lib.platforms.all;
+    } // (
+      let pos =
+        if (args.meta or {}) ? description then
+          builtins.unsafeGetAttrPos "description" args.meta
+        else
+          builtins.unsafeGetAttrPos "pname" args;
+      in lib.optionalAttrs
+        (pos != null)
+        { position = "${pos.file}:${toString pos.line}"; }
+    );
   })
 ))

--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, unstableGitUpdater
 , buildLua }:
 
 buildLua {
@@ -12,6 +13,7 @@ buildLua {
     rev   = "b26825316e3329882206ae78dc903ebc4613f039";
     hash  = "sha256-OTrLQE3rYvPQamEX23D6HttNjx3vafWdTMxTiWpDy90=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   meta = {
     homepage = "https://github.com/po5/chapterskip";

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -1,14 +1,22 @@
-{ lib, fetchgit, buildLua
-, yad, mkvtoolnix-cli, libnotify }:
+{ lib
+, fetchgit
+, unstableGitUpdater
+
+, buildLua
+, libnotify
+, mkvtoolnix-cli
+, yad
+}:
 
 buildLua {
   pname = "mpv-convert-script";
-  version = "2016-03-18";
+  version = "unstable-2015-07-02";
   src = fetchgit {
     url = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
     rev = "f95cee43e390e843a47e8ec9d1711a12a8cd343d";
     sha256 = "13m7l4sy2r8jv2sfrb3vvqvnim4a9ilnv28q5drlg09v298z3mck";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   patches = [ ./convert.patch ];
 

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -1,4 +1,4 @@
-{ lib, buildLua, fetchFromGitHub, makeWrapper }:
+{ lib, buildLua, fetchFromGitHub, makeWrapper, unstableGitUpdater }:
 
 buildLua {
   pname = "video-cutter";
@@ -10,6 +10,7 @@ buildLua {
     rev = "01a0396c075d5f8bbd1de5b571e6231f8899ab65";
     sha256 = "sha256-veoRFzUCRH8TrvR7x+WWoycpDyxqrJZ/bnp61dVc0pE=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/video/mpv/scripts/inhibit-gnome.nix
+++ b/pkgs/applications/video/mpv/scripts/inhibit-gnome.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, dbus, mpv-unwrapped }:
+{ lib, stdenv, fetchFromGitHub, gitUpdater, pkg-config, dbus, mpv-unwrapped }:
 
 stdenv.mkDerivation rec {
   pname = "mpv-inhibit-gnome";
@@ -9,6 +9,9 @@ stdenv.mkDerivation rec {
     repo = "mpv_inhibit_gnome";
     rev = "v${version}";
     hash = "sha256-LSGg5gAQE2JpepBqhz6D6d3NlqYaU4bjvYf1F+oLphQ=";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, glib, mpv-unwrapped, ffmpeg }:
+{ lib, stdenv, fetchFromGitHub, gitUpdater, pkg-config, glib, mpv-unwrapped, ffmpeg }:
 
 stdenv.mkDerivation rec {
   pname = "mpv-mpris";
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-vZIO6ILatIWa9nJYOp4AMKwvaZLahqYWRLMDOizyBI0=";
   };
+  passthru.updateScript = gitUpdater {};
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -1,4 +1,4 @@
-{ lib, buildLua, fetchFromGitHub, yt-dlp }:
+{ lib, buildLua, fetchFromGitHub, unstableGitUpdater, yt-dlp }:
 
 buildLua rec {
   pname = "mpv-playlistmanager";
@@ -10,6 +10,7 @@ buildLua rec {
     rev = "e479cbc7e83a07c5444f335cfda13793681bcbd8";
     sha256 = "sha256-Nh4g8uSkHWPjwl5wyqWtM+DW9fkEbmCcOsZa4eAF6Cs=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   postPatch = ''
     substituteInPlace playlistmanager.lua \

--- a/pkgs/applications/video/mpv/scripts/mpv-webm.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-webm.nix
@@ -2,7 +2,7 @@
 , buildLua
 , fetchFromGitHub
 , luaPackages
-, nix-update-script
+, unstableGitUpdater
 }:
 
 buildLua {
@@ -15,14 +15,11 @@ buildLua {
     rev = "6b5863f68275b3dc91c2507284c039ec8a4cbd97";
     hash = "sha256-rJamBm6FyxWcJO7VXXOUTO9piWCkPfEVdqGKGeJ/h0c=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   dontBuild = false;
   nativeBuildInputs = [ luaPackages.moonscript ];
   scriptPath = "build/webm.lua";
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=branch" ];
-  };
 
   meta = with lib; {
     description = "Simple WebM maker for mpv, with no external dependencies";

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -1,6 +1,7 @@
 { lib
 , buildLua
 , fetchFromGitHub
+, gitUpdater
 , curl
 , wl-clipboard
 , xclip
@@ -15,6 +16,9 @@ buildLua rec {
     repo = "mpvacious";
     rev = "v${version}";
     sha256 = "sha256-XTnib4cguWFEvZtmsLfkesbjFbkt2YoyYLT587ajyUM=";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   postPatch = ''

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -1,6 +1,7 @@
 { lib
 , buildLua
 , fetchFromGitHub
+, gitUpdater
 , oscSupport ? false
 }:
 
@@ -13,6 +14,9 @@ buildLua rec {
     repo = "mpv-quality-menu";
     rev = "v${version}";
     hash = "sha256-yrcTxqpLnOI1Tq3khhflO3wzhyeTPuvKifyH5/P57Ns=";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   scriptPath = "quality-menu.lua";

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -1,5 +1,7 @@
 { lib, buildLua
-, fetchFromGitHub }:
+, fetchFromGitHub
+, gitUpdater
+}:
 buildLua rec {
   pname = "simple-mpv-ui";
   version = "3.0.0";
@@ -10,6 +12,9 @@ buildLua rec {
     rev = "v${version}";
     hash = "sha256-I8lwpo3Hfpy3UnPMmHEJCdArVQnNL245NkxsYVmnMF0=";
     sparseCheckout = [ "main.lua" "webui-page" ];
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   scriptPath = ".";

--- a/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
@@ -1,6 +1,7 @@
 { lib
 , buildLua
 , fetchFromGitea
+, unstableGitUpdater
 , curl
 }:
 
@@ -16,6 +17,7 @@ buildLua {
     rev = "ca2844b8cf7674bfccd282d389a50427742251d3";
     hash = "sha256-28HWZ6nOhKiE+5Ya1N3Vscd8aeH9OKS0t72e/xPfFQQ=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   preInstall = ''
     substituteInPlace sponsorblock_minimal.lua \

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildLua, mpv-unwrapped }:
+{ lib, fetchFromGitHub, unstableGitUpdater, buildLua, mpv-unwrapped }:
 
 buildLua {
   pname = "mpv-thumbfast";
@@ -10,6 +10,7 @@ buildLua {
     rev = "03e93feee5a85bf7c65db953ada41b4826e9f905";
     hash = "sha256-5u5WBvWOEydJrnr/vilEgW4+fxkxM6wNjb9Fyyxx/1c=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   scriptPath = "thumbfast.lua";
 

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -1,4 +1,4 @@
-{ lib, buildLua, fetchFromGitHub, python3 }:
+{ lib, buildLua, fetchFromGitHub, gitUpdater, python3 }:
 
 buildLua rec {
   pname = "mpv-thumbnail-script";
@@ -10,6 +10,7 @@ buildLua rec {
     rev = version;
     sha256 = "sha256-J24Rou7BTE7zoiPlBkWuO9dtYJiuzkuwB4FROuzXzag=";
   };
+  passthru.updateScript = gitUpdater {};
 
   nativeBuildInputs = [ python3 ];
   postPatch = "patchShebangs concat_files.py";

--- a/pkgs/applications/video/mpv/scripts/uosc.nix
+++ b/pkgs/applications/video/mpv/scripts/uosc.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , fetchpatch
+, gitUpdater
 , makeFontsConf
 , buildLua
 , buildGoModule
@@ -17,6 +18,7 @@ buildLua (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-+4k8T1yX3IRXK3XkUShsuJSH9w1Zla7CaRENcIqX4iM=";
   };
+  passthru.updateScript = gitUpdater {};
 
   tools = buildGoModule {
     pname = "uosc-bin";

--- a/pkgs/applications/video/mpv/scripts/visualizer.nix
+++ b/pkgs/applications/video/mpv/scripts/visualizer.nix
@@ -2,6 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 buildLua {
   pname = "visualizer";
@@ -13,6 +14,7 @@ buildLua {
     rev = "7dbbfb283508714b73ead2a57b6939da1d139bd3";
     sha256 = "zzB4uBc1M2Gdr/JKY2uk8MY0hmQl1XeomkfTzuM45oE=";
   };
+  passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
     description = "various audio visualization";

--- a/pkgs/applications/video/mpv/scripts/vr-reversal.nix
+++ b/pkgs/applications/video/mpv/scripts/vr-reversal.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub, ffmpeg }:
+{ lib, stdenvNoCC, fetchFromGitHub, gitUpdater, ffmpeg }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "vr-reversal";
@@ -9,6 +9,9 @@ stdenvNoCC.mkDerivation rec {
     repo = pname;
     rev = "v${version}";
     sha256 = "1wn2ngcvn7wcsl3kmj782x5q9130qw951lj6ilrkafp6q6zscpqr";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   dontBuild = true;

--- a/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
@@ -1,4 +1,4 @@
-{ lib, buildNpmPackage, fetchFromGitHub, nodejs, python3 }:
+{ lib, buildNpmPackage, fetchFromGitHub, gitUpdater, nodejs, python3 }:
 
 buildNpmPackage rec {
   pname = "webtorrent-mpv-hook";
@@ -9,6 +9,9 @@ buildNpmPackage rec {
     repo = pname;
     rev = "v${version}";
     hash = "sha256-/dMtXcIyfAs++Zgz2CxRW0tkzn5QjS+WVGChlCyrU0U=";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

- Expose `meta.position` in `mpvScripts.buildLua`
  This is undocumented, but seems required for `common-update-scripts` to work.
- Fixed `mpvScripts.mpv-webm.updateScript`
  `nix-update` seems not to work even with the `buildLua` fix.
- Add `updateScript` to `chapterskip`, `convert`, `cutter`, `inhibit-gnome`, `mpris`, `mpv-playlistmanager`, `mpvacious`, `quality-menu`, `simple-mpv-ui`, `thumbfast`, `thumbnail`, `uosc`, `visualizer`, `vr-reversal`, and `webtorrent-mpv-hook`.
  The following packages do not have `updateScript`:
  - `acompressor`, `auto{crop, deint, load}`: part of `mpv`, inherit its `src` and `version`;
  - `blacklistExtensions`, `seekTo`: Already happening in #272108


## Things done

- [x] Ran the update scripts of all derivations under `mpvScripts`:
    nix-shell maintainers/scripts/update.nix --argstr path mpvScripts
- [x] Tested compilation of all affected packages using `nixpkgs-review`
  ~~⚠ Currently failing in `check-meta.nix`~~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  No change in outputs
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

