### PR TITLE
openvswitch: 3.1.1 -> 3.2.1, openvswitch-lts: 2.17.6 -> 2.17.8

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "3.1.1";
-  hash = "sha256-YEiRg6RNO5WlUiQHIhfF9tN6oRvhKnV2JRDO25Ok4gQ=";
+  version = "3.2.1";
+  hash = "sha256-nXdyDJIU60Lx9cvpLuUp3E7MUnaZvvGDm+UKbXJRH0o=";
 }

--- a/pkgs/os-specific/linux/openvswitch/generic.nix
+++ b/pkgs/os-specific/linux/openvswitch/generic.nix
@@ -1,5 +1,6 @@
 { version
 , hash
+, updateScriptArgs ? ""
 }:
 
 { lib
@@ -20,6 +21,7 @@
 , sphinxHook
 , util-linux
 , which
+, writeScript
 }:
 
 let
@@ -104,6 +106,10 @@ in stdenv.mkDerivation rec {
     pyparsing
     pytest
   ]);
+
+  passthru.updateScript = writeScript "ovs-update.nu" ''
+    ${./update.nu} ${updateScriptArgs}
+  '';
 
   meta = with lib; {
     changelog = "https://www.openvswitch.org/releases/NEWS-${version}.txt";

--- a/pkgs/os-specific/linux/openvswitch/lts.nix
+++ b/pkgs/os-specific/linux/openvswitch/lts.nix
@@ -1,4 +1,5 @@
 import ./generic.nix {
   version = "2.17.6";
   hash = "sha256-dNqvK+c0iuXdQBe6RbjaxlNB8Vn0+0paecVC/tQQENk=";
+  updateScriptArgs = "--lts=true --regex '2\.17.*'";
 }

--- a/pkgs/os-specific/linux/openvswitch/lts.nix
+++ b/pkgs/os-specific/linux/openvswitch/lts.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "2.17.6";
-  hash = "sha256-dNqvK+c0iuXdQBe6RbjaxlNB8Vn0+0paecVC/tQQENk=";
+  version = "2.17.8";
+  hash = "sha256-DWAwepAxl90ay7MXPCz++BicaeSHYuZ06O8VeFZac+U=";
   updateScriptArgs = "--lts=true --regex '2\.17.*'";
 }

--- a/pkgs/os-specific/linux/openvswitch/update.nu
+++ b/pkgs/os-specific/linux/openvswitch/update.nu
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p nushell common-updater-scripts
+
+def main [--lts: bool = false, --regex: string] {
+  let tags = list-git-tags --url=https://github.com/openvswitch/ovs | lines | sort --natural | str replace v ''
+
+  let latest_tag = if $regex == null { $tags } else { $tags | find --regex $regex } | last
+  let current_version = nix eval --raw -f default.nix $"openvswitch(if $lts {"-lts"}).version" | str trim
+
+  if $latest_tag != $current_version {
+    if $lts {
+      update-source-version openvswitch-lts $latest_tag $"--file=(pwd)/pkgs/os-specific/linux/openvswitch/lts.nix"
+    } else {
+      update-source-version openvswitch $latest_tag $"--file=(pwd)/pkgs/os-specific/linux/openvswitch/default.nix"
+    }
+  }
+
+  {"lts?": $lts, before: $current_version, after: $latest_tag}
+}


### PR DESCRIPTION
## Description of changes

openvswitch: add updateScript
openvswitch-lts: 2.17.6 -> 2.17.8
openvswitch: 3.1.1 -> 3.2.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
