### PR TITLE
tmuxPlugins.tmux-thumbs: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/misc/tmux-plugins/tmux-thumbs/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-thumbs/default.nix
@@ -1,16 +1,11 @@
-{ lib, mkTmuxPlugin, fetchFromGitHub, thumbs, substituteAll }:
+{ mkTmuxPlugin, thumbs, substituteAll }:
 
-mkTmuxPlugin rec {
-  pluginName = "tmux-thumbs";
-  version = "0.7.1";
+mkTmuxPlugin {
+
+  inherit (thumbs) version src meta;
+
+  pluginName = thumbs.src.repo;
   rtpFilePath = "tmux-thumbs.tmux";
-
-  src = fetchFromGitHub {
-    owner = "fcsonline";
-    repo = pluginName;
-    rev = version;
-    sha256 = "sha256-PH1nscmVhxJFupS7dlbOb+qEwG/Pa/2P6XFIbR/cfaQ=";
-  };
 
   patches = [
     (substituteAll {
@@ -19,11 +14,4 @@ mkTmuxPlugin rec {
     })
   ];
 
-  meta = with lib; {
-    homepage = "https://github.com/fcsonline/tmux-thumbs";
-    description = "A lightning fast version of tmux-fingers written in Rust for copy pasting with vimium/vimperator like hints.";
-    license = licenses.mit;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ghostbuster91 ];
-  };
 }

--- a/pkgs/misc/tmux-plugins/tmux-thumbs/fix.patch
+++ b/pkgs/misc/tmux-plugins/tmux-thumbs/fix.patch
@@ -1,19 +1,18 @@
-diff --git a/tmux-thumbs.sh b/tmux-thumbs.sh
-index 34dd528..8c05d54 100755
---- a/tmux-thumbs.sh
-+++ b/tmux-thumbs.sh
-@@ -1,22 +1,8 @@
+diff --git i/tmux-thumbs.sh w/tmux-thumbs.sh
+index 7e060e8..e7f0c57 100755
+--- i/tmux-thumbs.sh
++++ w/tmux-thumbs.sh
+@@ -1,22 +1,6 @@
  #!/usr/bin/env bash
  set -Eeu -o pipefail
  
--VERSION=$(grep 'version =' Cargo.toml | grep -oe "[0-9]\+.[0-9]\+.[0-9]\+")
--
- # Setup env variables to be compatible with compiled and bundled installations
- CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+-# Setup env variables to be compatible with compiled and bundled installations
+-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 -RELEASE_DIR="${CURRENT_DIR}/target/release"
 -
 -THUMBS_BINARY="${RELEASE_DIR}/thumbs"
 -TMUX_THUMBS_BINARY="${RELEASE_DIR}/tmux-thumbs"
+-VERSION=$(grep 'version =' "${CURRENT_DIR}/Cargo.toml" | grep -o "\".*\"" | sed 's/"//g')
 -
 -if [ ! -f "$THUMBS_BINARY" ]; then
 -  tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh"
@@ -22,10 +21,11 @@ index 34dd528..8c05d54 100755
 -  tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh update"
 -  exit
 -fi
- 
+-
  function get-opt-value() {
    tmux show -vg "@thumbs-${1}" 2> /dev/null
-@@ -36,7 +22,7 @@ function get-opt-arg() {
+ }
+@@ -35,7 +19,7 @@ function get-opt-arg() {
    fi
  }
  
@@ -34,12 +34,9 @@ index 34dd528..8c05d54 100755
  
  function add-param() {
    local type opt arg
-@@ -51,4 +37,4 @@ add-param upcase-command string
+@@ -50,4 +34,4 @@ add-param upcase-command string
  add-param multi-command  string
  add-param osc52          boolean
  
 -"${TMUX_THUMBS_BINARY}" "${PARAMS[@]}" || true
 +@tmuxThumbsDir@/tmux-thumbs "${PARAMS[@]}" || true
-
-
-

--- a/pkgs/tools/misc/thumbs/default.nix
+++ b/pkgs/tools/misc/thumbs/default.nix
@@ -2,22 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "thumbs";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "fcsonline";
     repo = "tmux-thumbs";
     rev = version;
-    sha256 = "sha256-PH1nscmVhxJFupS7dlbOb+qEwG/Pa/2P6XFIbR/cfaQ=";
+    sha256 = "sha256-XMz1ZOTz2q1Dt4QdxG83re9PIsgvxTTkytESkgKxhGM=";
   };
 
-  cargoSha256 = "sha256-6htKiXMMyYRFefJzvDnmdx3CJ3XL8zONhGlV2wcbr9g=";
+  cargoSha256 = "sha256-PfTx6PcW5DESShfr9Ekhbq1asZ0xUGM4Vi9EwmoDv+s";
 
   patches = [ ./fix.patch ];
 
   meta = with lib; {
     homepage = "https://github.com/fcsonline/tmux-thumbs";
-    description = "A lightning fast version copy/pasting like vimium/vimperator";
+    description = "A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator";
     license = licenses.mit;
     maintainers = with maintainers; [ ghostbuster91 ];
   };

--- a/pkgs/tools/misc/thumbs/fix.patch
+++ b/pkgs/tools/misc/thumbs/fix.patch
@@ -1,13 +1,13 @@
-diff --git a/src/swapper.rs b/src/swapper.rs
-index 6cf1e89..bcb0969 100644
---- a/src/swapper.rs
-+++ b/src/swapper.rs
+diff --git i/src/swapper.rs w/src/swapper.rs
+index c901f48..cbd278d 100644
+--- i/src/swapper.rs
++++ w/src/swapper.rs
 @@ -215,7 +215,7 @@ impl<'a> Swapper<'a> {
      };
-
+ 
      let pane_command = format!(
--        "tmux capture-pane -t {active_pane_id} -p{scroll_params} | tail -n {height} | {dir}/target/release/thumbs -f '%U:%H' -t {tmp} {args}; tmux swap-pane -t {active_pane_id}; {zoom_command} tmux wait-for -S {signal}",
-+        "tmux capture-pane -t {active_pane_id} -p{scroll_params} | tail -n {height} | {dir}/thumbs -f '%U:%H' -t {tmp} {args}; tmux swap-pane -t {active_pane_id}; {zoom_command} tmux wait-for -S {signal}",
+-        "tmux capture-pane -J -t {active_pane_id} -p{scroll_params} | tail -n {height} | {dir}/target/release/thumbs -f '%U:%H' -t {tmp} {args}; tmux swap-pane -t {active_pane_id}; {zoom_command} tmux wait-for -S {signal}",
++        "tmux capture-pane -J -t {active_pane_id} -p{scroll_params} | tail -n {height} | {dir}/thumbs -f '%U:%H' -t {tmp} {args}; tmux swap-pane -t {active_pane_id}; {zoom_command} tmux wait-for -S {signal}",
          active_pane_id = active_pane_id,
          scroll_params = scroll_params,
          height = self.active_pane_height.unwrap_or(i32::MAX),


### PR DESCRIPTION
## Description of changes

Update tmux-thumbs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
