### PR TITLE
flake: allow specifying the lib argument to nixosSystem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,13 @@
 
         nixosSystem = args:
           import ./nixos/lib/eval-config.nix (
-            args // { inherit (self) lib; } // lib.optionalAttrs (! args?system) {
+            {
+              lib = final;
               # Allow system to be set modularly in nixpkgs.system.
               # We set it to null, to remove the "legacy" entrypoint's
               # non-hermetic default.
               system = null;
-            }
+            } // args
           );
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
       checks.x86_64-linux = {
         tarball = jobs.tarball;
         # Test that ensures that the nixosSystem function can accept a lib argument
+        # Note: prefer not to extend or modify `lib`, especially if you want to share reusable modules
+        #       alternatives include: `import` a file, or put a custom library in an option or in `_module.args.<libname>`
         nixosSystemAcceptsLib = (self.lib.nixosSystem {
           lib = self.lib.extend (final: prev: {
             ifThisFunctionIsMissingTheTestFails = final.id;
@@ -45,7 +47,8 @@
               nixpkgs.hostPlatform = "x86_64-linux";
               boot.loader.grub.enable = false;
               fileSystems."/".device = "nodev";
-              system.stateVersion = lib.versions.majorMinor lib.version;
+              # See https://search.nixos.org/options?show=system.stateVersion&query=stateversion
+              system.stateVersion = lib.versions.majorMinor lib.version; # DON'T do this in real configs!
             })
           ];
         }).config.system.build.toplevel;


### PR DESCRIPTION
## Description of changes
Some configs rely on being able to pass their own lib argument into nixosSystem, for instance in order to add their own additional overlay to nixpkgs.lib.
This was broken by 039f73f134.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
