### PR TITLE
pythonPackages.django-otp: 1.1.3 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/django-otp/default.nix
+++ b/pkgs/development/python-modules/django-otp/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, python
+, hatchling
 , django
 , freezegun
 , pythonOlder
@@ -9,20 +11,20 @@
 
 buildPythonPackage rec {
   pname = "django-otp";
-  version = "1.1.3";
-  format = "setuptools";
+  version = "1.3.0";
+  format = "pyproject";
   disabled = pythonOlder "3";
 
   src = fetchFromGitHub {
     owner = "django-otp";
     repo = "django-otp";
     rev = "v${version}";
-    hash = "sha256-Ac9p7q9yaUr3WTTGxCY16Yo/Z8i1RtnD2g0Aj2pqSXY=";
+    hash = "sha256-T9sAKAjH8ZbfxYzRKgTDoAlZ/+uLj2R/T/ZHXhtjjVk=";
   };
 
-  postPatch = ''
-    patchShebangs manage.py
-  '';
+  nativeBuildInputs = [
+    hatchling
+  ];
 
   propagatedBuildInputs = [
     django
@@ -30,19 +32,22 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    django
     freezegun
   ];
 
   checkPhase = ''
-    ./manage.py test django_otp
+    export PYTHONPATH="test:$PYTHONPATH"
+    export DJANGO_SETTINGS_MODULE="test_project.settings"
+    ${python.interpreter} -s -m django test django_otp
   '';
 
   pythonImportsCheck = [ "django_otp" ];
 
   meta = with lib; {
-    homepage = "https://github.com/jazzband/django-model-utils";
+    homepage = "https://github.com/django-otp/django-otp/";
     description = "Pluggable framework for adding two-factor authentication to Django using one-time passwords";
-    license = licenses.bsd2;
+    license = licenses.unlicense;
     maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
## Description of changes
Changelog: https://github.com/django-otp/django-otp/blob/v1.3.0/CHANGES.rst

Note that this package is now using hatch/hatchling for packaging when the previous version used setuptools.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
