### PR TITLE
[23.05] vault: 1.13.7 -> 1.13.12, vault-bin: 1.13.7 -> 1.13.12

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "vault";
-  version = "1.13.7";
+  version = "1.13.12";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "sha256-ndH9b1glpWLyy1c9ThUpj9FR84cx35zRrzrwOMPG+Z0=";
+    hash = "sha256-lkCaf5HmEhRL+rYZrxPRkqEagyKKFnRZu+pWGat5gx8=";
   };
 
-  vendorHash = "sha256-kDJlGqETmo2T22AikQiaFUqqR3383t3Pz/cO79lob9g=";
+  vendorHash = "sha256-ksLEvl7pmGTc0mnzRXv5facgYqRicmFHyq5hp7zX9n4=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vault-bin";
-  version = "1.13.7";
+  version = "1.13.12";
 
   src =
     let
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
         aarch64-darwin = "darwin_arm64";
       };
       sha256 = selectSystem {
-        x86_64-linux = "sha256-SdTcfUPTQYDJKe9V+ycKl0X/r3V2MgOev6zk6e4qDjw=";
-        aarch64-linux = "sha256-+f6shcorp1wEbUVqq3WHQRZN+GUAmWocmvjq3btFo30=";
-        i686-linux = "sha256-eJim5d+p3vXs0dUCABh6CVlrno+E2+j0RqPk4ozQm/g=";
-        x86_64-darwin = "sha256-QvdN7l2/ZCGtLAhoXNBcE6uCrXsx/7CAcIuvvyBaM0Q=";
-        aarch64-darwin = "sha256-s2A9EE5GO2aV/FRdDObRgBdwY+0YhacFxzPZs4FMwA8=";
+        x86_64-linux = "sha256-lylEKenCnYKwyCxSExyr0PkxdOeSmrO05dVkWOI9uFI=";
+        aarch64-linux = "sha256-RTgRR0lN8cb59qNIzNSWkl+ptw22WyHoS5XgjdytILA=";
+        i686-linux = "sha256-cvnh7JJ7tVm48AZXSqojrhCosDDcq0d0eAP8rRktunE=";
+        x86_64-darwin = "sha256-4Q9MuffL6PSBWAliIvPIn8XG1zUTm07WvEiRs1uXPZU=";
+        aarch64-darwin = "sha256-6TLESi/Hu6gI/wroihneRLBoXYEF6c6VdUgMDS2R+R8=";
       };
     in
     fetchzip {


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-6337, CVE-2023-5954, CVE-2023-5954 and CVE-2023-3775.


https://github.com/hashicorp/vault/releases/tag/v1.13.12
https://github.com/hashicorp/vault/releases/tag/v1.13.11
https://github.com/hashicorp/vault/releases/tag/v1.13.10
https://github.com/hashicorp/vault/releases/tag/v1.13.9
https://github.com/hashicorp/vault/releases/tag/v1.13.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 274071` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>kubernetes-helmPlugins.helm-secrets</li>
    <li>vault</li>
    <li>vault-bin</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
