### PR TITLE
Revert "gh: 2.39.2 -> 2.40.0"

### DIFF
--- a/pkgs/applications/version-management/gh/default.nix
+++ b/pkgs/applications/version-management/gh/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "gh";
-  version = "2.40.0";
+  version = "2.39.2";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     rev = "v${version}";
-    hash = "sha256-ffmOyifoJPrrC9J4lZ7HWq+fww5/EOCYhYIfx6Been0=";
+    hash = "sha256-6FjsUEroHpAjQj+7Z/C935LunYbgAzRvQI2pORiLo3s=";
   };
 
   vendorHash = "sha256-jM9nwTMOTh+eXztLvHIwwH4qu3ZIMOtBrPEtByB9Ry8=";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#272713 until the home-manager stuff is figured out