### PR TITLE
jetbrains: actually update to 2023.3.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/readme.md
+++ b/pkgs/applications/editors/jetbrains/readme.md
@@ -17,12 +17,12 @@ To test the build process of every IDE (as well as the process for adding plugin
 ## How to update stuff:
  - Run ./bin/update_bin.py
  - This will update binary IDEs and plugins, and automatically commit them
- - Source builds need a bit more effort, as they aren't automated at the moment:
+ - Source builds need a bit more effort, as they **aren't automated at the moment**:
    - Find the build of the stable release you want to target (usually different for pycharm and idea, should have three components)
-   - I find this at https://jetbrains.com/updates/updates.xml (search for `fullNumber`)
+   - I find this at https://jetbrains.com/updates/updates.xml (search for `product name="`, then `fullNumber`)
    - Update the `buildVer` field in source/default.nix
    - Empty the `ideaHash`, `androidHash` and `jpsHash` (only `ideaHash` changes on a regular basis) fields and try to build to get the new hashes
-   - Run `nix build .#jetbrains.(idea/pycharm)-community-source.src`, then `./source/build_maven.py source/idea_maven_artefacts.json result/`
+   - Run `nix build .#jetbrains.(idea/pycharm)-community`, then `./source/build_maven.py source/idea_maven_artefacts.json result/`
    - Update `source/brokenPlugins.json` (from https://plugins.jetbrains.com/files/brokenPlugins.json)
    - Do a test build
    - If it succeeds, make a PR/merge

--- a/pkgs/applications/editors/jetbrains/source/default.nix
+++ b/pkgs/applications/editors/jetbrains/source/default.nix
@@ -3,19 +3,19 @@
 
 {
   idea-community = callPackage ./build.nix {
-    buildVer = "232.9921.47";
+    buildVer = "233.11799.300";
     buildType = "idea";
-    ideaHash = "sha256-sibp2Pa+NNHEeHMDRol45XOK0JzEhIZeI7TY04SkIx4=";
-    androidHash = "sha256-bc/UlR0DJQiQ3mdscucHkvzkSQxD0KnDFIM9UIb7Inw=";
-    jpsHash = "sha256-dBz64oATg45BMwd6etncQm84eHQSfSE9kDbuU9IVpmo=";
+    ideaHash = "sha256-Z0vNJC9KbnLPpvvQ1kLaUG3GhX16wRIuFOSvDugBDDY=";
+    androidHash = "sha256-Z0vNJC9KbnLPpvvQ1kLaUG3GhX16wRIuFOSvDugBDDY=";
+    jpsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJPS=";
     mvnDeps = ./idea_maven_artefacts.json;
   };
   pycharm-community = callPackage ./build.nix {
-    buildVer = "232.10072.31";
+    buildVer = "233.11799.298";
     buildType = "pycharm";
-    ideaHash = "sha256-NTQGz5HViQlJQaxcAnsliZS4NCKScVqx25FMILkBjpk=";
-    androidHash = "sha256-bc/UlR0DJQiQ3mdscucHkvzkSQxD0KnDFIM9UIb7Inw=";
-    jpsHash = "sha256-dBz64oATg45BMwd6etncQm84eHQSfSE9kDbuU9IVpmo=";
+    ideaHash = "sha256-Z0vNJC9KbnLPpvvQ1kLaUG3GhX16wRIuFOSvDugBDDY=";
+    androidHash = "sha256-Z0vNJC9KbnLPpvvQ1kLaUG3GhX16wRIuFOSvDugBDDY=";
+    jpsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJPS=";
     mvnDeps = ./idea_maven_artefacts.json;
   };
 }


### PR DESCRIPTION
## Description of changes

Previous PRs #273957, #265558, etc attempted to update the jetbrains packages, however only affected the binary builds, not the source builds (idea & pycharm community).

I've begun attempting to update as documented [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/jetbrains/readme.md#how-to-update-stuff), however I've run into an issue building the `jps` dependency (`jps-bootstrap-classpath.xml` is missing:

```
$ nix build .#jetbrains.pycharm-community --show-trace
path '/home/matt/Projects/nixpkgs/pkgs/applications/editors/jetbrains' does not contain a 'flake.nix', searching up
warning: Git tree '/home/matt/Projects/nixpkgs' is dirty
error: builder for '/nix/store/mn3r3r1rl12w5b9k2n6i7l15db4g12j5-jps-bootstrap-repository.drv' failed with exit code 1;
       last 2 log lines:
       > Buildfile: /nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/platform/jps-bootstrap/jps-bootstrap-classpath.xml does not exist!
       > Build failed
       For full logs, run 'nix log /nix/store/mn3r3r1rl12w5b9k2n6i7l15db4g12j5-jps-bootstrap-repository.drv'.
error: 1 dependencies of derivation '/nix/store/hvsxpp05f29y54wdm8zpr9rpb6awgwdj-jps-bootstrap-233.11799.298.drv' failed to build
error: 1 dependencies of derivation '/nix/store/mrmrah68rpqb93pn3wcz2g5yigi2ccnh-pycharm-community-233.11799.298.tar.gz.drv' failed to build
error (ignored): error: cannot unlink '/tmp/nix-build-libdbm-233.11799.298.drv-1/source/android/resources/images/material/icons/materialicons': Directory not empty
error (ignored): error: cannot unlink '/tmp/nix-build-fsnotifier-233.11799.298.drv-1/source/android/resources/images/material/icons/materialicons': Directory not empty
error: 1 dependencies of derivation '/nix/store/jvzqwdqwyiqfrc5idjjsaka2q0ww6yd7-pycharm-community-2023.3.1.drv' failed to build
```

Searching with `find` doesn't yield anything uesful:

```
$ find /nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/ -name "*jps*" -print
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/src/META-INF/services/org.jetbrains.jps.model.serialization.JpsModelSerializerExtension
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/vdcpdnwg8ln4p1ky6q07m4bnd1g80kw2-source/android/src/META-INF/services/org.jetbrains.jps.model.serialization.JpsModelSerializerExtension
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/vdcpdnwg8ln4p1ky6q07m4bnd1g80kw2-source/android/testData/snapshots/projects/jpsWithQualifiedNames
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/vdcpdnwg8ln4p1ky6q07m4bnd1g80kw2-source/android/testData/snapshots/sourceProviders/jpsWithQualifiedNames.txt
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/vdcpdnwg8ln4p1ky6q07m4bnd1g80kw2-source/android/testData/snapshots/projectViews/jpsWithQualifiedNames.txt
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/vdcpdnwg8ln4p1ky6q07m4bnd1g80kw2-source/jps-model
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/vdcpdnwg8ln4p1ky6q07m4bnd1g80kw2-source/jps-model/intellij.android.jps.model.iml
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/testData/snapshots/projects/jpsWithQualifiedNames
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/testData/snapshots/sourceProviders/jpsWithQualifiedNames.txt
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/android/testData/snapshots/projectViews/jpsWithQualifiedNames.txt
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/jps-model
/nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/jps-model/intellij.android.jps.model.iml
```

The suggested `nix log` command doesn't include anything that isn't already above:

```
$ nix log /nix/store/mn3r3r1rl12w5b9k2n6i7l15db4g12j5-jps-bootstrap-repository.drv
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/mn3r3r1rl12w5b9k2n6i7l15db4g12j5-jps-bootstrap-repository.drv^*'
Buildfile: /nix/store/dcgv46sisdh9kxpr9s6p2xrlz2dd515j-source/platform/jps-bootstrap/jps-bootstrap-classpath.xml does not exist!
Build failed
``` 

@GenericNerdyUsername @fabianhjr @dritter @wegank @danielslee

Therefore I'm marking this as a draft. If it is easier for someone more knowledgeable to work on this, feel free to take anything useful from this PR (no attribution required) and disregard.

Once `nix build .#jetbrains.pycharm-community` & `nix build .#jetbrains.idea-community` build & the jps hash is populated, the final step is to run `./source/build_maven.py source/idea_maven_artefacts.json result/`


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
