### PR TITLE
[23.11] wrangler: fix darwin build

### DIFF
--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -420,6 +420,15 @@ final: prev: {
 
   wrangler = prev.wrangler.override (oldAttrs:
     let
+      workerd = {
+        name = "workerd";
+        packageName = "workerd";
+        version = "1.20231030.0";
+        src = fetchurl {
+          url = "https://registry.npmjs.org/workerd/-/workerd-1.20231030.0.tgz";
+          sha512 = "36r129nzz4caz8i44blbbd2isfgypn6jdbprggif8vzy1pbj7zndrn2mq19hkrppxnfpp0zrg8rj3zls7zib9vniimw8zzmvpwrcm7q";
+        };
+      };
       linuxWorkerd = {
         name = "_at_cloudflare_slash_workerd-linux-64";
         packageName = "@cloudflare/workerd-linux-64";
@@ -469,7 +478,8 @@ final: prev: {
         # patch elf is trying to patch binary for sunos
         rm -r $out/lib/node_modules/wrangler/node_modules/@esbuild/sunos-x64
       '';
-      dependencies = oldAttrs.dependencies
+      dependencies = builtins.filter (d: d.packageName != "workerd") oldAttrs.dependencies
+        ++ [ workerd ]
         ++ lib.optional (stdenv.isLinux && stdenv.isx86_64) linuxWorkerd
         ++ lib.optional (stdenv.isLinux && stdenv.isAarch64) linuxWorkerdArm
         ++ lib.optional (stdenv.isDarwin && stdenv.isx86_64) darwinWorkerd


### PR DESCRIPTION
## Description of changes

Updates the workerd dependency to fix darwin builds until the next nodePackages bump.
This is a fix for the following backports:
- #272831
- #273648

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
