### PR TITLE
auto-gpt: init at 0.5.0

### DIFF
--- a/pkgs/by-name/au/auto-gpt/package.nix
+++ b/pkgs/by-name/au/auto-gpt/package.nix
@@ -1,0 +1,100 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+let
+  version = "0.5.0";
+  src = fetchFromGitHub {
+    owner = "Significant-Gravitas";
+    repo = "Auto-GPT";
+    rev = "autogpt-v${version}";
+    hash = "sha256-EkE4+mP341FOgLeD4BgkoSd5WTW5+wezYl+WudOGMLU=";
+    fetchSubmodules = true;
+  };
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "auto-gpt";
+  inherit version src;
+  format = "pyproject";
+
+  disabled = python3.pythonOlder "3.10";
+
+  sourceRoot = "${src.name}/autogpts/autogpt";
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    boto3
+    charset-normalizer
+    click
+    colorama
+    distro
+    docker
+    duckduckgo-search
+    # en-core-web-sm
+    fastapi
+    ftfy
+    google-api-python-client
+    gtts
+    hypercorn
+    inflection
+    jsonschema
+    numpy
+    openai
+    orjson
+    pillow
+    pinecone-client
+    playsound
+    prompt-toolkit
+    pydantic
+    pylatexenc
+    pypdf
+    python-docx
+    python-dotenv
+    pyyaml
+    readability-lxml
+    redis
+    requests
+    selenium
+    spacy
+    tiktoken
+    # webdriver-manager
+
+    # openapi-python-client
+
+    # agbenchmark
+    google-cloud-logging
+    google-cloud-storage
+    psycopg2
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    asynctest
+    coverage
+    pytest-asyncio
+    pytest-benchmark
+    pytest-cov
+    pytest-integration
+    pytest-mock
+    pytest-recording
+    pytest-xdist
+    vcrpy
+  ];
+
+  # asynctest is unmaintained and incompatible with 3.11
+  doCheck = false;
+
+  pythonImportsCheck = [ "autogpt" ];
+
+  meta = with lib; {
+    description = "An experimental open-source attempt to make GPT-4 fully autonomous";
+    homepage = "https://github.com/Significant-Gravitas/Auto-GPT";
+    changelog = "https://github.com/Significant-Gravitas/Auto-GPT/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ happysalada ];
+  };
+}


### PR DESCRIPTION
## Description of changes

I'm opening this PR just in case anyone is interested in taking over and finishing it.
there are a couple of things missing
packaging "forge" and agbenchmark from the repo and the auto-gpt-plugin-template dependency. 
it's 80% of the way there but it still needs a final push. I don't have time at the moment, so I would be happy for anyone to take over. I don't need attribution, and would be happy to review a PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
