### PR TITLE
Allow relative lua modules at runtime

### DIFF
--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -70,7 +70,7 @@ let
         inherit executable luaversion;
         luaOnBuild = luaOnBuildForHost.override { inherit packageOverrides; self = luaOnBuild; };
 
-        tests = callPackage ./tests { inherit (luaPackages) wrapLua; };
+        tests = callPackage ./tests { lua = self; inherit (luaPackages) wrapLua; };
 
         inherit luaAttr;
   };

--- a/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
@@ -17,7 +17,7 @@ addToLuaSearchPathWithCustomDelimiter() {
   local topDir="${absPattern%%\?*}"
 
   # export only if the folder exists else LUA_PATH/LUA_CPATH grow too large
-  if [[ ! -d "$topDir" ]]; then return; fi
+  if [[ ! -d "$topDir" ]] && [[ ! "$absPattern" =~ ^\./ ]]; then return; fi
 
   # export only if we haven't already got this dir in the search path
   if [[ ${!varName-} == *"$absPattern"* ]]; then return; fi

--- a/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
@@ -34,12 +34,22 @@ addToLuaPath() {
   fi
   cd "$dir"
   for pattern in @luapathsearchpaths@; do
-    addToLuaSearchPathWithCustomDelimiter LUA_PATH "$PWD/$pattern"
+    # handle relative paths at runtime
+    if [[ "$pattern" =~ ^\./ ]]; then
+        addToLuaSearchPathWithCustomDelimiter LUA_PATH "$pattern"
+    else
+        addToLuaSearchPathWithCustomDelimiter LUA_PATH "$PWD/$pattern"
+    fi
   done
 
   # LUA_CPATH
   for pattern in @luacpathsearchpaths@; do
-    addToLuaSearchPathWithCustomDelimiter LUA_CPATH "$PWD/$pattern"
+    # handle relative paths at runtime
+    if [[ "$pattern" =~ ^\./ ]]; then
+        addToLuaSearchPathWithCustomDelimiter LUA_CPATH "$pattern"
+    else
+        addToLuaSearchPathWithCustomDelimiter LUA_CPATH "$PWD/$pattern"
+    fi
   done
   cd - >/dev/null
 }

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation (finalAttrs:
     sha256 = hash;
   };
 
-  LuaPathSearchPaths  = [ "./?.lua" "./?/init.lua" ] ++ luaPackages.luaLib.luaPathList;
-  LuaCPathSearchPaths = [ "./?.so" ] ++ luaPackages.luaLib.luaCPathList;
+  LuaPathSearchPaths  = [ "./share/lua/${self.luaversion}/?.lua" "./?.lua" "./?/init.lua" ] ++ luaPackages.luaLib.luaPathList;
+  LuaCPathSearchPaths = [ "./lib/lua/${self.luaversion}/?.so" "./?.so" "./lib/lua/${self.luaversion}/loadall.so" ] ++ luaPackages.luaLib.luaCPathList;
   setupHook = luaPackages.lua-setup-hook
     finalAttrs.LuaPathSearchPaths
     finalAttrs.LuaCPathSearchPaths;
@@ -60,16 +60,7 @@ stdenv.mkDerivation (finalAttrs:
   inherit patches;
 
   # we can't pass flags to the lua makefile because for portability, everything is hardcoded
-  postPatch = ''
-    {
-      echo -e '
-        #undef  LUA_PATH_DEFAULT
-        #define LUA_PATH_DEFAULT "./share/lua/${luaversion}/?.lua;./?.lua;./?/init.lua"
-        #undef  LUA_CPATH_DEFAULT
-        #define LUA_CPATH_DEFAULT "./lib/lua/${luaversion}/?.so;./?.so;./lib/lua/${luaversion}/loadall.so"
-      '
-    } >> src/luaconf.h
-  '' + lib.optionalString (!stdenv.isDarwin && !staticOnly) ''
+  postPatch = lib.optionalString (!stdenv.isDarwin && !staticOnly) ''
     # Add a target for a shared library to the Makefile.
     sed -e '1s/^/LUA_SO = liblua.so/' \
         -e 's/ALL_T *= */&$(LUA_SO) /' \

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation (finalAttrs:
     sha256 = hash;
   };
 
-  LuaPathSearchPaths  = luaPackages.luaLib.luaPathList;
-  LuaCPathSearchPaths = luaPackages.luaLib.luaCPathList;
+  LuaPathSearchPaths  = [ "./?.lua" "./?/init.lua" ] ++ luaPackages.luaLib.luaPathList;
+  LuaCPathSearchPaths = [ "./?.so" ] ++ luaPackages.luaLib.luaCPathList;
   setupHook = luaPackages.lua-setup-hook
     finalAttrs.LuaPathSearchPaths
     finalAttrs.LuaCPathSearchPaths;

--- a/pkgs/development/interpreters/lua-5/tests/assert.sh
+++ b/pkgs/development/interpreters/lua-5/tests/assert.sh
@@ -8,9 +8,14 @@ function fail() {
 }
 
 
-function assertStringEqual {
-
+function assertStringEqual() {
     if ! diff <(echo "$1") <(echo "$2") ; then
         fail "Strings differ"
+    fi
+}
+
+function assertStringContains() {
+    if ! echo "$1" | grep -q "$2" ; then
+        fail "\"$1\" does not contain \"$2\""
     fi
 }

--- a/pkgs/development/interpreters/lua-5/tests/assert.sh
+++ b/pkgs/development/interpreters/lua-5/tests/assert.sh
@@ -10,12 +10,12 @@ function fail() {
 
 function assertStringEqual() {
     if ! diff <(echo "$1") <(echo "$2") ; then
-        fail "Strings differ"
+        fail "expected \"$1\" to be equal to \"$2\""
     fi
 }
 
 function assertStringContains() {
     if ! echo "$1" | grep -q "$2" ; then
-        fail "\"$1\" does not contain \"$2\""
+        fail "expected \"$1\" to contain \"$2\""
     fi
 }

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -40,7 +40,7 @@ in
       generated=$(lua -e 'print(package.path)')
       golden_LUA_PATH='./share/lua/${lua.luaversion}/?.lua;./?.lua;./?/init.lua'
 
-      assertStringEqual "$generated" "$golden_LUA_PATH"
+      assertStringContains "$generated" "$golden_LUA_PATH"
       '';
   };
 

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -8,7 +8,7 @@
 let
 
   runTest = lua: { name, command }:
-    pkgs.runCommandLocal "test-${lua.name}" ({
+    pkgs.runCommandLocal "test-${lua.name}-${name}" ({
       nativeBuildInputs = [lua];
       meta.platforms = lua.meta.platforms;
     }) (''
@@ -54,8 +54,8 @@ in
     }) (''
       source ${./assert.sh}
 
-      lua_vanilla_package_path=$(${lua}/bin/lua -e "print(package.path)")
-      lua_with_module_package_path=$(${luaWithModule}/bin/lua -e "print(package.path)")
+      lua_vanilla_package_path="$(${lua}/bin/lua -e "print(package.path)")"
+      lua_with_module_package_path="$(${luaWithModule}/bin/lua -e "print(package.path)")"
 
       assertStringContains "$lua_vanilla_package_path" "./?.lua"
       assertStringContains "$lua_vanilla_package_path" "./?/init.lua"

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -75,15 +75,6 @@ stdenv.mkDerivation rec {
       # passed by nixpkgs CC wrapper is insufficient on its own
       substituteInPlace src/Makefile --replace "#CCDEBUG= -g" "CCDEBUG= -g"
     fi
-
-    {
-      echo -e '
-        #undef  LUA_PATH_DEFAULT
-        #define LUA_PATH_DEFAULT "./share/lua/${luaversion}/?.lua;./?.lua;./?/init.lua"
-        #undef  LUA_CPATH_DEFAULT
-        #define LUA_CPATH_DEFAULT "./lib/lua/${luaversion}/?.so;./?.so;./lib/lua/${luaversion}/loadall.so"
-      '
-    } >> src/luaconf.h
   '';
 
   dontConfigure = true;
@@ -111,8 +102,8 @@ stdenv.mkDerivation rec {
     fi
   '';
 
-  LuaPathSearchPaths    = [ "./?.lua" "./?/init.lua" ] ++ luaPackages.luaLib.luaPathList;
-  LuaCPathSearchPaths   = [ "./?.so" ] ++ luaPackages.luaLib.luaCPathList;
+  LuaPathSearchPaths    = [ "./share/lua/${luaversion}/?.lua" "./?.lua" "./?/init.lua" ] ++ luaPackages.luaLib.luaPathList;
+  LuaCPathSearchPaths   = [ "./lib/lua/${luaversion}/?.so" "./?.so" "./lib/lua/${luaversion}/loadall.so" ] ++ luaPackages.luaLib.luaCPathList;
 
   setupHook = luaPackages.lua-setup-hook LuaPathSearchPaths LuaCPathSearchPaths;
 

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -111,10 +111,10 @@ stdenv.mkDerivation rec {
     fi
   '';
 
-  LuaPathSearchPaths    = luaPackages.luaLib.luaPathList;
-  LuaCPathSearchPaths   = luaPackages.luaLib.luaCPathList;
+  LuaPathSearchPaths    = [ "./?.lua" "./?/init.lua" ] ++ luaPackages.luaLib.luaPathList;
+  LuaCPathSearchPaths   = [ "./?.so" ] ++ luaPackages.luaLib.luaCPathList;
 
-  setupHook = luaPackages.lua-setup-hook luaPackages.luaLib.luaPathList luaPackages.luaLib.luaCPathList;
+  setupHook = luaPackages.lua-setup-hook LuaPathSearchPaths LuaCPathSearchPaths;
 
   # copied from python
   passthru = let


### PR DESCRIPTION
## Description of changes


I have made some changes to allow for relative lua package imports. This addresses the following two issues:

- https://github.com/NixOS/nixpkgs/issues/113110
- https://github.com/NixOS/nixpkgs/issues/189689

I decided to set these directly on the definitions of the lua / luajit derivations, so it's still possible to build versions of these packages that follow the previous, stricter path logic. I still think it makes sense to set these by default so that lua scripts are more easily portable (which in my mind is a nod to the fact that it's quite common to see lua scripts distributed without any package manager, but just as a tarball of a bunch of files).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
