### PR TITLE
minetest: 5.7.0 -> 5.8.0, cleanup

### DIFF
--- a/pkgs/development/libraries/irrlichtmt/default.nix
+++ b/pkgs/development/libraries/irrlichtmt/default.nix
@@ -7,34 +7,25 @@
 , libjpeg
 , libGL
 , libX11
-, withTouchSupport ? false
 , libXi
 , libXext
 , Cocoa
 , Kernel
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "irrlichtmt";
-  version = "1.9.0mt10";
+  version = "1.9.0mt13";
 
   src = fetchFromGitHub {
     owner = "minetest";
     repo = "irrlicht";
-    rev = version;
-    sha256 = "sha256-PA+gz77XkwxQ3TtubaT0ov9dsT7s3ZlrQxrOkD5ku3g=";
+    rev = finalAttrs.version;
+    hash = "sha256-BlQd7zbpvQnxqLv3IaHWrXzJ1pJFbQQ3DNWDAj14/YY=";
   };
 
   nativeBuildInputs = [
     cmake
   ];
-
-  # https://github.com/minetest/minetest/pull/10729
-  postPatch = lib.optionalString (!withTouchSupport) ''
-    sed -i '1i #define NO_IRR_LINUX_X11_XINPUT2_' include/IrrCompileConfig.h
-
-    # HACK: Fix mistake in build script
-    sed -i '/''${X11_Xi_LIB}/d' source/Irrlicht/CMakeLists.txt
-  '';
 
   buildInputs = [
     zlib
@@ -42,7 +33,6 @@ stdenv.mkDerivation rec {
     libjpeg
     libGL
     libX11
-  ] ++ lib.optionals withTouchSupport [
     libXi
     libXext
   ] ++ lib.optionals stdenv.isDarwin [
@@ -58,4 +48,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ DeeUnderscore ];
     description = "Minetest project's fork of Irrlicht, a realtime 3D engine written in C++";
   };
-}
+})

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -38,106 +38,101 @@
 , Carbon
 , Cocoa
 , withTouchSupport ? false
+, buildClient ? true
+, buildServer ? true
 }:
 
-with lib;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "minetest";
+  version = "5.8.0";
 
-let
-  boolToCMake = b: if b then "ON" else "OFF";
-
-  irrlichtmtInput = irrlichtmt.override { inherit withTouchSupport; };
-
-  generic = { version, rev ? version, sha256, dataRev ? version, dataSha256, buildClient ? true, buildServer ? false }: let
-    sources = {
-      src = fetchFromGitHub {
-        owner = "minetest";
-        repo = "minetest";
-        inherit rev sha256;
-      };
-      data = fetchFromGitHub {
-        owner = "minetest";
-        repo = "minetest_game";
-        rev = dataRev;
-        sha256 = dataSha256;
-      };
-    };
-  in stdenv.mkDerivation {
-    pname = "minetest";
-    inherit version;
-
-    src = sources.src;
-
-    cmakeFlags = [
-      "-G Ninja"
-      "-DBUILD_CLIENT=${boolToCMake buildClient}"
-      "-DBUILD_SERVER=${boolToCMake buildServer}"
-      "-DENABLE_GETTEXT=1"
-      "-DENABLE_SPATIAL=1"
-      "-DENABLE_SYSTEM_JSONCPP=1"
-
-      # Remove when https://github.com/NixOS/nixpkgs/issues/144170 is fixed
-      "-DCMAKE_INSTALL_BINDIR=bin"
-      "-DCMAKE_INSTALL_DATADIR=share"
-      "-DCMAKE_INSTALL_DOCDIR=share/doc"
-      "-DCMAKE_INSTALL_DOCDIR=share/doc"
-      "-DCMAKE_INSTALL_MANDIR=share/man"
-      "-DCMAKE_INSTALL_LOCALEDIR=share/locale"
-
-    ] ++ optionals buildServer [
-      "-DENABLE_PROMETHEUS=1"
-    ] ++ optionals withTouchSupport [
-      "-DENABLE_TOUCH=TRUE"
-    ];
-
-    env.NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
-
-    nativeBuildInputs = [ cmake doxygen graphviz ninja ];
-
-    buildInputs = [
-      irrlichtmtInput jsoncpp gettext freetype sqlite curl bzip2 ncurses
-      gmp libspatialindex
-    ] ++ [ (if lib.meta.availableOn stdenv.hostPlatform luajit then luajit else lua5_1) ] ++ [
-    ] ++ optionals stdenv.isDarwin [
-      libiconv OpenGL OpenAL Carbon Cocoa
-    ] ++ optionals buildClient [
-      libpng libjpeg libGLU openal libogg libvorbis xorg.libX11
-    ] ++ optionals buildServer [
-      leveldb postgresql hiredis prometheus-cpp
-    ];
-
-    postPatch = ''
-      substituteInPlace src/filesys.cpp --replace "/bin/rm" "${coreutils}/bin/rm"
-    '' + lib.optionalString stdenv.isDarwin ''
-      sed -i '/pagezero_size/d;/fixup_bundle/d' src/CMakeLists.txt
-    '';
-
-    postInstall = lib.optionalString stdenv.isLinux ''
-      mkdir -pv $out/share/minetest/games/minetest_game/
-      cp -rv ${sources.data}/* $out/share/minetest/games/minetest_game/
-      patchShebangs $out
-    '' + lib.optionalString stdenv.isDarwin ''
-      mkdir -p $out/Applications
-      mv $out/minetest.app $out/Applications
-    '';
-
-    meta = with lib; {
-      homepage = "http://minetest.net/";
-      description = "Infinite-world block sandbox game";
-      license = licenses.lgpl21Plus;
-      platforms = platforms.linux ++ platforms.darwin;
-      maintainers = with maintainers; [ pyrolagus fpletz fgaz ];
-    };
+  src = fetchFromGitHub {
+    owner = "minetest";
+    repo = "minetest";
+    rev = finalAttrs.version;
+    hash = "sha256-Oct8nQORSH8PjYs+gHU9QrKObMfapjAlGvycj+AJnOs=";
   };
 
-  v5 = {
-    version = "5.7.0";
-    sha256 = "sha256-9AL6gTmy05yTeYfCq3EMK4gqpBWdHwvJ5Flpzj8hFAE=";
-    dataSha256 = "sha256-wWgeO8513N5jQdWvZrq357fPpAU5ik06mgZraWCQawo=";
-  };
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_CLIENT" buildClient)
+    (lib.cmakeBool "BUILD_SERVER" buildServer)
+    (lib.cmakeBool "ENABLE_PROMETHEUS" buildServer)
+    (lib.cmakeBool "ENABLE_TOUCH" withTouchSupport)
+    # Ensure we use system libraries
+    (lib.cmakeBool "ENABLE_SYSTEM_GMP" true)
+    (lib.cmakeBool "ENABLE_SYSTEM_JSONCPP" true)
+    # Updates are handled by nix anyway
+    (lib.cmakeBool "ENABLE_UPDATE_CHECKER" false)
+    # ...but make it clear that this is a nix package
+    (lib.cmakeFeature "VERSION_EXTRA" "NixOS")
 
-  mkClient = version: generic (version // { buildClient = true; buildServer = false; });
-  mkServer = version: generic (version // { buildClient = false; buildServer = true; });
-in {
-  minetestclient_5 = mkClient v5;
-  minetestserver_5 = mkServer v5;
-}
+    # Remove when https://github.com/NixOS/nixpkgs/issues/144170 is fixed
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_DATADIR" "share")
+    (lib.cmakeFeature "CMAKE_INSTALL_DOCDIR" "share/doc/minetest")
+    (lib.cmakeFeature "CMAKE_INSTALL_MANDIR" "share/man")
+    (lib.cmakeFeature "CMAKE_INSTALL_LOCALEDIR" "share/locale")
+
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+    ninja
+  ];
+
+  buildInputs = [
+    irrlichtmt
+    jsoncpp
+    gettext
+    freetype
+    sqlite
+    curl
+    bzip2
+    ncurses
+    gmp
+    libspatialindex
+  ] ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform luajit) luajit
+    ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    OpenGL
+    OpenAL
+    Carbon
+    Cocoa
+  ] ++ lib.optionals buildClient [
+    libpng
+    libjpeg
+    libGLU
+    openal
+    libogg
+    libvorbis
+    xorg.libX11
+  ] ++ lib.optionals buildServer [
+    leveldb
+    postgresql
+    hiredis
+    prometheus-cpp
+  ];
+
+  postPatch = ''
+    substituteInPlace src/filesys.cpp --replace "/bin/rm" "${coreutils}/bin/rm"
+  '' + lib.optionalString stdenv.isDarwin ''
+    sed -i '/pagezero_size/d;/fixup_bundle/d' src/CMakeLists.txt
+  '';
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    patchShebangs $out
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/minetest.app $out/Applications
+  '';
+
+  meta = with lib; {
+    homepage = "https://minetest.net/";
+    description = "Infinite-world block sandbox game";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ pyrolagus fpletz fgaz ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -584,6 +584,8 @@ mapAliases ({
   miopen-hip = throw "'miopen-hip' has been replaced with 'rocmPackages.miopen-hip'"; # Added 2023-10-08
   miopen-opencl = throw "'miopen-opencl' has been replaced with 'rocmPackages.miopen-opencl'"; # Added 2023-10-08
   mime-types = mailcap; # Added 2022-01-21
+  minetestclient_5 = minetestclient; # Added 2023-12-11
+  minetestserver_5 = minetestserver; # Added 2023-12-11
   minizip2 = pkgs.minizip-ng; # Added 2022-12-28
   mirage-im = throw "'mirage-im' has been removed, as it was broken and unmaintained"; # Added 2023-11-26
   monero = monero-cli; # Added 2021-11-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38038,14 +38038,12 @@ with pkgs;
 
   moon-buggy = callPackage ../games/moon-buggy { };
 
-  inherit (callPackages ../games/minetest {
+  minetest = callPackage ../games/minetest {
     inherit (darwin.apple_sdk.frameworks) OpenGL OpenAL Carbon Cocoa;
-  })
-    minetestclient_5 minetestserver_5;
-
-  minetest = minetestclient;
-  minetestclient = minetestclient_5;
-  minetestserver = minetestserver_5;
+  };
+  minetestclient = minetest.override { buildServer = false; };
+  minetest-touch = minetest.override { buildServer = false; withTouchSupport = true; };
+  minetestserver = minetest.override { buildClient = false; };
 
   mnemosyne = callPackage ../games/mnemosyne {
     python = python3;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://blog.minetest.net/2023/12/04/5.8.0-released/

irrlichtmt: 1.9.0mt10 -> 1.9.0mt13

* Use finalAttrs
* Touch support is now unconditional

minetest: 5.7.0 -> 5.8.0, cleanup

* Inline the generic builder, since we don't build multiple versions
  anymore
* Remove unused patches, flags, and overrides
* Remove minetest_game, it has been debundled
* Use finalAttrs
* Use lib.cmake*
* Add a top-level attribute for the touch variant
* Define the server- and client-only variants through overrides in
  all-packages.nix
* Move the *_5 aliases to top-level/aliases.nix
* General cleanup

Closes NixOS#273207



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
