### PR TITLE
mpvScripts.quack: init at unstable-2020-05-26

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -72,6 +72,7 @@ let
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { };
+    quack = callPackage ./quack.nix { };
     quality-menu = callPackage ./quality-menu.nix { };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };

--- a/pkgs/applications/video/mpv/scripts/quack.nix
+++ b/pkgs/applications/video/mpv/scripts/quack.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, unstableGitUpdater
+, buildLua }:
+
+buildLua rec {
+  pname = "mpv-quack";
+
+  version = "unstable-2020-05-26";
+  src = fetchFromGitHub {
+    owner = "CounterPillow";
+    repo  = pname;
+    rev   = "1c87f36f9726d462dd112188c04be54d85692cf3";
+    hash  = "sha256-dEnJbS8RJoAxpKINdoMHN4l7vpEdf7+C5JVWpK0VXMw=";
+  };
+  passthru.updateScript = unstableGitUpdater {};
+
+  meta = {
+    description = "Reduce audio volume after seeking";
+    longDescription = ''
+      quack is an mpv script to temporarily reduce the volume after a seek,
+      in order to avoid loud noises when scrubbing through a movie.
+
+      The volume is linearly increased back up to its original level.
+      Repeated seeks before the transition is done work as well.
+    '';
+    homepage = "https://github.com/CounterPillow/quack";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ nicoo ];
+  };
+}


### PR DESCRIPTION
## Description of changes

init `mpvScripts.quack` at `unstable-2020-05-26`.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
