### PR TITLE
podman: 4.7.2 -> 4.8.1

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -62,13 +62,13 @@ let
 in
 buildGoModule rec {
   pname = "podman";
-  version = "4.7.2";
+  version = "4.8.1";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman";
     rev = "v${version}";
-    hash = "sha256-o5FTCuFUbTlENqvh+u6fPEfD816tKWPxHu2yhBi/Mf0=";
+    hash = "sha256-EDIgipbv8Z7nVV6VQ5IAmvHvvpLyGEDHMDnwhMUm/BQ=";
   };
 
   patches = [

--- a/pkgs/applications/virtualization/podman/rm-podman-mac-helper-msg.patch
+++ b/pkgs/applications/virtualization/podman/rm-podman-mac-helper-msg.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/machine/machine_common.go b/pkg/machine/machine_common.go
-index 649748947..a981d93bf 100644
+index 4e43dd54c..a981d93bf 100644
 --- a/pkg/machine/machine_common.go
 +++ b/pkg/machine/machine_common.go
 @@ -127,14 +127,6 @@ address can't be used by podman. `
@@ -7,10 +7,10 @@ index 649748947..a981d93bf 100644
  				if len(helper) < 1 {
  					fmt.Print(fmtString)
 -				} else {
--					fmtString += `If you would like to install it run the\nfollowing commands:
+-					fmtString += `If you would like to install it, run the following commands:
 -
 -        sudo %s install
--        podman machine stop%[1]s; podman machine start%[1]s
+-        podman machine stop%[2]s; podman machine start%[2]s
 -
 -                `
 -					fmt.Printf(fmtString, helper, suffix)


### PR DESCRIPTION
https://github.com/containers/podman/releases/tag/v4.8.1 https://github.com/containers/podman/releases/tag/v4.8.0

## Description of changes

Update to latest podman release. Relevant release notes attached in commit. No breaking changes found.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
