### PR TITLE
libwacom: 2.8.0 -> 2.9.0

### DIFF
--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/linuxwacom/libwacom/blob/${src.rev}/NEWS";
     description = "Libraries, configuration, and diagnostic tools for Wacom tablets running under Linux";
     maintainers = teams.freedesktop.members;
-    license = licenses.mit;
+    license = licenses.hpnd;
   };
 }

--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -6,14 +6,16 @@
 , glib
 , pkg-config
 , udev
+, libevdev
 , libgudev
+, libxml2
 , python3
 , valgrind
 }:
 
 stdenv.mkDerivation rec {
   pname = "libwacom";
-  version = "2.8.0";
+  version = "2.9.0";
 
   outputs = [ "out" "dev" ];
 
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "linuxwacom";
     repo = "libwacom";
     rev = "libwacom-${version}";
-    hash = "sha256-VjFZBlOIG1L4dXPJ8DWxrbfVqdQC+X7zVXFryo43FFc=";
+    hash = "sha256-oM3dd22hQaAXdNoO2Q2JvO2lJCkmfw8f0NWxYcVT3lA=";
   };
 
   postPatch = ''
@@ -38,6 +40,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     udev
+    libevdev
     libgudev
   ];
 
@@ -50,13 +53,18 @@ stdenv.mkDerivation rec {
     "-Dtests=${if doCheck then "enabled" else "disabled"}"
   ];
 
+  checkInputs = [
+    libxml2
+  ];
+
   nativeCheckInputs = [
     valgrind
-  ] ++ (with python3.pkgs; [
-    libevdev
-    pytest
-    pyudev
-  ]);
+    (python3.withPackages (ps: with ps; [
+      ps.libevdev
+      pytest
+      pyudev
+    ]))
+  ];
 
   meta = with lib; {
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/linuxwacom/libwacom/compare/libwacom-2.8.0...libwacom-2.9.0

Changelog: https://github.com/linuxwacom/libwacom/blob/libwacom-2.9.0/NEWS



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
