### PR TITLE
flight-core: init at 2.14.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20020,6 +20020,12 @@
     githubId = 973709;
     name = "Jairo Llopis";
   };
+  yamamech = {
+    email = "yama@yamamech.sh";
+    github = "yamamech";
+    githubId = 30635996;
+    name = "Tsumugchi";
+  };
   yana = {
     email = "yana@riseup.net";
     github = "yanalunaterra";

--- a/pkgs/games/flight-core/default.nix
+++ b/pkgs/games/flight-core/default.nix
@@ -1,11 +1,11 @@
 { lib, fetchurl, appimageTools }:
 let
   pname = "flight-core";
-  version = "2.14.8";
+  version = "2.14.9";
   name = "${pname}_${version}";
   src = fetchurl {
     url = "https://github.com/R2NorthstarTools/FlightCore/releases/download/v${version}/${name}_amd64.AppImage";
-    hash = "sha256-8POfWOCisd6aURwup8uSFXZV6etV5eTMx0Iw748LQ4c=";
+    hash = "sha256-DoVvX8ayxUeDq9GpFXccVDEuq7DvblvPPyhLCzDqz1M=";
   };
   appimageContents = appimageTools.extractType2 { inherit name src; };
 in

--- a/pkgs/games/flight-core/default.nix
+++ b/pkgs/games/flight-core/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchurl, appimageTools }:
+let
+  pname = "flight-core";
+  version = "2.14.8";
+  name = "${pname}_${version}";
+  src = fetchurl {
+    url = "https://github.com/R2NorthstarTools/FlightCore/releases/download/v${version}/${name}_amd64.AppImage";
+    hash = "sha256-8POfWOCisd6aURwup8uSFXZV6etV5eTMx0Iw748LQ4c=";
+  };
+  appimageContents = appimageTools.extractType2 { inherit name src; };
+in
+appimageTools.wrapType2 {
+  inherit name src;
+  extraPkgs = pkgs: with pkgs; [ libthai pango ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/flight-core.desktop -t $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "Installer/Updater/Launcher for Northstar";
+    homepage = "https://github.com/R2NorthstarTools/FlightCore";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yamamech ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "flight-core";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37765,6 +37765,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  flight-core = callPackage ../games/flight-core { };
+
   fltrator = callPackage ../games/fltrator {
     fltk = fltk-minimal;
   };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

[Flight Core](https://github.com/R2NorthstarTools/FlightCore) is an MIT licensed installer, launcher and mod-manager for [Northstar](https://northstar.tf/) for Linux. This derivation uses the official AppImage (currently at 2.14.9) as its source.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
