### PR TITLE
callFunction: init

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -358,6 +358,7 @@ rec {
   makeScope = newScope: f:
     let self = f self // {
           newScope = scope: newScope (self // scope);
+          callFunction = callFunctionWith self;
           callPackage = self.newScope {};
           overrideScope = g: makeScope newScope (extends g f);
           # Remove after 24.11 is released.
@@ -433,6 +434,7 @@ rec {
       spliced = extra spliced0 // spliced0 // keep self;
       self = f self // {
         newScope = scope: newScope (spliced // scope);
+        callFunction = callFunctionWith spliced;
         callPackage = newScope spliced; # == self.newScope {};
         # N.B. the other stages of the package set spliced in are *not*
         # overridden.

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -181,6 +181,39 @@ rec {
       else result);
 
 
+  /* Call the function or file continaing a function `fn` with the required
+    arguments automatically.  This should be preferred over callPackage
+    when the result is not a derivation.  The function
+    is called with the arguments `args`, but any missing arguments are obtained
+    from `autoArgs`.  This function is intended to be partially
+    parameterised, e.g.,
+
+      ```nix
+      callFunction = callFunctionWith pkgs;
+      pkgs = {
+        pkgSet = callFunction ./foo.nix { };
+        helperFn = callFunction ./bar.nix { };
+      };
+      ```
+
+    If the `myPkgSet` function expects an argument named `makeScope`, it is
+    automatically passed as an argument.  Overrides or missing
+    arguments can be supplied in `args`, e.g.
+
+      ```nix
+      python3PkgSet = callFunction ./myPkgSet.nix {
+        newScope = python3.pkgs.newScope;
+      };
+      ```
+
+    <!-- TODO: Apply "Example:" tag to the examples above -->
+
+    Type:
+      callFunctionWith :: AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a
+  */
+  callFunctionWith = callFunctionWithContinuation "callFunctionWith" lib.id;
+
+
   /* Call the package function in the file `fn` with the required
     arguments automatically.  The function is called with the
     arguments `args`, but any missing arguments are obtained from

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -114,8 +114,8 @@ let
     inherit (self.stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (self.customisation) overrideDerivation makeOverridable
-      callPackageWith callPackagesWith extendDerivation hydraJob
-      makeScope makeScopeWithSplicing makeScopeWithSplicing';
+      callFunctionWith callPackageWith callPackagesWith extendDerivation
+      hydraJob makeScope makeScopeWithSplicing makeScopeWithSplicing';
     inherit (self.derivations) lazyDerivation;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -102,6 +102,8 @@ with pkgs;
 
   stringsWithDeps = lib.stringsWithDeps;
 
+  callFunction = lib.callFunctionWith pkgs;
+
   ### Evaluating the entire Nixpkgs naively will fail, make failure fast
   AAAAAASomeThingsFailToEvaluate = throw ''
     Please be informed that this pseudo-package is not the only part


### PR DESCRIPTION
## Description of changes

There's a lot of use cases within nixpkgs where we use `callPackage` when we don't really want to add a `.override` or `.overrideDerivation` method (because mkOverride is universally called) to the resulting attr set. Some examples:
- Package sets
- non-derivation AttrSets in general

However, `callPackage` is commonly used because it's so darn convenient. This just allows for an alternative. 
```
[00:34:21] jon@jon-desktop /home/jon/projects/nixpkgs (callfunction)
$ nix-instantiate --eval -E 'with import ./. {}; callFunction ({ python3 }: "python3 path: ${python3}") { }'
"python3 path: /nix/store/5k91mg4qjylxbfvrv748smfh51ppjq0g-python3-3.11.6"
[00:34:36] jon@jon-desktop /home/jon/projects/nixpkgs (callfunction)
$ nix-instantiate --eval -E 'with import ./. {}; callFunction ({ python3 }: "python3 path: ${python3}") { python3 = python39; }'
"python3 path: /nix/store/s8f7vcj0wc94vf12k6smlb7igbq9xmvl-python3-3.9.18"

$ nix-instantiate --eval -E 'with import ./. {}; callFunction ({ python3 }: "python3 path: ${python3}") { python310 = python39; }'
error:
       … from call site

         at «string»:1:21:

            1| with import ./. {}; callFunction ({ python3 }: "python3 path: ${python3}") { python310 = python39; }
             |                     ^

       … while calling 'callFunctionWith'

         at /home/jon/projects/nixpkgs/lib/customisation.nix:184:36:

          183|   */
          184|   callFunctionWith = autoArgs: fn: args:
             |                                    ^
          185|     let

       error: function 'anonymous lambda' called with unexpected argument 'python310'

       at «string»:1:35:

            1| with import ./. {}; callFunction ({ python3 }: "python3 path: ${python3}") { python310 = python39; }
             |                                   ^
       Did you mean python3?
```

When working on #272830, I noticed that if I called `protobufVersion` with `callPackage`, that the packages in the package set inherited `override` from the package set scope... which was awkward. So I used `import + inherit`, but a `callFunction` call would have been nicer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
