### PR TITLE
youtube-music: 2.1.0 -> 3.1.0

### DIFF
--- a/pkgs/applications/audio/youtube-music/default.nix
+++ b/pkgs/applications/audio/youtube-music/default.nix
@@ -2,45 +2,89 @@
 , fetchFromGitHub
 , buildNpmPackage
 , makeWrapper
-, electron_25
+, electron
 , python3
 , stdenv
+, stdenvNoCC
 , copyDesktopItems
+, moreutils
+, cacert
+, jq
+, nodePackages
 , makeDesktopItem
 }:
 
 let
   pname = "youtube-music";
-  version = "2.1.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "th-ch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-aYEEUv+dybzcH0aNJlZ19XF++8cswFunrU0H+ZaKm4Y=";
+    hash = "sha256-6ZiftpdCwxCkJzcHryVrUKzM+mM1eQpdLNFl0Dja59Q=";
   };
-
-  electron = electron_25;
 
 in
-buildNpmPackage {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version src;
 
-  nativeBuildInputs = [ makeWrapper python3 ]
+  pnpmDeps = stdenvNoCC.mkDerivation {
+    pname = "${finalAttrs.pname}-pnpm-deps";
+    inherit (finalAttrs) src version ELECTRON_SKIP_BINARY_DOWNLOAD;
+
+    nativeBuildInputs = [ jq moreutils nodePackages.pnpm cacert ];
+
+    installPhase = ''
+      export HOME=$(mktemp -d)
+
+      pnpm config set store-dir $out
+      pnpm install --frozen-lockfile --ignore-script
+
+      rm -rf $out/v3/tmp
+      for f in $(find $out -name "*.json"); do
+        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
+        jq --sort-keys . $f | sponge $f
+      done
+    '';
+
+    dontBuild = true;
+    dontFixup = true;
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = {
+      x86_64-linux = "sha256-Oy11V7FXfVhLUR9gX0sjQEFuVPFpbaVdT518oOSLcvA=";
+      aarch64-linux = "sha256-6nXemaGiQjp2stjjKItPJ62VcH5Q5pRf63qKtl2haXI=";
+      x86_64-darwin = "sha256-jSMAw+AMD63vqPckZjblw4EDngA4E8h0WlsZu3hUShY=";
+      aarch64-darwin = "sha256-zujXURpIcw7IOw63AW167h6cywYXydhHZMzA2apGZAs=";
+    }.${stdenv.system} or (throw "Unsupported platform");
+  };
+
+  nativeBuildInputs =
+    [ makeWrapper python3 nodePackages.pnpm nodePackages.nodejs ]
     ++ lib.optionals (!stdenv.isDarwin) [ copyDesktopItems ];
 
-  npmDepsHash = "sha256-XGV0mTywYYxpMitojzIILB/Eu/8dfk/aCvUxIkx4SDQ=";
-  makeCacheWritable = true;
 
-  env = {
-    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-  };
+  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    export STORE_PATH=$(mktemp -d)
+
+    cp -Tr "$pnpmDeps" "$STORE_PATH"
+    chmod -R +w "$STORE_PATH"
+
+    pnpm config set store-dir "$STORE_PATH"
+    pnpm install --offline --frozen-lockfile --ignore-script
+    patchShebangs node_modules/{*,.*}
+  '';
 
   postBuild = lib.optionalString stdenv.isDarwin ''
     cp -R ${electron}/Applications/Electron.app Electron.app
     chmod -R u+w Electron.app
   '' + ''
-    npm exec electron-builder -- \
+    pnpm build
+    ./node_modules/.bin/electron-builder \
       --dir \
       -c.electronDist=${if stdenv.isDarwin then "." else "${electron}/libexec/electron"} \
       -c.electronVersion=${electron.version}
@@ -83,7 +127,7 @@ buildNpmPackage {
       icon = "youtube-music";
       desktopName = "Youtube Music";
       startupWMClass = "Youtube Music";
-      categories = ["AudioVideo"];
+      categories = [ "AudioVideo" ];
     })
   ];
 
@@ -93,6 +137,6 @@ buildNpmPackage {
     license = licenses.mit;
     maintainers = [ maintainers.aacebedo ];
     mainProgram = "youtube-music";
-    platforms = platforms.all;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Update to 3.1.0.
Had to change dependencies as upstream switched to pnpm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
