### PR TITLE
dep-scan: init at 5.0.2

### DIFF
--- a/pkgs/by-name/de/dep-scan/package.nix
+++ b/pkgs/by-name/de/dep-scan/package.nix
@@ -1,0 +1,66 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "dep-scan";
+  version = "5.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "owasp-dep-scan";
+    repo = "dep-scan";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-qiJyGBGxznNF4LNG9fbmjG7wX0odhrUO2LxOWABtLQA=";
+  };
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace " --cov-append --cov-report term --cov depscan" ""
+  '';
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    appthreat-vulnerability-db
+    defusedxml
+    jinja2
+    oras
+    pdfkit
+    pygithub
+    pyyaml
+    quart
+    rich
+    toml
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    httpretty
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "depscan"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTests = [
+    # Test is not present
+    "test_query_metadata2"
+  ];
+
+  meta = with lib; {
+    description = "Security and risk audit tool based on known vulnerabilities, advisories, and license limitations for project dependencies";
+    homepage = "https://github.com/owasp-dep-scan/dep-scan";
+    changelog = "https://github.com/owasp-dep-scan/dep-scan/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+    mainProgram = "dep-scan";
+  };
+}

--- a/pkgs/development/python-modules/oras/default.nix
+++ b/pkgs/development/python-modules/oras/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jsonschema
+, pytestCheckHook
+, pythonOlder
+, requests
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "oras";
+  version = "0.1.26";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "oras-project";
+    repo = "oras-py";
+    rev = "refs/tags/${version}";
+    hash = "sha256-t3098ZeAkwLhinyrFwmi7KKrFgZZKPN6qvp3REQNwG8=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    jsonschema
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "oras"
+  ];
+
+  disabledTests = [
+    # Test requires network access
+    "test_get_many_tags"
+  ];
+
+  meta = with lib; {
+    description = "ORAS Python SDK";
+    homepage = "https://github.com/oras-project/oras-py";
+    changelog = "https://github.com/oras-project/oras-py/blob/${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8653,6 +8653,8 @@ self: super: with self; {
 
   orange-widget-base = callPackage ../development/python-modules/orange-widget-base { };
 
+  oras = callPackage ../development/python-modules/oras { };
+
   orderedmultidict = callPackage ../development/python-modules/orderedmultidict { };
 
   ordered-set = callPackage ../development/python-modules/ordered-set { };


### PR DESCRIPTION
## Description of changes
Security and risk audit tool based on known vulnerabilities,
advisories, and license limitations for project dependencies

https://github.com/owasp-dep-scan/dep-scan

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
