### PR TITLE
Psmisc fall back to stat, when statx is missing

### DIFF
--- a/pkgs/os-specific/linux/psmisc/default.nix
+++ b/pkgs/os-specific/linux/psmisc/default.nix
@@ -5,6 +5,7 @@
 , automake
 , gettext
 , ncurses
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,21 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-TjnOn8a7HAgt11zcM0i5DM5ERmsvLJHvo1e5FOsl6IA=";
   };
+
+  patches = [
+    # Upstream patches to be released in the next version
+    (fetchpatch {
+      name = "fallback-to-stat-on-enosys.diff";
+      url = "https://gitlab.com/psmisc/psmisc/-/commit/c22d1e4edbfec6e24346cd8d89b822cb07cd6f5c.patch";
+      sha256 = "sha256-X6oEsxNgbywfeucSkhMSq6fVrfWmCg67bF11pUBc2zU=";
+      excludes = [ "ChangeLog" ];
+    })
+    (fetchpatch {
+      name = "fallback-to-stat-on-einval.diff";
+      url = "https://gitlab.com/psmisc/psmisc/-/commit/d681ce822066cb474b491c691b54fa901d08c002.patch";
+      sha256 = "sha256-m6NaKWdRz0XupMxm2m67kZnkEslSFZpqeCdhZU1lNgk=";
+    })
+  ];
 
   nativeBuildInputs = [ autoconf automake gettext ];
   buildInputs = [ ncurses ];


### PR DESCRIPTION
## Description of changes

on older kernels `statx() was added to Linux in kernel 4.11;` `fuser -km /path` fails due to statx failing, this upstream patch
https://gitlab.com/psmisc/psmisc/-/commit/c22d1e4edbfec6e24346cd8d89b822cb07cd6f5c falls back to stat when this happens

mark heroic unwrapped broken to pass nixpkgs-review, it's already broken due to unrelated issues 
https://hydra.nixos.org/job/nixos/release-23.11/nixpkgs.heroic-unwrapped.aarch64-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
