### PR TITLE
mpvScripts.reload: init at `unstable-2022-01-27`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -73,6 +73,7 @@ let
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { };
     quality-menu = callPackage ./quality-menu.nix { };
+    reload = callPackage ./reload.nix { };
     simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
     sponsorblock = callPackage ./sponsorblock.nix { };
     sponsorblock-minimal = callPackage ./sponsorblock-minimal.nix { };

--- a/pkgs/applications/video/mpv/scripts/reload.nix
+++ b/pkgs/applications/video/mpv/scripts/reload.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, unstableGitUpdater
+, buildLua }:
+
+buildLua rec {
+  pname = "mpv-reload";
+
+  version = "unstable-2023-12-19";
+  src = fetchFromGitHub {
+    owner = "4e6";
+    repo  = pname;
+    rev   = "133d596f6d369f320b4595bbed1f4a157b7b9ee5";
+    hash  = "sha256-B+4TCmf1T7MuwtbL+hGZoN1ktI31hnO5yayMG1zW8Ng=";
+  };
+  passthru.updateScript = unstableGitUpdater {};
+
+  meta = {
+    description = "Manual & automatic reloading of videos";
+    longDescription = ''
+      This script adds reloading of videos, automatically on timers (when stuck
+      buffering etc.) or manually on keybinds, to help with cases where a stream
+      is not loading further due to a network or remote issue.
+    '';
+    homepage = "https://github.com/4e6/mpv-reload";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nicoo ];
+  };
+}


### PR DESCRIPTION
## Description of changes

`mpvScripts.reload`: init at `unstable-2022-01-27`


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) - 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
