### PR TITLE
mpvScripts.chapterskip: Add missing metadata

### DIFF
--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -14,7 +14,13 @@ buildLua {
   };
 
   meta = {
+    description = "Automatically skips chapters based on title";
+    longDescription = ''
+    MPV script that skips chapters based on their title, categorized using regexes.
+    The set of skipped categories can be configured globally, or by an auto-profile.
+    '';
     homepage = "https://github.com/po5/chapterskip";
+    license = lib.licenses.unfree;  # https://github.com/po5/chapterskip/issues/10
     maintainers = with lib.maintainers; [ nicoo ];
   };
 }


### PR DESCRIPTION
## Description of changes

- `mpvScripts.chapterskip`: add missing metadata
  - `description` & `longDescription`
  - `license` (oops~)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Request backport, as the license metadata is missing in nixpkgs 23.11


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
