### PR TITLE
webtorrent-mpv-hook: 1.3.3 → 1.4.1

### DIFF
--- a/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
@@ -2,23 +2,23 @@
 
 buildNpmPackage rec {
   pname = "webtorrent-mpv-hook";
-  version = "1.3.3";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "mrxdst";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-AFKX31kriacXygZy0Mw+QwO+SwFEu13687mJ/WeAoKY=";
+    hash = "sha256-/dMtXcIyfAs++Zgz2CxRW0tkzn5QjS+WVGChlCyrU0U=";
   };
 
   postPatch = ''
     substituteInPlace src/webtorrent.ts --replace "node_path: 'node'" "node_path: '${nodejs}/bin/node'"
     # This executable is just for telling non-Nix users how to install
-    substituteInPlace package.json --replace '"bin": "build/bin.js",' ""
+    substituteInPlace package.json --replace '"bin": "build/bin.mjs",' ""
     rm -rf src/bin.ts
   '';
 
-  npmDepsHash = "sha256-GpNUJ5ZCgMjSYLqsIE/RwkTSFT3uAhxrHPe7XvGDRHE=";
+  npmDepsHash = "sha256-EqHPBoYyBuW9elxQH/XVTZoPkKHC6+7aksYo60t7WA4=";
   makeCacheWritable = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

webtorrent-mpv-hook: 1.3.3 → 1.4.1

cc @chuangzhu


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
