### PR TITLE
python3Packages.dlib: Inherit stdenv and build flags from main derivation, fix tests

### DIFF
--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,21 +1,20 @@
 {
-  stdenv,
   buildPythonPackage,
   dlib,
-  python,
   pytestCheckHook,
   more-itertools,
-  sse4Support ? stdenv.hostPlatform.sse4_1Support,
-  avxSupport ? stdenv.hostPlatform.avxSupport,
 }:
 
 buildPythonPackage {
   inherit (dlib)
+    stdenv
     pname
     version
     src
     nativeBuildInputs
     buildInputs
+    cmakeFlags
+    passthru
     meta
     ;
 
@@ -34,10 +33,26 @@ buildPythonPackage {
       --replace "pytest==3.8" "pytest"
   '';
 
-  setupPyBuildFlags = [
-    "--set USE_SSE4_INSTRUCTIONS=${if sse4Support then "yes" else "no"}"
-    "--set USE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}"
-  ];
+  # Pass CMake flags through to the build script
+  preConfigure = ''
+    for flag in $cmakeFlags; do
+      if [[ "$flag" == -D* ]]; then
+        setupPyBuildFlags+=" --set ''${flag#-D}"
+      fi
+    done
+  '';
 
   dontUseCmakeConfigure = true;
+
+  doCheck =
+    !(
+      # The tests attempt to use CUDA on the build platform.
+      # https://github.com/NixOS/nixpkgs/issues/225912
+      dlib.cudaSupport
+
+      # although AVX can be enabled, we never test with it. Some Hydra machines
+      # fail because of this, however their build results are probably used on hardware
+      # with AVX support.
+      || dlib.avxSupport
+    );
 }


### PR DESCRIPTION
## Description of changes

This PR updates dlib's Python derivation to use the same build flags as the C library derivation it's based on. Notably, this fixes CUDA support and removes duplication of optional feature logic.

Tests are also fixed in this PR by switching to `pytestCheckHook`. At the moment, builds are failing on `master`.

Closes #243880.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
