### PR TITLE
pcsx2: 1.7.5004 -> 1.7.5318

### DIFF
--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -1,12 +1,11 @@
 { cmake
 , fetchFromGitHub
 , lib
-, llvmPackages_16
+, llvmPackages_17
 , cubeb
 , curl
 , extra-cmake-modules
 , ffmpeg
-, fmt_8
 , gettext
 , harfbuzz
 , libaio
@@ -15,12 +14,12 @@
 , libsamplerate
 , libXrandr
 , libzip
+, makeWrapper
 , pkg-config
 , qtbase
 , qtsvg
 , qttools
 , qtwayland
-, rapidyaml
 , SDL2
 , soundtouch
 , strip-nondeterminism
@@ -37,27 +36,26 @@ let
   pcsx2_patches = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2_patches";
-    rev = "04d727b3bf451da11b6594602036e4f7f5580610";
-    sha256 = "sha256-zrulsSMRNLPFvrC/jeYzl53i4ZvFQ4Yl2nB0bA6Y8KU=";
+    rev = "42d7ee72b66955e3bbd2caaeaa855f605b463722";
+    sha256 = "sha256-Zd+Aeps2IWVX2fS1Vyczv/wAX8Z89XnCH1eqSPdYEw8=";
   };
 in
-llvmPackages_16.stdenv.mkDerivation rec {
+llvmPackages_17.stdenv.mkDerivation rec {
   pname = "pcsx2";
-  version = "1.7.5004";
+  version = "1.7.5318";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
     rev = "v${version}";
-    sha256 = "sha256-o+9VSuoZgTkS75rZ6qYM8ITD+0OcwXp+xh/hdUGpVK4=";
+    sha256 = "sha256-5SUlq3HQAzROG1yncA4u4XGVv+1I+s9FQ6LgJkiLSD0=";
   };
 
   cmakeFlags = [
-    "-DDISABLE_ADVANCE_SIMD=TRUE"
-    "-DUSE_SYSTEM_LIBS=ON"
+    "-DDISABLE_ADVANCE_SIMD=ON"
     "-DUSE_LINKED_FFMPEG=ON"
-    "-DDISABLE_BUILD_DATE=TRUE"
+    "-DDISABLE_BUILD_DATE=ON"
   ];
 
   nativeBuildInputs = [
@@ -72,7 +70,6 @@ llvmPackages_16.stdenv.mkDerivation rec {
   buildInputs = [
     curl
     ffmpeg
-    fmt_8
     gettext
     harfbuzz
     libaio
@@ -85,7 +82,6 @@ llvmPackages_16.stdenv.mkDerivation rec {
     qtsvg
     qttools
     qtwayland
-    rapidyaml
     SDL2
     soundtouch
     vulkan-headers
@@ -106,11 +102,22 @@ llvmPackages_16.stdenv.mkDerivation rec {
     strip-nondeterminism $out/bin/resources/patches.zip
   '';
 
-  qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([
-      vulkan-loader
-    ] ++ cubeb.passthru.backendLibs)}"
-  ];
+  qtWrapperArgs =
+    let
+      libs = lib.makeLibraryPath ([
+        vulkan-loader
+      ] ++ cubeb.passthru.backendLibs);
+    in [
+      "--prefix LD_LIBRARY_PATH : ${libs}"
+    ];
+
+  # https://github.com/PCSX2/pcsx2/pull/10200
+  # Can't avoid the double wrapping, the binary wrapper from qtWrapperArgs doesn't support --run
+  postFixup = ''
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram $out/bin/pcsx2-qt \
+      --run 'if [[ -z $I_WANT_A_BROKEN_WAYLAND_UI ]]; then export QT_QPA_PLATFORM=xcb; fi'
+  '';
 
   meta = with lib; {
     description = "Playstation 2 emulator";


### PR DESCRIPTION
## Description of changes

Update to the latest version.

~One thing I'm not able to implement: one of the changes made upstream is the disabling of Wayland, but you can enable it using the `I_WANT_A_BROKEN_WAYLAND_UI` environment variable.~
~This is the best I could do (inside `qtWrapperArgs`):~
```
    ''--set QT_QPA_PLATFORM "\''$(if [[ -z $I_WANT_A_BROKEN_WAYLAND_UI ]]; then echo 'xcb'; else echo \'\'; fi)"''
```
~Can someone more knowledgeable of Bash and escape hells fix this?~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
