### PR TITLE
libdrm: 2.4.117 -> 2.4.118

### DIFF
--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libdrm";
-  version = "2.4.117";
+  version = "2.4.118";
 
   src = fetchurl {
     url = "https://dri.freedesktop.org/${pname}/${pname}-${version}.tar.xz";


### PR DESCRIPTION
Hyprland requires version 2.4.118 as a dependency