### PR TITLE
tuxclocker: init at 1.4.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -23,6 +23,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Clevis](https://github.com/latchset/clevis), a pluggable framework for automated decryption, used to unlock encrypted devices in initrd. Available as [boot.initrd.clevis.enable](#opt-boot.initrd.clevis.enable).
 
+- [TuxClocker](https://github.com/Lurkki14/tuxclocker), a hardware control and monitoring program. Available as [programs.tuxclocker](#opt-programs.tuxclocker.enable).
+
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -766,6 +766,7 @@
   ./services/misc/tautulli.nix
   ./services/misc/tiddlywiki.nix
   ./services/misc/tp-auto-kbbl.nix
+  ./services/misc/tuxclocker.nix
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix
   ./services/misc/weechat.nix

--- a/nixos/modules/services/misc/tuxclocker.nix
+++ b/nixos/modules/services/misc/tuxclocker.nix
@@ -1,0 +1,71 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.tuxclocker;
+in
+{
+  options.programs.tuxclocker = {
+    enable = mkEnableOption (lib.mdDoc ''
+      TuxClocker, a hardware control and monitoring program
+    '');
+
+    enableAMD = mkEnableOption (lib.mdDoc ''
+      AMD GPU controls.
+      Sets the `amdgpu.ppfeaturemask` kernel parameter to 0xfffd7fff to enable all TuxClocker controls
+    '');
+
+    enabledNVIDIADevices = mkOption {
+      type = types.listOf types.int;
+      default = [ ];
+      example = [ 0 1 ];
+      description = lib.mdDoc ''
+        Enable NVIDIA GPU controls for a device by index.
+        Sets the `Coolbits` Xorg option to enable all TuxClocker controls.
+      '';
+    };
+
+    useUnfree = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = lib.mdDoc ''
+        Whether to use components requiring unfree dependencies.
+        Disabling this allows you to get everything from the binary cache.
+      '';
+    };
+  };
+
+  config = let
+      package = if cfg.useUnfree then pkgs.tuxclocker else pkgs.tuxclocker-without-unfree;
+    in
+      mkIf cfg.enable {
+        environment.systemPackages = [
+          package
+        ];
+
+        services.dbus.packages = [
+          package
+        ];
+
+        # MSR is used for some features
+        boot.kernelModules = [ "msr" ];
+
+        # https://download.nvidia.com/XFree86/Linux-x86_64/430.14/README/xconfigoptions.html#Coolbits
+        services.xserver.config = let
+          configSection = (i: ''
+            Section "Device"
+              Driver "nvidia"
+              Option "Coolbits" "31"
+              Identifier "Device-nvidia[${toString i}]"
+            EndSection
+          '');
+        in
+          concatStrings (map configSection cfg.enabledNVIDIADevices);
+
+        # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/amd/include/amd_shared.h#n207
+        # Enable everything modifiable in TuxClocker
+        boot.kernelParams = mkIf cfg.enableAMD [ "amdgpu.ppfeaturemask=0xfffd7fff" ];
+      };
+}

--- a/pkgs/applications/misc/tuxclocker/default.nix
+++ b/pkgs/applications/misc/tuxclocker/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, boost
+, fetchFromGitHub
+, git
+, makeWrapper
+, meson
+, ninja
+, pkg-config
+, python3
+, qtbase
+, qtcharts
+, tuxclocker-plugins
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tuxclocker";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Lurkki14";
+    repo = "tuxclocker";
+    fetchSubmodules = true;
+    rev = "${finalAttrs.version}";
+    hash = "sha256-8dtuZXBWftXNQpqYgNQOayPGfvEIu9QfbqDShfkt1qA=";
+  };
+
+  # Meson doesn't find boost without these
+  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
+  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
+
+  nativeBuildInputs = [
+    git
+    makeWrapper
+    meson
+    ninja
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost
+    qtbase
+    qtcharts
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/tuxclockerd" \
+      --prefix "TEXTDOMAINDIR" : "${tuxclocker-plugins}/share/locale" \
+      --prefix "TUXCLOCKER_PLUGIN_PATH" : "${tuxclocker-plugins}/lib/tuxclocker/plugins" \
+      --prefix "PYTHONPATH" : "${python3.pkgs.hwdata}/${python3.sitePackages}"
+  '';
+
+  mesonFlags = [
+    "-Dplugins=false"
+  ];
+
+  meta = with lib; {
+    description = "Qt overclocking tool for GNU/Linux";
+    homepage = "https://github.com/Lurkki14/tuxclocker";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ lurkki ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/by-name/tu/tuxclocker-nvidia-plugin/no-cpu-plugin.patch
+++ b/pkgs/by-name/tu/tuxclocker-nvidia-plugin/no-cpu-plugin.patch
@@ -1,0 +1,14 @@
+diff --git a/src/plugins/meson.build b/src/plugins/meson.build
+index cdd3b5b..a5a2174 100644
+--- a/src/plugins/meson.build
++++ b/src/plugins/meson.build
+@@ -63,9 +63,3 @@ if all_nvidia_linux_libs
+ 		install : true,
+ 		link_with : libtuxclocker)
+ endif
+-
+-shared_library('cpu', 'CPU.cpp', 'Utils.cpp',
+-        include_directories : [incdir, fplus_inc],
+-        install_dir : get_option('libdir') / 'tuxclocker' / 'plugins',
+-        install : true,
+-        link_with : libtuxclocker)

--- a/pkgs/by-name/tu/tuxclocker-nvidia-plugin/package.nix
+++ b/pkgs/by-name/tu/tuxclocker-nvidia-plugin/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, boost
+, libX11
+, libXext
+, linuxPackages
+, openssl
+, tuxclocker-plugins
+}:
+
+stdenv.mkDerivation {
+  pname = "tuxclocker-nvidia-plugin";
+
+  inherit (tuxclocker-plugins) src version meta BOOST_INCLUDEDIR BOOST_LIBRARYDIR nativeBuildInputs;
+
+  buildInputs = [
+    boost
+    libX11
+    libXext
+    linuxPackages.nvidia_x11
+    linuxPackages.nvidia_x11.settings.libXNVCtrl
+    openssl
+  ];
+
+  # Build doesn't have a way to disable building the CPU plugin, which is already
+  # provided by 'tuxclocker-plugins'
+  patches = [ ./no-cpu-plugin.patch ];
+
+  mesonFlags = [
+    "-Ddaemon=false"
+    "-Dgui=false"
+    "-Drequire-nvidia=true"
+  ];
+}

--- a/pkgs/by-name/tu/tuxclocker-plugins-with-unfree/package.nix
+++ b/pkgs/by-name/tu/tuxclocker-plugins-with-unfree/package.nix
@@ -1,0 +1,16 @@
+{ symlinkJoin
+, tuxclocker-nvidia-plugin
+, tuxclocker-plugins
+}:
+
+symlinkJoin rec {
+  inherit (tuxclocker-plugins) version meta;
+
+  pname = "tuxclocker-plugins-with-unfree";
+  name = "${pname}-${version}";
+
+  paths = [
+    tuxclocker-nvidia-plugin
+    tuxclocker-plugins
+  ];
+}

--- a/pkgs/by-name/tu/tuxclocker-plugins/package.nix
+++ b/pkgs/by-name/tu/tuxclocker-plugins/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, boost
+, cmake
+, gettext
+, git
+, libdrm
+, meson
+, ninja
+, openssl
+, pkg-config
+, python3
+, tuxclocker
+}:
+
+stdenv.mkDerivation {
+  inherit (tuxclocker) src version meta BOOST_INCLUDEDIR BOOST_LIBRARYDIR;
+
+  pname = "tuxclocker-plugins";
+
+  nativeBuildInputs = [
+    gettext
+    git
+    meson
+    ninja
+    pkg-config
+    (python3.withPackages(p: [ p.hwdata ]))
+  ];
+
+  buildInputs = [
+    boost
+    libdrm
+    openssl
+  ];
+
+  mesonFlags = [
+    "-Ddaemon=false"
+    "-Dgui=false"
+    "-Drequire-amd=true"
+    "-Drequire-python-hwdata=true"
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36016,6 +36016,12 @@ with pkgs;
 
   tut = callPackage ../applications/misc/tut { };
 
+  tuxclocker = libsForQt5.callPackage ../applications/misc/tuxclocker {
+    tuxclocker-plugins = tuxclocker-plugins-with-unfree;
+  };
+
+  tuxclocker-without-unfree = libsForQt5.callPackage ../applications/misc/tuxclocker { };
+
   tuxedo-rs = callPackage ../os-specific/linux/tuxedo-rs { };
 
   tuxguitar = callPackage ../applications/editors/music/tuxguitar {


### PR DESCRIPTION
## Description of changes
Added https://github.com/Lurkki14/tuxclocker and a NixOS module

Fixes #262668

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
