### PR TITLE
appstream: 0.15.5 → 1.0.1

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-software/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , substituteAll
 , pkg-config
 , meson
@@ -56,6 +57,17 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit isocodes;
+    })
+
+    # Add support for AppStream 1.0.
+    # https://gitlab.gnome.org/GNOME/gnome-software/-/issues/2393
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-software/-/commit/0655f358ed0e8455e12d9634f60bc4dbaee434e3.patch";
+      hash = "sha256-8IXXUfNeha5yRlRLuxQV8whwQmyNw7Aoi/r5NNFS/zA=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-software/-/commit/e431ab003f3fabf616b6eb7dc93f8967bc9473e5.patch";
+      hash = "sha256-Y5GcC1XMbb9Bl2/VKFnrV1B/ipLKxY4guse25LhxhKM=";
     })
   ];
 

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -23,12 +23,14 @@
 , gperf
 , vala
 , curl
+, systemd
 , nixosTests
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 }:
 
 stdenv.mkDerivation rec {
   pname = "appstream";
-  version = "0.15.5";
+  version = "1.0.1";
 
   outputs = [ "out" "dev" "installedTests" ];
 
@@ -36,7 +38,7 @@ stdenv.mkDerivation rec {
     owner = "ximion";
     repo = "appstream";
     rev = "v${version}";
-    sha256 = "sha256-KVZCtu1w5FMgXZMiSW55rbrI6W/A9zWWKKvACtk/jjk=";
+    sha256 = "sha256-ULqRHepWVuAluXsXJUoqxqJfrN168MGlwdVkoLLwSN0=";
   };
 
   patches = [
@@ -82,6 +84,8 @@ stdenv.mkDerivation rec {
     libxmlb
     libyaml
     curl
+  ] ++ lib.optionals withSystemd [
+    systemd
   ];
 
   mesonFlags = [
@@ -89,6 +93,8 @@ stdenv.mkDerivation rec {
     "-Ddocs=false"
     "-Dvapi=true"
     "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+  ] ++ lib.optionals (!withSystemd) [
+    "-Dsystemd=false"
   ];
 
   passthru = {

--- a/pkgs/development/libraries/appstream/fix-paths.patch
+++ b/pkgs/development/libraries/appstream/fix-paths.patch
@@ -1,28 +1,13 @@
-diff --git a/data/meson.build b/data/meson.build
-index 53f31cb4..90f40e77 100644
---- a/data/meson.build
-+++ b/data/meson.build
-@@ -68,7 +68,7 @@ test('as-validate_metainfo.cli',
- )
- 
- install_data('appstream.conf',
--             install_dir: get_option('sysconfdir'))
-+             install_dir: get_option('prefix') / 'etc')
- 
- if get_option('compose')
-     ascompose_metainfo = 'org.freedesktop.appstream.compose.metainfo.xml'
 diff --git a/meson.build b/meson.build
-index 2efe86b7..9dc79e28 100644
+index 5e7f57d5..3fe89e8c 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -107,12 +107,12 @@ if get_option ('gir')
-     dependency('gobject-introspection-1.0', version: '>=1.56')
- endif
- 
--stemmer_inc_dirs = include_directories(['/usr/include'])
-+stemmer_inc_dirs = include_directories(['@libstemmer_includedir@'])
+@@ -171,10 +171,10 @@ endif
+ stemmer_inc_dirs = include_directories()
  if get_option('stemming')
      stemmer_lib = cc.find_library('stemmer', required: true)
+-    stemmer_inc_dirs = include_directories(['/usr/include'])
++    stemmer_inc_dirs = include_directories(['@libstemmer_includedir@'])
      if not cc.has_header('libstemmer.h')
          if cc.has_header('libstemmer/libstemmer.h')
 -            stemmer_inc_dirs = include_directories('/usr/include/libstemmer')

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -1,8 +1,11 @@
-{ mkDerivation, appstream, qtbase, qttools, nixosTests }:
+{ lib, stdenv, appstream, qtbase, qttools, nixosTests }:
 
 # TODO: look into using the libraries from the regular appstream derivation as we keep duplicates here
 
-mkDerivation {
+let
+  qtSuffix = lib.optionalString (lib.versions.major qtbase.version == "5") "5";
+in
+stdenv.mkDerivation {
   pname = "appstream-qt";
   inherit (appstream) version src;
 
@@ -12,12 +15,14 @@ mkDerivation {
 
   nativeBuildInputs = appstream.nativeBuildInputs ++ [ qttools ];
 
-  mesonFlags = appstream.mesonFlags ++ [ "-Dqt=true" ];
+  mesonFlags = appstream.mesonFlags ++ [ "-Dqt${qtSuffix}=true" ];
 
   patches = appstream.patches;
 
+  dontWrapQtApps = true;
+
   postFixup = ''
-    sed -i "$dev/lib/cmake/AppStreamQt/AppStreamQtConfig.cmake" \
+    sed -i "$dev/lib/cmake/AppStreamQt${qtSuffix}/AppStreamQt${qtSuffix}Config.cmake" \
       -e "/INTERFACE_INCLUDE_DIRECTORIES/ s@\''${PACKAGE_PREFIX_DIR}@$dev@"
   '';
 


### PR DESCRIPTION
Since both kde-6 and gnome-46 will need this, doing early to make sure 2 PRs don't block each other.

https://github.com/ximion/appstream/compare/v0.15.5...v1.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
