### PR TITLE
timidity: fix ALSA plugins load path

### DIFF
--- a/pkgs/tools/misc/timidity/default.nix
+++ b/pkgs/tools/misc/timidity/default.nix
@@ -8,7 +8,9 @@
 , libjack2
 , ncurses
 , alsa-lib
+, alsa-plugins
 , buildPackages
+, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +30,10 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkg-config ]
+    ++ lib.optionals stdenv.isLinux [ makeWrapper ]
     ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [ memstreamHook ];
+
+
   buildInputs = [
     libjack2
     ncurses
@@ -83,6 +88,12 @@ stdenv.mkDerivation rec {
     substituteAllInPlace $out/share/timidity/timidity.cfg
     tar --strip-components=1 -xf $instruments -C $out/share/timidity/
   '';
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/timidity \
+      --set-default ALSA_PLUGIN_DIR ${alsa-plugins}/lib/alsa-lib
+  '';
+
   # This fixup step is unnecessary and fails on Darwin
   dontRewriteSymlinks = stdenv.isDarwin;
 


### PR DESCRIPTION
## Description of changes

`timidity` tries to load ALSA plugins from the output path of `alsa-lib`, while they are actually built in `alsa-plugins`. This leads to plugin load failures, and can result in failure initializing sound device access and thus an unusable main program:
```
ALSA lib conf.c:4005:(snd_config_hooks_call) Cannot open shared library libasound_module_conf_pulse.so (/nix/store/lxvizzp9h9fxrgr4pxclf7ydaz53rrcp-alsa-lib-1.2.9/lib/alsa-lib/libasound_module_conf_pulse.so: cannot open shared object file: No such file or directory)
ALSA lib pcm.c:2737:(snd_pcm_open_noupdate) Unknown PCM default
Can't open pcm device 'default'.
Couldn't open ALSA pcm device (`s')
```

This fixes it by appropriately setting `ALSA_PLUGIN_DIR`. See also https://github.com/NixOS/nixpkgs/issues/6860 for further background on the issue.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
