### PR TITLE
beetsPackages.audible: init at 1.0.0

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -54,6 +54,7 @@ lib.makeExtensible (self: {
   };
 
   alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };
+  audible = callPackage ./plugins/audible.nix { beets = self.beets-minimal; };
   copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
   extrafiles = callPackage ./plugins/extrafiles.nix { beets = self.beets-minimal; };
 })

--- a/pkgs/tools/audio/beets/plugins/audible.nix
+++ b/pkgs/tools/audio/beets/plugins/audible.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  beets,
+  beetsPackages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "beets-audible";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Neurrone";
+    repo = "beets-audible";
+    rev = "v${version}";
+    hash = "sha256-m955KPtYfjmtm9kHhkZLWoMYzVq0THOwvKCJYiVna7k=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    beets
+    beetsPackages.copyartifacts
+    markdownify
+    natsort
+    tldextract
+  ];
+
+  pythonImportsCheck = [
+    "beetsplug.api"
+    "beetsplug.audible"
+    "beetsplug.book"
+    "beetsplug.goodreads"
+  ];
+
+  meta = {
+    description = "Beets plugin to manage audiobook collections";
+    homepage = "https://github.com/Neurrone/beets-audible";
+    changelog = "https://github.com/Neurrone/beets-audible/blob/v${version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ dansbandit ];
+    license = lib.licenses.mit;
+    inherit (beets.meta) platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add beetsPackages.audible a package for sorting your Audible audiobooks with beets.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
