### PR TITLE
mpvScripts.sponsorblock-minimal: init at unstable-2023-08-20

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -20,6 +20,7 @@ in lib.recurseIntoAttrs
     quality-menu = callPackage ./quality-menu.nix { inherit buildLua; };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { inherit buildLua; };
     sponsorblock = callPackage ./sponsorblock.nix { };
+    sponsorblock-minimal = callPackage ./sponsorblock-minimal.nix { inherit buildLua; };
     thumbfast = callPackage ./thumbfast.nix { inherit buildLua; };
     thumbnail = callPackage ./thumbnail.nix { inherit buildLua; };
     uosc = callPackage ./uosc.nix { inherit buildLua; };

--- a/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildLua
+, fetchFromGitea
+, curl
+}:
+
+buildLua {
+  pname = "mpv_sponsorblock_minimal";
+  version = "unstable-2023-08-20";
+  scriptPath = "sponsorblock_minimal.lua";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "jouni";
+    repo = "mpv_sponsorblock_minimal";
+    rev = "ca2844b8cf7674bfccd282d389a50427742251d3";
+    hash = "sha256-28HWZ6nOhKiE+5Ya1N3Vscd8aeH9OKS0t72e/xPfFQQ=";
+  };
+
+  preInstall = ''
+    substituteInPlace sponsorblock_minimal.lua \
+      --replace "curl" "${lib.getExe curl}"
+  '';
+
+  meta = with lib; {
+    description = "A minimal script to skip sponsored segments of YouTube videos";
+    homepage = "https://codeberg.org/jouni/mpv_sponsorblock_minimal";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ arthsmn ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is a simplified script to integrate mpv with Sponsorblock. This one is more limited, can only skip segments, but it also doesn't depend on python.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
