### PR TITLE
python3Packages.debianbts: Remove unused inputs

### DIFF
--- a/pkgs/development/python-modules/debianbts/default.nix
+++ b/pkgs/development/python-modules/debianbts/default.nix
@@ -2,8 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , pysimplesoap
-, pytestCheckHook
-, pytest-xdist
 , pythonOlder
 , setuptools
 }:


### PR DESCRIPTION
## Description of changes

- Remove unused inputs to `python3Packages.debianbts`: `pytestCheckHook` and `pytest-xdist`.
  Those were leftover from f226c9f7ae5c065014d8a20a32fcf5fe1b3ab6c7 in #265626


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
  No rebuild needed
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  No change in output vs. `master`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
