### PR TITLE
ocamlPackages.functoria: 4.3.6 → 4.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/functoria/default.nix
+++ b/pkgs/development/ocaml-modules/functoria/default.nix
@@ -1,21 +1,19 @@
-{ lib, fetchurl, buildDunePackage, cmdliner
+{ lib, buildDunePackage, cmdliner
+, functoria-runtime
 , rresult, astring, fmt, logs, bos, fpath, emile, uri
+, alcotest
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname   = "functoria";
-  version = "4.3.6";
+  inherit (functoria-runtime) version src;
 
   minimalOCamlVersion = "4.08";
 
-  src = fetchurl {
-    url = "https://github.com/mirage/mirage/releases/download/v${version}/mirage-${version}.tbz";
-    hash = "sha256-i/5sZHfxECoKYMdGje+U21GWxJ6dDZreVcQGtbuo4SE=";
-  };
-
   propagatedBuildInputs = [ cmdliner rresult astring fmt logs bos fpath emile uri ];
 
-  doCheck = false;
+  doCheck = true;
+  checkInputs = [ alcotest functoria-runtime ];
 
   meta = with lib; {
     description = "A DSL to organize functor applications";

--- a/pkgs/development/ocaml-modules/functoria/runtime.nix
+++ b/pkgs/development/ocaml-modules/functoria/runtime.nix
@@ -1,14 +1,21 @@
-{ lib, buildDunePackage, functoria, cmdliner, fmt }:
+{ lib, buildDunePackage, fetchurl, cmdliner }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "functoria-runtime";
+  version = "4.4.1";
 
-  inherit (functoria) version src;
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage/releases/download/v${version}/mirage-${version}.tbz";
+    hash = "sha256-FKCdzrRJVpUrCWqrTiE8l00ZKJOYsvI9mNzJ0ZxDBwg=";
+  };
 
-  propagatedBuildInputs = [ cmdliner fmt ];
+  minimalOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [ cmdliner ];
 
   meta = with lib; {
-    inherit (functoria.meta) homepage license;
+    homepage    = "https://github.com/mirage/functoria";
+    license     = licenses.isc;
     description = "Runtime support library for functoria-generated code";
     maintainers = [ maintainers.sternenseemann ];
   };

--- a/pkgs/development/ocaml-modules/mirage/default.nix
+++ b/pkgs/development/ocaml-modules/mirage/default.nix
@@ -8,7 +8,6 @@ buildDunePackage rec {
   inherit (mirage-runtime) version src;
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/ocaml-modules/mirage/runtime.nix
+++ b/pkgs/development/ocaml-modules/mirage/runtime.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage, fetchurl, ipaddr, functoria-runtime
-, fmt, logs, lwt
+, logs, lwt
 , alcotest
 }:
 
@@ -8,9 +8,8 @@ buildDunePackage rec {
   inherit (functoria-runtime) src version;
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
-  propagatedBuildInputs = [ ipaddr functoria-runtime fmt logs lwt ];
+  propagatedBuildInputs = [ ipaddr functoria-runtime logs lwt ];
   checkInputs = [ alcotest ];
   doCheck = true;
 


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/mirage/mirage/v4.4.1/CHANGES.md

cc maintainer @sternenseemann

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
