### PR TITLE
qtbase: setup-hook: Don't override cmakeBuildType. 

### DIFF
--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -23,11 +23,11 @@ if [ -z "@debug@" ]; then
 fi
 
 # Integration with CMake:
-# Set the CMake build type corresponding to how qtbase was built.
+# If the CMake build type is not set explicitly, set it to how qtbase was built.
 if [ -n "@debug@" ]; then
-    cmakeBuildType="Debug"
+    cmakeBuildType=${cmakeBuildType:-Debug}
 else
-    cmakeBuildType="Release"
+    cmakeBuildType=${cmakeBuildType:-Release}
 fi
 
 providesQtRuntime() {

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -22,11 +22,11 @@ else # Only set up Qt once.
     fi
 
     # Integration with CMake:
-    # Set the CMake build type corresponding to how qtbase was built.
+    # If the CMake build type is not set explicitly, set it to how qtbase was built.
     if [ -n "@debug@" ]; then
-        cmakeBuildType="Debug"
+        cmakeBuildType=${cmakeBuildType:-Debug}
     else
-        cmakeBuildType="Release"
+        cmakeBuildType=${cmakeBuildType:-Release}
     fi
 
     # Build tools are often confused if QMAKE is unset.


### PR DESCRIPTION
## Description of changes

The goal is to fix #273632.

But I am not an expert in the nixpkgs Qt stuff, so marking it as draft PR for now.

cc @NixOS/qt-kde

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
