### PR TITLE
waagent: cleanups

### DIFF
--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -245,6 +245,27 @@ in
         pkgs.e2fsprogs
         pkgs.bash
 
+        pkgs.findutils
+        pkgs.gnugrep
+        pkgs.gnused
+        pkgs.iproute2
+        pkgs.iptables
+
+        # for hostname
+        pkgs.nettools
+
+        pkgs.openssh
+        pkgs.openssl
+        pkgs.parted
+
+        # for pidof
+        pkgs.procps
+
+        # for useradd, usermod
+        pkgs.shadow
+
+        pkgs.util-linux # for (u)mount, fdisk, sfdisk, mkswap
+
         # waagent's Microsoft.OSTCExtensions.VMAccessForLinux needs Python 3
         pkgs.python39
 

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -202,6 +202,13 @@ in
 
     services.udev.packages = [ pkgs.waagent ];
 
+    # Provide waagent-shipped udev rules in initrd too.
+    boot.initrd.services.udev.packages = [ pkgs.waagent ];
+    # udev rules shell out to chmod, cut and readlink, which are all
+    # provided by pkgs.coreutils, which is in services.udev.path, but not
+    # boot.initrd.services.udev.binPackages.
+    boot.initrd.services.udev.binPackages = [ pkgs.coreutils ];
+
     networking.dhcpcd.persistent = true;
 
     services.logrotate = {

--- a/pkgs/applications/networking/cluster/waagent/default.nix
+++ b/pkgs/applications/networking/cluster/waagent/default.nix
@@ -20,7 +20,7 @@ let
   inherit (lib) makeBinPath;
 
 in
-python39.pkgs.buildPythonPackage rec {
+python39.pkgs.buildPythonApplication rec {
   pname = "waagent";
   version = "2.8.0.11";
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/waagent/default.nix
+++ b/pkgs/applications/networking/cluster/waagent/default.nix
@@ -63,11 +63,12 @@ python39.pkgs.buildPythonApplication rec {
   '';
 
   meta = {
-    description = "The Microsoft Azure Linux Agent (waagent)
-                   manages Linux provisioning and VM interaction with the Azure
-                   Fabric Controller";
+    description = "The Microsoft Azure Linux Agent (waagent)";
+    longDescription = ''
+      The Microsoft Azure Linux Agent (waagent)
+      manages Linux provisioning and VM interaction with the Azure
+      Fabric Controller'';
     homepage = "https://github.com/Azure/WALinuxAgent";
     license = with lib.licenses; [ asl20 ];
   };
-
 }

--- a/pkgs/applications/networking/cluster/waagent/default.nix
+++ b/pkgs/applications/networking/cluster/waagent/default.nix
@@ -1,18 +1,9 @@
-{ fetchFromGitHub
-, findutils
-, gnugrep
-, gnused
-, iproute2
-, iptables
+{ bash
+, coreutils
+, fetchFromGitHub
 , lib
-, nettools
-, openssh
-, openssl
-, parted
-, procps
 , python39
-, shadow
-, util-linux
+, substituteAll
 }:
 
 let
@@ -46,26 +37,6 @@ python.pkgs.buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [ python.pkgs.distro ];
-
-  makeWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    (lib.makeBinPath [
-      findutils
-      gnugrep
-      gnused
-      iproute2
-      iptables
-      nettools # for hostname
-      openssh
-      openssl
-      parted
-      procps # for pidof
-      shadow # for useradd, usermod
-      util-linux # for (u)mount, fdisk, sfdisk, mkswap
-    ])
-  ];
 
   # The binary entrypoint and udev rules are placed to the wrong place.
   # Move them to their default location.

--- a/pkgs/applications/networking/cluster/waagent/default.nix
+++ b/pkgs/applications/networking/cluster/waagent/default.nix
@@ -1,18 +1,19 @@
-{ fetchFromGitHub,
-  findutils,
-  gnugrep,
-  gnused,
-  iproute2,
-  iptables,
-  lib,
-  nettools, # for hostname
-  openssh,
-  openssl,
-  parted,
-  procps, # for pidof,
-  python39, # the latest python version that waagent test against according to https://github.com/Azure/WALinuxAgent/blob/28345a55f9b21dae89472111635fd6e41809d958/.github/workflows/ci_pr.yml#L75
-  shadow, # for useradd, usermod
-  util-linux, # for (u)mount, fdisk, sfdisk, mkswap
+{ fetchFromGitHub
+, findutils
+, gnugrep
+, gnused
+, iproute2
+, iptables
+, lib
+, nettools
+, openssh
+, openssl
+, parted
+, procps
+  # the latest python version that waagent test against according to https://github.com/Azure/WALinuxAgent/blob/28345a55f9b21dae89472111635fd6e41809d958/.github/workflows/ci_pr.yml#L75
+, python39
+, shadow
+, util-linux
 }:
 
 let
@@ -52,13 +53,13 @@ python39.pkgs.buildPythonPackage rec {
   ];
 
   fixupPhase = ''
-     mkdir -p $out/bin/
-     WAAGENT=$(find $out -name waagent | grep sbin)
-     cp $WAAGENT $out/bin/waagent
-     wrapProgram "$out/bin/waagent" \
-         --prefix PYTHONPATH : $PYTHONPATH \
-         --prefix PATH : "${makeBinPath runtimeDeps}"
-     patchShebangs --build "$out/bin/"
+    mkdir -p $out/bin/
+    WAAGENT=$(find $out -name waagent | grep sbin)
+    cp $WAAGENT $out/bin/waagent
+    wrapProgram "$out/bin/waagent" \
+        --prefix PYTHONPATH : $PYTHONPATH \
+        --prefix PATH : "${makeBinPath runtimeDeps}"
+    patchShebangs --build "$out/bin/"
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes
This cleans up the waagent package, fixes its shipped udev rules to work again (by moving them to `$out/etc/udev/rules.d`), and moves all necessary $PATH dependencies of the `waagent` binary to the NixOS module.

This depends on https://github.com/NixOS/nixpkgs/pull/274264 (cherry-picked into here), so the udev rule works in initrd, too.

See individual commits for details.

Supersedes #269516.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
