### PR TITLE
composefs: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -3,11 +3,10 @@
 , fetchFromGitHub
 
 , autoreconfHook
-, pandoc
+, go-md2man
 , pkg-config
 , openssl
 , fuse3
-, yajl
 , libcap
 , libseccomp
 , python3
@@ -19,21 +18,18 @@
 , testers
 
 , fuseSupport ? lib.meta.availableOn stdenv.hostPlatform fuse3
-, yajlSupport ? lib.meta.availableOn stdenv.hostPlatform yajl
 , enableValgrindCheck ? false
 , installExperimentalTools ? false
 }:
-# https://github.com/containers/composefs/issues/204
-assert installExperimentalTools -> (!stdenv.hostPlatform.isMusl);
 stdenv.mkDerivation (finalAttrs: {
   pname = "composefs";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "composefs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-8YbDKw4jYEU6l3Nmqu3gsT9VX0lwYF/39hhcwzgTynY=";
+    hash = "sha256-ViZkmuLFV5DN1nqWKGl+yaqhYUEOztZ1zGpxjr1U/dw=";
   };
 
   strictDeps = true;
@@ -43,14 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i "s/noinst_PROGRAMS +\?=/bin_PROGRAMS +=/g" tools/Makefile.am
   '';
 
-  configureFlags = lib.optionals enableValgrindCheck [
-    (lib.enableFeature true "valgrind-test")
+  configureFlags = [
+    (lib.enableFeature true "man")
+    (lib.enableFeature enableValgrindCheck "valgrind-test")
   ];
 
-  nativeBuildInputs = [ autoreconfHook pandoc pkg-config ];
+  nativeBuildInputs = [ autoreconfHook go-md2man pkg-config ];
   buildInputs = [ openssl ]
     ++ lib.optional fuseSupport fuse3
-    ++ lib.optional yajlSupport yajl
     ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) (
     [
       libcap
@@ -58,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
-  # yajl is required to read the test json files
   doCheck = true;
   nativeCheckInputs = [ python3 which ]
     ++ lib.optional enableValgrindCheck valgrind
@@ -70,15 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace tests/*.sh \
       --replace " /tmp" " $TMPDIR" \
       --replace " /var/tmp" " $TMPDIR"
-  '' + lib.optionalString (stdenv.hostPlatform.isMusl || !yajlSupport) ''
-    # test relies on `composefs-from-json` tool
-    # MUSL: https://github.com/containers/composefs/issues/204
-    substituteInPlace tests/Makefile \
-      --replace " check-checksums" ""
-  '' + lib.optionalString enableValgrindCheck ''
-    # valgrind is incompatible with seccomp
-    substituteInPlace tests/test-checksums.sh \
-      --replace "composefs-from-json" "composefs-from-json --no-sandbox"
   '';
 
   passthru = {


### PR DESCRIPTION
## Description of changes

- Changes since 1.0.1:
  - Dropped composefs-from-json in tests in favour of using the composefs-info dump format.
  - libyajl dependency dropped
  - libcomposefs now limits the number of xattrs per file to 64k
  - Fixed build against libc without reallocarray
  - Performance fixes
  - go-md2man is used instead of pandoc for manpages
  - Minor fixes to spec file

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
