### PR TITLE
Revert recent unprompted additions of GitHub accounts to the maintainer listing

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18552,8 +18552,6 @@
   };
   tomkoid = {
     email = "tomaszierl@outlook.com";
-    github = "Tomkoid";
-    githubId = 67477750;
     name = "Tomkoid";
   };
   tomodachi94 = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6744,8 +6744,6 @@
   };
   gm6k = {
     email = "nix@quidecco.pl";
-    github = "zeuner";
-    githubId = 2545850;
     name = "Isidor Zeuner";
   };
   gmemstr = {


### PR DESCRIPTION
## Description of changes

Reverts the GitHub account additions from https://github.com/NixOS/nixpkgs/pull/272199. GitHub names/ids are not mandatory for now, so this wasn't necessary. See also https://github.com/NixOS/nixpkgs/pull/273220 and https://github.com/NixOS/nixpkgs/pull/273146.

Furthermore these users have not consented to their account information being added to the listing. While we can't reasonably change the git history, we can revert the change so it won't be included in future revisions.

## Things done

- [x] Ran the tests with `nix-build lib/tests/maintainers.nix`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
