### PR TITLE
`lib.fileset.gitTracked`: Support out-of-tree builds

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -763,6 +763,12 @@ in {
     Create a file set containing all [Git-tracked files](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository) in a repository.
     The first argument allows configuration with an attribute set,
     while the second argument is the path to the Git working tree.
+
+    `gitTrackedWith` does not perform any filtering when the path is a [Nix store path](https://nixos.org/manual/nix/stable/store/store-path.html#store-path) and not a repository.
+    In this way, it accommodates the use case where the expression that makes the `gitTracked` call does not reside in an actual git repository anymore,
+    and has presumably already been fetched in a way that excludes untracked files.
+    Fetchers with such equivalent behavior include `builtins.fetchGit`, `builtins.fetchTree` (experimental), and `pkgs.fetchgit` when used without `leaveDotGit`.
+
     If you don't need the configuration,
     you can use [`gitTracked`](#function-library-lib.fileset.gitTracked) instead.
 


### PR DESCRIPTION
> [!Note]
> This PR depended on https://github.com/NixOS/nixpkgs/pull/273883, now merged.
> Originally it also depended on https://github.com/NixOS/nixpkgs/pull/273884, but not anymore.

## Description of changes

This adds out-of-tree support for `lib.fileset.gitTracked`, where the repository is fetched using a method that already removes files not tracked by Git, such as `builtins.fetchGit`, `pkgs.fetchgit` or GitHub tarballs.

It works by falling back to importing the entire path if:
- The path is in a nix store path
- There's no `.git` directory

This fixes https://github.com/NixOS/nixpkgs/issues/269283.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done
- [x] Tidy code
- [x] Design/contributor documentation
- [x] User documentation
- [x] Tests

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
