### PR TITLE
doc: Test for broken URLs in `manpage-urls.json`

### DIFF
--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -29,4 +29,4 @@ jobs:
           name: nixpkgs-ci
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: Building Nixpkgs manual
-        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true pkgs/top-level/release.nix -A manual
+        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true pkgs/top-level/release.nix -A manual -A manual.tests

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -149,4 +149,26 @@ in pkgs.stdenv.mkDerivation {
     echo "doc manual $dest ${common.indexPath}" >> $out/nix-support/hydra-build-products
     echo "doc manual $dest nixpkgs-manual.epub" >> $out/nix-support/hydra-build-products
   '';
+
+  passthru.tests.manpage-urls = with pkgs; testers.invalidateFetcherByDrvHash
+    ({ name ? "manual_check-manpage-urls"
+     , script
+     , urlsFile
+     }: runCommand name {
+      nativeBuildInputs = [
+        cacert
+        (python3.withPackages (p: with p; [
+          aiohttp
+          rich
+          structlog
+        ]))
+      ];
+      outputHash = "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";  # Empty output
+    } ''
+      python3 ${script} ${urlsFile}
+      touch $out
+    '') {
+      script = ./tests/manpage-urls.py;
+      urlsFile = ./manpage-urls.json;
+    };
 }

--- a/doc/manpage-urls.json
+++ b/doc/manpage-urls.json
@@ -1,5 +1,5 @@
 {
-  "gnunet.conf(5)": "https://docs.gnunet.org/users/configuration.html",
+  "gnunet.conf(5)": "https://docs.gnunet.org/latest/users/configuration.html",
   "mpd(1)": "https://mpd.readthedocs.io/en/latest/mpd.1.html",
   "mpd.conf(5)": "https://mpd.readthedocs.io/en/latest/mpd.conf.5.html",
   "nix.conf(5)": "https://nixos.org/manual/nix/stable/command-ref/conf-file.html",

--- a/doc/tests/manpage-urls.py
+++ b/doc/tests/manpage-urls.py
@@ -1,0 +1,107 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i "python3 -I" -p "python3.withPackages(p: with p; [ aiohttp rich structlog ])"
+
+from argparse import ArgumentParser
+from collections import defaultdict
+from enum import IntEnum
+from http import HTTPStatus
+from pathlib import Path
+import asyncio, json, logging
+
+import aiohttp, structlog
+from structlog.contextvars import bound_contextvars as log_context
+
+
+LogLevel = IntEnum('LogLevel', {
+    lvl: getattr(logging, lvl)
+    for lvl in ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+})
+LogLevel.__str__ = lambda self: self.name
+
+
+EXPECTED_STATUS=frozenset((
+    HTTPStatus.OK, HTTPStatus.FOUND,
+    HTTPStatus.NOT_FOUND,
+))
+
+async def check(session, manpage: str, url: str) -> HTTPStatus:
+    with log_context(manpage=manpage, url=url):
+        logger.debug("Checking")
+        async with session.head(url) as resp:
+            st = HTTPStatus(resp.status)
+            match st:
+                case HTTPStatus.OK | HTTPStatus.FOUND:
+                    logger.debug("OK!")
+                case HTTPStatus.NOT_FOUND:
+                    logger.error("Broken link!")
+                case _ if st < 400:
+                    logger.info("Unexpected code", status=st)
+                case _ if 400 <= st < 600:
+                    logger.warn("Unexpected error", status=st)
+
+            return st
+
+async def main(urls_path):
+    logger.info(f"Parsing {urls_path}")
+    with urls_path.open() as urls_file:
+        urls = json.load(urls_file)
+
+    count = defaultdict(lambda: 0)
+
+    logger.info(f"Checking URLs from {urls_path}")
+    async with aiohttp.ClientSession() as session:
+        for status in asyncio.as_completed([
+            check(session, manpage, url)
+            for manpage, url in urls.items()
+        ]):
+            count[await status]+=1
+
+    ok = count[HTTPStatus.OK] + count[HTTPStatus.FOUND]
+    broken = count[HTTPStatus.NOT_FOUND]
+    unknown = sum(c for st, c in count.items() if st not in EXPECTED_STATUS)
+    logger.info(f"Done: {broken} broken links, "
+                f"{ok} correct links, and {unknown} unexpected status")
+
+    return count
+
+
+def parse_args(args=None):
+    parser = ArgumentParser(
+        prog = 'check-manpage-urls',
+        description = 'Check the validity of the manpage URLs linked in the nixpkgs manual',
+    )
+    parser.add_argument(
+        '-l', '--log-level',
+        default = os.getenv('LOG_LEVEL', 'INFO'),
+        type = lambda s: LogLevel[s],
+        choices = list(LogLevel),
+    )
+    parser.add_argument(
+        'file',
+        type = Path,
+        nargs = '?',
+    )
+
+    return parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    import os, sys
+
+    args = parse_args()
+
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(args.log_level),
+    )
+    logger = structlog.getLogger("check-manpage-urls.py")
+
+    urls_path = args.file
+    if urls_path is None:
+        REPO_ROOT = Path(__file__).parent.parent.parent.parent
+        logger.info(f"Assuming we are in a nixpkgs repo rooted at {REPO_ROOT}")
+
+        urls_path = REPO_ROOT / 'doc' / 'manpage-urls.json'
+
+    count = asyncio.run(main(urls_path))
+
+    sys.exit(0 if count[HTTPStatus.NOT_FOUND] == 0 else 1)


### PR DESCRIPTION
## Description of changes

- [x] Add `maintainers/scripts/doc/check-manpage-urls.py`
- [x] Fix broken manpage URLs
- [x] Document the script & its usage in `maintainers/scripts/README.md`


## Things done

- [x] Successfully run `check-manpage-urls.py` (on `x86_64-linux`)
- [x] Check with linter (`ruff`) and gradual type checker (`mypy`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
