### PR TITLE
haskellPackages.PortMidi: fix ALSA plugins load path

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1318,6 +1318,16 @@ self: super: {
     testToolDepends = (drv.testToolDepends or []) ++ [pkgs.postgresql];
   }) super.beam-postgres;
 
+  # PortMidi needs an environment variable to have ALSA find its plugins:
+  # https://github.com/NixOS/nixpkgs/issues/6860
+  PortMidi = overrideCabal (drv: {
+    patches = (drv.patches or []) ++ [ ./patches/portmidi-alsa-plugins.patch ];
+    postPatch = (drv.postPatch or "") + ''
+      substituteInPlace portmidi/pm_linux/pmlinuxalsa.c \
+        --replace @alsa_plugin_dir@ "${pkgs.alsa-plugins}/lib/alsa-lib"
+    '';
+  }) super.PortMidi;
+
   # Fix for base >= 4.11
   scat = overrideCabal (drv: {
     patches = [(fetchpatch {

--- a/pkgs/development/haskell-modules/patches/portmidi-alsa-plugins.patch
+++ b/pkgs/development/haskell-modules/patches/portmidi-alsa-plugins.patch
@@ -1,0 +1,31 @@
+diff -Naurd PortMidi-0.2.0.0/portmidi/pm_linux/pmlinuxalsa.c PortMidi-0.2.0.0-alsafix/portmidi/pm_linux/pmlinuxalsa.c
+--- PortMidi-0.2.0.0/portmidi/pm_linux/pmlinuxalsa.c	2023-12-13 11:35:12.517413022 +0000
++++ PortMidi-0.2.0.0-alsafix/portmidi/pm_linux/pmlinuxalsa.c	2023-12-13 11:35:12.565413037 +0000
+@@ -719,6 +719,18 @@
+ }
+ 
+ 
++static void set_alsa_plugin_path( void )
++{
++    char *existing;
++
++    existing = getenv("ALSA_PLUGIN_DIR");
++    if (NULL != existing) {
++        return;
++    }
++    setenv("ALSA_PLUGIN_DIR", "@alsa_plugin_dir@", 0);
++}
++
++
+ PmError pm_linuxalsa_init( void )
+ {
+     int  err;
+@@ -726,6 +738,8 @@
+     snd_seq_port_info_t *pinfo;
+     unsigned int caps;
+ 
++    set_alsa_plugin_path();
++
+     /* Previously, the last parameter was SND_SEQ_NONBLOCK, but this 
+      * would cause messages to be dropped if the ALSA buffer fills up.
+      * The correct behavior is for writes to block until there is 


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/273407 by setting the ALSA plugin load path environment variable from the `PortMidi` package before initializing ALSA, as suggested by @maralorn (https://github.com/NixOS/nixpkgs/pull/273757#issuecomment-1852928462).

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
