### PR TITLE
mpvScripts.mpv-playlistmanager: unstable-2023-08-09 → 2023-11-28

### DIFF
--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -2,13 +2,13 @@
 
 buildLua rec {
   pname = "mpv-playlistmanager";
-  version = "unstable-2023-08-09";
+  version = "unstable-2023-11-28";
 
   src = fetchFromGitHub {
     owner = "jonniek";
     repo = "mpv-playlistmanager";
-    rev = "e479cbc7e83a07c5444f335cfda13793681bcbd8";
-    sha256 = "sha256-Nh4g8uSkHWPjwl5wyqWtM+DW9fkEbmCcOsZa4eAF6Cs=";
+    rev = "579490c7ae1becc129736b7632deec4f3fb90b99";
+    hash = "sha256-swOtoB8UV/HPTpQRGXswAfUYsyC2Nj/QRIkGP8X1jk0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

mpvScripts.mpv-playlistmanager: unstable-2023-08-09 → 2023-11-28


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
