### PR TITLE
clisp: fix build

### DIFF
--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
   };
 
   strictDeps = true;
-  nativeBuildInputs = lib.optionals stdenv.isDarwin [ autoconf269 automake libtool ];
+  nativeBuildInputs = [ autoconf269 automake libtool ];
   buildInputs = [libsigsegv]
   ++ lib.optional (gettext != null) gettext
   ++ lib.optional (ncurses != null) ncurses
@@ -81,6 +81,7 @@ stdenv.mkDerivation {
   postPatch = ''
     sed -e 's@9090@64237@g' -i tests/socket.tst
     sed -i 's@/bin/pwd@${coreutils}&@' src/clisp-link.in
+    sed -i 's@1\.16\.2@${automake.version}@' src/aclocal.m4
     find . -type f | xargs sed -e 's/-lICE/-lXau &/' -i
   '';
 


### PR DESCRIPTION
## Description of changes

Without this patch, the following build error occurs for me on NixOS:

```
$ nix-build -A clisp --check
<snipped>
Running phase: buildPhase
build flags: SHELL=/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash
ln -s ../src/.gdbinit .gdbinit
rm -f build-aux
ln -s ../src/build-aux build-aux
mkdir -p gllib
test -f gllib/Makefile || sh config.status gllib/Makefile depfiles
cd gllib && make CFLAGS="-g -O2 -no-integrated-cpp -W -Wswitch -Wcomment -Wpointer-arith -Wreturn-type -Wmissing-declarations -Wimplicit -Wno-sign-compare -Wno-format-nonliteral -Wno-shift-negative-value -O -fwrapv -pthread -fno-strict-aliasing -DNO_ASM -DENABLE_UNICODE -DMULTITHREAD -DPOSIX_THREADS -DDYNAMIC_FFI -DDYNAMIC_MODULES  -fPIC -DPIC " top_srcdir="/build/source/src"
make[1]: Entering directory '/build/source/builddir/gllib'
 cd /build/source/src && /nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash /build/source/src/build-aux/missing automake-1.16 --gnits gllib/Makefile
/build/source/src/build-aux/missing: line 81: automake-1.16: command not found
WARNING: 'automake-1.16' is missing on your system.
         You should only need it if you modified 'Makefile.am' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'automake' program is part of the GNU Automake package:
         <https://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/autoconf>
         <https://www.gnu.org/software/m4/>
         <https://www.perl.org/>
make[1]: *** [Makefile:1333: ../../src/gllib/Makefile.in] Error 127
make[1]: Leaving directory '/build/source/builddir/gllib'
make: *** [Makefile:648: gllib/libgnu.a] Error 2
```

This message was also reproduced by @2xsaiko on their NAS machine.

I don't know why this error sometimes occurs and sometimes does not. On my Ubuntu machines, this error does not occur, and instead it does this:

```
Running phase: buildPhase
build flags: SHELL=/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash
ln -s ../src/.gdbinit .gdbinit
rm -f build-aux
ln -s ../src/build-aux build-aux
mkdir -p gllib
test -f gllib/Makefile || sh config.status gllib/Makefile depfiles
cd gllib && make CFLAGS="-g -O2 -no-integrated-cpp -W -Wswitch -Wcomment -Wpointer-arith -Wreturn-type -Wmissing-declarations -Wimplicit -Wno-sign-compare -Wno-format-nonliteral -Wno-shift-negative-value -O -fwrapv -pthread -fno-strict-aliasing -DNO_ASM -DENABLE_UNICODE -DMULTITHREAD -DPOSIX_THREADS -DDYNAMIC_FFI -DDYNAMIC_MODULES  -fPIC -DPIC " top_srcdir="/build/source/src"
make[1]: Entering directory '/build/source/builddir/gllib'
make[2]: Entering directory '/build/source/builddir'
make[2]: Nothing to be done for 'am--refresh'.
make[2]: Leaving directory '/build/source/builddir'
cd .. && make  am--refresh
make[2]: Entering directory '/build/source/builddir'
make[2]: Nothing to be done for 'am--refresh'.
make[2]: Leaving directory '/build/source/builddir'
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).