### PR TITLE
pkgs/README: recommend lockfiles are fetched rather than vendored

### DIFF
--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -722,6 +722,7 @@ Reviewing process:
 - Ensure that the meta field information [fits the guidelines](#meta-attributes) and is correct:
   - License can change with version updates, so it should be checked to match the upstream license.
   - If the package has no maintainer, a maintainer must be set. This can be the update submitter or a community member that accepts to take maintainership of the package.
+- Ensure that any added lockfiles that are not parsed at eval-time, are fetched rather than vendored.
 - Ensure that the code contains no typos.
 - Build the package locally.
   - Pull requests are often targeted to the master or staging branch, and building the pull request locally when it is submitted can trigger many source builds.
@@ -755,6 +756,7 @@ Sample template for a package update review is provided below.
 - [ ] all depending packages build
 - [ ] patches have a comment describing either the upstream URL or a reason why the patch wasn't upstreamed
 - [ ] patches that are remotely available are fetched rather than vendored
+- [ ] non-eval lockfiles are fetched rather than vendored
 
 ##### Possible improvements
 
@@ -775,6 +777,7 @@ Review process:
   - License must match the upstream license.
   - Platforms should be set (or the package will not get binary substitutes).
   - Maintainers must be set. This can be the package submitter or a community member that accepts taking up maintainership of the package.
+- Ensure that any added lockfiles that are not parsed at eval-time, are fetched rather than vendored.
 - Report detected typos.
 - Ensure the package source:
   - Uses `mirror://` URLs when available.
@@ -802,6 +805,7 @@ Sample template for a new package review is provided below.
 - [ ] when a phase (like `installPhase`) is overridden it starts with `runHook preInstall` and ends with `runHook postInstall`.
 - [ ] patches have a comment describing either the upstream URL or a reason why the patch wasn't upstreamed
 - [ ] patches that are remotely available are fetched rather than vendored
+- [ ] non-eval lockfiles are fetched rather than vendored
 
 ##### Possible improvements
 


### PR DESCRIPTION
## Description of changes

The amount of lockfiles vendored in nixpkgs is growing, and at a high pace considering that a single PR may [add to the tune of 14k LOC](https://github.com/NixOS/nixpkgs/pull/271034). Some lockfile vendoring is unavoidable with the current tooling, but much of it can be moved out of nixpkgs.

Lockfiles that are not parsed at eval time (i.e. not cargoLock) can be fetched remotely. Contributors can either A) create an upstream PR and `fetchpatch` the lockfile or get it merged, or B) create a gist and `fetchurl` it if upstream does/can not accept contributions.

I try to champion the use of the [review templates](https://github.com/NixOS/nixpkgs/tree/master/pkgs#reviewing-contributions) in my work, and while its use is [not yet wide spread](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+%22source+is+fetched+using+the+appropriate+function%22+) I believe it is a great place to codeify the standard we strive for in nixpkgs contributions. Hence this PR.

Pros:

* The nixpkgs tarball will become smaller
* The workload is widely shared, rather than carried by few who deeply care for this issue

Cons:

* More difficult to `grep` for vulnerable dependencies.
* No lockfile diff during review.
* Higher burden on contributors to find a suitable lockfile host and upload it.
  * Should we codeify a recommended file hosts? Can we tailor and self-host one for nixpkgs?



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
