### PR TITLE
maintainer-list: make `github`, `githubId` mandatory fields

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3,12 +3,12 @@
     handle = {
       # Required
       name = "Your name";
-
-      # Optional, but at least one of email, matrix or githubId must be given
-      email = "address@example.org";
-      matrix = "@user:example.org";
       github = "GithubUsername";
       githubId = your-github-id;
+
+      # Optional
+      email = "address@example.org";
+      matrix = "@user:example.org";
 
       keys = [{
         fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";


### PR DESCRIPTION
## Description of changes

Nixpkgs development takes place on 3 platforms:

- GitHub: github.com
- Discourse: discourse.nixos.org
- Matrix: nixos.org server.

As neither Discourse or Matrix are code-oriented platform, we usually expect _at least_ that maintainers are present over GitHub so we can mention them, interact with them via GitHub automation.

In the future, we may revisit this and remove this restriction if we have an equivalent silo of data containing information about our own users which we can consume.

In the time being, GitHub remains the only platform against where we can build identity authentication in the project, otherwise, such automation cannot be built or must exclude any maintainer who doesn't contain the right field.

At the moment, I do not believe it is the project's priority to pursue opening contributions from external platforms to GitHub as we do not have the tools neither the bandwidth to handle them.

As an example of usecase, the security tracker we are building in https://github.com/Nix-Security-WG/nix-security-tracker/ we have a need for logging via GitHub and we cannot build a local account silo (it doesn't really make sense), neither I feel like imposing myself on the infra team to maintain a LDAP or a directory of accounts. Therefore, GitHub login is the only solution we have here. Furthermore, permissions are really stored in the GitHub data silo rather than in any of our other platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
