### PR TITLE
HaskellPackages.PortMidi: fix ALSA plugins load path

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -321,6 +321,14 @@ self: super: {
   # https://github.com/FPtje/GLuaFixer/issues/165
   glualint = dontCheck super.glualint;
 
+  # PortMidi needs an environment variable to have ALSA find its plugins:
+  # https://github.com/NixOS/nixpkgs/issues/6860
+  PortMidi = overrideCabal (drv: {
+    processEnvVars = [
+      { key = "ALSA_PLUGIN_DIR"; value = "${pkgs.alsa-plugins}/lib/alsa-lib"; }
+    ];
+  }) super.PortMidi;
+
   # The Hackage tarball is purposefully broken, because it's not intended to be, like, useful.
   # https://git-annex.branchable.com/bugs/bash_completion_file_is_missing_in_the_6.20160527_tarball_on_hackage/
   git-annex = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -114,6 +114,7 @@ in
   # of `meta.pkgConfigModules`. This option defaults to false for now, since
   # this metadata is far from complete in nixpkgs.
   __onlyPropagateKnownPkgConfigModules ? false
+, processEnvVars ? []
 } @ args:
 
 assert editedCabalFile != null -> revision != null;
@@ -774,6 +775,12 @@ stdenv.mkDerivation ({
 
     env = envFunc { };
 
+    processEnv = processEnvVars
+      ++ lib.concatMap (dep:
+                         if (dep == null)
+                           then []
+                           else dep.passthru.processEnv or [])
+                       libraryHaskellDepends;
   };
 
   meta = { inherit homepage license platforms; }

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -109,7 +109,7 @@ symlinkJoin {
             ''--set NODE_PATH "${ghc.socket-io}/lib/node_modules"''
           } \
           ${lib.concatMapStringsSep " "
-            (entry: ''--set "${entry.key}" "${entry.value}"'')
+            (entry: ''--set-default "${entry.key}" "${entry.value}"'')
             shellEnv
           } \
           ${lib.optionalString useLLVM ''--prefix "PATH" ":" "${llvm}"''}


### PR DESCRIPTION
## Description of changes

Implements a mechanism that allows Haskell packages to define the process environment variables they require, having the existing wrapper mechanism from `ghcWithPackages` add it to processes like `ghci`. This is done also for transitive dependencies of the `ghc` environment.

This mechanism is used to fix ALSA plugin loading in `PortMidi`.

Fixes https://github.com/NixOS/nixpkgs/issues/273407

This is the first readily usable implementation. I'm happy about comments/criticism/suggestions. I also consider to switch from a list to an attrset for collecting the process environment variables, as this might avoid duplications when transitive dependencies get pulled into the environment multiple times.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
