### PR TITLE
ocaml-ng.ocamlPackages_5_1.ocaml: 5.1.0 → 5.1.1

### DIFF
--- a/pkgs/development/compilers/ocaml/5.1.nix
+++ b/pkgs/development/compilers/ocaml/5.1.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "5";
   minor_version = "1";
-  patch_version = "0";
-  sha256 = "sha256-bOjbOTqvwmTlr3McaPvrIJIKtq6E1b+TURllt0IzUas=";
+  patch_version = "1";
+  sha256 = "sha256-jX6Yv9o76UBgK3o53PkSotL96reR7UDmKgmkzWfd7vE=";
 }

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -25,7 +25,7 @@ let
     "4.14.1" = "4.13-414";
     "5.0.0" = "4.12-500";
     "5.1.0" = "4.13-501";
-    # "5.1.1" = "4.13.1-501";
+    "5.1.1" = "4.13.1-501";
   };
 
   hashes = {
@@ -34,6 +34,7 @@ let
     "4.12-500" = "sha256-j49R7KVzNKlXDL7WibTHxPG4VSOVv0uaz5/yMZZjkH8=";
     "4.13-414" = "sha256-AlzxqTuh5AkW9dnPIv51abv7r0A/VOS3JOT5IHix2wM=";
     "4.13-501" = "sha256-G/VrI+qBVj2wxuB2qE9P1M73IvDmqmTrBFAA6mp+NRE=";
+    "4.13.1-501" = "sha256-NVfgX3DFsQghApEgWilCgr5O2WSkwKtenZZFSJ1wwa0=";
   };
 
   version = lib.getAttr ocaml.version merlinVersions;


### PR DESCRIPTION
## Description of changes

https://discuss.ocaml.org/t/ocaml-5-1-1-released/13592

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
