### PR TITLE
rPackages.torch: Fix torch

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -498,6 +498,12 @@ let
     textshaping = [ pkgs.pkg-config ];
     ragg = [ pkgs.pkg-config ];
     qqconf = [ pkgs.pkg-config ];
+    torch = [  pkgs.cmake
+               pkgs.autoPatchelfHook
+               pkgs.addOpenGLRunpath
+               pkgs.cudaPackages.autoAddOpenGLRunpathHook
+               pkgs.patchelf
+            ];
   };
 
   packagesWithBuildInputs = {
@@ -634,6 +640,11 @@ let
     ijtiff = [ pkgs.libtiff ];
     ragg = with pkgs; [ freetype.dev libpng.dev libtiff.dev zlib.dev libjpeg.dev bzip2.dev ];
     qqconf = [ pkgs.fftw.dev ];
+    torch = [
+      pkgs.cudaPackages_11_7.cudatoolkit.lib
+      pkgs.cudaPackages_11_7.cuda_nvtx
+      pkgs.cudaPackages_11_7.cudnn
+            ];
   };
 
   packagesRequiringX = [
@@ -1390,9 +1401,63 @@ let
       '';
     });
 
-    torch = old.torch.overrideAttrs (attrs: {
+    torch = let
+      version =  "0.11.0";
+      libtorch-for-r-torch = fetchurl {
+        url = "https://download.pytorch.org/libtorch/cu117/libtorch-cxx11-abi-shared-with-deps-1.13.1%2Bcu117.zip";
+        sha256 = "sha256-hkLGZXroAnMKwfS0rkrZgO7iUVdlRH5HC4O0jM0ikt4=";
+      };
+      liblantern-for-r-torch = fetchurl {
+          url = "https://storage.googleapis.com/torch-lantern-builds/binaries/refs/heads/cran/v${version}/latest/lantern-${version}+cu117+x86_64-Linux.zip";
+          sha256 = "sha256-tfXRuTs0+IbFRm8SjfY0Rx1E+gnrcQZkUzMderq6hdY=";
+        };
+    in old.torch.overrideAttrs (attrs: {
+      env = {
+        TORCH_URL = "${libtorch-for-r-torch}";
+        LANTERN_URL = "${liblantern-for-r-torch}";
+        CUDA = "11.7";
+      };
+      autoPatchelfIgnoreMissingDeps = [
+        # This is the hardware-dependent userspace driver that comes from
+        # nvidia_x11 package. It must be deployed at runtime in
+        # /run/opengl-driver/lib or pointed at by LD_LIBRARY_PATH variable, rather
+        # than pinned in runpath
+        "libcuda.so.1"
+      ];
+      dontStrip = true;
+      postFixup = ''
+    addAutoPatchelfSearchPath "$out/library/torch/lib"
+
+    patchelf $out/library/torch/lib/libcudnn.so.8 --add-needed libcudnn_cnn_infer.so.8
+
+    pushd $out/library/torch/lib || exit 1
+      for LIBNVRTC in ./libnvrtc*
+      do
+        case "$LIBNVRTC" in
+          ./libnvrtc-builtins*) true;;
+          ./libnvrtc*) patchelf "$LIBNVRTC" --add-needed libnvrtc-builtins* ;;
+        esac
+      done
+    popd || exit 1
+  '';
       preConfigure = ''
         patchShebangs configure
+        # substituteInPlace configure \
+            # --replace "\$R_PACKAGE_DIR" "$out"
+      '';
+      preInstall = ''
+        # export TORCH_PATH=$(pwd)
+        echo $TORCH_PATH
+        pwd
+        ls -al
+        ls -al src
+        echo $installPhase
+        echo $sourceRoot
+      '';
+      postInstall = ''
+        $rCommand -e "torch::install_torch()"
+        # mkdir -p $out/library/torch/bin
+        # ln -s ${pkgs.libtorch-bin}/lib/lib/libtorch.so $out/library/torch/bin/torch.so
       '';
     });
   };


### PR DESCRIPTION
## Description of changes

The latest commit in NixOS/r-updates allows the R package `torch` to install. However, calling `library(torch)` causes the package to attempt to download and install binaries if it does not find them in `$TORCH_PATH`. This PR allows `torch` to actually run. I have been using `torch` with an RTX 3070 laptop card and it is working well

`torch` requires a range of CUDA related packages and libtorch. Python is not needed, liblantern is a wrapper for libtorch that interfaces with R.

Ideally, libtorch would be built from source. However, I struggled to get libtorch and liblantern to compile, but I did succeed in getting the binaries to download, install, and run correctly. I used libtorch-bin from nixpkgs as an example.

The PR is a draft. I don't like that it pulls binaries, or how the code is organised. `r-modules/default.nix` doesn't seem like the right place to put all the `torch` overrides. I also have very little free time for the next few months, so I don't think I can figure out how to make it fit nixpkgs better without assistance.

@jbedo 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
