### PR TITLE
mpvScripts.thumbfast: unstable-2023-06-04 → 2023-12-08

### DIFF
--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -2,13 +2,13 @@
 
 buildLua {
   pname = "mpv-thumbfast";
-  version = "unstable-2023-06-04";
+  version = "unstable-2023-12-08";
 
   src = fetchFromGitHub {
     owner = "po5";
     repo = "thumbfast";
-    rev = "4241c7daa444d3859b51b65a39d30e922adb87e9";
-    hash = "sha256-7EnFJVjEzqhWXAvhzURoOp/kad6WzwyidWxug6u8lVw=";
+    rev = "03e93feee5a85bf7c65db953ada41b4826e9f905";
+    hash = "sha256-5u5WBvWOEydJrnr/vilEgW4+fxkxM6wNjb9Fyyxx/1c=";
   };
 
   postPatch = ''

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -11,12 +11,11 @@ buildLua {
     hash = "sha256-5u5WBvWOEydJrnr/vilEgW4+fxkxM6wNjb9Fyyxx/1c=";
   };
 
-  postPatch = ''
-    substituteInPlace thumbfast.lua \
-      --replace 'mpv_path = "mpv"' 'mpv_path = "${lib.getExe mpv-unwrapped}"'
-  '';
-
   scriptPath = "thumbfast.lua";
+
+  passthru.extraWrapperArgs = [
+    "--prefix" "PATH" ":" "${lib.getBin mpv-unwrapped}/bin"
+  ];
 
   meta = {
     description = "High-performance on-the-fly thumbnailer for mpv";


### PR DESCRIPTION
## Description of changes

`mpvScripts.thumbfast`:
- unstable-2023-06-04 → 2023-12-08
- add `mpv-unwrapped` to `PATH` via `extraWrapperArgs`, instead of patching its path in
  this should be more robust against upstream changes, and doesn't need a rebuild whenever `mpv` is rebuilt


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
