### PR TITLE
trunk: 0.17.2 -> 0.18.0

### DIFF
--- a/pkgs/development/tools/trunk/default.nix
+++ b/pkgs/development/tools/trunk/default.nix
@@ -1,26 +1,56 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config
-, openssl, libiconv, CoreServices, Security }:
+{ lib,
+stdenv,
+rustPlatform,
+fetchFromGitHub,
+pkg-config,
+openssl,
+libiconv,
+jq,
+moreutils,
+CoreServices,
+Security
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "trunk";
-  version = "0.17.2";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "thedodd";
     repo = "trunk";
     rev = "v${version}";
-    sha256 = "sha256-A6h8TmYK5WOcmANk/uM9QO1h767BWASWTwLthtKqrEk=";
+    hash = "sha256-riebGbDCqkJTkDmvXCuD0ywjSfGfLgxywkHUPlGzCgI=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = if stdenv.isDarwin
     then [ libiconv CoreServices Security ]
     else [ openssl ];
-
   # requires network
   checkFlags = [ "--skip=tools::tests::download_and_install_binaries" ];
 
-  cargoHash = "sha256-+jz0J1qFK2fZ4OX089pgNtT2vfiOTf39qQjeXmLoFNs=";
+  cargoHash = "sha256-O2AKIOvAwDpZDzEyc/x5lF0E0UR+Mj/J///1bYRgoX4=";
+
+  # the dependency css-minify contains both README.md and Readme.md,
+  # which causes a hash mismatch on systems with a case-insensitive filesystem
+  # this removes the readme files and updates cargo's checksum file accordingly
+  depsExtraArgs = {
+    nativeBuildInputs = [
+      jq
+      moreutils
+    ];
+
+    postBuild = ''
+      pushd $name/css-minify
+
+      rm -f README.md Readme.md
+      jq 'del(.files."README.md") | del(.files."Readme.md")' \
+        .cargo-checksum.json -c \
+        | sponge .cargo-checksum.json
+
+      popd
+    '';
+  };
 
   meta = with lib; {
     homepage = "https://github.com/thedodd/trunk";


### PR DESCRIPTION
## Description of changes

fixes https://github.com/NixOS/nixpkgs/issues/274133

https://github.com/trunk-rs/trunk/releases/tag/v0.18.0
https://github.com/trunk-rs/trunk/compare/v0.17.2...v0.18.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
