### PR TITLE
feather-font: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4674,6 +4674,12 @@
     githubId = 283316;
     name = "Dane Lipscombe";
   };
+  dlyons = {
+    email = "dustin@dlyons.dev";
+    github = "dustinlyons";
+    githubId = 1292576;
+    name = "Dustin Lyons";
+  };
   dmalikov = {
     email = "malikov.d.y@gmail.com";
     github = "dmalikov";

--- a/pkgs/data/fonts/feather-font/default.nix
+++ b/pkgs/data/fonts/feather-font/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchzip }:
+let
+  version = "1.0";
+  pname = "feather-font";
+in
+fetchzip {
+  name = "${pname}-${version}";
+  url = "https://github.com/dustinlyons/feather-font/archive/refs/tags/${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype
+    unzip -D -j /build/${version}.zip  ${pname}-${version}/feather.ttf -d $out/share/fonts/truetype/
+  '';
+
+  sha256 = "1rdq37bk81k7h7bsdg26djldg0wfgzqhwsqy2y5akp9wh1r76g7b"
+
+  meta = with lib; {
+    homepage = "https://www.feathericons.com/";
+    description = "Set of font icons from the open source collection Feather Icons";
+    version = version;
+    longDescription = ''
+      Installs a TTF font: feather
+      Fonts provided by https://www.feathericons.com
+    '';
+    license = licenses.mit;
+    maintainers = [ maintainers.dlyons ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29314,6 +29314,8 @@ with pkgs;
 
   faba-mono-icons = callPackage ../data/icons/faba-mono-icons { };
 
+  feather-font = callPackage ../data/fonts/feather-font { };
+
   ferrum = callPackage ../data/fonts/ferrum { };
 
   fg-virgil = callPackage ../data/fonts/fg-virgil { };


### PR DESCRIPTION
## Description of changes

This is the open-source `feather` font package. I've tested this for some time in my own `nixpkgs` fork but would like to contribute it here.

https://github.com/dustinlyons/feather-font
https://feathericons.com/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
