### PR TITLE
aws-gate: init at 0.11.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18365,6 +18365,11 @@
     github = "NoneTirex";
     githubId = 26038207;
   };
+  tirimia = {
+    name = "Theodor-Alexandru Irimia";
+    github = "tirimia";
+    githubId = 11174371;
+  };
   titanous = {
     email = "jonathan@titanous.com";
     github = "titanous";

--- a/pkgs/by-name/aw/aws-gate/disable-bootstrap.patch
+++ b/pkgs/by-name/aw/aws-gate/disable-bootstrap.patch
@@ -1,0 +1,51 @@
+diff --git a/aws_gate/cli.py b/aws_gate/cli.py
+index ac37c2f..9743415 100644
+--- a/aws_gate/cli.py
++++ b/aws_gate/cli.py
+@@ -7,7 +7,6 @@ from marshmallow import ValidationError
+ from yaml.scanner import ScannerError
+
+ from aws_gate import __version__, __description__
+-from aws_gate.bootstrap import bootstrap
+ from aws_gate.config import load_config_from_files
+ from aws_gate.constants import (
+     SUPPORTED_KEY_TYPES,
+@@ -59,10 +58,14 @@ def get_argument_parser(*args, **kwargs):
+
+     # 'bootstrap' subcommand
+     bootstrap_parser = subparsers.add_parser(
+-        "bootstrap", help="Download and install session-manager-plugin"
++        "bootstrap",
++        help="Download and install session-manager-plugin (disabled by nix)",
+     )
+     bootstrap_parser.add_argument(
+-        "-f", "--force", action="store_true", help="Forces bootstrap operation"
++        "-f",
++        "--force",
++        action="store_true",
++        help="Forces bootstrap operation (disabled by nix)",
+     )
+
+     # 'exec' subcommand
+@@ -268,7 +271,9 @@ def main(args=None, argument_parser=None):
+     logger.debug('Using AWS profile "%s" in region "%s"', profile, region)
+
+     if args.subcommand == "bootstrap":
+-        bootstrap(force=args.force)
++        print(
++            f"The SSM Plugin will not be downloaded as aws-gate was installed from nixpkgs and the plugin comes pre-bundled. The '--force' flag will not override this behavior."
++        )
+     elif args.subcommand == "exec":
+         exec(
+             config=config,
+diff --git a/requirements/requirements.txt b/requirements/requirements.txt
+index 50b203e..8c3496f 100644
+--- a/requirements/requirements.txt
++++ b/requirements/requirements.txt
+@@ -3,5 +3,4 @@ cryptography==39.0.2
+ marshmallow==3.19.0
+ packaging==23.0
+ PyYAML>=5.1,<6.1
+-requests==2.28.2
+ unix-ar==0.2.1
+ wrapt==1.15.0

--- a/pkgs/by-name/aw/aws-gate/package.nix
+++ b/pkgs/by-name/aw/aws-gate/package.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchFromGitHub
+, installShellFiles
+, python3Packages
+, ssm-session-manager-plugin
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "aws-gate";
+  version = "0.11.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xen0l";
+    repo = pname;
+    rev = version;
+    hash = "sha256-9w2jP4s1HXf1gYiXX05Dt2iXt0bR0U48yc8h9T5M+EQ=";
+  };
+
+  patches = [
+    ./disable-bootstrap.patch
+  ];
+
+  postPatch = ''
+    rm aws_gate/bootstrap.py tests/unit/test_bootstrap.py
+  '';
+
+  nativeBuildInputs = [
+    python3Packages.setuptools
+    python3Packages.wheel
+    installShellFiles
+  ];
+
+  propagatedBuildInputs = [ ssm-session-manager-plugin ] ++ builtins.attrValues {
+    inherit (python3Packages) marshmallow boto3 pyyaml wrapt cryptography;
+  };
+
+  postInstall = ''
+    installShellCompletion --bash completions/bash/aws-gate
+    installShellCompletion --zsh completions/zsh/_aws-gate
+  '';
+
+  checkPhase = ''
+    $out/bin/${pname} --version
+  '';
+
+  meta = with lib; {
+    description = "Better AWS SSM Session manager CLI client";
+    homepage = "https://github.com/xen0l/aws-gate";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tirimia ];
+    platforms = with platforms; linux ++ darwin;
+    mainProgram = pname;
+  };
+}

--- a/pkgs/development/python-modules/unix-ar/default.nix
+++ b/pkgs/development/python-modules/unix-ar/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "unix-ar";
+  version = "0.2.1";
+  format = "wheel";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit format version;
+    pname = "unix_ar";
+    hash = "sha256-Kstxi8Ewi/gOW52iYU2CQswv475M2LL9Rxm84Ymq/PE=";
+  };
+
+  meta = with lib; {
+    description = "AR file handling for Python (including .deb files)";
+    homepage = "https://github.com/getninjas/unix_ar";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tirimia ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15455,6 +15455,8 @@ self: super: with self; {
 
   universal-silabs-flasher = callPackage ../development/python-modules/universal-silabs-flasher { };
 
+  unix-ar = callPackage ../development/python-modules/unix-ar { };
+
   unpaddedbase64 = callPackage ../development/python-modules/unpaddedbase64 { };
 
   unrardll = callPackage ../development/python-modules/unrardll { };


### PR DESCRIPTION
## Description of changes

Added `aws-gate`, a session manager that makes working with aws a lot smoother.
In the process of adding it, I also had to add the `unix-ar` python package as it was a runtime dependency not found in nixpkgs.
Left a comment regarding the necessity of `unix-ar` in the `aws-gate` recipe. Still relatively new to nix so not sure if my suggestion makes complete sense, looking forward to feedback 😄

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
