### PR TITLE
corectrl: 1.3.6 -> 1.3.8

### DIFF
--- a/pkgs/applications/misc/corectrl/default.nix
+++ b/pkgs/applications/misc/corectrl/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec{
   pname = "corectrl";
-  version = "1.3.6";
+  version = "1.3.8";
 
   src = fetchFromGitLab {
     owner = "corectrl";
     repo = "corectrl";
     rev = "v${version}";
-    sha256 = "sha256-a8cLtmv9nLtvN9o/aIwveTAT36XmTN1j85ZxVGIXO6E=";
+    sha256 = "sha256-lc6yWzJiSzGKMzJIpgOtirJONsh49vXWDWrhLV/erwQ=";
   };
   patches = [
     ./polkit-dir.patch

--- a/pkgs/applications/misc/corectrl/polkit-dir.patch
+++ b/pkgs/applications/misc/corectrl/polkit-dir.patch
@@ -1,5 +1,5 @@
 diff --git a/src/helper/CMakeLists.txt b/src/helper/CMakeLists.txt
-index 1b7ed7c..757748c 100644
+index 3fe2ace..2542ea1 100644
 --- a/src/helper/CMakeLists.txt
 +++ b/src/helper/CMakeLists.txt
 @@ -22,15 +22,7 @@ message("D-Bus files will be installed into ${DBUS_DATADIR_PREFIX_DIR}/dbus-1")
@@ -7,15 +7,15 @@ index 1b7ed7c..757748c 100644
  # Find polkit
  pkg_check_modules(POLKIT REQUIRED polkit-gobject-1)
 -execute_process(
--    COMMAND pkg-config --variable=policydir polkit-gobject-1
--    RESULT_VARIABLE POLKIT_POLICY_INSTALL_DIR_RESULT
--    OUTPUT_VARIABLE POLKIT_POLICY_INSTALL_DIR
--    OUTPUT_STRIP_TRAILING_WHITESPACE
+-  COMMAND pkg-config --variable=policydir polkit-gobject-1
+-  RESULT_VARIABLE POLKIT_POLICY_INSTALL_DIR_RESULT
+-  OUTPUT_VARIABLE POLKIT_POLICY_INSTALL_DIR
+-  OUTPUT_STRIP_TRAILING_WHITESPACE
 -)
 -if(NOT POLKIT_POLICY_INSTALL_DIR_RESULT EQUAL "0")
 -  message(FATAL_ERROR "Failed to retrieve Polkit `policydir` variable using pkg-config")
 -endif()
 +option(POLKIT_POLICY_INSTALL_DIR "Polkit policy directory")
  
- list(APPEND PROCESS_MONITOR_SRC
-   pmon/processmonitor.cpp
+ list(APPEND HELPER_COMPILE_DEFINITIONS
+   ELPP_THREAD_SAFE


### PR DESCRIPTION
Diff: https://gitlab.com/corectrl/corectrl/-/compare/v1.3.6...v1.3.8

## Description of changes

Build fixes for new GCC/kernel headers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
