### PR TITLE
simulide: init at 0.4.15-SR10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3010,6 +3010,12 @@
       fingerprint = "8BC7 74E4 A2EC 7507 3B61  A647 0BBB 1C8B 1C36 39EE";
     }];
   };
+  carloscraveiro = {
+    email = "carlos.craveiro@usp.br";
+    github = "CarlosCraveiro";
+    githubId = 85318248;
+    name = "Carlos Henrique Craveiro Aquino Veras";
+  };
   carlosdagos = {
     email = "m@cdagostino.io";
     github = "carlosdagos";

--- a/pkgs/applications/science/electronics/simulide/default.nix
+++ b/pkgs/applications/science/electronics/simulide/default.nix
@@ -1,0 +1,86 @@
+{ lib
+, fetchbzr
+, mkDerivation
+, qmake
+, qtserialport
+, qtmultimedia
+, qttools
+, qtscript
+}:
+
+let
+  version = "0.4.15";
+  release = "SR10";
+  branch = "simulide_0.4.14"; # the branch name does not mach the version for some reason
+  rev = "291";
+  sha256 = "sha256-BBoZr/S2pif0Jft5wrem8y00dXl08jq3kFiIUtOr3LM=";
+in
+mkDerivation {
+  pname = "simulide";
+  version = "${version}-${release}";
+
+  src = fetchbzr {
+    url = "https://code.launchpad.net/~arcachofo/simulide/${branch}";
+    inherit rev sha256;
+  };
+
+  postPatch = ''
+    # GCC 13 needs this header explicitly included
+    sed -i src/gpsim/value.h -e '1i #include <cstdint>'
+    sed -i src/gpsim/modules/watchdog.h -e '1i #include <cstdint>'
+
+    sed -i resources/simulide.desktop \
+      -e "s|^Exec=.*$|Exec=simulide|" \
+      -e "s|^Icon=.*$|Icon=simulide|"
+    sed -i SimulIDE.pro \
+      -e "s|^VERSION = .*$|VERSION = ${version}|" \
+      -e "s|^RELEASE = .*$|RELEASE = -${release}|" \
+      -e "s|^REV_NO = .*$|REV_NO = ${rev}|" \
+      -e "s|^BUILD_DATE = .*$|BUILD_DATE = ??-??-??|"
+  '';
+
+  preConfigure = ''
+    cd build_XX
+  '';
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtserialport
+    qtmultimedia
+    qttools
+    qtscript
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ../resources/simulide.desktop $out/share/applications/simulide.desktop
+    install -Dm644 ../resources/icons/hicolor/256x256/simulide.png $out/share/icons/hicolor/256x256/apps/simulide.png
+
+    mkdir -p $out/share/simulide $out/bin
+
+    pushd executables/SimulIDE_*
+    cp -r share/simulide/* $out/share/simulide
+    cp bin/simulide $out/bin/simulide
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple real time electronic circuit simulator";
+    longDescription = ''
+      SimulIDE is a simple real time electronic circuit simulator, intended for hobbyist or students
+      to learn and experiment with analog and digital electronic circuits and microcontrollers.
+      It supports PIC, AVR, Arduino and other MCUs and MPUs.
+    '';
+    homepage = "https://simulide.com/";
+    license = licenses.gpl3Only;
+    mainProgram = "simulide";
+    maintainers = with maintainers; [ carloscraveiro tomasajt ];
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39672,6 +39672,8 @@ with pkgs;
 
   appcsxcad = libsForQt5.callPackage ../applications/science/electronics/appcsxcad { };
 
+  simulide = libsForQt5.callPackage ../applications/science/electronics/simulide { };
+
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 
   caneda = libsForQt5.callPackage ../applications/science/electronics/caneda { };


### PR DESCRIPTION
## Description of changes
closes #273621 

Adds the version 0.4.15-SR10 of SimulIDE Circuit Simulator, a simple real time electronic circuit simulator, intended for hobbyist or students to learn and experiment with analog and digital electronic circuits and microcontrollers.
It supports PIC, AVR , Arduino and other MCUs and MPUs.

homepage URL: https://simulide.com/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->