### PR TITLE
stdenv/check-meta: Use bespoke type checking

### DIFF
--- a/pkgs/stdenv/generic/meta-types.nix
+++ b/pkgs/stdenv/generic/meta-types.nix
@@ -1,0 +1,76 @@
+{ lib }:
+# Simple internal type checks for meta.
+# This file is not a stable interface and may be changed arbitrarily.
+#
+# TODO: add a method to the module system types
+#       see https://github.com/NixOS/nixpkgs/pull/273935#issuecomment-1854173100
+let
+  inherit (builtins) isString isInt isAttrs isList all any attrValues isFunction isBool concatStringsSep isFloat;
+  isTypeDef = t: isAttrs t && t ? name && isString t.name && t ? verify && isFunction t.verify;
+
+in
+lib.fix (self: {
+  string = {
+    name = "string";
+    verify = isString;
+  };
+  str = self.string;  # Type alias
+
+  any = {
+    name = "any";
+    verify = _: true;
+  };
+
+  int = {
+    name = "int";
+    verify = isInt;
+  };
+
+  float = {
+    name = "float";
+    verify = isFloat;
+  };
+
+  bool = {
+    name = "bool";
+    verify = isBool;
+  };
+
+  attrs = {
+    name = "attrs";
+    verify = isAttrs;
+  };
+
+  list = {
+    name = "list";
+    verify = isList;
+  };
+
+  attrsOf = t: assert isTypeDef t; let
+    inherit (t) verify;
+  in {
+    name = "attrsOf<${t.name}>";
+    verify =
+      # attrsOf<any> can be optimised to just isAttrs
+      if t == self.any then isAttrs
+      else attrs: isAttrs attrs && all verify (attrValues attrs);
+  };
+
+  listOf = t: assert isTypeDef t; let
+    inherit (t) verify;
+  in {
+    name = "listOf<${t.name}>";
+    verify =
+      # listOf<any> can be optimised to just isList
+      if t == self.any then isList
+      else v: isList v && all verify v;
+  };
+
+  union = types: assert all isTypeDef types; let
+    # Store a list of functions so we don't have to pay the cost of attrset lookups at runtime.
+    funcs = map (t: t.verify) types;
+  in {
+    name = "union<${concatStringsSep "," (map (t: t.name) types)}>";
+    verify = v: any (func: func v) funcs;
+  };
+})


### PR DESCRIPTION
## Description of changes

Aka `checkMeta` goes brrr.

Using the module system type checking works OK & generates good error messages. The performance of using it however is terrible because of the value merging it does being very allocation heavy.

By implementing a very minimal type checker we can drastically improve the performance when nixpkgs is evaluated with `checkMeta = true`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
