### PR TITLE
muse: 4.1.0 -> 4.2.1

### DIFF
--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, extra-cmake-modules
 , pkg-config
 , qttools
 , wrapQtAppsHook
@@ -27,18 +28,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "muse-sequencer";
-  version = "4.1.0";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "muse-sequencer";
     repo = "muse";
     rev = finalAttrs.version;
-    hash = "sha256-JPvoximDL4oKO8reXW7alMegwUyUTSAcdq3ueXeUMMY=";
+    hash = "sha256-LxibuqopMHuKEfTWXSEXc1g3wTm2F3NQRiV71FHvaY0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
-  nativeBuildInputs = [ cmake pkg-config qttools wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config qttools wrapQtAppsHook ];
 
   buildInputs = [
     alsa-lib


### PR DESCRIPTION
## Description of changes

Changelog:
https://github.com/muse-sequencer/muse/blob/4.2.1/src/ChangeLog

> 
> 24.09.2023
>     *** MusE 4.2.1 ***
> 23.09.2023
>     - Fix issue 1247: compilation only succeeds with MODULES_BUILD_STATIC=1 (Tim)
>       Five undefined symbols. Remove 'inline' from five functions in mididev.cpp
> 20.09.2023
>     - Fixed issue 1243 Slow startup: Always rescanning when file contains no plugins. (Tim)
>       File ladspa_dsp.so was causing rescanning all the time because it is normally empty
>        until a configuration file is hand-entered by the user.
>     - Fixed missing simpledrums MESS synth: Moved files automation_mode_toolbar.h/.cpp
>        from widgets folder to components folder because it contains icons, and simpledrums
>        uses our widgets library and it is not supposed to contain icons.
> 10.09.2023
>     *** MusE 4.2 ***
> 03.09.2023
>     - Fluidsynth MESS: Fixed deprecated function calls at version >= 2.2 (Tim)
> 31.08.2023
>     - Fixed issue 1106: Running scripts in midi editors takes waaay too long. (Tim)
>       In Scripts::executeScript(): Changed from applyOperation for each event
>        which is very slow, to applyOperationGroup just once for the whole lot.
> 30.08.2023
>     - Fixed issue 1238: Not responding to program MSB from inputs. (Tim)
>       Ancient bug, 20 years? Problem with Midi Filter and midiFilterCtrlxxx globals.
> 28.08.2023
>     * New: Midi remote control feature redesigned. (Tim)
>       Now with learning, port, channel, value type trigger/toggle/momentary, global/song settings.
>     - Also rewrote midi-to-audio controller assignment learning code, to follow these changes.
> 03.08.2023
>     - Fixed issue 1233: RtAudio 6 compatibility. (Tim)
>       Tested OK with RtAudio 6.0.1
> 31.07.2023
>     - Fixed midi remote control: Don't accept note-offs. (Tim)
>       Symptoms were: Double step-record entries, transport record toggling, double play etc.
>     - Changed all references to the app's url, help url etc. (Website has changed).
>       Created ORGANIZATION_URL, ORGANIZATION_HELP_URL, ORGANIZATION_CODE_REPO_URL in config.h.in
> 26.07.2023
>     - Fixed broken midi to logarithmic audio controller assignment, such as volume. (Tim)
> 06.07.2023
>     - Hexfloat values: Rework code with help from donarturo11. (Tim)
>       Avoid per-thread thread-safe locale calls (uselocale etc). Not available on mingw for ex.
> 17.06.2023
>     - Fixed: LV2 Synths like Odin-II not responding to automation since around 29.04.2023. (Tim)
> 15.06.2023
>     - Fixed issue 1121: Undefined symbol ipatch_close. (Tim)
>       ipatch_close was introduced in libinstpatch 1.1.0
>     - Changed: Midi export: Turn off 'export zero velocity note-offs' setting by default.
> 13.06.2023
>     - Fixed: File menu > close hanging. Further to 13.05.2023 (Tim)
>       Check if immediate deletions took place. Also, in track info panel, NULL the strip widgets
>        BEFORE deleting them, instead of deleting then nulling.
> 12.06.2023
>     - Oops. Fixed mistake at 15.05.2023: Link libinstpatch with 'muse' module, not 'core'. (Tim)
> 11.06.2023
>     - Fixed issue 1120 "Cannot clone parts". (Tim)
>       Several pieces of code were fixed, including one 10-year-old mistake.
>       Tested OK copy/paste/clone with several different tracks types.
> 29.05.2023
>     - Fixed: Still more crashes / bad behaviour on song (re)load. Further to 25.05.2023. (Tim)
>       Fix at 13.05.2023 (wait for top level widgets to be deleted before continuing with load) was good
>        but needed to include more than just the top levels. Child widget destructors are called AFTER
>        the parent. So there was no choice - add SOME of those widgets to the list of pending deletes.
>       Specifically, widgets connected to external signals heartBeat timer, songChanged, configChanged.
>     - Fixed: Another crash in Master Editor: Removed members 'hscroll' and 'vscroll' which were hiding
>        base MidiEditor versions causing crash. Also initialize base hscroll, vscroll, time to null.
> 26.05.2023
>     - Fixed: DSSI plugins: Crash with plugins that have run_multiple_synths(). (Tim)
>       The function was not being called correctly, valid arrays must be passed even if empty.
> 25.05.2023
>     - Fixed: More crashes / bad behaviour during song (re)loading. Further to 08.05.2023. (Tim)
>       Eliminated QPointer<MasterEdit> in class MusE. Bug was pre-existing (not me).
>       The pointer was failing to nullify itself soon enough, causing crashes and/or errors like:
>         "QMdiArea::setActiveSubWindow: window is not inside workspace" and "unknown tag <...> at line xxxx".
> 
>     - Fixed: Rewrote several functions in class MusE for more safety. readToplevels() and accompanying
>         findOpenEditor(), startDrumEditor(), startMasterEditor(), startWaveEditor(), startPianoroll().
>       It was too easy for readToplevels() to mess up badly if it failed starting an editor.
> 
>     - Fixed: Some, possibly all, ancient intermittent crashes when recording or playing wave tracks.
>       Our SndFile class used a reference counting system but it was non-atomic and not thread-safe.
>       Code disassembly revealed timing holes where other threads could wreak havoc.
>       Replaced with atomic reference counter and atomic pointer to SndFile.
>       Carefully rearranged and rewrote the reference counting system. Testing stable so far...
> 
>     - Fixed: Transport completely unresponsive upon song load, intermittent. (My fault long ago).
>       Do not call audioPrefetch->msgSeek() in seqStart() since it's already initiated by audio start.
>       It was a non-no: Two different threads - gui and audio - had put seek messages into the prefetch
>         message pipe. The result was chaos with 'seekCount' on the prefetch end of the pipe.
>       Reset prefetch 'seekCount' to zero in AudioPrefetch::start(). In case 'seekCount' ever messes up
>         again, this allows simply reloading a song, or menu > 'Restart Audio', to fix the problem.
>       Disk prefetch thread is NO LONGER REALTIME! It is now a default NORMAL thread. (My fault long ago).
>       Rewrote MusE::seqStart() so prefetch is started before audio. Also, wait until prefetch is running!
>       TESTED OK playing and recording complex songs. The prefetch cache maintained a high fill level.
>       TODO: Now that disk prefetch thread is no longer realtime, replace its pthreads with QThread,
>         for easier cross-compatibility!
>       TO FIX: A small bug where the transport sometimes fails to return to the saved place on song load.
> 
>     - Fixed: Subtle error: Editors wouldn't open multiple parts sometimes.
>       Failed if another editor contained the same number of parts AND at least one of the same parts.
>       It was a pre-existing bug in MusE::findOpenEditor() (not me).
> 
> 17.05.2023
>     - Fixed serious typo at 13.05.2023: On load, midi config wasn't cleared, causing crashes. (Tim)
> 16.05.2023
>     - Fixed (maybe): LV2: Missing link with libserd. (Tim)
>       Found this at opensuse live build log/multimedia:proaudio/muse/openSUSE_Tumbleweed/x86_64:
>       "undefined reference to symbol 'serd_node_new_file_uri'"
>       Only one serd call was added in 2015 by danvd. A later neglect by me perhaps?
> 15.05.2023:
>     - Fixed: Crashes with certain plugins that use libinstpatch (Fluida lv2 etc). (Tim)
>       It was recommended to call ipatch_init() in the main app. This was added.
> 13.05.2023:
>     - Rewrite of 08.05.2023: Use alternate method for top level closing (wait for destroyed signals). (Tim)
>       Qt bug reports response told me not to do it the other way.
>     - Fixed: Pre-existing long-time crashes pressing Ctrl-N (New) -O (Open) etc. more than once rapidly.
>       Install mechanism to ignore such multiple actions while in the middle of clearing/loading a song.
> 09.05.2023:
>     - LV2: Slight tweak: When a control port's maximum is not specified, set to 1 instead of 0. (Tim)
>       TODO: It's likely intended to allow user settable min and max, but we have no mechanism to let them.
> 08.05.2023:
>     - Fixed: Ancient crashes when loading another song or file > new or file > close. (Tim)
>       In MusE::clearSong(), after calling close() on the windows (which may be marked as delete-on-close),
>        make freakin' sure to call "qApp->sendPostedEvents(nullptr, QEvent::DeferredDelete)".
>       It turns out that delete-on-close calls deleteLater() - NOT delete!
>       It also turns out that there's a kind of Qt bug where you cannot simply call sendPostedEvents(0, 0).
>       See comments in MusE::clearSong() about how difficult this was, and how the solution was found.
> 29.04.2023:
>     - Fixed: Synths/plugins: Crashes in getData()/apply(). Caused by 14.04 changes. (Tim)
>       Oops. Reinstate check for zero slice size in LV2 VST DSSI ::getData(), and PluginI::apply().
>     - Fixed: VST: Crashes revealed by Pianoteq 8. (Tim)
>       Remove idling code in audioMasterUpdateDisplay and move it to audioMasterIdle, in the callback.
>       In VstNativeEditor, add a close() function and call it from destructor. Remove code from closeEvent().
> 28.04.2023:
>     - Revert: Pull 1099: "Move event list editor from dock to window." (Tim)
>       This was kinda not good. The list editor really belongs in a dock beside the pr/drum editor
>        as a 'companion' since highlighting notes is supposed to work both ways. It is more
>        convenient to have the two editors side-by-side rather than having the event list editor
>        in a separate tab or floating. The pull code was kept. A define in cobject.h switches
>        between the pull being off or on. It is called MOVE_LISTEDIT_FROM_DOCK_TO_WINDOW_PULL1099.
>     - Fixed: Event List Editor: (When pull 1099 is applied) Added missing 'Display' menu. (Tim)
>       Allows to 'float' the event list editor window.
>     - Fixed issue 1119: Routing doesn't work with utf-8 symbols in names. (Tim)
>       Changed all QString::toLatin1()/tolocal8Bit() usages to QString::toUtf8() in the following files so far:
>        jack.cpp, jackmidi.cpp, route.cpp, routepopup.cpp.
>       TODO: CHECK: Likely (many) more to do, EXCEPT some parts like xml, where we want SOME latin1 compatibility.
> 25.04.2023:
>     - Follow-ups to 14.04.2023: More fixes/features. (Tim)
>     * NEW: Export midi: When exporting only selected parts, a new option in the import/export settings
>        dialog allows alignment of the exported parts to bar zero (removes unused space to the left).
>     - Fixed crashes: Certain operations, for example when turning off grid after markers added.
>       Lambda from MasterEdit.cpp was still active after MasterEdit closed and deleted!
>        connect(MusEGlobal::muse, &MusE::configChanged, [this]() { configChanged(); } );
>       Fixed all places using lambda connections from outside. Delete the connections in the destructors.
>       Qt docs warn that such connections are NOT automatically deleted.
>     - Fixed: Midi export: Old, slight timing mistake in 14-bit/(N)RPN/Patch controller event export times.
>       Was sending each component event at t, t + 1, t + 2 etc. All component events should be at the same time.
>     - Fixed: Midi playback and midi export: Some or all (N)RPN controller graph values were being discarded.
>       Was a problem with optimization in MPEventList::add(). Re-wrote to be less strictly optimizing.
>     - Fixed: Midi import, export, and recording: Channel-less event types were not sorted correctly in the event list.
>       In MEvent::operator<(), do not compare channels if either event is channel-less.
>     - Fixed: Midi import, export, and recording: Patch event types were not sorted correctly in the event list.
>       In MEvent::sortingWeight(), ensure high and low bank controller events come before program events.
>     - Fixed: Midi recording and midi import: Composite controllers like (N)RPN and Patch were mis-read as non-composite.
>       Re-wrote ending (optimizing) part of midi.cpp:buildMidiEventList(). Handle controllers separately than other events.
>     - Fixed: Midi export: Do not export events that are outside part borders.
>     - Refine spamatica's "Fixed compatibility with qt5.9.5" commit 489034a.
>     - Refine spamatica's "Fixed another qt5.9.5 compatibility issue" commit a335362.
>     - Refine spamatica's "fixed another compat build error" commit 3c6777f.
> 22.04.2023:
>     - Briefly show "Project saved." message on status bar after project has been saved (rj)
> 16.04.2023
>     - From 14.04: Old songs' automation values not loading correctly in locales other than 'C'. (Tim)
>       Oops, force c locale to 'C' in museStringFromDouble() and museStringToDouble().
>       Using a per-thread thread-safe technique with uselocale() et al.
> 15.04.2023
>     - From 14.04: Unable to enter values in entry boxes in locales other than 'C'. (Tim)
>       Oops, add locale in DoubleLabel::valueFromText(). Test OK with locale = fr.
> 
> 14.04.2023
>     * Spring 2023 large fixes and features: (Tim)
> 
>     * NEW: Soft bypass support for plugins.
>       Different types are supported: True soft bypass controller (LV2, future VST3),
>        soft bypass function with no controller (VST2), emulated bypass controller (TODO),
>        and regular emulated bypass with no controller (LADSPA, DSSI etc.).
>       When a plugin is soft bypassed we (must) let it run ALWAYS so that the plugin handles
>        all the bypassing itself (we trust - hope - it will be 'lighter' CPU usage).
>       The generic plugin UI 'Bypass' button overrides any soft bypass controller graph.
> 
>     * NEW: Generic plugin UI 'Off' button. This completely bypasses the plugin even if
>        it has soft bypass. It is the ultimate 'turn off' mechanism, guaranteed to
>        bypass all processing, whereas 'Bypass' may still process if it's soft.
> 
>     * NEW: Some entry boxes (log, linear) now support metric suffixes, where appropriate.
>       You can type "0.000001234" or "1.234u", and "12345" or "12.345K" for example.
> 
>     * NEW: Value units. Where supported (LV2), units will be shown in the edit boxes
>        such as Hz, dB, ms etc. Don't be alarmed if you see things like "1.234K ms".
>       I just had to keep the units and the metric suffixes separate, it was the only way.
>       LV2 has unit conversions, but they were not quite robust enough to do what I wanted.
>       Plus when units change say from "s" to "min", then our slider/meter scales would show
>        wrong units and would have to dynamically change with the units. Very difficult.
> 
>     * NEW: Hexadecimal floating point storage. Preserves 100% accuracy in song files.
>       Used where appropriate (too many decimal digits).
>       Both hex and decimal values can be mixed (manual decimal entry for example).
>       Applied to audio controller values and graphs for now. More later.
>       C/C++ have supported hex floats for many years. But Qt doesn't seem to natively.
> 
>     * NEW: Export midi selected visible tracks only. In main app menu.
> 
>     * NEW: Export midi selected parts on visible tracks only. In main app menu.
> 
>     * NEW: LV2 midi-out support added. Supports things like midi arpeggiators, midi effects etc.
> 
>     Fixed: VST midi-out: Recording times were way off. (Midi arpeggiators, midi effects etc.)
>     Added: Latency correction for VST midi-out.
> 
>     Fixed: Crash in undo/redo system: Major regression several months ago.
>     For example delete a part or track, then undo redo etc. caused crash.
>     Rewrote undo's clearDelete() and deleteUndoOp() routines.
> 
>     Fixed: Crash when removing or replacing plugins from rack.
>     Some heavy graphics moves were being done in realtime thread.
> 
>     Fixed: Crash in track list TList::mouseReleaseEvent() when track is NULL.
> 
>     Fixed: Crash in midi/synth configuration dialog when clicking on port device column.
>     Popup's action text was being read AFTER the popup was deleted.
>     Seems to be my fault from 2019 according to annotations?
> 
>     Fixed: Crashes in remaining places calling wrong undo constructor. See 06.12.2022
> 
>     Fixed: Occasional show-stopping glitch when recording or live-monitoring midi:
>     Notes would become badly timed, very old notes would play along with new ones in a
>      weird 'cycling' effect, requiring restart.
>     Replaced old class MidiRecFifo with more recent LockFreeMPSCRingBuffer<MidiRecordEvent>.
>     Caught old class skipping read position and mis-reporting the size, leaving a messed-up state.
>     It was concluded that this may have been an concurrency/atomic problem.
>     LockFreeMPSCRingBuffer was added few years ago. It has worked flawlessly so far.
>     Stack Exchange was consulted on the old class and whether the newer FIFO was really sound.
>     Old class agreed bad - use of 'volatile'. New class favourable but with TOC-TOU warnings.
>     Hopefully this cures the bug. Remains to be seen again - or not?
> 
>     Fixed: Pianoroll and drum editor: Copy/paste broken:
>     Oops! Pasted from bar 0 instead of first copied note.
>     Rewrote pasting routines in functions.cpp
> 
>     Fixed: When track off could not click on mixer strip expand arrow icon or double click name.
>     Don't disable the track mixer strip label.
> 
>     Fixed: 'Fine' slider Shift key operation (was making it coarse not fine, and
>      plugin sliders were messed up - moving way too much when Shift held).
> 
>     Fixed: Midi event buffers overflow when a synth track's synth is 'unavailable'.
>     Flush ring buffers and device event lists in SynthI::getData().
> 
>     Fixed: Editors: Opening multiple parts in editor (via arranger right-click popup)
>      also caused track rename dialog to pop up.
>     Do not respond to actions that have no integer data value.
> 
>     Fixed: Wave Editor: Could not open multiple parts (via arranger right-click popup).
> 
>     Fixed: Audio track automation graphs: Copying+pasting points from multiple controllers:
>     Oops. They were accumulating in each target controller graph as paste progressed.
>     It was a problem in functions.cpp : readAudioAutomation().
> 
>     Fixed: All places using MidiDevice::openFlags() to check if read/write is OK
>      have been changed to use MidiDevice::readEnable()/writeEnable().
>     This is because openFlags() are the DESIRED flags whereas readEnable()/writeEnable()
>      indicate whether the device was ACTUALLY successful in opening in read/write mode.
>     So it's more faithful to the read/write columns of Devices list in Midi Config dialog.
> 
>     * Major plugin/controller/logarithmic/UI changes: (Tim)
> 
>       Fixed broken plugin/synth logarithmic audio controls, edit boxes, and graphs.
> 
>       Significant streamlining and redesign of classes Meter, Slider, DRange, DoubleLabel,
>        mixer strips AStrip and MStrip, generic plugin UI, and several others.
>       Support logarithmic and dB controller streams.
>       Previously mixer strips and generic plugin UI were responsible for all conversions
>        to and from log, dB, or integer values, to be shown in sliders, meters, and boxes.
>       Now all of these widgets operate independently and do all conversions themselves.
>       In other words they simply 'hook onto' a controller stream with no further work
>        required by the parent. That cleaned up strips and generic plugin UI code
>        A WHOLE LOT.
> 
>       Significant speed optimizations: Classes Meter, Slider, DRange, and DoubleLabel
>        are now highly optimized for drawing. They use QRegion for fine-grained
>        updating and painting. Most paths and rectangles are pre-calculated in
>        resizeEvent() instead of paintEvent(). In particular, Meter is one of the
>        few large widgets that is constantly being animated, and it is very fast now.
> 
>       Fixed weak support for rare 'reverse' controllers where minimum is greater than maximum.
>       (AlienWah plugin 'phase control' for example.)
> 
>       When the minimum slider and minimum meter Global Settings differ, meter scales
>        are automatically shown. They MUST be shown to avoid the misconception
>        that the meter scale is the same as the slider scale, which it is not!
> 
>       Replaced generic plugin UI meter output edit boxes (useless) with faster labels.
> 
> 06.12.2022
>     * Fixed issue with wrong constructor being instantiated when clicking
>       rec-arm and input monitor when having multiple tracks selected (rj)
> 21.11.2022
>     * Reworded quit and load new dialogs to make it clearer that
>       data will be discarded (rj)
>     * Dirty flag was not kept when cancelling the load New operation (rj)
> 14.11.2022
>     - Automation READ mode: Play: Re-enable graph streams when controls released. (Tim)
>       Also re-enabe the streams if the graph is edited.
> 10.11.2022
>     - Fix issue 1088: Cannot copy/paste parts. Fix previous 9/24/22 fix. (Tim)
>       Was slight problem in parseArrangerPasteXml().
> 27.10.2022
>     * Fix open editor in tab or new window behavior
>     * Move List Editor from dock to window  
> 23.10.2022
>     * Changed project create default to make a sub directory (rj)
> 10.07.2022
>     * Midi assign and mixer overhaul, fixes: (Tim)
>     * New: Midi control assignment: Mute and Solo buttons can now be assigned to.
>       Note this does NOT mean that Mute and Solo have actual controller graphs,
>        it was decided against that. (A request from forums.)
>     * New: Midi control assignment: Two assignment types now available in the
>       Midi Control dialog: Track, which dedicates assignments to a single track,
>        and Song which assigns to ANY tracks when they are selected.
>       Availability of this new option varies with selected target control,
>        for example only Volume and Pan audio controllers can be set to Song
>        assignment type because they are the only ones common to ALL audio tracks,
>        and other controllers mean different things to different tracks.
>     * New: Momentary Mute and Solo buttons! Enable them in Global Settings or via
>        the mixer or strip menus.
>       Mixer: Fixed bug: When empty would not add any new tracks.
>       Mixer: Ensure mixer is always large enough to show 'Create' and 'View' menus.
>       Mixer strips: Code cleanup: Replaced Strip::mousePress/Release/MoveEvent
>        with track name label handling and context event hadling because all the Qt
>        standard controls on the strip were passing events to the strip. Rewrote
>        strip popup menus, most stuff moved into the mixer View menu.
> 19.06.2022
>     * MORE Complete audio automation graphs redesign (Part 2): (Tim)
>     * New: Audio automation graphs: Choice of DISCRETE or INTERPOLATED points.
>       Buttons on toolbar select which mode to draw new points. Works per-point!
>       A context menu item allows to change mode of all selected points.
>       Role of 'interpolated' has been greatly reduced to that of just drawing,
>        and all control recording, including external midi, is DISCRETE now.
>       DISCRETE points are drawn as squares. INTERPOLATED points are drawn as circles.
>       Note, INTERPOLATED mode only works for controllers that support it, such as
>        non-integer or logarithmic. TODO: Make an integer interpolator so that
>       INTERPOLATED works even on DISCRETE graphs!
>     * New: LATCH automation mode, in addition to OFF, READ, TOUCH, WRITE modes.
>     * New: Audio automation graphs: "Align all selected to point" context menu item.
>       Vertically aligns selected points to the clicked point.
>     * New: Adjustable graph point size. In Global Settings > GUI tab.
>     * New: Buttons on toolbar turn the graph points on and off !
>       Allows to see the graphs more clearly.
>     * New: Toolbar button avoids redundant recorded straight line automation points.
>     - Reworked graph point hit detection and drawing. Precisely accurate now.
>     - Midi controller graphs: Controllers popup menu: Midi controllers that are
>        mapped to (synthesizer) audio control ports have their own heading now,
>        to make it much clearer that they exist and what they do.
>     - Fixed old bug in Audio::processMidi(): When a midi controller
>        was assigned to an audio controller, operating the midi control would
>        suddenly leave the audio controls inoperative. Likely happened years
>        ago when time-stamp mechanism changed, this area was neglected.
>     - Fixed Midi-to-Audio controller assignment not recording properly.
>       Recorded frames were way off. Likely same reason as above.
>     - Fixed audio automation 'WRITE' mode not storing initial value and not
>        disabling the controller streams, when going from stop to play.
>       Seems to have been broken for many years (since first github checkin?)
>     - Eliminated old ugly HACK in class CtrlList: Removed _guiUpdatePending and support.
>       Replaced (integrated) with an IPC mechanism.
>     - Switched all code from muse_val2dbr (rounded) to new muse_val2db (unrounded).
>     - Fixed some memory leaks in class UndoList when clearing the list. Allocated items
>        were not being deleted.
>     - As requested: Uncluttered the Arranger popup context menu by moving audio
>        automation items into a sub-menu.
>     - Bumped up songfile version number to ensure toolbars are updated correctly.
> 12.06.2022
>     - Fix clone parts not loading correctly. Oops, was a typo at 17.04.2022 (Tim)
> 04.05.2022
>     - Reverse script that reverses MIDI and DRUM parts incl controllers. (Staffan)
> 03.05.2022
>     - Reuploaded script (Fix issue 1037: Time stretching/shrinking for midi/drum parts.) (Staffan)
> 26.04.2022
>     - Added shortcut (meta+h) for toggling track height. If any track is larger 
>       than minimum, the first press will minimize all tracks, second press will
>       expand all tracks to the alternate size, which is now settable in the 
>       configuration (rj)
> 18.04.2022
>     - Fix issue 1022: Allow even more zoom out in piano roll. (StaffanMelin)
>     - Further to 17.04.2022: Added audio automation horizontal snap-to-grid. (Tim)
> 17.04.2022
>     * NEW Complete audio automation graphs redesign: (Tim)
>     - Multiple graph points can now be selected. Lasso works.
>     - Standard keys behaviour, same as found in parts, notes etc.
>     - Copy/cut/paste/del supported.
>     - Audio automation graphs can now be copied to other controller graphs.
>       See 'Paste' each controller's color popup menu.
>     - Points can be dragged past other points now.
>     - Three paste/drop existing points erase modes (see right-click menu):
>       Erase none, Erase (groups), Erase complete range.
>     - After dropping moved points, a 'move mode' coloured block is active until
>        blank space is clicked, which allows the points to be moved further,
>        exposing existing points that were erased when dropped upon.
>     - More colors and custom colors for audio automation graphs.
>     - Controller names have been removed from the controller graphs and
>       placed into the Track List 'Automation' column (expand to see more!).
>     - All plugin controllers now have different colors instead of all green.
>       Old green color scheme in old songs is detected by checking if two or more
>       plugin controllers are green and changing them.
>     * Other:
>     - Eliminated OLD UGLY HACK: The global cloneList in songfile.cpp.
>       Replaced with an informational structure passed among the functions.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
