### PR TITLE
tectonic, biber-for-tectonic: wrap tectonic with biber-2.17, fix #88067

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2722,6 +2722,12 @@
     githubId = 53131727;
     name = "Bryan Albuquerque";
   };
+  bryango = {
+    name = "Bryan Lai";
+    email = "bryanlais@gmail.com";
+    github = "bryango";
+    githubId = 26322692;
+  };
   bryanhonof = {
     name = "Bryan Honof";
     email = "bryanhonof@gmail.com";

--- a/pkgs/tools/typesetting/tectonic/biber.nix
+++ b/pkgs/tools/typesetting/tectonic/biber.nix
@@ -1,0 +1,54 @@
+/*
+  This package, `biber-for-tectonic`, provides a compatible version of `biber`
+  as an optional runtime dependency of `tectonic`.
+
+  The development of tectonic is slowing down recently, such that its `biber`
+  dependency has been lagging behind the one in the nixpkgs `texlive` bundle.
+  See:
+
+  https://github.com/tectonic-typesetting/tectonic/discussions/1122
+
+  It is now feasible to track the biber dependency in nixpkgs, as the
+  version bump is not very frequent, and it would provide a more complete
+  user experience of tectonic in nixpkgs.
+*/
+
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, biber
+}:
+
+let version = "2.17"; in (
+  biber.override {
+    /*
+      It is necessary to first override the `version` data here, which is
+      passed to `buildPerlModule`, and then to `mkDerivation`.
+
+      If we simply do `biber.overrideAttrs` the resulting package `name`
+      would be incorrect, since it has already been preprocessed by
+      `buildPerlModule`.
+    */
+    texlive.pkgs.biber.texsource = {
+      inherit version;
+      inherit (biber) pname meta;
+    };
+  }
+).overrideAttrs (prevAttrs: {
+  src = fetchFromGitHub {
+    owner = "plk";
+    repo = "biber";
+    rev = "v${version}";
+    hash = "sha256-Tt2sN2b2NGxcWyZDj5uXNGC8phJwFRiyH72n3yhFCi0=";
+  };
+  patches = [
+    # Perl>=5.36.0 compatibility
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/plk/biber/pull/411.patch";
+      hash = "sha256-osgldRVfe3jnMSOMnAMQSB0Ymc1s7J6KtM2ig3c93SE=";
+    })
+  ];
+  meta = prevAttrs.meta // {
+    maintainers = with lib.maintainers; [ doronbehar bryango ];
+  };
+})

--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -33,13 +33,14 @@ rustPlatform.buildRustPackage rec {
   # workaround for https://github.com/NixOS/nixpkgs/issues/166205
   NIX_LDFLAGS = lib.optionalString (stdenv.cc.isClang && stdenv.cc.libcxx != null) " -l${stdenv.cc.libcxx.cxxabi.libName}";
 
-  postInstall = lib.optionalString stdenv.isLinux ''
+  postInstall = ''
+    # Makes it possible to automatically use the V2 CLI API
+    ln -s $out/bin/tectonic $out/bin/nextonic
+  '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace dist/appimage/tectonic.desktop \
       --replace Exec=tectonic Exec=$out/bin/tectonic
     install -D dist/appimage/tectonic.desktop -t $out/share/applications/
     install -D dist/appimage/tectonic.svg -t $out/share/icons/hicolor/scalable/apps/
-
-    ln -s $out/bin/tectonic $out/bin/nextonic
   '';
 
   doCheck = true;

--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -1,3 +1,11 @@
+/*
+  This file provides the `tectonic-unwrapped` package. On the other hand,
+  the `tectonic` package is defined in `./wrapper.nix`, by wrapping
+  - [`tectonic-unwrapped`](./default.nix) i.e. this package, and
+  - [`biber-for-tectonic`](./biber.nix),
+    which provides a compatible version of `biber`.
+*/
+
 { lib
 , stdenv
 , fetchFromGitHub
@@ -25,7 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-1WjZbmZFPB1+QYpjqq5Y+fDkMZNmWJYIxmMFWg7Tiac=";
 
-  nativeBuildInputs = [ pkg-config makeBinaryWrapper ];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ icu fontconfig harfbuzz openssl ]
     ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ ApplicationServices Cocoa Foundation ]);
@@ -51,6 +59,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/tectonic-typesetting/tectonic/blob/tectonic@${version}/CHANGELOG.md";
     license = with licenses; [ mit ];
     mainProgram = "tectonic";
-    maintainers = with maintainers; [ lluchs doronbehar ];
+    maintainers = with maintainers; [ lluchs doronbehar bryango ];
   };
 }

--- a/pkgs/tools/typesetting/tectonic/wrapper.nix
+++ b/pkgs/tools/typesetting/tectonic/wrapper.nix
@@ -1,0 +1,56 @@
+{ lib
+, symlinkJoin
+, tectonic-unwrapped
+, biber-for-tectonic
+, makeWrapper
+}:
+
+symlinkJoin {
+  name = "${tectonic-unwrapped.pname}-wrapped-${tectonic-unwrapped.version}";
+  paths = [ tectonic-unwrapped ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  passthru = {
+    unwrapped = tectonic-unwrapped;
+    biber = biber-for-tectonic;
+  };
+
+  # Replace the unwrapped tectonic with the one wrapping it with biber
+  postBuild = ''
+    rm $out/bin/{tectonic,nextonic}
+  ''
+    # Ideally, we would have liked to also pin the version of the online TeX
+    # bundle that Tectonic's developer distribute, so that the `biber` version
+    # and the `biblatex` version distributed from there are compatible.
+    # However, that is not currently possible, due to lack of upstream support
+    # for specifying this in runtime, there were 2 suggestions sent upstream
+    # that suggested a way of improving the situation:
+    #
+    # - https://github.com/tectonic-typesetting/tectonic/pull/1132
+    # - https://github.com/tectonic-typesetting/tectonic/pull/1131
+    #
+    # The 1st suggestion seems more promising as it'd allow us to simply use
+    # makeWrapper's --add-flags option. However, the PR linked above is not
+    # complete, and as of currently, upstream hasn't even reviewed it, or
+    # commented on the idea.
+    #
+    # Note also that upstream has announced that they will put less time and
+    # energy for the project:
+    #
+    # https://github.com/tectonic-typesetting/tectonic/discussions/1122
+    #
+    # Hence, we can be rather confident that for the near future, the online
+    # TeX bundle won't be updated and hence the biblatex distributed there
+    # won't require a higher version of biber.
+  + ''
+    makeWrapper ${lib.getBin tectonic-unwrapped}/bin/tectonic $out/bin/tectonic \
+      --prefix PATH : "${lib.getBin biber-for-tectonic}/bin"
+    ln -s $out/bin/tectonic $out/bin/nextonic
+  '';
+
+  meta = tectonic-unwrapped.meta // {
+    description = "Tectonic TeX/LaTeX engine, wrapped with a compatible biber";
+    maintainers = with lib.maintainers; [ doronbehar bryango ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6689,6 +6689,8 @@ with pkgs;
 
   biber = callPackage ../tools/typesetting/biber { };
 
+  biber-for-tectonic = callPackage ../tools/typesetting/tectonic/biber.nix { };
+
   biber-ms = callPackage ../tools/typesetting/biber-ms { };
 
   biblatex-check = callPackage ../tools/typesetting/biblatex-check { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25317,7 +25317,9 @@ with pkgs;
 
   tecla = callPackage ../development/libraries/tecla { };
 
-  tectonic = callPackage ../tools/typesetting/tectonic {
+  tectonic = callPackage ../tools/typesetting/tectonic/wrapper.nix { };
+
+  tectonic-unwrapped = callPackage ../tools/typesetting/tectonic {
     harfbuzz = harfbuzzFull;
   };
 


### PR DESCRIPTION
### Note
- This PR has undergone major design change. Please jump to https://github.com/NixOS/nixpkgs/pull/273740#issuecomment-1859932466 and onwards for the current design.
- It is easy to review this PR commit by commit: https://github.com/NixOS/nixpkgs/pull/273740/commits.

## Description of changes

The version of `biber` is strongly coupled to the TeX-like system it works with. For example, the biber version required by `tectonic` is not found in nixpkgs, since the texlive bundle used by tectonic lags behind the one in nixpkgs. This has been a [known](https://github.com/tectonic-typesetting/tectonic/issues/893) [issue](https://github.com/NixOS/nixpkgs/issues/88067). Previously, a user had to manually download (or pin nixpkgs to) a particular version of biber to use with the appropriate TeX system, in this case, `tectonic`.

In this PR, we introduce the `biber-for-tectonic` package as an alternative version of `biber` required by the current tectonic. At the same time, we make `tectonic` into a wrapper, which bundles `tectonic-unwrapped` with `biber-for-tectonic`. This fixes #88067.

Some nixpkgs code by @collares and @doronbehar is recycled for use in this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
