### PR TITLE
xed-editor: Backport libxml2 2.12 build fix

### DIFF
--- a/pkgs/applications/editors/xed-editor/default.nix
+++ b/pkgs/applications/editors/xed-editor/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , libxml2
 , libpeas
 , glib
@@ -27,6 +28,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-IpUBB7Viwc/nRfwzFllRiWoOmUxRZzS2BcxyM7W3oHI=";
   };
+
+  patches = [
+    # Fix missing include for libxml2 2.12
+    # https://github.com/linuxmint/xed/pull/611
+    (fetchpatch {
+      url = "https://github.com/linuxmint/xed/commit/28cb2e8136c1bfe90faf5f2341bde66156990778.patch";
+      hash = "sha256-AqIb7Jj19SF3tIriPwn1JeB7niCmPbBsLE4ch2AX7fk=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
Tested building with libxml2 2.12.

```
../xed/xed-metadata-manager.c: In function 'xed_metadata_manager_save':
../xed/xed-metadata-manager.c:536:5: error: 'xmlIndentTreeOutput' undeclared (first use in this function)
  536 |     xmlIndentTreeOutput = TRUE;
      |     ^~~~~~~~~~~~~~~~~~~
../xed/xed-metadata-manager.c:536:5: note: each undeclared identifier is reported only once for each function it appears in
```

/cc #269060

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
