### PR TITLE
treewide-ish: set meta.mainProgram on a few packages

### DIFF
--- a/pkgs/applications/editors/howl/default.nix
+++ b/pkgs/applications/editors/howl/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     description = "A general purpose, fast and lightweight editor with a keyboard-centric minimalistic user interface";
     license = licenses.mit;
     maintainers = with maintainers; [ pacien ];
+    mainProgram = "howl";
 
     # LuaJIT and Howl builds fail for x86_64-darwin and aarch64-linux respectively
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -153,5 +153,6 @@ perlPackages.buildPerlPackage rec {
     homepage = "https://gscan2pdf.sourceforge.net/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ pacien ];
+    mainProgram = "gscan2pdf";
   };
 }

--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -39,5 +39,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/firecat53/urlscan/releases/tag/${version}";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ dpaetzel ];
+    mainProgram = "urlscan";
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch-addrlookup/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-addrlookup/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ mog ];
     platforms = platforms.unix;
     license = licenses.mit;
+    mainProgram = "notmuch-addrlookup";
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -146,5 +146,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ flokli puckipedia ];
     platforms   = platforms.unix;
+    mainProgram = "notmuch";
   };
 }

--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -71,5 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ viric ];
     platforms = platforms.unix;
+    mainProgram = "unison";
   };
 })

--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -90,5 +90,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ agpl3 gpl3Plus ];
     platforms = platforms.all;
     maintainers = with maintainers; [ pacien dotlambda ];
+    mainProgram = "beamerpresenter";
   };
 }

--- a/pkgs/development/tools/misc/mdctags/default.nix
+++ b/pkgs/development/tools/misc/mdctags/default.nix
@@ -18,5 +18,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/wsdjeg/mdctags.rs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pacien ];
+    mainProgram = "mdctags";
   };
 }

--- a/pkgs/servers/matrix-appservice-discord/default.nix
+++ b/pkgs/servers/matrix-appservice-discord/default.nix
@@ -103,5 +103,6 @@ in mkYarnPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pacien ];
     platforms = lib.platforms.linux;
+    mainProgram = "matrix-appservice-discord";
   };
 }

--- a/pkgs/servers/rmfakecloud/default.nix
+++ b/pkgs/servers/rmfakecloud/default.nix
@@ -31,5 +31,6 @@ buildGoModule rec {
     homepage = "https://ddvk.github.io/rmfakecloud/";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ pacien martinetd ];
+    mainProgram = "rmfakecloud";
   };
 }

--- a/pkgs/tools/backup/zrepl/default.nix
+++ b/pkgs/tools/backup/zrepl/default.nix
@@ -45,5 +45,6 @@ buildGoModule rec {
     platforms = platforms.linux;
     license = licenses.mit;
     maintainers = with maintainers; [ cole-h danderson mdlayher ];
+    mainProgram = "zrepl";
   };
 }

--- a/pkgs/tools/text/colordiff/default.nix
+++ b/pkgs/tools/text/colordiff/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ SuperSandro2000 ];
+    mainProgram = "colordiff";
   };
 }


### PR DESCRIPTION
## Description of changes

This sets `meta.mainProgram` for a few packages,
for which `mainProgram = pname`,
just so that I stop drowning under the warnings from `lib.getExe` due to this
missing meta attribute.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
