### PR TITLE
rapidcheck: Simplify installation, update, pkg-config

### DIFF
--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -16,19 +16,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-nq2VBDREkAOnvtdYr3m0TYNXx7mv9hbV5HZFVL2uTTg=";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "RC_INSTALL_ALL_EXTRAS" true)
   ];
-
-  # Install the extras headers
-  postInstall = ''
-    cp -r $src/extras $out
-    chmod -R +w $out/extras
-    rm $out/extras/CMakeLists.txt
-    rm $out/extras/**/CMakeLists.txt
-  '';
 
   passthru.updateScript = unstableGitUpdater { };
 

--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -3,9 +3,10 @@
 , fetchFromGitHub
 , cmake
 , unstableGitUpdater
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rapidcheck";
   version = "unstable-2023-12-14";
 
@@ -25,13 +26,25 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "RC_INSTALL_ALL_EXTRAS" true)
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
 
   meta = with lib; {
     description = "A C++ framework for property based testing inspired by QuickCheck";
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     maintainers = with maintainers; [ ];
     license = licenses.bsd2;
+    pkgConfigModules = [
+      "rapidcheck"
+      # Extras
+      "rapidcheck_boost"
+      "rapidcheck_boost_test"
+      "rapidcheck_catch"
+      "rapidcheck_doctest"
+      "rapidcheck_gtest"
+    ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rapidcheck";
-  version = "unstable-2023-04-16";
+  version = "unstable-2023-12-14";
 
   src = fetchFromGitHub {
     owner = "emil-e";
     repo  = "rapidcheck";
-    rev   = "a5724ea5b0b00147109b0605c377f1e54c353ba2";
-    hash = "sha256-nq2VBDREkAOnvtdYr3m0TYNXx7mv9hbV5HZFVL2uTTg=";
+    rev   = "ff6af6fc683159deb51c543b065eba14dfcf329b";
+    hash = "sha256-Ixz5RpY0n8Un/Pv4XoTfbs40+70iyMbkQUjDqoLaWOg=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -182,8 +182,6 @@ self = stdenv.mkDerivation {
     "--enable-gc"
   ] ++ lib.optionals (!enableDocumentation) [
     "--disable-doc-gen"
-  ] ++ lib.optionals atLeast214 [
-    "CXXFLAGS=-I${lib.getDev rapidcheck}/extras/gtest/include"
   ] ++ lib.optionals stdenv.isLinux [
     "--with-sandbox-shell=${busybox-sandbox-shell}/bin/busybox"
   ] ++ lib.optionals (atLeast210 && stdenv.isLinux && stdenv.hostPlatform.isStatic) [


### PR DESCRIPTION
## Description of changes

### Simplify installation

We had neglected to nice `RC_INSTALL_ALL_EXTRAS`, which will take care of installing the extras for us.

Now that they are in a standard directory, we don't need to smuggle in the extra `-I` for Nix's tests either.

### Update

unstable-2023-04-16 -> unstable-2023-08-15

### Add `meta.pkgConfigModules` and test

The last update added pkg-config support, from https://github.com/emil-e/rapidcheck/pull/319
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
