### PR TITLE
cc-wrapper: add `zerocallusedregs` hardening flag, add `pkgsExtraHardening` package set

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -195,6 +195,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `stdenv`: The `--replace` flag in `substitute`, `substituteInPlace`, `substituteAll`, `substituteAllStream`, and `substituteStream` is now deprecated if favor of the new `--replace-fail`, `--replace-warn` and `--replace-quiet`. The deprecated `--replace` equates to `--replace-warn`.
 
+- A new hardening flag, `zerocallusedregs` was made available, corresponding to the gcc/clang option `-fzero-call-used-regs=used-gpr`.
+
 - The Yama LSM is now enabled by default in the kernel, which prevents ptracing
   non-child processes. This means you will not be able to attach gdb to an
   existing process, but will need to start that process from gdb (so it is a

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -214,6 +214,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [](#opt-boot.kernel.sysctl._net.core.wmem_max_) changed from a string to an integer because of the addition of a custom merge option (taking the highest value defined to avoid conflicts between 2 services trying to set that value), just as [](#opt-boot.kernel.sysctl._net.core.rmem_max_) since 22.11.
 
+- A new top-level package set, `pkgsExtraHardening` is added. This is a set of packages built with stricter hardening flags - those that have not yet received enough testing to be applied universally, those that are more likely to cause build failures or those that have drawbacks to their use (e.g. performance or required hardware features).
+
 - `services.zfs.zed.enableMail` now uses the global `sendmail` wrapper defined by an email module
   (such as msmtp or Postfix). It no longer requires using a special ZFS build with email support.
 

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -32,7 +32,7 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
 fi
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 stackprotector pie pic strictoverflow format)
+  declare -a allHardeningFlags=(fortify fortify3 stackprotector pie pic strictoverflow format zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -109,6 +109,10 @@ for flag in "${!hardeningEnableMap[@]}"; do
     format)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling format >&2; fi
       hardeningCFlagsBefore+=('-Wformat' '-Wformat-security' '-Werror=format-security')
+      ;;
+    zerocallusedregs)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling zerocallusedregs >&2; fi
+      hardeningCFlagsBefore+=('-fzero-call-used-regs=used-gpr')
       ;;
     *)
       # Ignore unsupported. Checked in Nix that at least *some*

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -223,6 +223,15 @@ let
 
   defaultHardeningFlags = bintools.defaultHardeningFlags or [];
 
+  # if cc.hardeningUnsupportedFlagsByTargetPlatform exists, this is
+  # called with the targetPlatform as an argument and
+  # cc.hardeningUnsupportedFlags is completely ignored - the function
+  # is responsible for including the constant hardeningUnsupportedFlags
+  # list however it sees fit.
+  ccHardeningUnsupportedFlags = if cc ? hardeningUnsupportedFlagsByTargetPlatform
+    then cc.hardeningUnsupportedFlagsByTargetPlatform targetPlatform
+    else (cc.hardeningUnsupportedFlags or []);
+
   darwinPlatformForCC = optionalString stdenv.targetPlatform.isDarwin (
     if (targetPlatform.darwinPlatform == "macos" && isGNU) then "macosx"
     else targetPlatform.darwinPlatform
@@ -584,7 +593,7 @@ stdenv.mkDerivation {
     ## Hardening support
     ##
     + ''
-      export hardening_unsupported_flags="${builtins.concatStringsSep " " (cc.hardeningUnsupportedFlags or [])}"
+      export hardening_unsupported_flags="${builtins.concatStringsSep " " ccHardeningUnsupportedFlags}"
     ''
 
     # Machine flags. These are necessary to support

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -407,6 +407,7 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
     inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD langJava version;
     isGNU = true;
     hardeningUnsupportedFlags = lib.optional is48 "stackprotector"
+      ++ lib.optional (!atLeast11) "zerocallusedregs"
       ++ lib.optional (!atLeast12) "fortify3"
       ++ lib.optionals (langFortran) [ "fortify" "format" ];
   };

--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -90,7 +90,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -95,7 +95,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/12/clang/default.nix
+++ b/pkgs/development/compilers/llvm/12/clang/default.nix
@@ -89,7 +89,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/13/clang/default.nix
+++ b/pkgs/development/compilers/llvm/13/clang/default.nix
@@ -83,7 +83,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/14/clang/default.nix
+++ b/pkgs/development/compilers/llvm/14/clang/default.nix
@@ -86,7 +86,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/15/clang/default.nix
+++ b/pkgs/development/compilers/llvm/15/clang/default.nix
@@ -97,7 +97,11 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [
+        "fortify3"
+        # supported on x86_64/aarch64 only
+        "zerocallusedregs"
+      ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/15/clang/default.nix
+++ b/pkgs/development/compilers/llvm/15/clang/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation (rec {
+  self = stdenv.mkDerivation (finalAttrs: rec {
     pname = "clang";
     inherit version;
 
@@ -99,9 +99,10 @@ let
       isClang = true;
       hardeningUnsupportedFlags = [
         "fortify3"
-        # supported on x86_64/aarch64 only
-        "zerocallusedregs"
       ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/16/clang/default.nix
+++ b/pkgs/development/compilers/llvm/16/clang/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation (rec {
+  self = stdenv.mkDerivation (finalAttrs: rec {
     pname = "clang";
     inherit version;
 
@@ -93,9 +93,10 @@ let
       isClang = true;
       hardeningUnsupportedFlags = [
         "fortify3"
-        # supported on x86_64/aarch64 only
-        "zerocallusedregs"
       ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/16/clang/default.nix
+++ b/pkgs/development/compilers/llvm/16/clang/default.nix
@@ -91,7 +91,11 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [
+        "fortify3"
+        # supported on x86_64/aarch64 only
+        "zerocallusedregs"
+      ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/17/clang/default.nix
+++ b/pkgs/development/compilers/llvm/17/clang/default.nix
@@ -95,7 +95,11 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [
+        "fortify3"
+        # supported on x86_64/aarch64 only
+        "zerocallusedregs"
+      ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/17/clang/default.nix
+++ b/pkgs/development/compilers/llvm/17/clang/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation (rec {
+  self = stdenv.mkDerivation (finalAttrs: rec {
     pname = "clang";
     inherit version;
 
@@ -97,9 +97,10 @@ let
       isClang = true;
       hardeningUnsupportedFlags = [
         "fortify3"
-        # supported on x86_64/aarch64 only
-        "zerocallusedregs"
       ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -102,7 +102,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -97,7 +97,7 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/git/clang/default.nix
+++ b/pkgs/development/compilers/llvm/git/clang/default.nix
@@ -95,7 +95,11 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-      hardeningUnsupportedFlags = [ "fortify3" ];
+      hardeningUnsupportedFlags = [
+        "fortify3"
+        # supported on x86_64/aarch64 only
+        "zerocallusedregs"
+      ];
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/git/clang/default.nix
+++ b/pkgs/development/compilers/llvm/git/clang/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation (rec {
+  self = stdenv.mkDerivation (finalAttrs: rec {
     pname = "clang";
     inherit version;
 
@@ -97,9 +97,10 @@ let
       isClang = true;
       hardeningUnsupportedFlags = [
         "fortify3"
-        # supported on x86_64/aarch64 only
-        "zerocallusedregs"
       ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -341,7 +341,10 @@ in
                 ln -s ${bootstrapTools}/lib/clang $out/lib
                 ln -s ${bootstrapTools}/include   $out
               '';
-              passthru.isFromBootstrapFiles = true;
+              passthru = {
+                isFromBootstrapFiles = true;
+                hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+              };
             };
             clang-unwrapped = selfTools.libclang;
             libllvm = self.stdenv.mkDerivation {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -249,6 +249,7 @@ let
     "relro"
     "stackprotector"
     "strictoverflow"
+    "zerocallusedregs"
   ];
   defaultHardeningFlags =
     (if stdenv.hasCC then stdenv.cc else {}).defaultHardeningFlags or

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
@@ -15,5 +15,5 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" ];
+  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
 } // extraAttrs)

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -15,5 +15,5 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" ];
+  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
 } // extraAttrs)

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -53,6 +53,7 @@ let
     pkgsStatic = true;
     pkgsCross = true;
     pkgsi686Linux = true;
+    pkgsExtraHardening = true;
   };
 
   # No release package attrname may have any of these at a component

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -276,6 +276,19 @@ let
         gcc.abi = "elfv2";
       };
     });
+
+    pkgsExtraHardening = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsExtraHardening = super';
+          stdenv = super'.withDefaultHardeningFlags (
+            super'.stdenv.cc.defaultHardeningFlags ++ [
+              "zerocallusedregs"
+            ]
+          ) super'.stdenv;
+        })
+      ] ++ overlays;
+    };
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
## Description of changes

More information on `-fzero-call-used-regs`: https://www.jerkeby.se/newsletter/posts/rop-reduction-zero-call-user-regs/

Short version: this hardening flag (available in gcc >= 11) reduces the number of ROP gadgets present in code by inserting instructions zeroing registers on function returns. The choice of `used-gpr` as a setting for regular use comes from the conclusions of the above article noting other projects making this choice.

This flag *is* also available in clang >= 15 but only for x86_64 & aarch64, and our `hardeningUnsupportedFlags` mechanism isn't sophisticated enough to manage variation by *target* platform ~(we could trivially vary `hardeningUnsupportedFlags` based on `stdenv.targetPlatform`, but that might produce the wrong result when called as a cross-compiler). So for now I've had to disable it for clang. (Perhaps `hardeningUnsupportedFlags` could accept a function taking a platform? let's not get too diverted..)~ Not such a problem after all, implemented, see comment below :point_down: 

The more visible change in this PR is adding a new package set, `pkgsExtraHardening`, which I'd like to use as a testing ground for new hardening flags or flags which are still known to cause some problems. Users of other "hardened" features may be interested in using this package set. The name is a little clunky - I was also considering `pkgsHarder` (`pkgsMeHarder`? maybe not..)

Have tested bootstrapping `pkgsExtraHardening` on macos 12 x86_64, nixos x86_64 (+`pkgsi686Linux`, `pkgsLLVM`, `pkgsCross.aarch64-multiplatform`...). A couple of months ago I built quite a lot of nixos x86_64 with this flag set and struggled to find anything that had a problem with it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
