### PR TITLE
openclonk: unbreak

### DIFF
--- a/pkgs/games/openclonk/default.nix
+++ b/pkgs/games/openclonk/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config
+{ lib, stdenv, fetchurl, fetchDebianPatch, fetchpatch, cmake, pkg-config
 , SDL2, libvorbis, libogg, libjpeg, libpng, freetype, glew, tinyxml, openal
-, freealut, readline, gcc-unwrapped
+, freealut, readline, libb2, gcc-unwrapped
 , enableSoundtrack ? false # Enable the "Open Clonk Soundtrack - Explorers Journey" by David Oerther
 }:
 
@@ -18,6 +18,21 @@ in stdenv.mkDerivation rec {
     sha256 = "0imkqjp8lww5p0cnqf4k4mb2v682mnsas63qmiz17rspakr7fxik";
   };
 
+  patches = [
+    (fetchDebianPatch {
+      pname = "openclonk";
+      version = "8.1";
+      debianRevision = "3";
+      patch = "system-libb2.patch";
+      hash = "sha256-zuH6zxSQXRhnt75092Xwb6XYv8UG391E5Arbnr7ApiI=";
+    })
+    (fetchpatch {
+      name = "fix-gcc-11-build.patch";
+      url = "https://github.com/openclonk/openclonk/commit/e304efde2c8643bbc0fc1ad5e85024982744b233.patch";
+      hash = "sha256-jfVCgeZuYo4x53zhljKcnMDMIBECTRsUSxkl6JaL6HA=";
+    })
+  ];
+
   postInstall = ''
     mv -v $out/games/openclonk $out/bin/
   '' + lib.optionalString enableSoundtrack ''
@@ -28,7 +43,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     SDL2 libvorbis libogg libjpeg libpng freetype glew tinyxml openal freealut
-    readline
+    readline libb2
   ];
 
   cmakeFlags = [ "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar" "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib" ];
@@ -39,8 +54,8 @@ in stdenv.mkDerivation rec {
     description = "Free multiplayer action game in which you control clonks, small but witty and nimble humanoid beings";
     homepage = "https://www.openclonk.org";
     license = if enableSoundtrack then licenses.unfreeRedistributable else licenses.isc;
+    mainProgram = "openclonk";
     maintainers = with maintainers; [ lheckemann ];
     platforms = [ "x86_64-linux" "i686-linux" ];
-    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38119,7 +38119,7 @@ with pkgs;
 
   openlierox = callPackage ../games/openlierox { };
 
-  openclonk = callPackage ../games/openclonk { stdenv = gcc10StdenvCompat; };
+  openclonk = callPackage ../games/openclonk { };
 
   openjk = callPackage ../games/openjk { };
 


### PR DESCRIPTION
## Description of changes

Imported patches from Debian, which also allows building and running on aarch64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
