### PR TITLE
jetbrains: Add Minecraft plugins

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -180,6 +180,16 @@
       },
       "name": "-deprecated-rust-beta"
     },
+    "8327": {
+      "compatible": [
+        "idea-community",
+        "idea-ultimate"
+      ],
+      "builds": {
+        "233.11799.300": "https://plugins.jetbrains.com/files/8327/439463/Minecraft_Development-2023.3-1.6.11.zip"
+      },
+      "name": "minecraft-development"
+    },
     "8554": {
       "compatible": [
         "goland",
@@ -493,6 +503,7 @@
     "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip": "sha256-ZlSfPvhPixEz5JxU9qyG0nL3jiSjr4gKaf/xYcQI1vQ=",
     "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip": "sha256-NeAF3umfaSODjpd6J1dT8Ei5hF8g8OA+sgk7VjBodoU=",
     "https://plugins.jetbrains.com/files/8182/395553/intellij-rust-0.4.201.5424-232.zip": "sha256-pVwBEyUCx/DJET9uIm8vxFeChE8FskWyfLjDpfg2mAE=",
+    "https://plugins.jetbrains.com/files/8327/439463/Minecraft_Development-2023.3-1.6.11.zip": "sha256-ny1ECCBb6GgjKyEnc2b7QDWxNqPDthvaF47tS9BON8Q=",
     "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip": "sha256-xN0FUCIa4KcqFAGwaOWf74qpIEY2f/QtksEeNTKG7zw=",
     "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip": "sha256-Dwitpu5yLPWx+IUilpN5iqnN8FkKgaxUNjroBEx5lkM=",
     "https://plugins.jetbrains.com/files/9568/445967/go-plugin-233.11799.196.zip": "sha256-d8O5VRNdw7ru20l0VOicVJRUcVxje5A2Gua1O9yXogM="

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -342,6 +342,37 @@
       },
       "name": "eclipse-keymap"
     },
+    "12839": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "232.10072.781": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.284": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.286": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.287": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.290": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.293": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.296": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.297": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.298": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.300": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip",
+        "233.11799.303": "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip"
+      },
+      "name": "minecraft-nbt-support"
+    },
     "13017": {
       "compatible": [
         "clion",
@@ -487,6 +518,7 @@
     "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip": "sha256-9keDJ73bSHkzAEq8nT96I5sp05BgMZ08/4BzarOjO5g=",
     "https://plugins.jetbrains.com/files/12559/364124/keymap-eclipse-232.8660.88.zip": "sha256-eRCsivZbDNrc+kesa9jVsOoMFFz+WpYfSMXxPCCjWjw=",
     "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip": "sha256-IsmoWuUroAp1LLuphp4F1dun4tQOOitZxoG+Nxs5pYk=",
+    "https://plugins.jetbrains.com/files/12839/115174/minecraft-nbt-intellij-plugin-1.5.2.zip": "sha256-Uq0m6qWSNHZbkEydWMFxnlvXCcS6xIM3uTlGdAQ6nzs=",
     "https://plugins.jetbrains.com/files/13017/364038/keymap-visualStudio-232.8660.88.zip": "sha256-5S8u7w14fLkaTcjACfUSun9pMNtPk20/8+Dr5Sp9sDE=",
     "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip": "sha256-Nb2tSxL+mAY1qJ3waipgV8ep+0R/BaYnzz7zfwtLHmk=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -435,6 +435,16 @@
       },
       "name": "darcula-pitch-black"
     },
+    "16210": {
+      "compatible": [
+        "idea-community",
+        "idea-ultimate"
+      ],
+      "builds": {
+        "233.11799.300": "https://plugins.jetbrains.com/files/16210/262619/architectury-idea-plugin-1.6.3.jar"
+      },
+      "name": "architectury"
+    },
     "17718": {
       "compatible": [
         "clion",
@@ -522,6 +532,7 @@
     "https://plugins.jetbrains.com/files/13017/364038/keymap-visualStudio-232.8660.88.zip": "sha256-5S8u7w14fLkaTcjACfUSun9pMNtPk20/8+Dr5Sp9sDE=",
     "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip": "sha256-Nb2tSxL+mAY1qJ3waipgV8ep+0R/BaYnzz7zfwtLHmk=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
+    "https://plugins.jetbrains.com/files/16210/262619/architectury-idea-plugin-1.6.3.jar": "sha256-rPPnj9nNi/aNBln0P775ZGWH8WEcTvaM1o+v5jjFyj4=",
     "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip": "sha256-MiF8MVWBEQqupoYyI+QOyXhSvJcoSgptePENByURphI=",
     "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip": "sha256-JmME4MEN6nK1ueiz12VefCQHaE629jXYqYM5jxIyfGQ=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",


### PR DESCRIPTION
## Description of changes

Updated plugins and added three Minecraft-related plugins:

- [Minecraft Development](https://plugins.jetbrains.com/plugin/8327-minecraft-development)
- [Architectury](https://plugins.jetbrains.com/plugin/16210-architectury)
- [Minecraft NBT Support](https://plugins.jetbrains.com/plugin/12839-minecraft-nbt-support)

This being my first PR to nixpkgs, I'm somewhat unfamiliar with building/testing on master. [This](https://nixos.wiki/wiki/Nixpkgs/Create_and_debug_packages#How_to_install_from_the_local_repository) looks like the relevant documentation?

I've done `nix-build --attr jetbrains.idea-community`, which builds fine, however when I try to run binaries in `./result` the shell script appears to be launching intellij installed on my system (2023.2.2) rather than the one built from this branch (2023.3).

If I try to build using `nix-build --expr` (to test `plugins.addPlugins`) I get "undefined variable" errors - I'm not sure how I should be passing an expression such as `pkgs.jetbrains.plugins.addPlugins pkgs.jetbrains.idea-community [ "minecraft-development" ]` so that `pkgs` is defined...?

I'm not going to check the box below until I'm confident I'm doing this correctly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Maintainers

Tagging @GenericNerdyUsername, @wegank & @pbsds as they seem to be active recently
And also the listed maintainers:  @edwtjo @gytis-ivaskevicius @steinybot @AnatolyPopov @tymscar

(Is tagging maintainers like this this the _done thing_?)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
