### PR TITLE
nixos/ups: fix shutting down the UPS from primary monitors

### DIFF
--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -590,6 +590,7 @@ in
       "d /var/lib/nut 700"
     ];
 
+    services.udev.packages = [ pkgs.nut ];
 
 /*
     users.users.nut =

--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -30,6 +30,13 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # This patch injects a default value for NUT_CONFPATH into the nutshutdown script
+    # since the way we build the package results in the binaries being hardcoded to check
+    # $out/etc/ups.conf instead of /etc/nut/ups.conf (where the module places the file).
+    # We also cannot use `--sysconfdir=/etc/nut` since that results in the install phase
+    # trying to install directly into /etc/nut which predictably fails
+    ./nutshutdown-conf-default.patch
+
     (substituteAll {
       src = ./hardcode-paths.patch;
       avahi = "${avahi}/lib";

--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -85,6 +85,9 @@ stdenv.mkDerivation rec {
 
     # we don't need init.d scripts
     rm -r $out/share/solaris-init
+
+    # Suspicious/overly broad rule, remove it until we know better
+    rm $out/etc/udev/rules.d/52-nut-ipmipsu.rules
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -18,6 +18,7 @@
 , substituteAll
 , systemd
 , udev
+, gnused
 }:
 
 stdenv.mkDerivation rec {
@@ -70,13 +71,17 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/lib/systemd/system-shutdown/nutshutdown \
+      --replace /bin/sed "${gnused}/bin/sed" \
       --replace /bin/sleep "${coreutils}/bin/sleep" \
       --replace /bin/systemctl "${systemd}/bin/systemctl"
 
     for file in system/{nut-monitor.service,nut-driver-enumerator.service,nut-server.service,nut-driver@.service} system-shutdown/nutshutdown; do
-    substituteInPlace $out/lib/systemd/$file \
-      --replace "$out/etc/nut.conf" "/etc/nut.conf"
+      substituteInPlace $out/lib/systemd/$file \
+        --replace "$out/etc/nut.conf" "/etc/nut/nut.conf"
     done
+
+    substituteInPlace $out/lib/systemd/system/nut-driver-enumerator.path \
+      --replace "$out/etc/ups.conf" "/etc/nut/ups.conf"
 
     # we don't need init.d scripts
     rm -r $out/share/solaris-init

--- a/pkgs/applications/misc/nut/nutshutdown-conf-default.patch
+++ b/pkgs/applications/misc/nut/nutshutdown-conf-default.patch
@@ -1,0 +1,10 @@
+diff --git a/scripts/systemd/nutshutdown.in b/scripts/systemd/nutshutdown.in
+index ace2485b3..9dee869bb 100755
+--- a/scripts/systemd/nutshutdown.in
++++ b/scripts/systemd/nutshutdown.in
+@@ -1,4 +1,5 @@
+ #!/bin/sh
++export NUT_CONFPATH="${NUT_CONFPATH-/etc/nut}"
+ 
+ # This script requires both nut-server (drivers)
+ # and nut-client (upsmon) to be present locally


### PR DESCRIPTION
## Description of changes

During my testing I noticed that NUT was not able to successfully issue a shutdown command to my UPS due to several issues:

1. Due to the way the package is built, it results in all the binaries trying to use `$out/etc/ups.conf` as their configuration file, and not `/etc/nut/ups.conf` as the module defines. I patched the `nutshutdown` script to set a default value for `NUT_CONFPATH` to `/etc/nut` to work around this
2. I also updated the NixOS module to install NUT's udev rules. This further allows the usbhid driver to successfully issue the shutdown command

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
