### PR TITLE
devkitPPC: init at r44.2

### DIFF
--- a/pkgs/development/compilers/devkitppc/0001-Use-generate_compile_commands-from-PATH.patch
+++ b/pkgs/development/compilers/devkitppc/0001-Use-generate_compile_commands-from-PATH.patch
@@ -1,0 +1,25 @@
+From 743a1c9cc3e354ccfbca535931267b1f70c174c9 Mon Sep 17 00:00:00 2001
+From: novenary <novenary@kwak.zip>
+Date: Mon, 11 Dec 2023 15:28:14 +0200
+Subject: [PATCH 1/2] Use generate_compile_commands from PATH
+
+---
+ base_tools | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/base_tools b/base_tools
+index 0a9e0ac..89e67f3 100644
+--- a/base_tools
++++ b/base_tools
+@@ -63,7 +63,7 @@ endef
+ # Generate compile commands
+ #---------------------------------------------------------------------------------
+ ifeq ($(GENERATE_COMPILE_COMMANDS),1)
+-    ADD_COMPILE_COMMAND := @/opt/devkitpro/tools/bin/generate_compile_commands
++    ADD_COMPILE_COMMAND := @generate_compile_commands
+ else
+     ADD_COMPILE_COMMAND := @true
+ endif
+-- 
+2.40.1
+

--- a/pkgs/development/compilers/devkitppc/0002-Allow-installing-to-another-prefix.patch
+++ b/pkgs/development/compilers/devkitppc/0002-Allow-installing-to-another-prefix.patch
@@ -1,0 +1,32 @@
+From ef0070ec175f37bfc1750c736cde4b6ac809d90f Mon Sep 17 00:00:00 2001
+From: novenary <novenary@kwak.zip>
+Date: Mon, 11 Dec 2023 15:36:38 +0200
+Subject: [PATCH 2/2] Allow installing to another prefix
+
+For distro packaging
+---
+ Makefile | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index e9d142f..b4fbe8d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -4,11 +4,13 @@ _PATCH	:= 1
+ 
+ FILES	:=	base_rules base_tools gamecube_rules wii_rules
+ 
++PREFIX	?=	$(DEVKITPRO)/devkitPPC
++
+ all:
+ 	@echo "use dist or install targets"
+ 
+ install:
+-	@cp -v $(FILES) $(DESTDIR)$(DEVKITPRO)/devkitPPC
++	@cp -v $(FILES) $(DESTDIR)$(PREFIX)
+ 
+ dist:
+ 	@tar -cJf devkitppc-rules-$(_MAJOR).$(_MINOR).$(_PATCH).tar.xz $(FILES) Makefile
+-- 
+2.40.1
+

--- a/pkgs/development/compilers/devkitppc/binutils.nix
+++ b/pkgs/development/compilers/devkitppc/binutils.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, callPackage
+, lib
+}:
+
+let
+  sources = callPackage ./sources.nix { };
+in stdenv.mkDerivation rec {
+  pname = "devkitPPC-binutils";
+  src = sources.binutils;
+  inherit (src) version;
+
+  patches = [
+    "${sources.buildscripts}/dkppc/patches/binutils-${version}.patch"
+  ];
+
+  configureFlags = [
+    "--target=${sources.target}"
+    "--enable-poison-system-directories"
+    "--enable-plugins" "--enable-lto"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "GNU Binutils (devkitPPC)";
+    homepage = "https://www.gnu.org/software/binutils/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.novenary ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/devkitppc/default.nix
+++ b/pkgs/development/compilers/devkitppc/default.nix
@@ -1,0 +1,24 @@
+{ symlinkJoin
+, callPackage
+, lib
+, devkitPPC-rules
+, devkitPPC-gcc
+}:
+
+let
+  sources = callPackage ./sources.nix { };
+in symlinkJoin {
+  name = "devkitPPC-r${sources.buildscripts.version}";
+
+  paths = [
+    devkitPPC-rules
+    devkitPPC-gcc
+  ];
+
+  meta = {
+    description = "Toolchain for Nintendo Gamecube & Wii homebrew development";
+    homepage = "https://github.com/devkitPro/buildscripts";
+    maintainers = [ lib.maintainers.novenary ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/devkitppc/gcc.nix
+++ b/pkgs/development/compilers/devkitppc/gcc.nix
@@ -1,0 +1,103 @@
+{ stdenv
+, callPackage
+, lib
+, applyPatches
+, gmp, mpfr, libmpc
+, texinfo
+, devkitPPC-binutils
+, devkitPPC-newlib
+, lndir
+, stage1 ? false
+}:
+
+let
+  sources = callPackage ./sources.nix { };
+in stdenv.mkDerivation rec {
+  pname = "devkitPPC-gcc" + lib.optionalString stage1 "-stage1";
+  src = sources.gcc;
+  inherit (src) version;
+
+  patches = [
+    "${sources.buildscripts}/dkppc/patches/gcc-${version}.patch"
+  ];
+
+  nativeBuildInputs = [
+    gmp mpfr libmpc
+    texinfo
+  ];
+
+  buildInputs = [
+    devkitPPC-binutils
+  ];
+
+  __structuredAttrs = true;
+
+  hardeningDisable = [ "format" ];
+
+  env = rec {
+    gcc_cv_libc_provides_ssp = "yes";
+    CFLAGS_FOR_TARGET = lib.concatStringsSep " " ([
+      "-O2"
+      "-ffunction-sections"
+      "-fdata-sections"
+      "-DCUSTOM_MALLOC_LOCK"
+    ] ++ lib.optionals (!stage1) [
+      "-isystem" "${lib.getLib devkitPPC-newlib}${devkitPPC-newlib.incdir}"
+    ]);
+    CXXFLAGS_FOR_TARGET = CFLAGS_FOR_TARGET;
+    LDFLAGS_FOR_TARGET = lib.concatStringsSep " " ([
+    ] ++ lib.optionals (!stage1) [
+      "-L${lib.getLib devkitPPC-newlib}${devkitPPC-newlib.libdir}"
+    ]);
+  };
+
+  configureFlags = [
+    "--enable-languages=c,c++,objc,lto"
+    "--enable-lto"
+    "--with-cpu=750"
+    "--disable-shared"
+    "--enable-threads=dkp"
+    "--disable-multilib"
+    "--disable-libstdcxx-pch"
+    "--disable-libstdcxx-verbose"
+    "--enable-libstdcxx-time=yes"
+    "--enable-libstdcxx-filesystem-ts"
+    "--disable-tm-clone-registry"
+    "--disable-__cxa_atexit"
+    "--disable-libssp"
+    "--enable-cxx-flags=-ffunction-sections -fdata-sections"
+    "--target=${sources.target}"
+    "--with-newlib"
+    # FIXME do we want to leave this in?
+    #"--with-bugurl=https://github.com/devkitpro/buildscripts/issues"
+    "--with-pkgversion=devkitPPC release ${sources.buildscripts.version}"
+  ] ++ lib.optionals stage1 [
+    "--disable-nls"
+  ];
+
+  preConfigure = ''
+    mkdir ../build
+    cd ../build
+    configureScript=../$sourceRoot/configure
+  '';
+
+  enableParallelBuilding = true;
+  enableParallelInstalling = false;
+
+  buildFlags = lib.optionals stage1 [ "all-gcc" ];
+  installTargets = lib.optionals stage1 [ "install-gcc" ];
+
+  postInstall = ''
+    '${lndir}/bin/lndir' -silent '${devkitPPC-binutils}' "$out"
+  '' + lib.optionalString (!stage1) ''
+    '${lndir}/bin/lndir' -silent '${devkitPPC-newlib}' "$out"
+  '';
+
+  meta = {
+    description = "GNU Compiler Collection (devkitPPC)";
+    homepage = "https://gcc.gnu.org/";
+    license = lib.licenses.gpl3Plus; # runtime support libraries are typically LGPLv3+
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.novenary ];
+  };
+}

--- a/pkgs/development/compilers/devkitppc/newlib.nix
+++ b/pkgs/development/compilers/devkitppc/newlib.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, callPackage
+, lib
+, texinfo
+, devkitPPC-gcc
+}:
+
+let
+  sources = callPackage ./sources.nix { };
+in stdenv.mkDerivation rec {
+  pname = "devkitPPC-newlib";
+  src = sources.newlib;
+  inherit (src) version;
+
+  patches = [
+    "${sources.buildscripts}/dkppc/patches/newlib-${version}.patch"
+  ];
+
+  nativeBuildInputs = [
+    texinfo
+    devkitPPC-gcc
+  ];
+
+  __structuredAttrs = true;
+
+  env = {
+    inherit (devkitPPC-gcc.env)
+      gcc_cv_libc_provides_ssp
+      CFLAGS_FOR_TARGET
+    ;
+  };
+
+  configureFlags = [
+    "--target=${sources.target}"
+    "--enable-newlib-mb"
+    "--enable-newlib-register-fini"
+  ];
+
+  preConfigure = ''
+    mkdir ../build
+    cd ../build
+    configureScript=../$sourceRoot/configure
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    incdir = "/${sources.target}/include";
+    libdir = "/${sources.target}/lib";
+  };
+
+  meta = {
+    description = "a C library intended for use on embedded systems (devkitPPC)";
+    homepage = "https://sourceware.org/newlib/";
+    # arch has "bsd" while gentoo has "NEWLIB LIBGLOSS GPL-2" while COPYING has "gpl2"
+    # there are 5 copying files in total
+    # COPYING
+    # COPYING.LIB
+    # COPYING.LIBGLOSS
+    # COPYING.NEWLIB
+    # COPYING3
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.novenary ];
+  };
+}

--- a/pkgs/development/compilers/devkitppc/rules.nix
+++ b/pkgs/development/compilers/devkitppc/rules.nix
@@ -1,0 +1,38 @@
+{ stdenvNoCC
+, callPackage
+, lib
+}:
+
+let
+  sources = callPackage ./sources.nix { };
+in stdenvNoCC.mkDerivation rec {
+  pname = "devkitPPC-rules";
+  src = sources.rules;
+  inherit (src) version;
+
+  patches = [
+    ./0001-Use-generate_compile_commands-from-PATH.patch
+    ./0002-Allow-installing-to-another-prefix.patch
+  ];
+
+  noConfigurePhase = true;
+  noBuildPhase = true;
+
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    make install PREFIX="$out"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Makefile includes for devkitPPC";
+    homepage = "https://github.com/devkitPro/devkitppc-rules";
+    # FIXME https://github.com/devkitPro/devkitppc-rules/issues/7
+    #license = ???;
+    maintainers = [ lib.maintainers.novenary ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/devkitppc/sources.nix
+++ b/pkgs/development/compilers/devkitppc/sources.nix
@@ -1,0 +1,48 @@
+{ fetchurl
+, fetchFromGitHub
+}:
+
+let
+  # Lifted from the Wine package
+  fetchurl' = args@{url, hash, ...}:
+    fetchurl { inherit url hash; } // args;
+
+  fetchFromGitHub' = args@{owner, repo, rev, hash, ...}:
+    fetchFromGitHub { inherit owner repo rev hash; } // args;
+in {
+  target = "powerpc-eabi";
+
+  buildscripts = fetchFromGitHub' rec {
+    version = "44.2";
+    hash = "sha256-nrencSFHIommdZyEO3HFLuMU8B0Gz0U2x+U56ZSMOs8=";
+    owner = "devkitPro";
+    repo = "buildscripts";
+    rev = "devkitPPC_r${version}";
+  };
+
+  rules = fetchFromGitHub' rec {
+    version = "1.2.1";
+    hash = "sha256-SnbsyvnEQcHkLTVZBPat0lk+Dr/7OT/MrR036gxGe98=";
+    owner = "devkitPro";
+    repo = "devkitppc-rules";
+    rev = "v${version}";
+  };
+
+  binutils = fetchurl' rec {
+    version = "2.41";
+    url = "mirror://gnu/binutils/binutils-${version}.tar.bz2";
+    hash = "sha256-pMS+wFL3uDcAJOYDieGUN38/SLVmGEGOpRBn9nqqsws=";
+  };
+
+  gcc = fetchurl' rec {
+    version = "13.2.0";
+    url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
+    hash = "sha256-4nXnZEKmBnNBon8Exca4PYYTFEAEwEE1KIY9xrXHQ9o=";
+  };
+
+  newlib = fetchurl' rec {
+    version = "4.3.0.20230120";
+    url = "ftp://sourceware.org/pub/newlib/newlib-${version}.tar.gz";
+    hash = "sha256-g6Yqma9Z4465sMWO0JLuJNcA//Q6IsA+QzlVET7zUVA=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3853,6 +3853,16 @@ with pkgs;
 
   gamecube-tools = callPackage ../development/tools/gamecube-tools { };
 
+  devkitPPC = callPackage ../development/compilers/devkitppc { };
+  devkitPPC-rules = callPackage ../development/compilers/devkitppc/rules.nix { };
+  devkitPPC-binutils = callPackage ../development/compilers/devkitppc/binutils.nix { };
+  devkitPPC-newlib = callPackage ../development/compilers/devkitppc/newlib.nix {
+    devkitPPC-gcc = devkitPPC-gcc.override {
+      stage1 = true;
+    };
+  };
+  devkitPPC-gcc = callPackage ../development/compilers/devkitppc/gcc.nix { };
+
   gammaray = qt6Packages.callPackage ../development/tools/gammaray { };
 
   gams = callPackage ../tools/misc/gams (config.gams or {});


### PR DESCRIPTION
## Description of changes

devkitPPC is a GCC toolchain targeting the Nintendo GameCube, Wii and Wii U.

Upstream only distributes binaries through a Pacman repo, and asks users to install Pacman on non-Arch distros, but that's obviously problematic, especially for NixOS, so I've decided to package it here.

In order to remain close to upstream, I decided not to build this on top of the existing cross-compiling infrastructure in nixpkgs.

For now this is only the toolchain, and none of the libraries, which I will probably handle in a repo outside of nixpkgs. The toolchain itself would benefit from Hydra builds and the binary cache though.

The root devkitPPC package is equivalent to upstream's /opt/devkitpro/devkitPPC, meaning you can point `$DEVKITPPC` right at it.

I've tested functionality by building [iplboot](https://github.com/redolution/iplboot). The resulting binary is not identical to what the upstream toolchain produces, but it's the same size byte for byte and it boots in Dolphin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
