### PR TITLE
mpvScripts: Fix remaining issues with `.lua` suffixes and `scriptName`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -46,7 +46,7 @@ lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
           exit 1
         }
         mkdir -p "${scriptsDir}"
-        cp -a "${scriptPath}" "${scriptsDir}/${lib.removeSuffix ".lua" scriptName}"
+        cp -a "${scriptPath}" "${scriptsDir}/${scriptName}"
       else
         install -m644 -Dt "${scriptsDir}" \
           ${escapedList ([ scriptPath ] ++ extraScripts)}

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -13,7 +13,7 @@ buildLua rec {
   };
 
   scriptPath = ".";
-  passthru.scriptName = "webui.lua";
+  passthru.scriptName = "webui";
 
   meta = with lib; {
     description = "A web based user interface with controls for the mpv mediaplayer";


### PR DESCRIPTION
## Description of changes

Under `mpvScripts`:
- `buildLua`: don't strip a (non-existent) `.lua` suffix when installing a directory;
- `simple-mpv-webui`: drop `.lua` from `scriptName`, this is a dir-packaged script.
  cc @cript0nauta, @zopieux, sorry for getting it wrong in 183a4ceba7ff7f3992ed6184c18d7b33e2edf40e


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
