### PR TITLE
nixos/networking-interfaces: fix rootless ping

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1396,6 +1396,8 @@ in
       "net.ipv4.conf.all.forwarding" = mkDefault (any (i: i.proxyARP) interfaces);
       "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
       "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
+      # allow all users to do ICMP echo requests (ping)
+      "net.ipv4.ping_group_range" = mkDefault "0 2147483647";
       # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
       "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
     } // listToAttrs (forEach interfaces


### PR DESCRIPTION
## Description of changes

In 759ec111 the ping setuid wrapper was removed in favour of giving permissions to perform ICMP echo requests to all users.
The problem is that the systemd file that was supposed to change the `net.ipv4.ping_group_range` sysctl is not always installed, specifically only if systemd.coredump.enable.
In that case the range is "0 1", which is effectively restricts ping to only root.

This change explicitely sets the range to "0 2^31-1", as systemd does.


## Things done

I tested this in NixOS 23.11.

Before:
```
$ ping -c1 example.org
ping: socktype: SOCK_RAW
ping: socket: Operation not permitted
ping: => missing cap_net_raw+p capability or setuid?
```

After:
```
$ ping -c1 example.org
PING example.org (93.184.216.34) 56(84) bytes of data.
64 bytes from 93.184.216.34 (93.184.216.34): icmp_seq=1 ttl=52 time=106 ms

--- example.org ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 106.023/106.023/106.023/0.000 ms
```
