### PR TITLE
duckstation: unstable-2023-09-30 -> unstable-2023-12-04

### DIFF
--- a/pkgs/applications/emulators/duckstation/002-hardcode-vars.diff
+++ b/pkgs/applications/emulators/duckstation/002-hardcode-vars.diff
@@ -1,5 +1,5 @@
 diff --git a/src/scmversion/gen_scmversion.sh b/src/scmversion/gen_scmversion.sh
-index 9c1dacab..d1f895ee 100755
+index 9122cd8b..5022457c 100755
 --- a/src/scmversion/gen_scmversion.sh
 +++ b/src/scmversion/gen_scmversion.sh
 @@ -10,10 +10,10 @@ else
@@ -8,7 +8,7 @@ index 9c1dacab..d1f895ee 100755
  
 -HASH=$(git rev-parse HEAD)
 -BRANCH=$(git rev-parse --abbrev-ref HEAD | tr -d '\r\n')
--TAG=$(git describe --tags --dirty --exclude latest --exclude preview --exclude legacy --exclude previous-latest | tr -d '\r\n')
+-TAG=$(git describe --dirty | tr -d '\r\n')
 -DATE=$(git log -1 --date=iso8601-strict --format=%cd)
 +HASH="@gitHash@"
 +BRANCH="@gitBranch@"

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "duckstation";
-  version = "unstable-2023-09-30";
+  version = "unstable-2023-12-04";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = "duckstation";
-    rev = "d5608bf12df7a7e03750cb94a08a3d7999034ae2";
-    hash = "sha256-ktfZgacjkN6GQb1vLmyTZMr8QmmH12qAvFSIBTjgRSs=";
+    rev = "1e0dbe34045f5954bde24bb6cd8a56384e0957b9";
+    hash = "sha256-J0jKYVcBzhhaLCToDoXX49Nx9Hi2BRSBzMvb1zf8q2M=";
   };
 
   patches = [
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./002-hardcode-vars.diff;
       gitHash = finalAttrs.src.rev;
       gitBranch = "master";
-      gitTag = "0.1-5889-gd5608bf1";
-      gitDate = "2023-09-30T23:20:09+10:00";
+      gitTag = "0.1-6141-g1e0dbe34";
+      gitDate = "2023-12-04T14:15:49+10:00";
     })
   ];
 


### PR DESCRIPTION
## Description of changes


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
