### PR TITLE
chickenPackages_5.chickenEggs: fix license

### DIFF
--- a/pkgs/development/compilers/chicken/5/default.nix
+++ b/pkgs/development/compilers/chicken/5/default.nix
@@ -27,12 +27,29 @@ lib.makeScope newScope (self: {
             "https://code.call-cc.org/cgi-bin/gitweb.cgi?p=eggs-5-latest.git;a=tree;f=${pname}/${version}";
           meta.description = synopsis;
           meta.license = (lib.licenses // {
+            "agpl" = lib.licenses.agpl3Only;
+            "artistic" = lib.licenses.artistic2;
+            "bsd" = lib.licenses.bsd3;
             "bsd-1-clause" = lib.licenses.bsd1;
             "bsd-2-clause" = lib.licenses.bsd2;
             "bsd-3-clause" = lib.licenses.bsd3;
+            "gpl" = lib.licenses.gpl3Only;
+            "gpl-2" = lib.licenses.gpl2Only;
+            "gplv2" = lib.licenses.gpl2Only;
+            "gpl-3" = lib.licenses.gpl3Only;
+            "gpl-3.0" = lib.licenses.gpl3Only;
+            "gplv3" = lib.licenses.gpl3Only;
+            "lgpl" = lib.licenses.lgpl3Only;
+            "lgpl-2" = lib.licenses.lgpl2Only;
             "lgpl-2.0+" = lib.licenses.lgpl2Plus;
+            "lgpl-2.1" = lib.licenses.lgpl21Only;
             "lgpl-2.1-or-later" = lib.licenses.lgpl21Plus;
+            "lgpl-3" = lib.licenses.lgpl3Only;
+            "lgplv3" = lib.licenses.lgpl3Only;
             "public-domain" = lib.licenses.publicDomain;
+            "srfi" = lib.licenses.bsd3;
+            "unicode" = lib.licenses.ucd;
+            "zlib-acknowledgement" = lib.licenses.zlib;
           }).${license} or license;
         })
       (lib.importTOML ./deps.toml))));


### PR DESCRIPTION
## Description of changes

#269788

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
