### PR TITLE
bitwarden: use Electron 27 instead of 26 to fix bug

### DIFF
--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -3,7 +3,7 @@
 , cargo
 , copyDesktopItems
 , dbus
-, electron_26
+, electron_27
 , fetchFromGitHub
 , fetchpatch2
 , glib
@@ -25,10 +25,10 @@
 let
   description = "A secure and free password manager for all of your devices";
   icon = "bitwarden";
-  electron = electron_26;
+  electron = electron_27;
 in buildNpmPackage rec {
   pname = "bitwarden";
-  version = "2023.12.0"; # TODO add back Electron version check below
+  version = "2023.12.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
@@ -43,13 +43,15 @@ in buildNpmPackage rec {
       url = "https://github.com/solopasha/bitwarden_flatpak/raw/daec07b067b9cec5e260b44a53216fc65866ba1d/wayland-clipboard.patch";
       hash = "sha256-hcaRa9Nl7MYaTNwmB5Qdm65Mtufv3z+IPwLDPiO3pcw=";
     })
+    # Workaround Electron 25 EOL and 26 has https://github.com/bitwarden/clients/issues/6560
+    ./electron-27.patch
   ];
 
   nodejs = nodejs_18;
 
   makeCacheWritable = true;
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-bnYpvHO9Pnob+MbrSshv03mSwXCADH/2xw33nLVKMdg=";
+  npmDepsHash = "sha256-QwG+D0M94HN1AyQlmzKeScZyksiUr5A9igEaox9DYN4=";
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     name = "${pname}-${version}";
@@ -82,14 +84,12 @@ in buildNpmPackage rec {
     libsecret
   ];
 
-  # FIXME add back once upstream moves to Electron >= 26
-  # we use electron_26 because electron_25 is EOL
-  /*preBuild = ''
+  preBuild = ''
     if [[ $(jq --raw-output '.devDependencies.electron' < package.json | grep -E --only-matching '^[0-9]+') != ${lib.escapeShellArg (lib.versions.major electron.version)} ]]; then
       echo 'ERROR: electron version mismatch'
       exit 1
     fi
-  '';*/
+  '';
 
   postBuild = ''
     pushd apps/desktop

--- a/pkgs/tools/security/bitwarden/electron-27.patch
+++ b/pkgs/tools/security/bitwarden/electron-27.patch
@@ -1,0 +1,69 @@
+From e2c15e826fe9d4d2d12868ef5409e423e3191b58 Mon Sep 17 00:00:00 2001
+From: Daniel James Smith <2670567+djsmith85@users.noreply.github.com>
+Date: Fri, 8 Dec 2023 13:07:46 +0100
+Subject: [PATCH] Bump electron to v27.1.3 (#7134)
+
+Co-authored-by: Daniel James Smith <djsmith85@users.noreply.github.com>
+
+(cherry picked from commit d76602343f36d8e17a9b0204e0290488456c96d5)
+---
+ apps/desktop/electron-builder.json | 2 +-
+ package-lock.json                  | 8 ++++----
+ package.json                       | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/apps/desktop/electron-builder.json b/apps/desktop/electron-builder.json
+index 69d1c0074f..a12870bd96 100644
+--- a/apps/desktop/electron-builder.json
++++ b/apps/desktop/electron-builder.json
+@@ -19,7 +19,7 @@
+     "**/node_modules/@bitwarden/desktop-native/index.js",
+     "**/node_modules/@bitwarden/desktop-native/desktop_native.${platform}-${arch}*.node"
+   ],
+-  "electronVersion": "25.9.1",
++  "electronVersion": "27.1.3",
+   "generateUpdatesFilesForAllChannels": true,
+   "publish": {
+     "provider": "generic",
+diff --git a/package-lock.json b/package-lock.json
+index 3f0afde95b..9b7b2dbcd9 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -125,7 +125,7 @@
+         "cross-env": "7.0.3",
+         "css-loader": "6.8.1",
+         "del": "6.1.1",
+-        "electron": "25.9.1",
++        "electron": "27.1.3",
+         "electron-builder": "23.6.0",
+         "electron-log": "5.0.0",
+         "electron-reload": "2.0.0-alpha.1",
+@@ -20173,9 +20173,9 @@
+       }
+     },
+     "node_modules/electron": {
+-      "version": "25.9.1",
+-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.9.1.tgz",
+-      "integrity": "sha512-Uo/Fh7igjoUXA/f90iTATZJesQEArVL1uLA672JefNWTLymdKSZkJKiCciu/Xnd0TS6qvdIOUGuJFSTQnKskXQ==",
++      "version": "27.1.3",
++      "resolved": "https://registry.npmjs.org/electron/-/electron-27.1.3.tgz",
++      "integrity": "sha512-7eD8VMhhlL5J531OOawn00eMthUkX1e3qN5Nqd7eMK8bg5HxQBrn8bdPlvUEnCano9KhrVwaDnGeuzWoDOGpjQ==",
+       "dev": true,
+       "hasInstallScript": true,
+       "dependencies": {
+diff --git a/package.json b/package.json
+index 9ee884b31d..4a5c3513fd 100644
+--- a/package.json
++++ b/package.json
+@@ -88,7 +88,7 @@
+     "cross-env": "7.0.3",
+     "css-loader": "6.8.1",
+     "del": "6.1.1",
+-    "electron": "25.9.1",
++    "electron": "27.1.3",
+     "electron-builder": "23.6.0",
+     "electron-log": "5.0.0",
+     "electron-reload": "2.0.0-alpha.1",
+-- 
+2.42.0
+


### PR DESCRIPTION
Seems to only occur on some GPUs, e.g. some Intel GPUs. See also https://github.com/bitwarden/clients/issues/6560. Cannot go back to electron 25 easily due to
https://github.com/NixOS/nixpkgs/issues/272912.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested on amdgpu and i915

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
