### PR TITLE
nixos/openrazer: add additional battery notifier options

### DIFF
--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -89,7 +89,7 @@ in
       };
 
       batteryNotifier = mkOption {
-        description = lib.mdDoc ''
+        description = ''
           Settings for device battery notifications.
         '';
         default = {};
@@ -98,14 +98,14 @@ in
             enable = mkOption {
               type = types.bool;
               default = true;
-              description = lib.mdDoc ''
+              description = ''
                 Mouse battery notifier.
               '';
             };
             frequency = mkOption {
               type = types.int;
               default = 600;
-              description = lib.mdDoc ''
+              description = ''
                 How often battery notifications should be shown (in seconds).
                 A value of 0 disables notifications.
               '';
@@ -114,7 +114,7 @@ in
             percentage = mkOption {
               type = types.int;
               default = 33;
-              description = lib.mdDoc ''
+              description = ''
                 At what battery percentage the device should reach before
                 sending notifications.
               '';

--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -19,7 +19,9 @@ let
       [Startup]
       sync_effects_enabled = ${toPyBoolStr cfg.syncEffectsEnabled}
       devices_off_on_screensaver = ${toPyBoolStr cfg.devicesOffOnScreensaver}
-      mouse_battery_notifier = ${toPyBoolStr cfg.mouseBatteryNotifier}
+      battery_notifier = ${toPyBoolStr cfg.mouseBatteryNotifier}
+      battery_notifier_freq = ${builtins.toString cfg.mouseBatteryNotifierFrequency}
+      battery_notifier_percent = ${builtins.toString cfg.mouseBatteryNotifierPercentage}
 
       [Statistics]
       key_statistics = ${toPyBoolStr cfg.keyStatistics}
@@ -86,6 +88,24 @@ in
         '';
       };
 
+      mouseBatteryNotifierFrequency = mkOption {
+        type = types.int;
+        default = 600;
+        description = lib.mdDoc ''
+          How often battery notifications should be shown (in seconds).
+          A value of 0 disables notifications.
+        '';
+      };
+
+      mouseBatteryNotifierPercentage = mkOption {
+        type = types.int;
+        default = 33;
+        description = lib.mdDoc ''
+          At what battery percentage the device should reach before
+          sending notifications.
+        '';
+      };
+
       keyStatistics = mkOption {
         type = types.bool;
         default = false;
@@ -127,15 +147,15 @@ in
     systemd.user.services.openrazer-daemon = {
       description = "Daemon to manage razer devices in userspace";
       unitConfig.Documentation = "man:openrazer-daemon(8)";
-        # Requires a graphical session so the daemon knows when the screensaver
-        # starts. See the 'devicesOffOnScreensaver' option.
-        wantedBy = [ "graphical-session.target" ];
-        partOf = [ "graphical-session.target" ];
-        serviceConfig = {
-          Type = "dbus";
-          BusName = "org.razer";
-          ExecStart = "${daemonExe} --foreground";
-          Restart = "always";
+      # Requires a graphical session so the daemon knows when the screensaver
+      # starts. See the 'devicesOffOnScreensaver' option.
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.razer";
+        ExecStart = "${daemonExe} --foreground";
+        Restart = "always";
       };
     };
   };


### PR DESCRIPTION
## Description of changes

Adds options for battery notification percentage threshold and frequency from manpage https://github.com/openrazer/openrazer/blob/v3.6.1/daemon/resources/man/razer.conf.5

Rewrote mouse mouse_battery_notifier to battery_notifier based on https://github.com/openrazer/openrazer/blob/v3.6.1/daemon/openrazer_daemon/daemon.py#L291-L295

Tested with local nixos configuration (systemd service runs successfully) and output of razer.conf  with `batteryNotifier = { enable = true; frequency = 15; percentage = 10; }`:
```
[General]
verbose_logging = False

[Startup]
sync_effects_enabled = True
devices_off_on_screensaver = True
battery_notifier = True
battery_notifier_freq = 15
battery_notifier_percent = 10

[Statistics]
key_statistics = False
```

Does any of this require a release notes entry?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
