### PR TITLE
llm-ls: fix darwin build (in progress)

### DIFF
--- a/pkgs/by-name/ll/llm-ls/package.nix
+++ b/pkgs/by-name/ll/llm-ls/package.nix
@@ -1,13 +1,9 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-}:
+{ lib, stdenv, darwin, rustPlatform, fetchFromGitHub }:
 
 let
   pname = "llm-ls";
   version = "0.4.0";
-in
-rustPlatform.buildRustPackage {
+in rustPlatform.buildRustPackage {
   inherit pname version;
 
   src = fetchFromGitHub {
@@ -19,13 +15,19 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-Z6BO4kDtlIrVdDk1fiwyelpu1rj7e4cibgFZRsl1pfA=";
 
+  buildInputs =
+    lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+
+  NIX_CFLAGS_COMPILE = lib.optionals (stdenv.cc.isClang && stdenv.isDarwin) [
+    "-fno-lto" # work around https://github.com/NixOS/nixpkgs/issues/19098
+  ];
+
   meta = with lib; {
     description = "LSP server leveraging LLMs for code completion (and more?)";
     homepage = "https://github.com/huggingface/llm-ls";
     license = licenses.asl20;
     maintainers = with maintainers; [ jfvillablanca ];
     platforms = platforms.all;
-    badPlatforms = platforms.darwin;
     mainProgram = "llm-ls";
   };
 }


### PR DESCRIPTION
See #273596, related to #19098.

Currently, this change builds successfully for 933d7dc155096e7575d207be6fb7792bc9f34f6d (my nixpkgs/nixos-23.11) and 06b4b4ea3b35711810986f70271a886107f8365c (my nixpkgs unstable), but it does not build when branched from 102c34231850b2f18bc2eb295f2ff69b20d07c05. I'd love some help debugging the reason. The log from the build failure is [here](https://gist.github.com/JackSullivan/3d1833e3409dd9aa891c600e0457ac64). @jfvillablanca is the maintainer listed for this package and asked me to shepherd this because they do not have access to an `aarch64-darwin` machine.

## Description of changes

Added in a flag to not use Link-Time Optimization as per #19098. (The particular change is shameless lifted from 3ade63b87b4a5265b8abd895a0073125b9a7db16, thanks @michaelhthomas)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
