### PR TITLE
[Backport nixpkgs-23.11-darwin] zsh-fzf-tab: fix build with clang 16

### DIFF
--- a/pkgs/shells/zsh/zsh-fzf-tab/default.nix
+++ b/pkgs/shells/zsh/zsh-fzf-tab/default.nix
@@ -16,6 +16,14 @@ in stdenv.mkDerivation rec {
   strictDeps = true;
   buildInputs = [ ncurses ];
 
+  # https://github.com/Aloxaf/fzf-tab/issues/337
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=implicit-int"
+    ];
+  };
+
   postConfigure = ''
     pushd modules
     ./configure --disable-gdbm --without-tcsetpgrp


### PR DESCRIPTION
Backport #271088 to `nixpkgs-23.11-darwin`.

* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2023-12-10T19%3A29%3A27Z#changes-acceptable-for-releases).
  * Even as a non-commiter, if you find that it is not acceptable, leave a comment.