### PR TITLE
linphone: 5.0.16 -> 5.1.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -11,6 +11,7 @@
 , minizip-ng
 , mkDerivation
 , qtgraphicaleffects
+, qtmultimedia
 , qtquickcontrols2
 , qttools
 }:
@@ -33,7 +34,7 @@
 
 mkDerivation rec {
   pname = "linphone-desktop";
-  version = "5.0.16";
+  version = "5.1.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -41,7 +42,7 @@ mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    hash = "sha256-zS0JyK+HGiHY7tPdl3RK6fJJOUS+fKM1u3npNxDAAYE=";
+    hash = "sha256-Pu2tGKe3C1uR4lzXkC5sJFu8iJBqF76UfWJXYjPwBkc=";
   };
 
   patches = [
@@ -72,6 +73,7 @@ mkDerivation rec {
 
     minizip-ng
     qtgraphicaleffects
+    qtmultimedia
     qtquickcontrols2
   ];
 
@@ -86,6 +88,9 @@ mkDerivation rec {
 
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
+
+    # Requires EQt5Keychain
+    "-DENABLE_QT_KEYCHAIN=OFF"
   ];
 
   # The default install phase fails because the paths are somehow messed up in

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -49,6 +49,7 @@ mkDerivation rec {
     ./do-not-build-linphone-sdk.patch
     ./remove-bc_compute_full_version-usage.patch
     ./no-store-path-in-autostart.patch
+    ./reset-output-dirs.patch
   ];
 
   # See: https://gitlab.linphone.org/BC/public/linphone-desktop/issues/21
@@ -56,6 +57,8 @@ mkDerivation rec {
     echo "project(linphoneqt VERSION ${version})" >linphone-app/linphoneqt_version.cmake
     substituteInPlace linphone-app/src/app/AppController.cpp \
       --replace "APPLICATION_SEMVER" "\"${version}\""
+    substituteInPlace CMakeLists.txt \
+      --subst-var out
   '';
 
   # TODO: After linphone-desktop and liblinphone split into separate packages,
@@ -91,23 +94,17 @@ mkDerivation rec {
 
     # Requires EQt5Keychain
     "-DENABLE_QT_KEYCHAIN=OFF"
+
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
-  # The default install phase fails because the paths are somehow messed up in
-  # the makefiles. The errors were like:
-  #
-  #   CMake Error at cmake_builder/linphone_package/cmake_install.cmake:49 (file):
-  #     file INSTALL cannot find
-  #     "/build/linphone-desktop-.../build/linphone-sdk/desktop//nix/store/.../bin":
-  #     No such file or directory.
-  #
-  # If someone is able to figure out how to fix that, great. For now, just
-  # trying to pick all the relevant files to the output.
-  #
-  # Also, the exec path in linphone.desktop file remains invalid, pointing to
-  # the build directory, after the whole nix build process. So, let's use sed to
-  # manually fix that path.
-  #
+  preInstall = ''
+    mkdir -p $out/share/linphone
+    mkdir -p $out/share/sounds/linphone
+  '';
+
   # In order to find mediastreamer plugins, mediastreamer package was patched to
   # support an environment variable pointing to the plugin directory. Set that
   # environment variable by wrapping the Linphone executable.
@@ -121,26 +118,17 @@ mkDerivation rec {
   # It is quite likely that there are some other files still missing and
   # Linphone will randomly crash when it tries to access those files. Then,
   # those just need to be copied manually below.
-  installPhase = ''
-    mkdir -p $out/bin $out/lib
-    cp linphone-app/linphone $out/bin/
-    cp linphone-app/libapp-plugin.so $out/lib/
+  postInstall = ''
     mkdir -p $out/lib/mediastreamer/plugins
     ln -s ${mediastreamer-openh264}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
     ln -s ${mediastreamer}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
-    wrapProgram $out/bin/linphone \
-      --set MEDIASTREAMER_PLUGINS_DIR \
-            $out/lib/mediastreamer/plugins
-    mkdir -p $out/share/applications
-    cp linphone-app/linphone.desktop $out/share/applications/
-    mkdir -p $out/share/icons/hicolor/scalable/apps
-    cp ../linphone-app/assets/images/linphone_logo.svg $out/share/icons/hicolor/scalable/apps/linphone.svg
+
     mkdir -p $out/share/belr/grammars
     ln -s ${liblinphone}/share/belr/grammars/* $out/share/belr/grammars/
     ln -s ${belle-sip}/share/belr/grammars/* $out/share/belr/grammars/
-    mkdir -p $out/share/linphone
-    ln -s ${liblinphone}/share/linphone/* $out/share/linphone/
-    ln -s ${liblinphone}/share/sounds $out/share/sounds
+
+    wrapProgram $out/bin/linphone \
+      --set MEDIASTREAMER_PLUGINS_DIR $out/lib/mediastreamer/plugins
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/linphone/do-not-build-linphone-sdk.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/do-not-build-linphone-sdk.patch
@@ -4,58 +4,72 @@ Date: Fri, 28 Jan 2022 02:36:01 +0100
 Subject: [PATCH] Remove Linphone SDK build
 
 ---
- CMakeLists.txt                                | 86 ++-----------------
- .../cmake_builder/additional_steps.cmake      |  9 --
- 2 files changed, 5 insertions(+), 90 deletions(-)
+ CMakeLists.txt                                | 100 +-----------------
+ .../cmake_builder/additional_steps.cmake      |   9 --
+ 2 files changed, 5 insertions(+), 104 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2002b925..6d92a8e5 100644
+index b5a4ab5..3afcd88 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -152,7 +152,6 @@ list(APPEND APP_OPTIONS "-DENABLE_RELATIVE_PREFIX=${ENABLE_RELATIVE_PREFIX}")
- list(APPEND APP_OPTIONS "-DLINPHONE_OUTPUT_DIR=${LINPHONE_OUTPUT_DIR}")
+@@ -194,7 +194,6 @@ list(APPEND APP_OPTIONS "-DQTKEYCHAIN_TARGET_NAME=${QTKEYCHAIN_TARGET_NAME}")
+ 
  list(APPEND APP_OPTIONS "-DENABLE_QT_GL=${ENABLE_VIDEO}")#Activate on video
  
 -include(ExternalProject)
  set(PROJECT_BUILD_COMMAND "")
  if(CMAKE_BUILD_PARALLEL_LEVEL)
  	list(APPEND APP_OPTIONS "-DCMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}")
-@@ -190,30 +189,8 @@ if(ENABLE_BUILD_APP_PLUGINS)
+@@ -237,41 +236,8 @@ if(ENABLE_BUILD_APP_PLUGINS)
  	endif()
  endif()
  
--
 -if(NOT LINPHONE_QT_ONLY)
--ExternalProject_Add(sdk PREFIX "${CMAKE_BINARY_DIR}/sdk"
--    SOURCE_DIR "${CMAKE_SOURCE_DIR}/linphone-sdk"
--    INSTALL_DIR "${LINPHONE_OUTPUT_DIR}"
--    STAMP_DIR "${SDK_BUILD_DIR}/stamp"
--    BINARY_DIR "${SDK_BUILD_DIR}"
--    STEP_TARGETS build
--    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
--    INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
--    LIST_SEPARATOR | # Use the alternate list separator
--    CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
--    BUILD_ALWAYS NO #${DO_BUILD}
--)
--ExternalProject_Add_Step(sdk force_build
--	COMMENT "Forcing build for 'desktop'"
--	DEPENDEES configure
--	DEPENDERS build
--	ALWAYS 1
--)
+-#add_subdirectory(external/qtkeychain)
+-	if(ENABLE_QT_KEYCHAIN)
+-		ExternalProject_Add(app-qtkeychain PREFIX "${CMAKE_BINARY_DIR}/qtkeychain"
+-			SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/qtkeychain"
+-			INSTALL_DIR "${QTKEYCHAIN_OUTPUT_DIR}"
+-			BINARY_DIR "${SDK_BUILD_DIR}/qtkeychain"
+-			BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
+-			LIST_SEPARATOR | # Use the alternate list separator
+-			CMAKE_ARGS ${APP_OPTIONS} ${QTKEYCHAIN_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_OSX_ARCHITECTURES=${LINPHONESDK_MACOS_ARCHS}
+-			BUILD_ALWAYS NO #${DO_BUILD}
+-		)
+-	endif()
+-	ExternalProject_Add(sdk PREFIX "${CMAKE_BINARY_DIR}/sdk"
+-		SOURCE_DIR "${CMAKE_SOURCE_DIR}/linphone-sdk"
+-		INSTALL_DIR "${LINPHONE_OUTPUT_DIR}"
+-		STAMP_DIR "${SDK_BUILD_DIR}/stamp"
+-		BINARY_DIR "${SDK_BUILD_DIR}"
+-		STEP_TARGETS build
+-		BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
+-		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
+-		LIST_SEPARATOR | # Use the alternate list separator
+-		CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_OSX_ARCHITECTURES=${LINPHONESDK_MACOS_ARCHS}
+-		BUILD_ALWAYS NO #${DO_BUILD}
+-	)
+-	ExternalProject_Add_Step(sdk force_build
+-		COMMENT "Forcing build for 'sdk'"
+-		DEPENDEES configure
+-		DEPENDERS build
+-		ALWAYS 1
+-	)
 -endif()
  include(FindPkgConfig)
  
--set(APP_DEPENDS sdk)
- find_package(Qt5 5.10 COMPONENTS Core REQUIRED)
- 
- if ( NOT Qt5_FOUND )
-@@ -227,62 +204,9 @@ find_package(belcard CONFIG QUIET)
- find_package(Mediastreamer2 CONFIG QUIET)
+-set(APP_DEPENDS sdk)# Used if NOT LINPHONE_QT_ONLY
+ if(ENABLE_QT_KEYCHAIN)
+ 	list(APPEND APP_DEPENDS app-qtkeychain)
+ endif()
+@@ -289,65 +255,9 @@ find_package(Mediastreamer2 CONFIG QUIET)
  find_package(ortp CONFIG QUIET)
+ find_package(${QTKEYCHAIN_TARGET_NAME} CONFIG QUIET)
  
--if(NOT (LinphoneCxx_FOUND) OR NOT (Linphone_FOUND) OR NOT (bctoolbox_FOUND) OR NOT (belcard_FOUND) OR NOT (Mediastreamer2_FOUND) OR NOT (ortp_FOUND) OR FORCE_APP_EXTERNAL_PROJECTS)
+-if(NOT (LinphoneCxx_FOUND) OR NOT (Linphone_FOUND) OR NOT (bctoolbox_FOUND) OR NOT (belcard_FOUND) OR NOT (Mediastreamer2_FOUND) OR NOT (ortp_FOUND)
+-	OR ( ENABLE_QT_KEYCHAIN AND NOT(${QTKEYCHAIN_TARGET_NAME}_FOUND) )
+-	OR FORCE_APP_EXTERNAL_PROJECTS
+-)
 -	message("Projects are set as External projects. You can start building them by using for example : cmake --build . --target install")
 -	ExternalProject_Add(linphone-qt PREFIX "${CMAKE_BINARY_DIR}/linphone-app"
 -		SOURCE_DIR "${CMAKE_SOURCE_DIR}/linphone-app"
@@ -65,7 +79,7 @@ index 2002b925..6d92a8e5 100644
 -		BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
 -		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
 -		LIST_SEPARATOR | # Use the alternate list separator
--		CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
+-		CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_OSX_ARCHITECTURES=${LINPHONESDK_MACOS_ARCHS}
 -	# ${APP_OPTIONS}
 -		BUILD_ALWAYS ON
 -	)
@@ -78,10 +92,10 @@ index 2002b925..6d92a8e5 100644
 -			BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
 -			INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
 -			LIST_SEPARATOR | # Use the alternate list separator
--			CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
+-			CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_OSX_ARCHITECTURES=${LINPHONESDK_MACOS_ARCHS}
 -		)
 -	endif()
--	install(CODE "message(STATUS Running install)")
+-	install(CODE "message(STATUS \"Running install\")")
 -	set(AUTO_REGENERATION auto_regeneration)
 -	if(	ENABLE_BUILD_APP_PLUGINS)
 -		add_custom_target(${AUTO_REGENERATION} ALL
@@ -115,12 +129,12 @@ index 2002b925..6d92a8e5 100644
 -    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
 -#    INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
 -    LIST_SEPARATOR | # Use the alternate list separator
--    CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
+-    CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_OSX_ARCHITECTURES=${LINPHONESDK_MACOS_ARCHS}
 -    EXCLUDE_FROM_ALL ON
 -    #BUILD_ALWAYS ON
 -)
 diff --git a/linphone-app/cmake_builder/additional_steps.cmake b/linphone-app/cmake_builder/additional_steps.cmake
-index 7f7fd573..a69a04e8 100644
+index 7f7fd57..a69a04e 100644
 --- a/linphone-app/cmake_builder/additional_steps.cmake
 +++ b/linphone-app/cmake_builder/additional_steps.cmake
 @@ -54,14 +54,5 @@ if (ENABLE_PACKAGING)
@@ -139,5 +153,5 @@ index 7f7fd573..a69a04e8 100644
    endif ()
  endif ()
 -- 
-2.25.1
+2.39.3 (Apple Git-145)
 

--- a/pkgs/applications/networking/instant-messengers/linphone/reset-output-dirs.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/reset-output-dirs.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b5a4ab5..b6b89c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,10 +59,10 @@ set(CMAKE_CXX_STANDARD 11)
+ 
+ # Prepare gobal CMAKE configuration specific to the current project
+ set(SDK_BUILD_DIR "${CMAKE_BINARY_DIR}/WORK")       # SDK build in WORK. Keep all in it.
+-set(LINPHONE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/linphone-sdk/desktop")
+-set(QTKEYCHAIN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/qtkeychain")
++set(LINPHONE_OUTPUT_DIR "@out@")
++set(QTKEYCHAIN_OUTPUT_DIR "@out@")
+ set(QTKEYCHAIN_TARGET_NAME "EQt5Keychain")
+-set(APPLICATION_OUTPUT_DIR "${CMAKE_BINARY_DIR}/OUTPUT")
++set(APPLICATION_OUTPUT_DIR "@out@")
+ 
+ set(CMAKE_PREFIX_PATH "${LINPHONE_OUTPUT_DIR};${APPLICATION_OUTPUT_DIR};${APPLICATION_OUTPUT_DIR}/include${PREFIX_PATH}")
+ if(WIN32)


### PR DESCRIPTION
## Description of changes

Closes #273612.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
