### PR TITLE
dmd, dtools: 2.105.2 -> 2.106.0

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "2.105.2";
-  dmdSha256 = "sha256-IjzIQZttB1711VayKDWcpYvf1MAan+GWGTdpdDTgo1k=";
-  phobosSha256 = "sha256-2hAq48sBC1qvS1XBWZhGIPUlsA4pGcn4pHNok6lC8R0=";
+  version = "2.106.0";
+  dmdSha256 = "sha256-H28X+8qAjnc5KIvZ7HRVCtjNpf1hBwSPL6QIVeWCjKM=";
+  phobosSha256 = "sha256-umsPMQbomJUu/QBMSgSC0jEajxiJwv1Lay4q4tvfnsI=";
 }

--- a/pkgs/development/compilers/dmd/generic.nix
+++ b/pkgs/development/compilers/dmd/generic.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation rec {
     rm dmd/compiler/test/runnable/gdb15729.sh
     rm dmd/compiler/test/runnable/gdb4149.d
     rm dmd/compiler/test/runnable/gdb4181.d
+    rm dmd/compiler/test/compilable/ddocYear.d
 
     # Disable tests that rely on objdump whitespace until fixed upstream:
     #   https://issues.dlang.org/show_bug.cgi?id=23317
@@ -103,12 +104,7 @@ stdenv.mkDerivation rec {
     rm dmd/compiler/test/compilable/cdcmp.d
   ''
 
-  + lib.optionalString (lib.versionOlder version "2.091.0") ''
-    # This one has tested against a hardcoded year, then against a current year on
-    # and off again. It just isn't worth it to patch all the historical versions
-    # of it, so just remove it until the most recent change.
-    rm dmd/compiler/test/compilable/ddocYear.d
-  '' + lib.optionalString (lib.versionAtLeast version "2.089.0" && lib.versionOlder version "2.092.2") ''
+  + lib.optionalString (lib.versionAtLeast version "2.089.0" && lib.versionOlder version "2.092.2") ''
     rm dmd/compiler/test/dshell/test6952.d
   '' + lib.optionalString (lib.versionAtLeast version "2.092.2") ''
     substituteInPlace dmd/compiler/test/dshell/test6952.d --replace "/usr/bin/env bash" "${bash}/bin/bash"

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dtools";
-  version = "2.105.2";
+  version = "2.106.0";
 
   src = fetchFromGitHub {
     owner = "dlang";


### PR DESCRIPTION
## Description of changes

https://dlang.org/changelog/2.106.0.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
