### PR TITLE
 home-assistant-custom-components.waste_collection_schedule: init at 1.44.0

### DIFF
--- a/pkgs/development/python-modules/icalevents/default.nix
+++ b/pkgs/development/python-modules/icalevents/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, poetry-core
+, datetime
+, httplib2
+, icalendar
+, python-dateutil
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "icalevents";
+  version = "0.1.27";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-vSYQEJFBjXUF4WwEAtkLtcO3y/am00jGS+8Vj+JMMqQ=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    datetime
+    httplib2
+    icalendar
+    python-dateutil
+    pytz
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Makes HTTP calls
+    "test_events_url"
+    "test_events_async_url"
+  ];
+
+  pythonImportsCheck = [ "icalevents" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/jazzband/icalevents/releases/tag/v${version}";
+    description = "Python module for iCal URL/file parsing and querying";
+    homepage = "https://github.com/jazzband/icalevents";
+    maintainers = with maintainers; [ jamiemagee ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -9,4 +9,6 @@
   miele = callPackage ./miele {};
 
   prometheus_sensor = callPackage ./prometheus_sensor {};
+
+  waste_collection_schedule = callPackage ./waste_collection_schedule {};
 }

--- a/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, fetchpatch
+, beautifulsoup4
+, icalendar
+, icalevents
+, lxml
+, recurring-ical-events
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "mampfes";
+  domain = "waste_collection_schedule";
+  version = "1.44.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "hacs_${domain}";
+    rev = "refs/tags/${version}";
+    hash = "sha256-G1x7HtgdtK+IaPAfxT+7xsDJi5FnXN4Pg3q7T5Xr8lA=";
+  };
+
+  patches = [
+    # Corrects a dependency on beautifulsoup4
+    (fetchpatch {
+      url = "https://github.com/mampfes/hacs_waste_collection_schedule/pull/1515.patch";
+      hash = "sha256-dvmicKTjolEcCrKRtZfpN0M/9RQCEQkFk+M6E+qCqfQ=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    icalendar
+    icalevents
+    lxml
+    recurring-ical-events
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/mampfes/hacs_waste_collection_schedule/releases/tag/${version}";
+    description = "Home Assistant integration framework for (garbage collection) schedules";
+    homepage = "https://github.com/mampfes/hacs_waste_collection_schedule";
+    maintainers = with maintainers; [jamiemagee];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5345,6 +5345,8 @@ self: super: with self; {
 
   icalendar = callPackage ../development/python-modules/icalendar { };
 
+  icalevents = callPackage ../development/python-modules/icalevents { };
+
   icecream = callPackage ../development/python-modules/icecream { };
 
   iceportal = callPackage ../development/python-modules/iceportal { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the `icalevents` Python package and `waste_collection_schedule` Home Assistant custom component.

There is one patch applied to `waste_collection_schedule` that is in PR upstream: https://github.com/mampfes/hacs_waste_collection_schedule/pull/1515

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
