### PR TITLE
openvswitch: 3.1.1 -> 3.2.1, openvswitch-lts: v2.17.6 -> v2.17.8

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "3.1.1";
-  hash = "sha256-YEiRg6RNO5WlUiQHIhfF9tN6oRvhKnV2JRDO25Ok4gQ=";
+  version = "3.2.1";
+  hash = "sha256-nXdyDJIU60Lx9cvpLuUp3E7MUnaZvvGDm+UKbXJRH0o=";
 }

--- a/pkgs/os-specific/linux/openvswitch/generic.nix
+++ b/pkgs/os-specific/linux/openvswitch/generic.nix
@@ -105,6 +105,8 @@ in stdenv.mkDerivation rec {
     pytest
   ]);
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     changelog = "https://www.openvswitch.org/releases/NEWS-${version}.txt";
     description = "A multilayer virtual switch";

--- a/pkgs/os-specific/linux/openvswitch/lts.nix
+++ b/pkgs/os-specific/linux/openvswitch/lts.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "2.17.6";
-  hash = "sha256-dNqvK+c0iuXdQBe6RbjaxlNB8Vn0+0paecVC/tQQENk=";
+  version = "2.17.8";
+  hash = "sha256-DWAwepAxl90ay7MXPCz++BicaeSHYuZ06O8VeFZac+U=";
 }

--- a/pkgs/os-specific/linux/openvswitch/update.sh
+++ b/pkgs/os-specific/linux/openvswitch/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p common-updater-scripts
+
+let tags = list-git-tags --url=https://github.com/openvswitch/ovs | lines | sort --natural | str replace v ''
+
+let latest = $tags | last
+let lts = $tags | find --regex "2\\.17.*" | last
+
+let current_latest = nix eval --raw -f default.nix openvswitch.version | str trim
+let current_lts = nix eval --raw -f default.nix openvswitch-lts.version | str trim
+
+if $latest != $current_latest {
+  update-source-version openvswitch $latest $"--file=(pwd)/pkgs/os-specific/linux/openvswitch/default.nix"
+}
+
+if $lts != $current_lts {
+  update-source-version openvswitch-lts $lts $"--file=(pwd)/pkgs/os-specific/linux/openvswitch/lts.nix"
+}
+
+[
+  {release: latest, before: $current_latest, after: $latest},
+  {release: lts, before: $current_lts, after: $lts}
+]


### PR DESCRIPTION
- libglvnd: enable 64-bit file APIs
- nixos/release: fix versionSuffix eval
- ctranslate2: withCUDA sets stdenv = gcc11Stdenv
- python311Packages.imageio: 2.32.0 -> 2.33.0
- python311Packages.av: disable crashing tests on darwin
- python311Packages.imageio: disable failing tests on darwin
- prefetch-yarn-deps: add cacert to provide certificates during fetches
- buildMozillaMach: unpin ffmpeg version
- doc: Add lib.meta to the library functions ToC
- jupyter: fix runtime error
- nss_latest: 3.94 -> 3.95
- python311Packages.jupyterlab-git: 0.50.0rc0 -> 0.50.0
- python311Packages.jupyterlab-git: add meta.changelog
- workflows/check-by-name: If channel no existent, fall back to nixos-unstable
- dua: 2.20.2 -> 2.20.3
- systemd: 254.3 -> 254.6
- figma-linux: update src.hash
- pyqt6: 6.5.2 -> 6.6.0
- pdk: init at 3.0.0
- python311Packages.speechbrain: 0.5.15 -> 0.5.16
- python311Packages.jupyter-events: 0.7.0 -> 0.9.0
- python311Packages.xformers: 0.03 -> 0.0.22.post7
- cacert: 3.92 -> 3.95
- haskell.compiler.ghc*: set abs paths for cctools bintools w/ hadrian
- rspamd: fix build on non-x86_64 platforms
- ferretdb: 1.14.0 -> 1.15.0 (#269190)
- redmine: 5.0.5 -> 5.0.6
- gitlab: downgrade Ruby from 3.2 to 3.1 (#269204)
- rapidcheck: Build shared/static following defaults
- nix: Fix build now that rapidcheck is a shared library
- akira-unstable: unbreak by removing vala-lint dependency
- bork: 7.0.1 → 7.0.2
- xmlada: 23.0.0 -> 24.0.0
- gprbuild: 23.0.0 -> 24.0.0
- gnatcoll-*: 23.0.0 -> 24.0.0
- emacs.pkgs.ada-mode: fix installPhase
- gnatcoll-python3: use python 3.9
- libdeltachat: 1.131.1 -> 1.131.6
- deltachat-desktop: 1.41.1 -> 1.41.4
- vulkan-utility-libraries: fix hash
- vulkan-utility-libraries: add nickcao to maintainers
- maddy: fix build with clang
- bpf-linker: add workaround for #166205
- lib.fileset.maybeMissing: init
- lib.fileset: Document decision for strict existence checks
- fluentd: fix service start up
- consul-template: add meta.mainProgram
- prismlauncher: add pciutils to wrapper
- python3Packages.skytemple-files: fix build
- peertube: Clarify option descriptions of `listenHttp`, `listenWeb`, `enableWebHttps`
- beets: fix build with Sphinx 6
- beets-minimal: fix building with no plugins
- sequoia-chameleon-gnupg: 0.3.2 -> unstable-2023-11-22
- python2Packages.pycairo: backport test fix
- mcuboot-imgtool: fix pname
- python311Packages.aiocomelit: 0.5.0 -> 0.6.0
- python311Packages.ical: 5.1.1 -> 6.1.0
- python311Packages.gcal-sync: 5.0.0 -> 6.0.1
- python311Packages.python-matter-server: 4.0.1 -> 4.0.2
- python311Packages.velbus-aio: 2023.10.2 -> 2023.11.0
- python311Packages.zwave-js-server-python: 0.53.1 -> 0.54.0
- home-assistant: 2023.11.2 -> 2023.11.3
- aws2cli: fix urllib3 build (#269351)
- [Backport release-23.11] python311Packages.homeassistant-stubs: 2023.11.2 -> 2023.11.3 (#269352)
- python311Packages.bqscales: fix build
- python311Packages.polars: remove patch for rustc < 1.73; fix build
- python311Packages.jupyter-server: 2.7.3 -> 2.10.1
- python3Packages.plum-py: unbreak by disabling a test
- python3Packages.types-appdirs: Fix typo in `meta.homepage`
- python3Packages.lpc-checksum: init at 3.0.0
- wireplumber: 0.4.15 -> 0.4.16
- Revert "chromium: add libglvnd to rpath" (#269413)
- chromium: add rpath to libGLESv2.so from libANGLE (#269414)
- mpvScripts.thumbfast: Refactor with `buildLua`
- mpvScripts.thumbfast: unstable-2023-06-06 → 2023-06-08
- prefetch-npm-deps: detect and error out when generating an empty cache
- fetchNpmDeps: add forceEmptyCache option
- buildNpmPackage: add forceEmptyCache option
- fit-trackee: pin flask-sqlalchemy to 3.0.5
- bcachefs: fix lib.kernel.option miss use.
- nixos/apache-kafka: structured settings
- nixos/tests/kafka: test KRaft mode
- nixos/apache-kafka: release notes
- nixos/apache-kafka: Add manual chapter
- figlet: ignore implicit-function-declaration; fix build
- teams-for-linux: 1.3.19 -> 1.3.22
- [Backport release-23.11] nixos/nvidia: load `nvidia-uvm` kernel module via `softdep` (#269473)
- treewide: add mainProgram
- php81: 8.1.25 -> 8.1.26
- php82: 8.2.12 -> 8.2.13
- php83: 8.3.0RC6 -> 8.3.0
- mousai: 0.7.5 -> 0.7.6
- exiftool: 12.68 -> 12.70
- nixos: fix bcachefs filesystem with symlinks
- rl-2311: Add release notes on lib
- lib.fileset.fileFilter: Predicate attribute for file extension
- lean4: fix build on darwin
- protege-distribution: 5.5.0 -> 5.6.3
- cmospwd: restrict platform to x86_64-linux
- darling: unstable-2023-05-02 -> unstable-2023-11-07
- python311Packages.labelbox: 3.52.0 -> 3.56.0
- python311Packages.jupyter-core: 5.3.1 -> 5.5.0
- python311Packages.jupyter-core: update meta
- python311Packages.nbconvert: 7.8.0 -> 7.11.0
- python311Packages.nbconvert: update meta
- maintainers/lxd: fix double modules
- [Backport release-23.11] vaultwarden: 1.30.0 -> 1.30.1 (#269534)
- [Backport release-23.11] esphome: 2023.11.2 -> 2023.11.3 (#269537)
- gst-plugins-good: add openssl dependency
- touchosc: 1.2.4.180 -> 1.2.5.183
- postgresqlPackages.postgis: fix build on clang 12+
- libnl-tiny: build only on linux
- python313: 3.13.0a1 -> 3.13.0a2
- wrapFirefox: fix error message
- nextcloud-notify_push: 0.6.3 -> 0.6.5
- lib.systems.elaborate: fix passing `rust`
- rustc-wasm32: fix targetPlatform
- qutebrowser-qt5: replace qt5.qutebrowser
- qutebrowser: use spliced qt6Packages
- miniflux: fix http user agent regression
- nixos/caddy: Fixed RestartSec typo.
- kyverno: 1.10.4 -> 1.10.5
- sssd: add adcli path
- gnutls: 3.8.1 -> 3.8.2
- ghostscript: 10.02.0 -> 10.02.1
- signal-desktop: 6.39.0 -> 6.39.1, 6.40.0-beta.1 -> 6.40.0-beta.2
- rpm: declare darwin as badPlatform
- gnomeExtensions.pano: refresh patch
- hydrus: 552 -> 553
- maintainers: add EBADBEEF
- zxtune: init at r5055
- meilisearch: 1.3.1 -> 1.5.0
- rubyPackages: gtk2 -> gtk3
- tor-browser: 13.0.1 -> 13.0.5
- mullvad-browser: 13.0.1 -> 13.0.4
- python311Packages.pymc: 5.9.1 -> 5.9.2
- python311Packages.pytensor: 2.17.3 -> 2.18.1
- usql: fix build with clang 12+
- vala-lint: unstable-2023-05-25 -> unstable-2023-11-12
- dssp: 4.4.4.1 -> 4.4.5
- root: fix excessive build log size
- cargo-watch: fix build on darwin
- conan: 2.0.5 -> 2.0.14
- netbird: 0.24.2 -> 0.24.3
- treewide: add mainProgram
- gns3-gui: fix running on Wayland
- uptime-kuma: 1.23.6 -> 1.23.7
- petsc: 3.19.2 -> 3.19.4, fix tests, add more options
- halide: 15.0.1 -> 16.0.0
- halide: build against llvmPackages_16
- halide: disable float16 support on aarch16-linux
- halide: patch to remove dependency on Apple SDK
- halide: ::aligned_alloc is not available on x86_64-darwin
- halide: disable fuzzing tests
- halide: use preCheck instead of overwriting checkPhase
- psutils: fix build on darwin by setting -std=c89
- qt6.qtwebengine: set correct platforms
- gnomeExtensions.ddterm: unbreak
- gnomeExtensions.freon: fix patch
- gnomeExtensions.gsconnect: 55 -> 56
- DisnixWebService: fix build for Axis2 1.8.1
- DisnixWebService: add meta.{changelog,homepage}
- bundix: fix license attribute
- bundix: update homepage
- river: 0.2.4 -> 0.2.5
- rivercarro: 0.1.4 -> 0.3.0
- river: 0.2.5 -> 0.2.6
- pyqt6: fix build on darwin
- celeste: 0.8.0 -> 0.8.1
- python/hooks: use python.pythonVersion to support PyPy
- Skip `sqlite3_bind_bug68849.phpt` php unit test on i686 linux
- nixos/nextcloud: fix docu of packages
- pipewire: 0.3.84 -> 0.3.85
- rapidfuzz-cpp: 2.1.1 -> 2.2.3
- python311Packages.rapidfuzz: 3.4.0 -> 3.5.2
- igraph: 0.10.7 -> 0.10.8
- python311Packages.igraph: 0.11.2 -> 0.11.3
- warp: 0.5.4 -> 0.6.1
- impression: 2.1 -> 3.0.1
- libpostal: fix on darwin
- forgejo: 1.20.5-0 -> 1.20.5-1
- linux_xanmod: 6.1.62 -> 6.1.63
- linux_xanmod_latest: 6.5.11 -> 6.5.12
- udiskie: 2.5.0 -> 2.5.1
- augeas: 1.12.0 -> 1.14.1; fix darwin build
- python311Packages.augeas: 1.1.0 -> 1.2.0
- llvm-mode: update src location
- python311Packages.radios: 0.1.1 -> 0.3.0
- python311Packages.radios: fix darwin sandbox build
- photofield: 0.11.0 -> 0.13.0
- photofield: add passthru.tests.version
- photofield: add meta.mainProgram
- gvisor: 20221102.1 -> 20231113.0
- nixosTests.gvisor: remove flaky test
- edk2: fix cross compilation
- edk2: 202308 -> 202311
- edk2: support RISC-V
- OVMF: disable `sourceDebug` by default
- OVMF: support RISC-V
- OVMF: mark broken on Darwin
- python3Packages.pykdl: use system pybind11
- pythonPackages.pyheck: fix build on darwin
- rustic-rs: fix build on darwin
- libmcrypt: fix build on darwin
- mcrypt: fix build on darwin
- newsflash: 2.3.1 -> 3.0.2
- python311Packages.uri-template: 1.2.0 -> 1.3.0
- python311Packages.phik: refactor, disable failing tests
- gst_all_1.gstreamer: 1.22.6 -> 1.22.7
- gst_all_1.gst-plugins-base: 1.22.6 -> 1.22.7
- gst_all_1.gst-plugins-good: 1.22.6 -> 1.22.7
- gst_all_1.gst-plugins-bad: 1.22.6 -> 1.22.7
- gst_all_1.gst-plugins-ugly: 1.22.6 -> 1.22.7
- gst_all_1.gst-libav: 1.22.6 -> 1.22.7
- gst_all_1.gst-vaapi: 1.22.6 -> 1.22.7
- gst_all_1.gst-devtools: 1.22.6 -> 1.22.7
- gst_all_1.gst-rtsp-server: 1.22.6 -> 1.22.7
- gst_all_1.gst-editing-services: 1.22.6 -> 1.22.7
- python311Packages.gst-python: 1.22.6 -> 1.22.7
- kicad: 7.0.7 -> 7.0.8
- kicad: 7.0.8 -> 7.0.9
- gnomeExtensions.pop-shell: unstable-2023-04-27 -> unstable-2023-11-10
- python3Packages.wasmer-compiler-llvm: fix build failure
- nixos/tmate-ssh-server: fix tmate-client-config script
- osquery: add unreleased upstream patch for current Clang version
- osquery: also apply `Use-locale.h-instead-of-removed-xlocale.h-header.patch` on aarch64
- tor-browser: add missing libGL required for wayland
- mullvad-browser: add missing libGL required for wayland
- datadog-agent: fix metric submission
- dnf5: 5.1.7 -> 5.1.8
- dnf5: re-enable tests
- dnf5: add man pages
- dnf5: add version test
- iaito: fix desktop entry icon
- apptainer, singularity: drop obsolete LOCALSTATEDIR dirs
- apptainer, singularity: make LOCALSTATEDIR internal by default
- netbird-ui: fix broken systray icon path
- centrifugo: 5.1.1 -> 5.1.2
- xdg-desktop-portal: fix disabling Geo location
- linuxPackages.systemtap: fix cross-build by depending on host Python
- nixos/mediawiki: update url option defaultText
- qrscan: Pin libclang to version 15
- lp_solve: ignore implicit int warnings, add x64 darwin ldflags
- python311Packages.bitstring: 4.1.2 -> 4.1.3
- jellyfin-web: 10.8.11 -> 10.8.12
- jellyfin: 10.8.11 -> 10.8.12
- darwin.linuxBuilder: Fix working directory in documentation
- nixos-render-docs: take header and footer on CLI
- nixos-render-docs: header and footer as list[str]
- nixos/containers: warn if containers are used but disabled
- nixos/release-notes: Tidy-up location of `sudo-rs` link definition
- nixos/sudo-rs: Simplify activation
- nixos/release-notes: Document pitfall when switching to sudo-rs
- nixos/sudo-rs: uniformize ssh-agent auth behaviour with `security.sudo`
- nixos/sudo-rs: Drop checks for sudo implementation
- nixos/sudo-rs: Fix bug putting the wrong version of sudo in `environment.systemPackages`
- nixos/tests/sudo-rs: cleanup
- nixos/sudo-rs: refactor processing of `cfg.extraRules`
- nixos/sudo-rs: Refactor option definitions
- nixos/sudo-rs: Clarify `security.sudo-rs.enable`'s description
- nixos/sudo-rs: Move support for `pam_ssh_agent_auth(8)` to PAM's NixOS module
- nixos-render-docs: fix mypy test
- libxmlxx: code predates c++17, use -std=c++11; fix darwin
- nixos/btrbk: Support both Miller's sudo and sudo-rs
- nixos/ssm-agent: Handle sudo-rs too
- qgis: 3.34.0 -> 3.34.1
- python3Packages.yamlpath: mark as broken
- python3Packages.yamlpath: explain why the package is broken
- mmlgui: unstable-2023-09-20 -> unstable-2023-11-16
- prefetch-yarn-deps: Fix parsing of scoped packages
- prefetch-yarn-deps: Fix access to `.resolved`
- kamailio: refactor expression
- kamailio: 5.7.2 -> 5.7.3
- kamailio: make "modules" customiziable by overrideAttrs
- kamailio: make "modules" customiziable by overrideAttrs
- kamailio: add TLS support
- lib.meta: Avoid attrset allocation in platformMatch
- qgis-ltr: 3.28.12 -> 3.28.13
- zfs: 2.2.0 -> 2.2.1
- zfsUnstable: 2.2.1-unstable-2023-10-21 -> 2.2.1
- lib2geom: pick patch from Inkscape 1.3.1
- inkscape: 1.3 → 1.3.1
- osl: fix build, 1.12.13.0 -> 1.12.14.0
- osl: fix build on darwin
- armagetronad: 0.2.9.1.0 -> 0.2.9.1.1 + passthrus for other versions
- armagetronad: reproducible build by setting version
- libdeltachat: 1.131.6 -> 1.131.7
- deltachat-desktop: 1.41.4 -> 1.42.1
- deltachat-desktop: ensure libdeltachat version matches jsonrpc-client
- libdeltachat: add deltachat-desktop to passthru.tests
- python311Packages.clarifai: 9.7.1 -> 9.10.4
- python311Packages.clarifai-grpc: 9.10.0 -> 9.10.5
- python311Packages.pyvoro: mark as broken and unmaintained, preparing for removal (#270041)
- tectonic: fixed compilation issue
- amdgpu_top: 0.1.11 -> 0.3.1
- nixos/dolibarr: add package option
- maintainers: add ldprg
- preload: init at 0.6.4
- nixos/preload: init
- setzer: 61 -> 62
- diebahn: 1.5.0 -> 2.1.0
- python311Packages.img2pdf: 0.5.0 -> 0.5.1
- nixos/syncoid: add possibility to use string type for sshKey options
- ocamlPackages.caqti*: improve meta.license
- samba: fix samba-tool
- nix-output-monitor: 2.0.0.7 -> 2.1.1
- kapacitor: fix build of embedded `libflux` dependency with current rust
- kapacitor: fix aarch64-darwin build
- lib.attrsets.matchAttrs: Avoid some list allocations when walking structure
- python3Packages.{shiboken6,pyside6}: 6.5.2 -> 6.6.0
- pgrok: 1.4.0 -> 1.4.1
- jo: add meta.mainProgram
- osu-lazer-bin: remove version from name
- python311Packages.torch: choose magma at the expression level
- python311Packages.torch: fix typo in the cuda&&rocm error message
- magma: respect the global isStatic
- slack: 4.34.121 -> 4.35.126
- nixos/forgejo docs: correct phrasing
- zfs: default disable zfs_dmu_offset_next_sync to avoid data corruption
- xearth: improve meta.license
- ngrep: improve meta.license
- t1utils: improve meta.license
- Mark `nix-ld` as broken on 32 bit targets
- fh: 0.1.7 -> 0.1.8
- python311Packages.pyregion: 2.1.1 -> 2.2.0; fix darwin build
- python311Packages.py-partialql-parser: 0.4.0 -> 0.4.2
- python311Packages.moto: 4.2.6 -> 4.2.10
- nixos/x2goserver: Work with both Miller's sudo and sudo-rs
- nss_latest: 3.94 -> 3.95
- firefox-beta-unwrapped: 120.0b9 -> 121.0b3
- firefox-devedition-unwrapped: 120.0b9 -> 121.0b3
- buildMozillaMach: update no-buildconfig patch for 121+
- sonic-server: fix build with clang 16
- buildMozillaMach: replace dbus workaround with upstream patch
- vesktop: add desktop item categories
- python3Packages.pytest-testinfra: 9.0.0 -> 10.0.0
- fractal: 4.4.2 -> 5
- fractal: enable gstreamer-good support
- hashcat: fix darwin build (#270213)
- buildMozillaMach: prune patches
- dconf2nix: 0.0.12 -> 0.1.1
- xfce.xfce4-whiskermenu-plugin: 2.8.1 -> 2.8.2
- geph: add cacert to provide certificates during fetches
- ktfmt: fix meta.license
- tuxmux: fix meta.license
- qt6: 6.6.0 -> 6.6.1
- qt6.qtbase: refresh patches
- qt6.qtbase: derive plugin load path from PATH
- qt6.qtsvg: drop outdated patches
- qt6.qtwayland: drop outdated patches
- qt6.qtbase: fix build on older macOS
- python311Packages.gentools: switch to pyproject; fix build
- python311Packages.gentools: add changelog to meta
- python311Packages.gentools: adjust inputs
- sftpgo: 2.5.4 -> 2.5.5
- soft-serve: 0.7.2 -> 0.7.3
- nixos/clamav: ensure freshclam starts before clamav (if enabled)
- fw: 2.18.0 -> 2.19.0
- cargo-mutants: 23.11.1 -> 23.11.2
- symbolicator: 23.11.0 -> 23.11.2
- gql: 0.8.0 -> 0.9.0
- jql: 7.0.6 -> 7.0.7
- felix-fm: 2.10.1 -> 2.10.2
- treewide: add mainProgram
- rl-2311: Link to blog post on the file set library
- darwin.linux-builder: Disable evaluation
- nixos/system.disableInstallerTools: Do define options without effect
- darwin.linux-builder: Disable installer tools
- forgejo: 1.20.5-1 -> 1.20.6-0
- homepage-dashboard: 0.7.4 -> 0.8.2
- sourcehut.pastesrht: add myself as maintainer
- nixos/sourcehut: compile and integrate paste.sr.ht API component
- sourcehut.pastesrht: 0.15.1 -> 0.15.2
- sccache: 0.7.2 -> 0.7.4
- dnf5: tag was moved, fix hash
- moonlander: mark as broken
- kotlin-native: update darwin hashes; fix build
- firefox: Adds patch for systems without a default page size
- firefox-beta-unwrapped: 121.0b3 -> 121.0b4
- firefox-devedition-unwrapped: 121.0b3 -> 121.0b4
- redis-plus-plus: 1.3.7 -> 1.3.10
- liberasurecode: ignore strict prototypes on clang; fix darwin
- httptunnel: update to latest rev; fix darwin
- gifski: 1.13.0 -> 1.31.1
- cargo-tarpaulin: 0.27.1 -> 0.27.2
- runelite: fix desktop entry
- tuba: 0.4.1 -> 0.5.0
- ocamlPackages.bap: use LLVM 14
- poco: fix static build
- fsautocomplete: sdk_6_0 -> sdk_7_0
- nextcloud26: 26.0.8 -> 26.0.9
- nextcloud27: 27.1.3 -> 27.1.4
- nextcloud26Packages: regen
- nextcloud27Packages: regen
- nixos/tests/nextcloud: fix with-declarative-redis-and-secrets test
- khal: no longer broken on Darwin
- microsoft-edge: 119.0.2151.44 -> 119.0.2151.72
- poetry: 1.7.0 -> 1.7.1
- poetryPlugins.poetry-plugin-up: 0.7.0 -> 0.7.1
- cargo-show-asm: 0.2.22 -> 0.2.23
- oelint-adv: 3.26.2 -> 3.26.4
- python310Packages.oelint-parser: 2.11.4 -> 2.11.6
- readline63: fix clang build
- maintainers: rename jgarcia to chewblacka
- remnote: 1.12.64 -> 1.13.0
- gifski: fix version
- mininet: 2.3.0 -> 2.3.1b4
- nixos/mininet: wrap with mininet in PYTHONPATH and ifconfig in PATH
- cargo-modules: 0.11.0 -> 0.11.2
- uuu: fix updateScript to pass specific version-regexp
- python311Packages.astropy-healpix: upstream patch to fix darwin build
- coqPackages.VST: 2.12 → 2.13
- python311Packages.hdbscan: fix build
- coqPackages.mathcomp-word: 2.1 → {2.2, 3.0}
- sysdig: 0.33.1 -> 0.34.1
- kea: 2.4.0 -> 2.4.1
- linux_testing: 6.7-rc2 -> 6.7-rc3
- linux_6_6: 6.6.2 -> 6.6.3
- linux_6_5: 6.5.12 -> 6.5.13
- linux_6_1: 6.1.63 -> 6.1.64
- linux_5_15: 5.15.139 -> 5.15.140
- linux_5_10: 5.10.201 -> 5.10.202
- linux_5_4: 5.4.261 -> 5.4.262
- linux_4_19: 4.19.299 -> 4.19.300
- linux_4_14: 4.14.330 -> 4.14.331
- linux-rt_5_10: 5.10.199-rt97 -> 5.10.201-rt98
- gnome.gpaste: Fix typelib path modification
- gnomeExtensions.arcmenu: 44 -> 52
- gnomeExtensions: auto-update
- libreoffice: skip tests for now
- python311Packages.pot: pypi missing files, switch to github; fixbuild
- biome: 1.3.3 -> 1.4.0
- src-cli: 5.2.0 -> 5.2.1
- frogmouth: 0.9.0 -> 0.9.1
- risor: 1.1.1 -> 1.1.2
- python311Packages.afdko: fix build on clang
- tuba: fix clang build
- expr: 1.15.4 -> 1.15.5
- zellij: 0.39.1 -> 0.39.2
- matrix-synapse: 1.95.1 -> 1.97.0
- nixosTests.matrix-synapse: fix requests certificate validation by using minica instead of openssl
- homebank: 5.7.1 -> 5.7.2
- jellyfin: 10.8.12 -> 10.8.13
- jellyfin-web: 10.8.12 -> 10.8.13
- Backport and converge release notes editorial updates (#270990)
- Release NixOS 23.11
- nixos/esphome: fix bwrap
- zfs_2_1: init at 2.1.13
- zfs: improve description and long description
- pythonPackages.nbxmpp: 4.5.0 → 4.5.3
- gajim: 1.8.3 → 1.8.4
- timg: 1.5.2 -> 1.5.3
- capnproto: 1.0.1 -> 1.0.1.1
- linux-pam: fix cross-compilation from darwin
- neomutt: fix build on x86_64-darwin
- mkosi: drop patches backported to systemd 254.6
- teeworlds: fix build on Darwin
- teeworlds-server: fix unbundling of wavpack dependency
- uhdm: 1.77 -> 1.80
- surelog: 1.76 -> 1.80
- yosys-synlig: 2023-10-26 -> 2023-11-28
- stargazer: 1.0.5 -> 1.1.0
- nixosTests.stargazer: switch to using gemget
- stargazer: Add nixosTests.stargazer to passthru.tests
- inlyne: 0.3.1 -> 0.3.2
- argc: 1.12.0 -> 1.14.0
- rman: fix clang build
- rxp: fix clang build
- rzip: fix clang build
- buddy: fix clang build
- bisq-desktop: 1.9.12 -> 1.9.14
- cutter: fix build; switch from qt5 to qt6
- rz-ghidra: switch from qt5 to qt6
- uni: 2.5.1 -> 2.6.0
- postgresqlPackages.timescaledb: 2.12.2 -> 2.13.0
- postgresql12Packages.timescaledb: mark broken
- libLAS: apply upstream patch to fix compile error
- vscode-extensions.devsense.composer-php-vscode: 1.36.13428 -> 1.41.14332
- vscode-extensions.devsense.profiler-php-vscode: 1.36.13428 -> 1.41.14332
- vscode-extensions.devsense.phptools-vscode: 1.36.13428 -> 1.41.14332
- brave: 1.60.118 -> 1.60.125
- python311Packages.keyrings-passwordstore: mark broken
- python311Packages.keyrings-google-artifactregistry-auth: 1.1.1 -> 1.1.2
- ddclient: 3.11.1 -> 3.11.2
- python311Packages.optimum: 1.14.0 -> 1.14.1
- python310Packages.clarifai-grpc: 9.10.5 -> 9.10.6
- nixos/jitsi-meet: fix `cfg.caddy.enable`
- nixosTests.jitsi-meet: test `cfg.caddy.enable`
- python311Packages.anthropic: 0.5.0 -> 0.7.4
- gcc6: don’t link libstdc++ to CoreFoundation
- python3Packages.importlab: fix darwin support
- bazel_6: fix CLang 16 Werror-s on darwin
- coqPackages.gaia: 1.15 → 1.17
- coqPackages.{hydra-battles,gaia-hydras}: 0.6 → 0.9
- bazel_5: fix CLang 16 Werror-s on darwin
- bazel_4: fix CLang 16 Werror-s on darwin
- heatshrink: add cmake build script
- libbgcode: init at 2023-11-16
- prusa-slicer: 2.6.1 -> 2.7.0
- svg2pdf: 0.9.0 -> 0.9.1
- consul: 1.16.1 -> 1.16.3
- firefox-unwrapped: 120.0 -> 120.0.1
- firefox: move page size patch to buildMozillaMach
- materia-theme: fix build
- linux-rt_latest: remove patch that doesn't apply
- teeworlds: fix meta.license
- firefox-beta-unwrapped: 121.0b4 -> 121.0b5
- firefox-devedition-unwrapped: 121.0b4 -> 121.0b5
- nixos/i3: add updateSessionEnvironment option
- libreoffice: backport fix for expired test certs
- Revert "libreoffice: skip tests for now"
- prometheus: 2.47.2 -> 2.48.0
- hydrus: 553 -> 554
- nixos/libvirtd: add netcat and support
- conan: add xcrun to nativeCheckInputs on darwin
- sparse: set llvm to llvm_14
- vscode-extensions.bmewburn.vscode-intelephense-client: 1.9.5 -> 1.10.1
- chromium: 119.0.6045.159 -> 119.0.6045.199
- ungoogled-chromium: 119.0.6045.159-1 -> 119.0.6045.199-1
- chromium: add update script command to use unreleased ungoogled-chromium
- libwacom: disable tests if isPower
- cargo-udeps: set meta.mainProgram
- libserdes: link with libc++ libc++abi; fix build
- clex: 4.6.patch10 -> 4.7
- librewolf-unwrapped: 119.0.1-1 -> 120.0-1
- zfsStable/zfsUnstable: 2.2.1 -> 2.2.2
- zfs_2_1: 2.1.13 -> 2.1.14
- spotdl: 4.2.1 -> 4.2.2
- traefik: 2.10.5 -> 2.10.6
- nixos/opensearch: check plugins directory exists before checking content
- python311Packages.cvxopt: use LP64 blas on darwin; fix build
- python311Packages.cvxopt: set env vars in env rather than preConfigure
- liberasurecode: remove -Werror
- openocd-rp2040: override openocd package instead
- rio: 0.0.27 -> 0.0.28
- vencord: 1.6.3 -> 1.6.4
- common-licenses: 11.1 -> 13
- sogo: add note to also update sogo
- sope: 5.8.0 -> 5.9.0
- sogo: fix build
- wavebox: 10.118.5-2 -> 10.119.8-2
- trigger-control: unstable-2023-06-18 -> 1.5.1
- spdk: fix python installation prefix
- litterbox: init at 1.9
- maintainers: add ajwhouse
- inkscape: 1.3.1 → 1.3.2
- telegram-desktop: 4.11.8 -> 4.12.2
- telegram-desktop.tg_owt: unstable-2023-11-01 -> unstable-2023-11-17
- mattermost: 8.1.4 -> 9.2.2
- mattermost: 8.1.4 -> 8.1.6
- Update version to 8.1.7
- skalibs: 2.14.0.0 -> 2.14.0.1
- s6: 2.12.0.0 -> 2.12.0.2
- s6-dns: 2.3.6.0 -> 2.3.7.0
- s6-networking: 2.6.0.0 -> 2.7.0.0
- tipidee: 0.0.1.0 -> 0.0.2.0
- nixos-anywhere: 1.0.0 -> 1.1.0
- gdtoolkit: fix lark override
- sca2d: fix lark override
- spooles: fix compiler errors and link properly; fix darwin build
- rubyPackages: update
- gitea: 1.20.5 -> 1.20.6
- remmina: 1.4.31 -> 1.4.33
- sagittarius-scheme: unbreak on darwin
- sagittarius-scheme: mark broken on aarch64-darwin
- ycmd: unstable-2022-08-15 -> unstable-2023-11-06
- signal-desktop: 6.39.1 -> 6.40.0 https://github.com/signalapp/Signal-Desktop/releases
- opera: 100.0.4815.47 -> 105.0.4970.21
- gscan2pdf: fix build failures
- gscan2pdf: re-add previously removed test
- gscan2pdf: add patch to remove warnings during test
- gscan2pdf: patch from upstream with utf8 filenames
- valent: unstable-2023-08-26 -> unstable-2023-11-11
- why3: 1.6.0 → 1.7.0
- wireshark: 4.0.10 -> 4.0.11
- palemoon-bin: 32.5.0 -> 32.5.1
- palemoon-bin: Fix WebGL support
- fetch-yarn-deps: fix missing cert when fetching packages
- element-{web,desktop}: 1.11.47 -> 1.11.50
- element-desktop: migrate to prefetch-yarn-deps
- nifi: 1.23.2 -> 1.24.0
- owncast: 0.1.1 -> 0.1.2
- libadwaita: 1.4.0 -> 1.4.1
- opensearch: 2.11.0 -> 2.11.1
- nheko: Add meta.mainProgram
- python311Packages.flask-themes2: 1.0.0 -> 1.0.1
- python310Packages.ipykernel: 6.25.2 -> 6.27.1
- open62541: 1.3.7 -> 1.3.8
- wasmtime: 14.0.4 -> 15.0.0
- wasmtime: 15.0.0 -> 15.0.1
- mako: add mainProgram
- mdbook: 0.4.35 -> 0.4.36
- librewolf: 120.0-1 -> 120.0.1-1
- nixos/matrix-appservice-irc: fix syscall filter
- amoeba: fix build
- esphome: 2023.11.4 -> 2023.11.6
- nixos/mysql-auth: fix passwords in config files
- nixos/tests/auth-mysql: fix test
- pam_mysql: add test
- libnss-mysql: add test
- nixos/preload: fix log permission
- mpdcron: fix build by correcting a C function conflict in `nokogiri`
- nixos-render-docs: don't drop code languages anymore
- nixos-render-docs: wrap code in <pre><code>, not <pre>
- documentation-highlighter: 9.12.0 -> 11.9.0, add new langs
- agdsn-zsh-config: 0.8.0 -> 0.9.0
- qrcode: update latest rev to fix compiler errors
- prefetch-npm-deps: bump deps
- prefetch-npm-deps: make cargo happy
- prefetch-npm-deps: instrument some logging
- prefetch-npm-deps: use default value when lockfile has no deps
- fetchNpmDeps: add test case where empty default lockfile packages is needed
- lib.systems.elaborate: fix passing `rust` (more) (#271790)
- gcc11: drop AVR patch on Darwin (no longer needed)
- gcc{6,7,8,9}: use target bintools on Darwin
- gcc11: mark as bad on aarch64-darwin when building a cross-compiler
- gcc{6,7,8,9,10,11}: fix cross-compiler build on x86_64-darwin
- keycloak: 22.0.5 -> 23.0.0
- vagrant: 2.3.4 -> 2.3.7
- vagrant: libvirt-provider: 0.8.2 -> 0.12.2
- pango: fix update version policy
- evolution: 3.50.1 → 3.50.2
- gnome.gnome-disk-utility: 45.0 → 45.1
- gnome.gnome-software: 45.1 → 45.2
- gnome.gnome-sudoku: 45.2 → 45.3
- deja-dup: 44.2 → 45.1
- libadwaita: 1.4.1 → 1.4.2
- loupe: 45.1 → 45.2
- xdg-desktop-portal-gnome: 45.0 → 45.1
- evolution-data-server: 3.50.1 → 3.50.2
- gnome-podcasts: 0.6.0 → 0.6.1
- gnome-firmware: 43.2 → 45.0
- runelite: fix GPU error (missing libGL.so.1)
- vesktop: 0.4.3 -> 0.4.4
- llvmPackages_{7,8,9}.{llvm-polly,libllvm-polly}: fix build with clang 16
- llvmPackages_6.lldb: fix build on x86_64-darwin
- sunshine: add libglvnd to runtimeDependencies
- light: Add `meta.mainProgram`
- spotify: 1.2.22.982.g794acc0a -> 1.2.25.1011.g0348b2ea
- netbox: 3.6.3 -> 3.6.4
- netbox: 3.6.4 -> 3.6.6
- wireplumber: 0.4.16 -> 0.4.17
- libnbd: 1.18.0 -> 1.18.1 and apply patch for CVE-2023-5871
- dosbox-x: Fix modem & IPX support
- dosbox: Fix modem & IPX support
- dosbox-x: Fix stash smashing when launching Windows 3.0
- libunicode: init at 0.3.0-unstable-2023-03-05
- termbench-pro: init at unstable-2023-01-26
- contour: 0.3.1.200 -> 0.3.12.262
- maintainers.moni: fix github id
- python310Packages.flask-seasurf: fix build
- powerdns-admin: fix build
- powerdns-admin: use patch files
- flask-seasurf: use patch files
- qemu: 8.1.2 -> 8.1.3
- python311Packages.nethsm: init at 1.0.0
- pynitrokey: 0.4.40 -> 0.4.42
- php: use a versioned url for install-pear-nozlib.phar
- maintainers: add tc-kaluza
- insulator2: init at 2.12.2
- nixos/keepalived: add openFirewall option
- linux_testing: 6.7-rc3 -> 6.7-rc4
- linux_6_6: 6.6.3 -> 6.6.4
- linux_6_1: 6.1.64 -> 6.1.65
- linux_5_15: 5.15.140 -> 5.15.141
- linux-rt_6_1: 6.1.59-rt16 -> 6.1.64-rt17
- freefilesync: 13.1 -> 13.2
- python3.pkgs.ariadne: remove opentracing dependency (#272023)
- nixos/redmine: Fix database assertions
- vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.17.5 -> 0.17.10
- vscode-extensions.davidanson.vscode-markdownlint: 0.52.0 -> 0.53.0
- nixos/mastodon: clarify the need to set streamingProcesses
- python311Packages.torchaudio: fix build when cudaSupport is enabled
- qdigidoc: 4.2.12 -> 4.4.0
- python310Packages.oelint-parser: 2.11.6 -> 2.12.0
- ncurses: gate postFixup related to unicode support (closes #271716)
- python3Packages.torch: enable cuDNN & NCCL only if available
- python3Packages.jaxlib-bin: move asserts to broken to avoid breaking eval
- ctranslate2: enable cuDNN only if it is available
- python3Packages.tensorflow: move asserts to broken to avoid breaking eval
- cudaPackages.nccl-tests: support building with CUDA < 11.4 with cudatoolkit
- cudaPackages.nccl: support building with CUDA < 11.4 with cudatoolkit
- apptainer: 1.2.4 -> 1.2.5
- vault: 1.14.4 -> 1.14.7
- aws-workspaces: 4.6.0 include missing xcbutil dependency
- pkcs11helper: 1.29.0 -> 1.30.0
- mastodon: 4.2.1 -> 4.2.2
- postgresql.pkgs.timescaledb_toolkit: 1.16.0 -> 1.18.0
- pat: 0.15.0 -> 0.15.1
- libdeltachat: 1.131.7 -> 1.131.9
- deltachat-desktop: 1.42.1 -> 1.42.2
- element-desktop: use electron version 27
- element-desktop: add jq to update script
- gitlab: 16.5.1 -> 16.5.3
- gitlab-container-registry: 3.85.0 -> 3.86.2
- samba: fix cross compilation
- libsForQt5.bismuth: Fix generated JS
- coqPackages_8_16: fix evaluation with math-comp ≥ 2.0
- sgfutils: init at unstable-2017-11-27
- rustc-wasm32: fix build
- pythonPackages.cirq-core: fix build on aarch64
- python3Packages.cirq-core: fix build on aarch64
- python310Packages.subliminal: mark as broken
- python311Packages.django_5: 5.0b1 -> 5.0rc1
- python311Packages.django_5: 5.0rc1 -> 5.0
- magic-wormhole-rs: 0.6.0 -> 0.6.1
- open62541: 1.3.8 -> 1.3.9
- geant4: unbreak for darwin
- clp: unbreak on aarch64-linux
- ferretdb: 1.15.0 -> 1.16.0 (#272305)
- tomcat9: 9.0.82 -> 9.0.83
- tomcat10: 10.1.15 -> 10.1.16
- tomcat9,tomcat10: rename sha256 to hash
- tomcat: refactor
- tomcat: sync meta.platforms with jre
- nixos/tomcat: add anthonyroussel to maintainers
- nixosTests.tomcat: add anthonyroussel to maintainers
- rl-2311: Minor ToC change
- rl-2311: Use stable references
- gnomeExtensions.unite: 72 -> 77
- fwupd: 1.9.9 -> 1.9.10
- warp: 0.6.1 -> 0.6.2
- remmina: enable wayland
- buildHomeAssistantComponent: fix install with patches applied
- buildHomeAssistantComponent: migrate from pname to owner/domain
- python3Packages.python-mapnik: disable more failing tests
- yggdrasil: 0.5.2 → 0.5.4
- plasma: 5.27.9 -> 5.27.10
- libsForQt5.qcoro: 0.9.0 -> 0.10.0
- matrix-sliding-sync: 0.99.12 -> 0.99.13
- qpwgraph: 0.6.0 -> 0.6.1
- mate.mate-applets: Add missing mate-desktop
- _1password-gui-beta: 8.10.20-1 -> 8.10.22-21
- cuneiform: make install path match rpath; fix runtime
- aws-encryption-sdk-cli: fix build, pin urllib3
- c-ares: update source URL
- certmgr-selfsigned: fix fetchpatch hash
- fish: 3.6.1 -> 3.6.4
- vscode-extensions.ms-toolsai.jupyter: patch to avoid writing to read-only store
- timeular: fix hash
- maintainers: add bloveless
- wash-cli: init at 0.24.0
- mozillavpn: 2.16.1 → 2.17.1
- mozillavpn: 2.17.1 → 2.18.0
- mozillavpn: 2.18.0 → 2.18.1
- mozillavpn: 2.18.1 → 2.19.0
- nixos/caddy: Use caddyfile adapter by default when explicitly specifying configFile
- radiotray-ng: add libsoup_3 and glib-networking; fix runtime
- guix: add foo-dogsquared to meta.maintainers
- guix: add parameters for certain configure flags
- nixos/guix: init
- greetd: create cache dir for tuigreet
- nixos/ejabberd: ensure erlang cookie is made
- nixos/teeworlds: reduce closure size
- paraview: fix strlcat symbol provided by glibc 2.38
- nixos/keycloak: Allow setting hostname-url
- x264: Add mingw32 hostPlatform support
- gnomeExtensions.ddterm: fix gjs path
- wakelan: code predates c99, use -std=c89; fix darwin
- nixos/git: add prompt.enable
- bazel_6: fix: make patched bash a native binary
- Update pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
- Revert "wordpress: fixed installing of languages"
- mesa: unbreak on darwin
- libGLU: fix on darwin
-  python311Packages.jupyterhub: not broken on aarch64
- pkg-config: Fix MinGW build
- vulkan-loader: Fix MinGW build
- bitcoin: fix darwin builds
- caffe: fix eval when CUDNN is not available
- nixos/wyoming/{faster-whisper,piper}: hook up enable option
- wasm-bindgen-cli: 0.2.88 -> 0.2.89
- vscode: add libGL.so.1 and libEGL.so.1 to vscode
- maptool: extract application JARs from package
- enscript: use system getopt for all builds; fix darwin
- clipcat: 0.5.1 -> 0.6.2
- clipcat: 0.6.2 -> 0.7.0
- clipcat: 0.7.0 -> 0.7.1
- clipcat: 0.7.1 -> 0.8.0
- clipcat: 0.8.0 -> 0.9.0
- clipcat: 0.9.0 -> 0.11.0
- clipcat: 0.11.0 -> 0.13.0
- schildichat-web: add knownVulnerabilities (#272757)
- wrangler: Fix broken workerd on linux
- catdvi: fix generated code in configure script; fix darwin
- tor-browser: 13.0.5 -> 13.0.6
- mullvad-browser: 13.0.4 -> 13.0.6
- element-{desktop,web}: 1.11.50 -> 1.11.51
- linux_6_6: 6.6.4 -> 6.6.5
- linux_6_1: 6.1.65 -> 6.1.66
- linux_5_15: 5.15.141 -> 5.15.142
- linux_5_10: 5.10.202 -> 5.10.203
- linux_5_4: 5.4.262 -> 5.4.263
- linux_4_19: 4.19.300 -> 4.19.301
- linux_4_14: 4.14.331 -> 4.14.332
- linux-rt_5_15: 5.15.137-rt71 -> 5.15.141-rt72
- linux-rt_6_1: 6.1.64-rt17 -> 6.1.65-rt18
- webkitgtk: 2.42.2 → 2.42.3
- yq-go: 4.40.1 -> 4.40.3
- yq-go: 4.40.3 -> 4.40.4
- llvmPackages: Dedupe `llvm_meta`
- llvmPackages: Dedupe releaseInfo
- llvmPackages: Dedupe monorepoSrc
- llvmPackages_{13,14}: Use releaseInfo and monorepoSrc
- llvmPackages: Remove dead code
- llvmPackages_11.compiler-rt: restore `libcxxabi` argument
- llvmPackages_16.libclc: fix cross eval
- cinnamon.cinnamon-screensaver: Fix broken theming with pygobject 3.46
- cinnamon.cinnamon-screensaver: Update the pygobject 3.46 patch to use try/except
- redoc-cli: mark broken
- redocly-cli: init at 1.5.0
- kde/gear: 23.08.3 -> 23.08.4
- coqPackages.coq-ext-lib: 0.11.8 → 0.12.0
- llvmPackages_17: init
- indiepass-desktop: init at unstable-2023-05-19
- nixos/guix: fix user activation script
- nvc: 1.10.4 -> 1.11.0
- wordpress: 6.4.1 -> 6.4.2
- mastodon: 4.2.2 -> 4.2.3
- nixos/nix.nix: Support new Nix 2.20 command syntax
- thunderbird-unwrapped: 115.4.2 -> 115.5.1
- nixos/transmission: correct typo on systemd StateDirectory
- nixos/teamspeak3: SSH and HTTP ip+port options
- netlify-cli: Set meta.mainProgram
- llvmPackages_git: sync with llvmPackages_17
- yarn-berry: Add `meta.mainProgram`
- maintainers: add tornax
- rio: v0.0.28 -> v0.0.29
- python312: 3.12.0 -> 3.12.1
- spotdl: 4.2.2 -> 4.2.4 (#273074)
- dotnet-sdk: 6.0.416 -> 6.0.417
- dotnet-sdk_7: 7.0.403 -> 7.0.404
- dotnet-sdk_8: 8.0.100-rc.2.23502.2 -> 8.0.100
- dotnet-sdk_8: fix smoke test
- nixos/postgresqlBackup: add --rsyncable to compression programs
- nixos/postgresqlBackup: add Scrumplex as maintainer
- brave: 1.60.125 -> 1.61.101
- llvmPackages_17: 17.0.2 -> 17.0.6
- chromium: 119.0.6045.199 -> 120.0.6099.71
- ungoogled-chromium: 119.0.6045.199-1 -> 120.0.6099.71-1
- chromedriver: 119.0.6045.105 -> 120.0.6099.71
- couchdb3: 3.3.2 -> 3.3.3
- linux_xanmod: 6.1.63 -> 6.1.65
- linux_xanmod_latest: 6.5.12 -> 6.6.4
- chromium: fix build for chromium >=120
- cutter: add qtwayland to build inputs
- caddy: 2.7.5 -> 2.7.6
- lib.sortOn: init
- lib.callPackageWith: Optimize levenshtein sort
- nixos/btrbk: Optimize sort
- lib.sort: Make doc consistent with sortOn
- linux: drop XEN on 32-bit
- zenith: 0.14.0 -> 0.14.0-unstable-2023-11-21
- zenith: update meta.maintainers
- ghdl-llvm: use compatible llvm version
- webex: 43.8.0.26955 -> 43.11.0.27795
- haskellPackages.scat: unbreak
- snowflake: 2.7.0 -> 2.8.0
- root: 6.28.08 -> 6.28.10
- mate.mate-system-monitor: 1.26.1 -> 1.26.2
- lib.types.boolByOr: init
- tpm2-tools: 5.5 -> 5.6
- haskellPackages.selda: unbreak
- libbacktrace: disable tests on musl
- gnome.zenity: 3.99.2 → 4.0.0
- gnome.mutter: 45.1 → 45.2
- gnome.gnome-shell: 45.1 → 45.2
- gnome.gnome-shell-extensions: 45.1 → 45.2
- gnome.gnome-control-center: 45.1 → 45.2
- gnome.nautilus: 45.1 → 45.2.1
- gnome.file-roller: 43.0 → 43.1
- gnome.gnome-maps: 45.1 → 45.2
- shotwell: 0.32.3 → 0.32.4
- snapshot: 45.0 → 45.1
- sauce-connect: 4.5.4 -> 4.9.1
- router: add CVE-2023-45812 to knownVulnerabilities
- nixos/home-automation: fix lovelace card entrypoint
- nixos/home-automation: really fix lovelace card entrypoint
- nixos/home-assistant: fix error when switching between writable and none writable lovelace config
- nixos/home-assistant: fix custom lovelace module loading
- nixos/tests/home-assistant: check for lovelace resources in config
- nixos/home-assistant: fix broken reference in option example
- home-assistant: use overridden dependencies in overrides
- tandoor-recipes: Fix URL import
- gtkcord4: 0.0.12 -> 0.0.16-1
- gtkcord4: fix description and add mainProgram
- zsh-fzf-tab: fix build with clang 16
- fsautocomplete: fix build
- lxgw-wenkai: 1.311 -> 1.312
- dnf5: 5.1.8 -> 5.1.9
- linux_xanmod: 6.1.65 -> 6.1.66
- linux_xanmod_latest: 6.6.4 -> 6.6.5
- electron_26: 26.4.0 -> 26.6.2
- electron_27: 27.0.0 -> 27.1.3
- electron_28: 28.0.0-alpha.3 -> 28.0.0
- electron_27: remove versions patch
- electron_25: eol
- electron_26: fix backported patch conflict
- bitwarden: 2023.10.1 -> 2023.12.0
- bitwarden-cli: 2023.10.0 -> 2023.12.0
- bitwarden: use electron_26
- linux_testing: 6.7-rc4 -> 6.7-rc5
- linux_6_6: 6.6.5 -> 6.6.6
- linux_6_1: 6.1.66 -> 6.1.67
- lib.attrsets.longestValidPathPrefix: init
- lib.attrsets.hasAttrByPath: Document law and laziness, and test it
- upx: add update script
- upx: 4.2.0 -> 4.2.1
- upx: use finalAttrs
- upx: add version test
- keycloak: 23.0.0 -> 23.0.1
- unison-ucm: M5g -> M5j
- rio: 0.0.29 -> 0.0.30
- warzone2100: 4.4.0 -> 4.4.1
- nixos/networking-interfaces: fix rootless ping
- python3Packages.torch: gate NCCL with cudaSupport
- faircamp: 0.8.0 -> 0.11.0
- wrangler: support darwin and arm64
- firefox-beta-unwrapped: 121.0b5 -> 121.0b9
- firefox-devedition-unwrapped: 121.0b5 -> 121.0b9
- rss2email: add mainProgram
- i3-balance-workspace: add mainProgram
- howl: set meta.mainProgram
- gscan2pdf: set meta.mainProgram
- urlscan: set meta.mainProgram
- notmuch-addrlookup: set meta.mainProgram
- notmuch: set meta.mainProgram
- unison: set meta.mainProgram
- beamerpresenter: set meta.mainProgram
- mdctags: set meta.mainProgram
- matrix-appservice-discord: set meta.mainProgram
- rmfakecloud: set meta.mainProgram
- zrepl: set meta.mainProgram
- colordiff: set meta.mainProgram
- warzone2100: fix fetch url
- haskellPackages.scat, haskellPackages.selda: drop hydraPlatforms = lib.platforms.none
- ungoogled-chromium: add `ungoogled-` prefix to `chromium-unwrapped`
- chromium: move stray patches into `./patches` directory
- chromium: fix increased build time for non-cross-compilation builds
- grafana-loki,promtail: 2.9.2 -> 2.9.3
- yq-go: 4.40.4 -> 4.40.5
- shattered-pixel-dungeon: fix crash on startup
- tor: 0.4.8.9 -> 0.4.8.10
- nixos/nix-serve: fix module compatibility with unflaked Nix
- llvmPackages_17.libclc: init
- matrix-synapse: 1.97.0 -> 1.98.0
- vlang: weekly.2023.44 -> 0.4.3
- remmina: Add `meta.mainProgram`
- nixos/syncthing: add databaseDir option
- htmlq: set meta.mainProgram
- restic: set meta.mainProgram
- lib.fileset: Refactor gitTracked and gitTrackedWith
- lib.fileset.gitTracked: Improve error when passing files
- ocamlPackages.merlin: 4.12 → 4.13
- ocamlPackages.merlin: Drop unused source hashes
- ocamlPackages.batteries: 3.7.1 → 3.7.2
- openvpn-auth-ldap: fix build
- ocaml-ng.ocamlPackages_5_1.ocaml: 5.1.0 → 5.1.1
- pythonPackages.wtforms-bootstrap5: init at 0.3.0
- pythonPackages.imia: init at 0.5.3
- pythonPackages.starlette-wtf: init at 0.4.3
- python3.pkgs.asgi-logger: init at 0.1.0
- python3.pkgs.smtpdfix: init at 0.5.1
- irrd: 4.3.0.post1 -> 4.4.2
- bcc: 0.28.0 -> 0.29.1
- nixos/jenkins: set StateDirectory if home is /var/lib/jenkins
- neovim-qt: Add `meta.mainProgram`
- nixos/guix: remove Service.MemoryDenyWriteExecute for GC service
- nixos/guix: add test for GC service
- forgejo: 1.20.6-0 -> 1.20.6-1
- openvswitch: add updateScript
- openvswitch-lts: v2.17.6 -> v2.17.8
- openvswitch: 3.1.1 -> 3.2.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
