### PR TITLE
bazel_6: Fix empty bzlmod lock file

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_6/bootstrap.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/bootstrap.patch
@@ -1,0 +1,35 @@
+diff --git a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+index 4ec5588541..18dbec994c 100644
+--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
++++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+@@ -1,5 +1,5 @@
+-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+ load("//tools/build_rules:java_rules_skylark.bzl", "bootstrap_java_binary", "bootstrap_java_library")
++load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+ 
+ # Description:
+ #   The Java library builders, which are used by Bazel to compile Java
+@@ -170,7 +170,6 @@ bootstrap_java_library(
+     name = "starlark-deps",
+     srcs = ["//:bootstrap-derived-java-srcs"],
+     jars = [
+-        "//third_party:auto_value-jars",
+         "//:bootstrap-derived-java-jars",
+         "//third_party:bootstrap_guava_and_error_prone-jars",
+         "//third_party:jsr305-jars",
+@@ -178,6 +177,7 @@ bootstrap_java_library(
+         "//third_party/grpc-java:bootstrap-grpc-jars",
+         "//third_party:tomcat_annotations_api-jars",
+     ],
++    neverlink_jars = ["//third_party:auto_value-jars"],
+     tags = ["manual"],
+ )
+ 
+@@ -209,6 +209,7 @@ bootstrap_java_binary(
+         "javac/WerrorCustomOption.java",
+     ],
+     main_class = "com.google.devtools.build.buildjar.VanillaJavaBuilder",
++    neverlink_jars = ["//third_party:auto_value-jars"],
+     tags = ["manual"],
+     deps = [
+         ":starlark-deps",


### PR DESCRIPTION
## Description of changes

This works around an issue with bootstrapping bazel from scratch, see
https://github.com/bazelbuild/bazel/issues/20501

Fixes #273500

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
