### PR TITLE
mpvScripts.visualizer: unstable-2021-07-10 → 2023-08-13

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -23,7 +23,7 @@ in lib.recurseIntoAttrs
     thumbfast = callPackage ./thumbfast.nix { inherit buildLua; };
     thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };
     uosc = callPackage ./uosc.nix { inherit buildLua; };
-    visualizer = callPackage ./visualizer.nix { };
+    visualizer = callPackage ./visualizer.nix { inherit buildLua; };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
     cutter = callPackage ./cutter.nix { };

--- a/pkgs/applications/video/mpv/scripts/visualizer.nix
+++ b/pkgs/applications/video/mpv/scripts/visualizer.nix
@@ -5,13 +5,13 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "visualizer";
-  version = "unstable-2021-07-10";
+  version = "unstable-2023-08-13";
 
   src = fetchFromGitHub {
     owner = "mfcc64";
     repo = "mpv-scripts";
-    rev = "a0cd87eeb974a4602c5d8086b4051b5ab72f42e1";
-    sha256 = "1xgd1nd117lpj3ppynhgaa5sbkfm7l8n6c9a2fy8p07is2dkndrq";
+    rev = "7dbbfb283508714b73ead2a57b6939da1d139bd3";
+    sha256 = "zzB4uBc1M2Gdr/JKY2uk8MY0hmQl1XeomkfTzuM45oE=";
   };
 
   dontBuild = true;

--- a/pkgs/applications/video/mpv/scripts/visualizer.nix
+++ b/pkgs/applications/video/mpv/scripts/visualizer.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  stdenvNoCC,
+  buildLua,
   fetchFromGitHub,
 }:
-stdenvNoCC.mkDerivation {
+buildLua {
   pname = "visualizer";
   version = "unstable-2023-08-13";
 
@@ -14,21 +14,9 @@ stdenvNoCC.mkDerivation {
     sha256 = "zzB4uBc1M2Gdr/JKY2uk8MY0hmQl1XeomkfTzuM45oE=";
   };
 
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/mpv/scripts
-    cp visualizer.lua $out/share/mpv/scripts
-    runHook postInstall
-  '';
-
-  passthru.scriptName = "visualizer.lua";
-
   meta = with lib; {
     description = "various audio visualization";
     homepage = "https://github.com/mfcc64/mpv-scripts";
-    platforms = platforms.all;
     maintainers = with maintainers; [kmein];
   };
 }


### PR DESCRIPTION
## Description of changes

`mpvScripts.visualizer`:
- unstable-2021-07-10 → 2023-08-13
- simplified with `buildLua`


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
