### PR TITLE
homebox: init at 0.10.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1274,6 +1274,7 @@
   ./services/web-apps/healthchecks.nix
   ./services/web-apps/hedgedoc.nix
   ./services/web-apps/hledger-web.nix
+  ./services/web-apps/homebox.nix
   ./services/web-apps/honk.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.homebox;
+in {
+  meta.maintainers = pkgs.homebox.meta.maintainers;
+
+  options.services.homebox = {
+
+    enable = lib.mkEnableOption "homebox";
+    package = lib.mkPackageOption pkgs "homebox" { };
+
+    environment = lib.mkOption {
+      default = { };
+      type = lib.types.attrsOf lib.types.str;
+      example = lib.literalExpression
+        ''
+          # Both of these defaults are /data/ which we defentivly don't want.
+          # The prefered thing would be if upstream just used the `$(pwd)` where the program is started in.
+          # Because that's the systemd-default and can also easily be used in a oci container.
+          {
+            HBOX_STORAGE_DATA = "/var/lib/homebox";
+            HBOX_STORAGE_SQLITE_URL = "/var/lib/homebox/homebox.db?_fk=1";
+          }
+        '';
+      description = lib.mdDoc "homebox config environment variables, for other options read the [documentation](https://hay-kot.github.io/homebox/quick-start/#env-variables-configuration)";
+    };
+    environmentFiles = lib.mkOption {
+      type = with lib.types; listOf path;
+      default = [ ];
+      example = [ "/root/homebox.env" ];
+      description = lib.mdDoc ''
+        File to load environment variables
+        from. This is helpful for specifying secrets.
+        Example content of environmentFile:
+        ```
+        HBOX_MAILER_USERNAME=homebox@example.com
+        HBOX_MAILER_PASSWORD=password
+        ```
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services = {
+      homebox = {
+        description = "Homebox Service";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        serviceConfig = {
+          DynamicUser = true;
+          WorkingDirectory = "%S/homebox";
+          StateDirectory = "homebox";
+          StateDirectoryMode = "0700";
+          UMask = "0007";
+          ConfigurationDirectory = "homebox";
+          EnvironmentFile = cfg.environmentFiles;
+          ExecStart = lib.getExe cfg.package;
+          Restart = "on-failure";
+          RestartSec = 15;
+          CapabilityBoundingSet = "";
+          # Security
+          NoNewPrivileges = true;
+          # Sandboxing
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [ "AF_UNIX AF_INET AF_INET6" ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          PrivateMounts = true;
+          # System Call Filtering
+          SystemCallArchitectures = "native";
+          SystemCallFilter = "~@clock @privileged @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io @reboot @setuid @swap";
+        };
+        inherit (cfg) environment;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -395,6 +395,7 @@ in {
   hocker-fetchdocker = handleTest ./hocker-fetchdocker {};
   hockeypuck = handleTest ./hockeypuck.nix { };
   home-assistant = handleTest ./home-assistant.nix {};
+  homebox = handleTest ./homebox.nix {};
   hostname = handleTest ./hostname.nix {};
   hound = handleTest ./hound.nix {};
   hub = handleTest ./git/hub.nix {};

--- a/nixos/tests/homebox.nix
+++ b/nixos/tests/homebox.nix
@@ -1,0 +1,32 @@
+# This test does a basic functionality check for homebox
+
+{ system ? builtins.currentSystem
+, pkgs ? import ../.. { inherit system; config = { }; }
+}:
+
+let
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
+in
+makeTest {
+  name = "homebox";
+  nodes = {
+    host1 = {
+      services.homebox = {
+        enable = true;
+        environment = {
+          HBOX_STORAGE_DATA = "/var/lib/homebox";
+          HBOX_STORAGE_SQLITE_URL = "/var/lib/homebox/homebox.db?_fk=1";
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    host1.wait_for_unit("homebox.service")
+    host1.wait_for_open_port(7745)
+    host1.succeed("curl http://localhost:7745 | grep 'Track, Organize, and Manage your Things.'")
+  '';
+}
+

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -1,0 +1,115 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, stdenvNoCC
+, jq
+, moreutils
+, nodePackages
+, stdenv
+, esbuild
+}:
+let
+  pname = "homebox";
+  version = "0.10.2";
+
+  src = fetchFromGitHub {
+    owner = "hay-kot";
+    repo = "homebox";
+    rev = "v${version}";
+    hash = "sha256-pdX64V3M4PjcC2alzE5szDJXs1Zrk6wA6IID3/uqS3Q=";
+  };
+
+  pnpm-deps = stdenvNoCC.mkDerivation {
+    pname = "${pname}-pnpm-deps";
+    src = "${src}/frontend";
+    inherit version;
+
+    nativeBuildInputs = [
+      jq
+      moreutils
+      nodePackages.pnpm
+    ];
+
+    installPhase = ''
+      export HOME=$(mktemp -d)
+      pnpm config set store-dir $out
+      # use --ignore-script and --no-optional to avoid downloading binaries
+      # use --frozen-lockfile to avoid checking git deps
+      pnpm install --frozen-lockfile --no-optional --ignore-script
+
+      # Remove timestamp and sort the json files
+      rm -rf $out/v3/tmp
+      for f in $(find $out -name "*.json"); do
+        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
+        jq --sort-keys . $f | sponge $f
+      done
+    '';
+
+    dontFixup = true;
+    outputHashMode = "recursive";
+    outputHash = "sha256-wVGDsVv7+tz0LITrtd3c9Bi4xfnS15fVcZGV3azcZDA=";
+  };
+
+  frontend = stdenv.mkDerivation {
+    pname = "${pname}-frontend";
+    src = "${src}/frontend";
+    inherit version;
+
+    nativeBuildInputs = [
+      nodePackages.pnpm
+    ];
+
+    ESBUILD_BINARY_PATH = "${lib.getExe (esbuild.override {
+      buildGoModule = args: buildGoModule (args // rec {
+        version = "0.17.19";
+        src = fetchFromGitHub {
+          owner = "evanw";
+          repo = "esbuild";
+          rev = "v${version}";
+          hash = "sha256-PLC7OJLSOiDq4OjvrdfCawZPfbfuZix4Waopzrj8qsU=";
+        };
+        vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+      });
+    })}";
+
+    preBuild = ''
+      export HOME=$(mktemp -d)
+      pnpm config set store-dir ${pnpm-deps}
+      pnpm install --offline --frozen-lockfile --no-optional --ignore-script --shamefully-hoist
+
+      chmod -R +w ./node_modules
+      patchShebangs node_modules
+      NUXT_TELEMETRY_DISABLED=1 pnpm build
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mv .output $out
+
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule {
+  inherit pname version;
+  src = "${src}/backend";
+
+  vendorHash = "sha256-cT6o39DjAVBtwW4qA8yQX3bWcnDs3DZgruJJVQVyy2w=";
+
+  passthru = { inherit frontend; };
+
+  preBuild = ''
+    mkdir -p app/api/static
+    cp -R ${frontend}/public app/api/static
+  '';
+
+  meta = with lib; {
+    description = "A inventory and organization system built for the Home User";
+    homepage = "https://hay-kot.github.io/homebox/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ janik ];
+    mainProgram = "api";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a package for [homebox](https://hay-kot/homebox/).
I can't seem to get the api working, only the webinterface, I asked in there discord but am waiting for an answer.
The curl command in the vmTest currently fails because the string is rendered by javascript and I have to switch the test to use a api endpoint once I got them working. 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
