### PR TITLE
`lib.path.splitStorePath`: init

### DIFF
--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -3,7 +3,15 @@
 { libpath }:
 let
   lib = import libpath;
-  inherit (lib.path) hasPrefix removePrefix append splitRoot hasStorePathPrefix subpath;
+  inherit (lib.path)
+    hasPrefix
+    removePrefix
+    append
+    splitRoot
+    hasStorePathPrefix
+    splitStorePath
+    subpath
+    ;
 
   # This is not allowed generally, but we're in the tests here, so we'll allow ourselves.
   storeDirPath = /. + builtins.storeDir;
@@ -117,6 +125,40 @@ let
     testHasStorePathPrefixExample6 = {
       expr = hasStorePathPrefix (storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo.drv");
       expected = true;
+    };
+
+    testSplitStorePathExample1 = {
+      expr = (builtins.tryEval (splitStorePath /home/user)).success;
+      expected = false;
+    };
+    testSplitStorePathExample2 = {
+      expr = (builtins.tryEval (splitStorePath storeDirPath)).success;
+      expected = false;
+    };
+    testSplitStorePathExample3 = {
+      expr = (builtins.tryEval (splitStorePath (storeDirPath + "/.links/10gg8k3rmbw8p7gszarbk7qyd9jwxhcfq9i6s5i0qikx8alkk4hq"))).success;
+      expected = false;
+    };
+    testSplitStorePathExample4 = {
+      expr = splitStorePath (storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo");
+      expected = {
+        storePath = storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo";
+        subpath = "./.";
+      };
+    };
+    testSplitStorePathExample5 = {
+      expr = splitStorePath (storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo/bar/baz");
+      expected = {
+        storePath = storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo";
+        subpath = "./bar/baz";
+      };
+    };
+    testSplitStorePathExample6 = {
+      expr = splitStorePath (storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo.drv");
+      expected = {
+        storePath = storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo.drv";
+        subpath = "./.";
+      };
     };
 
     # Test examples from the lib.path.subpath.isValid documentation


### PR DESCRIPTION
> [!Note]
> This was dependent on https://github.com/NixOS/nixpkgs/pull/273883

## Description of changes

In order to implement https://github.com/NixOS/nixpkgs/issues/269283 I need a function to split a path within a store path into its store path and the subpath. So this PR adds a function to do that:
```nix
splitStorePath /nix/store/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo/bar/baz
-> {
  storePath = /nix/store/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo;
  subpath = "./bar/baz";
}
```

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done
- [x] Documentation
- [x] Tidy code
- [x] Tests

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
