### PR TITLE
emacs: darwin: use architecture-native SDK

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -4,25 +4,14 @@ lib.makeScope pkgs.newScope (self:
   let
     gconf = pkgs.gnome2.GConf;
     inherit (self) callPackage;
-    stdenv = if pkgs.stdenv.isDarwin
-             then pkgs.darwin.apple_sdk_11_0.stdenv
-             else pkgs.stdenv;
     inheritedArgs = {
       inherit gconf;
-      inherit stdenv;
 
       inherit (pkgs.darwin) sigtool;
-      inherit (pkgs.darwin.apple_sdk_11_0) llvmPackages_14;
-      inherit (pkgs.darwin.apple_sdk_11_0.frameworks)
+      inherit (pkgs.darwin.apple_sdk.frameworks)
         Accelerate AppKit Carbon Cocoa GSS ImageCaptureCore ImageIO IOKit OSAKit
-        Quartz QuartzCore UniformTypeIdentifiers WebKit;
-      gnutls =
-        if pkgs.stdenv.isDarwin
-        then pkgs.gnutls.override {
-          inherit stdenv;
-          inherit (pkgs.darwin.apple_sdk_11_0.frameworks) Security;
-        }
-        else pkgs.gnutls;
+        Quartz QuartzCore WebKit;
+      inherit (pkgs.darwin.apple_sdk_11_0.frameworks) UniformTypeIdentifiers;
     };
   in {
     sources = import ./sources.nix {

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -293,12 +293,13 @@ mkDerivation (finalAttrs: {
     OSAKit
     Quartz
     QuartzCore
-    UniformTypeIdentifiers
     WebKit
     # TODO are these optional?
     GSS
     ImageCaptureCore
     ImageIO
+  ] ++ lib.optionals (variant == "macport" && stdenv.hostPlatform.isAarch64) [
+    UniformTypeIdentifiers
   ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31360,7 +31360,7 @@ with pkgs;
 
   em = callPackage ../applications/editors/em { };
 
-  inherit (recurseIntoAttrs (darwin.apple_sdk_11_0.callPackage ../applications/editors/emacs { }))
+  inherit (recurseIntoAttrs (callPackage ../applications/editors/emacs { }))
     emacs28
     emacs28-gtk2
     emacs28-gtk3


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#253892 bumped the Emacs derivations to `apple_sdk_11_0` for headers required by the Mac port on Apple Silicon Macs. That change [caused] many [issues] on older macOS versions. This change switches back to the platform-native SDK (10.12 on `x86_64-darwin` and 11.0 on `aarch64-darwin`) and gates the newly required headers by architecture.

CC @quentinmit and @knl. I tested `emacs-macport` for `x86_64-darwin` and the problematic `aligned_alloc` isn't being imported anymore, but I would appreciate confirmation from your end.

[caused]: https://github.com/NixOS/nixpkgs/issues/253502
[issues]: https://github.com/NixOS/nixpkgs/pull/253892#issuecomment-1843836896

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
