### PR TITLE
nixos/ssh: pass XAUTHORITY to ssh-askpass

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -14,6 +14,7 @@ let
     ''
       #! ${pkgs.runtimeShell} -e
       export DISPLAY="$(systemctl --user show-environment | ${pkgs.gnused}/bin/sed 's/^DISPLAY=\(.*\)/\1/; t; d')"
+      export XAUTHORITY="$(systemctl --user show-environment | ${pkgs.gnused}/bin/sed 's/^XAUTHORITY=\(.*\)/\1/; t; d')"
       export WAYLAND_DISPLAY="$(systemctl --user show-environment | ${pkgs.gnused}/bin/sed 's/^WAYLAND_DISPLAY=\(.*\)/\1/; t; d')"
       exec ${askPassword} "$@"
     '';


### PR DESCRIPTION
## Description of changes

When using `programs.ssh.startAgent` and `programs.ssh.enableAskPassword`, the askpass program invocation from `ssh-agent` did not work in the X11 session in some system configurations:
- when using the `gdm` display manager in NixOS 23.11 and 23.05 (maybe even earlier);
- when using the `sddm` display manager in NixOS 23.11 (this configuration was previously working in NixOS 23.05).

It turned out that these display managers set the `XAUTHORITY` environment variable to something other than `$HOME/.Xauthority` (`/run/user/$UID/gdm/Xauthority` in case of `gdm`, or `/tmp/xauth_${random_string}` in case of `sddm` >= 0.20), but this environment variable was not passed to the `x11-ssh-askpass` process, therefore `x11-ssh-askpass` could not connect to the X server (it tried to use `$HOME/.Xauthority` by default, but in the problematic configurations that file did not contain the required authentication info).

One way to trigger the problem is using `ssh-add` with the `-c` option, which causes `ssh-agent` to prompt the user through the askpass program before allowing the key to be used.

Passing the `XAUTHORITY` environment variable from the systemd user environment to the askpass process fixes the problem.

The fixed module was verified in NixOS 23.05 and 23.11 with the `gdm`, `sddm` and `lightdm` display managers and the `none+i3` session, and also with the `gdm` and `sddm` display managers and the `sway` (Wayland) session (in the latter case the `XAUTHORITY` variable is not present in the systemd user environment, but apparently Xwayland does not require authentication through that mechanism).

The PR would need to be backported to NixOS 23.11 (the problem with `sddm` is triggered by the Xauth handling change in sddm/sddm#1230, included in `sddm-0.20.0`, which is present in NixOS 23.11; and the problem with `gdm` appeared even earlier, but somehow went unnoticed).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
