### PR TITLE
raspberrypi-eeprom: 2023.10.30-2712 -> 2023.12.06-2712

### DIFF
--- a/pkgs/by-name/ra/raspberrypi-eeprom/package.nix
+++ b/pkgs/by-name/ra/raspberrypi-eeprom/package.nix
@@ -12,13 +12,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raspberrypi-eeprom";
-  version = "2023.10.30-2712";
+  version = "2023.12.06-2712";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-TKvby0qIXidM5Qk7q+ovLk0DpHsCbdQe7xndrgKrSXk=";
+    hash = "sha256-bX+WSWj8Lk0S9GgauJsqElur+AAp5JB8LMEstB6aRGo=";
   };
 
   buildInputs = [ python3 ];

--- a/pkgs/by-name/ra/raspberrypi-eeprom/package.nix
+++ b/pkgs/by-name/ra/raspberrypi-eeprom/package.nix
@@ -1,14 +1,23 @@
-{ stdenvNoCC, lib, fetchFromGitHub, makeWrapper
-, python3, binutils-unwrapped, findutils, gawk, kmod, pciutils, libraspberrypi
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, makeWrapper
+, python3
+, binutils-unwrapped
+, findutils
+, gawk
+, kmod
+, pciutils
+, libraspberrypi
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raspberrypi-eeprom";
   version = "2023.10.30-2712";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
-    rev = "refs/tags/v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-TKvby0qIXidM5Qk7q+ovLk0DpHsCbdQe7xndrgKrSXk=";
   };
 
@@ -60,4 +69,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with maintainers; [ das_j Luflosi ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ra/raspberrypi-eeprom/package.nix
+++ b/pkgs/by-name/ra/raspberrypi-eeprom/package.nix
@@ -58,5 +58,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-4-boot-eeprom";
     license = with licenses; [ bsd3 unfreeRedistributableFirmware ];
     maintainers = with maintainers; [ das_j Luflosi ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28655,8 +28655,6 @@ with pkgs;
   raspberrypifw = callPackage ../os-specific/linux/firmware/raspberrypi { };
   raspberrypiWirelessFirmware = callPackage ../os-specific/linux/firmware/raspberrypi-wireless { };
 
-  raspberrypi-eeprom = callPackage ../os-specific/linux/raspberrypi-eeprom { };
-
   raspberrypi-armstubs = callPackage ../os-specific/linux/firmware/raspberrypi/armstubs.nix { };
 
   reap = callPackage ../os-specific/linux/reap { };


### PR DESCRIPTION
## Description of changes
https://github.com/raspberrypi/rpi-eeprom/releases/tag/v2023.12.06-2712

Also do some cleanup:
- Move each function argument into its own line for better git diffs in the future
- Use `finalAttrs` instead of `rec`

Also migrate to by-name.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
