### PR TITLE
openvpn-auth-ldap: fix build

### DIFF
--- a/pkgs/tools/networking/openvpn/auth-ldap-fix-conftest.patch
+++ b/pkgs/tools/networking/openvpn/auth-ldap-fix-conftest.patch
@@ -1,0 +1,36 @@
+diff --git a/aclocal.m4 b/aclocal.m4
+index e5b7dbf..01cecf1 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -73,6 +73,7 @@ AC_DEFUN([OD_OBJC_RUNTIME],[
+ 				AC_LANG_PROGRAM([
+ 						#include <objc/objc.h>
+ 						#include <objc/Object.h>
++						#include <stdio.h>
+ 					], [
+ 						Object *obj = @<:@Object alloc@:>@;
+ 						puts(@<:@obj name@:>@);
+@@ -94,6 +95,7 @@ AC_DEFUN([OD_OBJC_RUNTIME],[
+ 					AC_LANG_PROGRAM([
+ 							#include <objc/objc.h>
+ 							#include <objc/Object.h>
++							#include <stdio.h>
+ 						], [
+ 							Object *obj = @<:@Object alloc@:>@;
+ 							puts(@<:@obj name@:>@);
+@@ -131,6 +133,7 @@ AC_DEFUN([OD_OBJC_RUNTIME],[
+ 					AC_LANG_PROGRAM([
+ 							#include <objc/objc.h>
+ 							#include <objc/objc-api.h>
++							#include <stdio.h>
+ 						], [
+ 							id class = objc_lookUpClass("Object");
+ 							id obj = @<:@class alloc@:>@;
+@@ -162,6 +165,7 @@ AC_DEFUN([OD_OBJC_RUNTIME],[
+ 							#else
+ 							#include <objc/objc-api.h>
+ 							#endif
++							#include <stdio.h>
+ 						], [
+ 							#ifdef __GNU_LIBOBJC_
+ 							Class class = objc_lookUpClass("Object");

--- a/pkgs/tools/networking/openvpn/openvpn-auth-ldap.nix
+++ b/pkgs/tools/networking/openvpn/openvpn-auth-ldap.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
     sha256 = "1j30sygj8nm8wjqxzpb7pfzr3dxqxggswzxd7z5yk7y04c0yp1hb";
   };
 
+  patches = [
+    ./auth-ldap-fix-conftest.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     gnustep.base


### PR DESCRIPTION
## Description of changes
fix build

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [ ] 
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
