### PR TITLE
xwaylandvideobridge: 0.2 -> 0.3.0

### DIFF
--- a/pkgs/tools/wayland/xwaylandvideobridge/default.nix
+++ b/pkgs/tools/wayland/xwaylandvideobridge/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchFromGitLab
+, fetchurl
 , cmake
 , extra-cmake-modules
 , pkg-config
@@ -14,14 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xwaylandvideobridge";
-  version = "0.2";
+  version = "0.3.0";
 
-  src = fetchFromGitLab {
-    domain = "invent.kde.org";
-    owner = "system";
-    repo = "xwaylandvideobridge";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-79Z4BH7C85ZF+1Zivs3bTey7IdUnaDKhvZxzL6sDqUs=";
+  src = fetchurl {
+    url = "mirror://kde/stable/xwaylandvideobridge/xwaylandvideobridge-${finalAttrs.version}.tar.xz";
+    hash = "sha256-+Npuj+DsO9XqeXr4qtj+Haqzb8PHfi02u3RDgyzfz/o=";
   };
 
   nativeBuildInputs = [
@@ -42,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Utility to allow streaming Wayland windows to X applications";
     homepage = "https://invent.kde.org/system/xwaylandvideobridge";
-    license = lib.licenses.gpl2Plus;
+    license = with lib.licenses; [ bsd3 cc0 gpl2Plus ];
     maintainers = with lib.maintainers; [ stepbrobd ];
     platforms = lib.platforms.linux;
     mainProgram = "xwaylandvideobridge";


### PR DESCRIPTION
## Description of changes

- 0.2 -> 0.3.0

- switch from <https://invent.kde.org/system/xwaylandvideobridge> to <https://download.kde.org/stable/xwaylandvideobridge>

- add bsd3 cc0 licenses

```diff
diff --git a/pkgs/tools/wayland/xwaylandvideobridge/default.nix b/pkgs/tools/wayland/xwaylandvideobridge/default.nix
index 83b2186c8ab1..9e29f781c0a1 100644
--- a/pkgs/tools/wayland/xwaylandvideobridge/default.nix
+++ b/pkgs/tools/wayland/xwaylandvideobridge/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchFromGitLab
+, fetchurl
 , cmake
 , extra-cmake-modules
 , pkg-config
@@ -14,14 +14,11 @@

 stdenv.mkDerivation (finalAttrs: {
   pname = "xwaylandvideobridge";
-  version = "0.2";
+  version = "0.3.0";

-  src = fetchFromGitLab {
-    domain = "invent.kde.org";
-    owner = "system";
-    repo = "xwaylandvideobridge";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-79Z4BH7C85ZF+1Zivs3bTey7IdUnaDKhvZxzL6sDqUs=";
+  src = fetchurl {
+    url = "https://download.kde.org/stable/xwaylandvideobridge/xwaylandvideobridge-${finalAttrs.version}.tar.xz";
+    hash = "sha256-+Npuj+DsO9XqeXr4qtj+Haqzb8PHfi02u3RDgyzfz/o=";
   };

   nativeBuildInputs = [
@@ -42,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Utility to allow streaming Wayland windows to X applications";
     homepage = "https://invent.kde.org/system/xwaylandvideobridge";
-    license = lib.licenses.gpl2Plus;
+    license = with lib.licenses; [ bsd3 cc0 gpl2Plus ];
     maintainers = with lib.maintainers; [ stepbrobd ];
     platforms = lib.platforms.linux;
     mainProgram = "xwaylandvideobridge";
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
