### PR TITLE
graalvm-ce: use NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION instead of CC wrapper

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -49,6 +49,13 @@ stdenv.mkDerivation ({
 
   nativeImageBuildArgs = nativeImageBuildArgs ++ extraNativeImageBuildArgs ++ [ graalvmXmx ];
 
+  # Workaround GraalVM issue where the builder does not have access to the
+  # environment variables since 21.0.0
+  # https://github.com/oracle/graal/pull/6095
+  # https://github.com/oracle/graal/pull/6095
+  # https://github.com/oracle/graal/issues/7502
+  env.NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION = "true";
+
   buildPhase = args.buildPhase or ''
     runHook preBuild
 


### PR DESCRIPTION
## Description of changes

Instead of using a hacky CC wrapper to re-inject the environment variables needed to build, we set the `NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION=true` that is in 21.0.0 release changelog:
https://github.com/oracle/graal/blob/489611a304ec808cdcb1e07e9a9799e6240fd2e1/substratevm/CHANGELOG.md?plain=1#L48

This is deprecated behavior for now, and will be removed in future, but this will allow us more time until we figure a proper solution.

See:
- https://github.com/oracle/graal/issues/7502
- https://github.com/oracle/graal/issues/7981
- https://github.com/oracle/graal/pull/6095

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
