### PR TITLE
pantheon: Backport AppStream 1.0 build fix

### DIFF
--- a/pkgs/desktops/pantheon/apps/appcenter/default.nix
+++ b/pkgs/desktops/pantheon/apps/appcenter/default.nix
@@ -11,7 +11,8 @@
 , json-glib
 , libgee
 , libhandy
-, libsoup
+, libportal-gtk3
+, libsoup_3
 , libxml2
 , meson
 , ninja
@@ -23,13 +24,15 @@
 
 stdenv.mkDerivation rec {
   pname = "appcenter";
-  version = "7.4.0";
+  version = "7.4.0-unstable-2023-12-04";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-L6MGbzzujr4tEB2Cpd7IU+3mOtSCt2hLPw4mOfZ4TkQ=";
+    # Add support for AppStream 1.0.
+    # https://github.com/elementary/appcenter/pull/2099
+    rev = "d93e135a0b0c9a6e0fbad18fe90d46425823a42c";
+    hash = "sha256-b7xux6MuvYZFxufQ5T7DoDNBlsJ/fDR0aUY2Hk/xJoY=";
   };
 
   nativeBuildInputs = [
@@ -50,7 +53,8 @@ stdenv.mkDerivation rec {
     json-glib
     libgee
     libhandy
-    libsoup
+    libportal-gtk3
+    libsoup_3
     libxml2
     polkit
   ];

--- a/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -32,6 +33,13 @@ stdenv.mkDerivation rec {
     # https://github.com/ximion/appstream/blob/v0.15.2/src/as-pool.c#L117
     # https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location
     ./fix-metadata-path.patch
+
+    # Add support for AppStream 1.0.
+    # https://github.com/elementary/feedback/pull/102
+    (fetchpatch {
+      url = "https://github.com/elementary/feedback/commit/037b20328f5200a0dac25e6835c0c3f8a7c36f39.patch";
+      hash = "sha256-tjUNTCsEBjy/3lzwyIwR4VED57ATiG2CWCmRh7qps+4=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Picked from https://github.com/NixOS/nixpkgs/pull/273297/files, which will go staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
