### PR TITLE
codexctl: init at 1701639955

### DIFF
--- a/pkgs/applications/misc/remarkable/codexctl/default.nix
+++ b/pkgs/applications/misc/remarkable/codexctl/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonApplication, fetchFromGitHub, python3Packages }:
+
+buildPythonApplication rec {
+  pname = "codexctl";
+  version = "1701639955";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "jayy001";
+    repo = pname;
+    rev = version;
+    hash = "sha256-7+4gNISI2TBcoyX+2Xj9Ch4NopAnFNNUh2zhp8jiBYQ=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/codexctl
+    cp codexctl.py $out/share/codexctl
+    cp -r modules/ $out/share/codexctl
+
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/codexctl \
+      --set PYTHONPATH "$PYTHONPATH" \
+      --add-flags "-O $out/share/codexctl/codexctl.py"
+
+    runHook postInstall
+  '';
+
+  propagatedBuildInputs = with python3Packages; [ paramiko psutil requests loguru protobuf six ];
+
+  meta = with lib; {
+    description = "A tool to modify remarkable device versions";
+    homepage = "https://github.com/jayy001/codexctl";
+    license = licenses.gpl3;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6359,6 +6359,8 @@ with pkgs;
 
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
+  codexctl = python3Packages.callPackage ../applications/misc/remarkable/codexctl { };
+
   restream = callPackage ../applications/misc/remarkable/restream { };
 
   ropgadget = with python3Packages; toPythonApplication ropgadget;


### PR DESCRIPTION
## Description of changes

add https://github.com/jayy001/codexctl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
