### PR TITLE
Initrd verify stage 2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1418,6 +1418,7 @@
   ./system/boot/initrd-network.nix
   ./system/boot/initrd-openvpn.nix
   ./system/boot/initrd-ssh.nix
+  ./system/boot/initrd-verify.nix
   ./system/boot/kernel.nix
   ./system/boot/kexec.nix
   ./system/boot/loader/efi.nix

--- a/nixos/modules/system/boot/initrd-verify.nix
+++ b/nixos/modules/system/boot/initrd-verify.nix
@@ -1,0 +1,46 @@
+{ lib, config, ... }: let
+  cfg = config.boot.initrd.verify;
+  nix = config.nix.package;
+in {
+  options.boot.initrd.verify = {
+    enable = lib.mkEnableOption "verifying the stage 2 closure during initrd";
+    trustedPublicKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = lib.mdDoc "Keys to verify the closure against.";
+    };
+    sigsNeeded = lib.mkOption {
+      type = lib.types.int;
+      description = lib.mdDoc "Number of signatures required.";
+      default = 1;
+    };
+    signing = {
+      enable = lib.mkEnableOption "signing the system profiles when configuring the boot loader";
+      keyFile = lib.mkOption {
+        type = lib.types.path;
+        description = lib.mdDoc "Path to the signing key.";
+        example = "/run/keys/signing-key";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.initrd = {
+      systemd.storePaths = [ "${nix}/bin/nix" ];
+      systemd.services.verify-store = {
+        requiredBy = [ "initrd-nixos-activation.service" ];
+        before = [ "initrd-nixos-activation.service" ];
+        requires = [ "initrd-fs.target" ];
+        after = [ "initrd-fs.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${nix}/bin/nix --experimental-features nix-command verify -r --store /sysroot --trusted-public-keys \"${lib.concatStringsSep " " cfg.trustedPublicKeys}\" ${if cfg.sigsNeeded == 0 then "--no-trust" else "--sigs-needed " + toString cfg.sigsNeeded} \${NIXOS_SYSTEM_CLOSURE}";
+        };
+      };
+    };
+
+    boot.loader.systemd-boot.extraInstallCommands = lib.mkIf cfg.signing.enable ''
+      echo Signing system generations
+      nix --experimental-features nix-command store sign -k ${toString cfg.signing.keyFile} -r /nix/var/nix/profiles/system*
+    '';
+  };
+}

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -110,6 +110,27 @@ let
     postBuild = concatStringsSep "\n" (mapAttrsToList (n: v: "ln -sf '${v}' $out/bin/'${n}'") cfg.extraBin);
   };
 
+  envGenerator = pkgs.writeShellScriptBin "nixos-environment-generator" ''
+    # Figure out what closure to boot
+    closure=
+    for o in $(< /proc/cmdline); do
+        case $o in
+            init=*)
+                IFS== read -r -a initParam <<< "$o"
+                closure="$(dirname "''${initParam[1]}")"
+                ;;
+        esac
+    done
+
+    # Sanity check
+    if [ -z "''${closure:-}" ]; then
+      echo 'No init= parameter on the kernel command line' >&2
+      exit 1
+    fi
+
+    echo NIXOS_SYSTEM_CLOSURE=$closure
+  '';
+
   initialRamdisk = pkgs.makeInitrdNG {
     name = "initrd-${kernel-name}";
     inherit (config.boot.initrd) compressor compressorArgs prepend;
@@ -398,6 +419,9 @@ in {
           ManagerEnvironment=${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment)}
         '';
 
+        # Make the system closure available as an environment variable.
+        "/etc/systemd/system-environment-generators/nixos-environment-generator".source = "${envGenerator}/bin/nixos-environment-generator";
+
         "/lib/modules".source = "${modulesClosure}/lib/modules";
         "/lib/firmware".source = "${modulesClosure}/lib/firmware";
 
@@ -490,28 +514,11 @@ in {
           set -uo pipefail
           export PATH="/bin:${cfg.package.util-linux}/bin"
 
-          # Figure out what closure to boot
-          closure=
-          for o in $(< /proc/cmdline); do
-              case $o in
-                  init=*)
-                      IFS== read -r -a initParam <<< "$o"
-                      closure="$(dirname "''${initParam[1]}")"
-                      ;;
-              esac
-          done
-
-          # Sanity check
-          if [ -z "''${closure:-}" ]; then
-            echo 'No init= parameter on the kernel command line' >&2
-            exit 1
-          fi
-
           # If we are not booting a NixOS closure (e.g. init=/bin/sh),
           # we don't know what root to prepare so we don't do anything
-          if ! [ -x "/sysroot$(readlink "/sysroot$closure/prepare-root" || echo "$closure/prepare-root")" ]; then
+          if ! [ -x "/sysroot$(readlink "/sysroot$NIXOS_SYSTEM_CLOSURE/prepare-root" || echo "$NIXOS_SYSTEM_CLOSURE/prepare-root")" ]; then
             echo "NEW_INIT=''${initParam[1]}" > /etc/switch-root.conf
-            echo "$closure does not look like a NixOS installation - not activating"
+            echo "$NIXOS_SYSTEM_CLOSURE does not look like a NixOS installation - not activating"
             exit 0
           fi
           echo 'NEW_INIT=' > /etc/switch-root.conf
@@ -524,7 +531,7 @@ in {
 
           # Initialize the system
           export IN_NIXOS_SYSTEMD_STAGE1=true
-          exec chroot /sysroot $closure/prepare-root
+          exec chroot /sysroot $NIXOS_SYSTEM_CLOSURE/prepare-root
         '';
       };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -403,6 +403,7 @@ in {
   initrdNetwork = handleTest ./initrd-network.nix {};
   initrd-secrets = handleTest ./initrd-secrets.nix {};
   initrd-secrets-changing = handleTest ./initrd-secrets-changing.nix {};
+  initrd-verify = handleTest ./initrd-verify.nix {};
   input-remapper = handleTest ./input-remapper.nix {};
   inspircd = handleTest ./inspircd.nix {};
   installer = handleTest ./installer.nix {};

--- a/nixos/tests/initrd-verify.nix
+++ b/nixos/tests/initrd-verify.nix
@@ -1,0 +1,50 @@
+import ./make-test-python.nix ({ ... }: {
+  name = "initrd-verify";
+
+  nodes.machine = {
+    boot.initrd.systemd.enable = true;
+    boot.initrd.verify = {
+      enable = true;
+      trustedPublicKeys = [(builtins.readFile ./initrd-verify.pub)];
+      signing = {
+        enable = true;
+        keyFile = "${./initrd-verify.secret}";
+      };
+    };
+
+    # We want to detect failure in stage 1 ourselves.
+    testing.initrdBackdoor = true;
+    boot.initrd.systemd.services.panic-on-fail.enable = false;
+
+    virtualisation.useBootLoader = true;
+    virtualisation.useEFIBoot = true;
+    boot.loader.timeout = 0;
+    boot.loader.systemd-boot.enable = true;
+  };
+
+  testScript = ''
+    machine.switch_root()
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed(
+        "mount -o remount,rw /nix/store",
+        # Invalidate a dependency (systemd) to verify recursion
+        "echo invalidate > /run/current-system/systemd/invalidated",
+        "sync",
+    )
+    machine.shutdown()
+    machine.start()
+    def check_failed(_) -> bool:
+        info = machine.get_unit_info("verify-store.service")
+        state = info["ActiveState"]
+        if state == "failed":
+            return True
+        else:
+            status, jobs = machine.systemctl("list-jobs --full 2>&1")
+            if "No jobs" in jobs:
+                raise Exception('verify-store.service never failed as it should have.')
+            else:
+                return False
+    with machine.nested("Waiting for verification to fail"):
+        retry(check_failed)
+  '';
+})

--- a/nixos/tests/initrd-verify.pub
+++ b/nixos/tests/initrd-verify.pub
@@ -1,0 +1,1 @@
+not-secret:mS/WQyNhrsO6hMN/3IwbSoIda/DCaKkD1lJpC+II2eY=

--- a/nixos/tests/initrd-verify.secret
+++ b/nixos/tests/initrd-verify.secret
@@ -1,0 +1,1 @@
+not-secret:0f9ZmCOeRdEa5HitWkOOfQDJQcrif06V+apZpSSHJ/WZL9ZDI2Guw7qEw3/cjBtKgh1r8MJoqQPWUmkL4gjZ5g==


### PR DESCRIPTION
## Description of changes

Adds options for verifying the system closure during boot, and signing during switch-to-configuration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
