### PR TITLE
qrencode: Add support for PIC image type

### DIFF
--- a/pkgs/development/libraries/qrencode/add_pic_image_type.patch
+++ b/pkgs/development/libraries/qrencode/add_pic_image_type.patch
@@ -1,0 +1,186 @@
+diff --git a/qrenc.c b/qrenc.c
+index c09c4ab..f7ccbaf 100644
+--- a/qrenc.c
++++ b/qrenc.c
+@@ -68,7 +68,8 @@ enum imageType {
+ 	ANSIUTF8_TYPE,
+ 	ANSI256UTF8_TYPE,
+ 	UTF8i_TYPE,
+-	ANSIUTF8i_TYPE
++	ANSIUTF8i_TYPE,
++	PIC_TYPE
+ };
+ 
+ static enum imageType image_type = PNG_TYPE;
+@@ -134,8 +135,8 @@ static void usage(int help, int longopt, int status)
+ "               specify the width of the margins. (default=4 (2 for Micro QR)))\n\n"
+ "  -d NUMBER, --dpi=NUMBER\n"
+ "               specify the DPI of the generated PNG. (default=72)\n\n"
+-"  -t {PNG,PNG32,EPS,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8},\n"
+-"  --type={PNG,PNG32,EPS,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}\n"
++"  -t {PNG,PNG32,EPS,PIC,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8},\n"
++"  --type={PNG,PNG32,EPS,PIC,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}\n"
+ "               specify the type of the generated image. (default=PNG)\n\n"
+ "  -S, --structured\n"
+ "               make structured symbols. Version must be specified with '-v'.\n\n"
+@@ -148,13 +149,13 @@ static void usage(int help, int longopt, int status)
+ "  -M, --micro  encode in a Micro QR Code.\n\n"
+ "      --rle    enable run-length encoding for SVG.\n\n"
+ "      --svg-path\n"
+-"               use single path to draw modules for SVG.\n\n"
++"               use single path to draw modules for SVG or PIC.\n\n"
+ "      --inline only useful for SVG output, generates an SVG without the XML tag.\n\n"
+ "      --foreground=RRGGBB[AA]\n"
+ "      --background=RRGGBB[AA]\n"
+ "               specify foreground/background color in hexadecimal notation.\n"
+ "               6-digit (RGB) or 8-digit (RGBA) form are supported.\n"
+-"               Color output support available only in PNG, EPS and SVG.\n\n"
++"               Color output support available only in PNG, EPS, PIC and SVG.\n\n"
+ "      --strict-version\n"
+ "               disable automatic version number adjustment. If the input data is\n"
+ "               too large for the specified version, the program exits with the\n"
+@@ -192,7 +193,7 @@ static void usage(int help, int longopt, int status)
+ "  -v NUMBER    specify the minimum version of the symbol. (default=auto)\n"
+ "  -m NUMBER    specify the width of the margins. (default=4 (2 for Micro))\n"
+ "  -d NUMBER    specify the DPI of the generated PNG. (default=72)\n"
+-"  -t {PNG,PNG32,EPS,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}\n"
++"  -t {PNG,PNG32,EPS,PIC,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}\n"
+ "               specify the type of the generated image. (default=PNG)\n"
+ "  -S           make structured symbols. Version number must be specified with '-v'.\n"
+ "  -k           assume that the input text contains kanji (shift-jis).\n"
+@@ -520,6 +521,71 @@ static int writeEPS(const QRcode *qrcode, const char *outfile)
+ 	return 0;
+ }
+ 
++static void writePIC_drawModules(FILE *fp, int x, int y, int width, const char* col)
++{
++	if(svg_path) {
++		fprintf(fp, "line left %d color \"%s\" at (%d,%d)\n", width, col, x, y);
++	} else {
++    fprintf(fp, "box width %d height 1 color \"%s\" at (%d,%d)\n", width, col, x, -y);
++	}
++}
++
++static int writePIC(const QRcode *qrcode, const char *outfile)
++{
++	FILE *fp;
++	unsigned char *row, *p;
++	int x, y;
++	int symwidth;
++	float scale;
++	char fg[7], bg[7];
++
++	fp = openFile(outfile);
++
++	scale = dpi * INCHES_PER_METER / 100.0;
++
++	symwidth = qrcode->width + margin * 2;
++
++	snprintf(fg, 7, "%02x%02x%02x", fg_color[0], fg_color[1],  fg_color[2]);
++	snprintf(bg, 7, "%02x%02x%02x", bg_color[0], bg_color[1],  bg_color[2]);
++
++	/* PIC code start */
++  fputs(".PS ", fp);
++
++	/* Vanity remark */
++	fprintf(fp, "\\\" Created with qrencode %s (https://fukuchi.org/works/qrencode/index.html)\n", QRcode_APIVersionString());
++
++  fprintf(fp,  ".defcolor qrpicfg rgb #%s\n", fg );
++  fprintf(fp,  ".defcolor qrpicbg rgb #%s\n", bg );
++  if (svg_path) {
++    fputs( ".nop \\X'ps: exec 0 setlinecap'\\c\n", fp);
++    fputs( "linethick=3\n", fp );
++  }
++  fputs( "move down 0;move left 0\n", fp );
++
++  float symoffset = (qrcode->width - margin * 0.25) * 0.5;
++  fprintf( fp, "box width %d height %d color \"qrpicbg\" at (%f,%f)\n", symwidth, symwidth, symoffset, symoffset * ((svg_path) ? 1.0 : -1.0));
++
++	/* Write data */
++	p = qrcode->data;
++	for(y = 0; y < qrcode->width; y++) {
++		row = (p+(y*qrcode->width));
++
++    for(x = 0; x < qrcode->width; x++) {
++      if(*(row+x)&0x1) {
++        writePIC_drawModules(fp, x, y, 1, "qrpicfg");
++      }
++    }
++	}
++
++  fprintf( fp, "scale=%.f\n", scale );
++
++	/* Close PIC code */
++  fputs(".PE\n", fp);
++	fclose(fp);
++
++	return 0;
++}
++
+ static void writeSVG_drawModules(FILE *fp, int x, int y, int width, const char* col, float opacity)
+ {
+ 	if(svg_path) {
+@@ -1057,6 +1123,9 @@ static void qrencode(const unsigned char *intext, int length, const char *outfil
+ 		case EPS_TYPE:
+ 			writeEPS(qrcode, outfile);
+ 			break;
++		case PIC_TYPE:
++			writePIC(qrcode, outfile);
++			break;
+ 		case SVG_TYPE:
+ 			writeSVG(qrcode, outfile);
+ 			break;
+@@ -1125,6 +1194,9 @@ static void qrencodeStructured(const unsigned char *intext, int length, const ch
+ 		case EPS_TYPE:
+ 			type_suffix = ".eps";
+ 			break;
++		case PIC_TYPE:
++			type_suffix = ".pic";
++			break;
+ 		case SVG_TYPE:
+ 			type_suffix = ".svg";
+ 			break;
+@@ -1324,6 +1396,8 @@ int main(int argc, char **argv)
+ 					image_type = PNG_TYPE;
+ 				} else if(strcasecmp(optarg, "eps") == 0) {
+ 					image_type = EPS_TYPE;
++				} else if(strcasecmp(optarg, "pic") == 0) {
++					image_type = PIC_TYPE;
+ 				} else if(strcasecmp(optarg, "svg") == 0) {
+ 					image_type = SVG_TYPE;
+ 				} else if(strcasecmp(optarg, "xpm") == 0) {
+diff --git a/qrencode.1.in b/qrencode.1.in
+index c8e31da..3280d19 100644
+--- a/qrencode.1.in
++++ b/qrencode.1.in
+@@ -43,10 +43,10 @@ specify the width of margin. (default=4)
+ specify the DPI of the generated PNG. (default=72)
+ .TP
+ .PD 0
+-.B \-t {PNG,PNG32,EPS,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}
++.B \-t {PNG,PNG32,EPS,PIC,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}
+ .TP
+ .PD
+-.B \-\-type={PNG,PNG32,EPS,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}
++.B \-\-type={PNG,PNG32,EPS,PIC,SVG,XPM,ANSI,ANSI256,ASCII,ASCIIi,UTF8,UTF8i,ANSIUTF8,ANSIUTF8i,ANSI256UTF8}
+ specify the type of the generated image. (default=PNG)
+ .TP
+ .B \-S, \-\-structured
+@@ -71,7 +71,7 @@ encode in a Micro QR Code. See MICRO QR CODE for more information.
+ enable run-length encoding for SVG.
+ .TP
+ .B \-\-svg-path
+-use single path to draw modules for SVG.
++use single path to draw modules for SVG or PIC.
+ .TP
+ .B \-\-inline
+ only useful for SVG output, generates an SVG without the XML tag.
+@@ -83,7 +83,7 @@ only useful for SVG output, generates an SVG without the XML tag.
+ .B \-\-background=RRGGBB[AA]
+ specify foreground/background color in hexadecimal notation.
+ 6-digit (RGB) or 8-digit (RGBA) form are supported.
+-Color output support available only in PNG, EPS and SVG.
++Color output support available only in PNG, EPS, PIC and SVG.
+ .TP
+ .B \-\-strict\-version
+ disable automatic version number adjustment. If the input data is

--- a/pkgs/development/libraries/qrencode/default.nix
+++ b/pkgs/development/libraries/qrencode/default.nix
@@ -8,8 +8,12 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://fukuchi.org/works/qrencode/qrencode-${version}.tar.gz";
-    sha256 = "sha256-2kSO1PUqumvLDNSMrA3VG4aSvMxM0SdDFAL8pvgXHo4=";
+    hash = "sha256-2kSO1PUqumvLDNSMrA3VG4aSvMxM0SdDFAL8pvgXHo4=";
   };
+
+  # Remove once a new version of qrencode is released that includes
+  # https://github.com/fukuchi/libqrencode/pull/208
+  patches = [ ./add_pic_image_type.patch ];
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the changes from [fukuchi/libqrencode#208](https://github.com/fukuchi/libqrencode/pull/208) PR, to the qrencode nixpkgs.
[fukuchi/libqrencode#208](https://github.com/fukuchi/libqrencode/pull/208) brings support for the PIC (a graphics format used with groff and TeX) image type.

ℹ️ The `add_pic_image_type.patch` patch slightly differs from the changes proposed in [fukuchi/libqrencode#208](https://github.com/fukuchi/libqrencode/pull/208) as those target the master branch, where nixpkgs patch file targets the latest release, i.e. [4.1.1](https://github.com/fukuchi/libqrencode/releases/tag/v4.1.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
