### PR TITLE
mkvtoolnix: use utf8cpp from nixpkgs

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -25,6 +25,7 @@
 , pugixml
 , qtbase
 , qtmultimedia
+, utf8cpp
 , xdg-utils
 , zlib
 , withGUI ? true
@@ -32,7 +33,8 @@
 }:
 
 let
-  inherit (lib) enableFeature optional optionals optionalString;
+  inherit (lib)
+    enableFeature getDev getLib optionals optionalString;
 
   phase = name: args:
     ''
@@ -64,10 +66,9 @@ stdenv.mkDerivation rec {
     pkg-config
     rake
   ]
-  ++ optional withGUI wrapQtAppsHook;
+  ++ optionals withGUI [ wrapQtAppsHook ];
 
-  # 1. qtbase and qtmultimedia are needed without the GUI
-  # 2. we have utf8cpp in nixpkgs but it doesn't find it
+  # qtbase and qtmultimedia are needed without the GUI
   buildInputs = [
     boost
     expat
@@ -84,11 +85,12 @@ stdenv.mkDerivation rec {
     pugixml
     qtbase
     qtmultimedia
+    utf8cpp
     xdg-utils
     zlib
   ]
-  ++ optional withGUI cmark
-  ++ optional stdenv.isDarwin libiconv;
+  ++ optionals withGUI [ cmark ]
+  ++ optionals stdenv.isDarwin [ libiconv ];
 
   # autoupdate is not needed but it silences a ton of pointless warnings
   postPatch = ''
@@ -103,9 +105,11 @@ stdenv.mkDerivation rec {
     "--disable-static-qt"
     "--disable-update-check"
     "--enable-optimization"
-    "--with-boost-libdir=${lib.getLib boost}/lib"
+    "--with-boost-libdir=${getLib boost}/lib"
     "--with-docbook-xsl-root=${docbook_xsl}/share/xml/docbook-xsl"
     "--with-gettext"
+    "--with-extra-includes=${getDev utf8cpp}/include/utf8cpp"
+    "--with-extra-libs=${getLib utf8cpp}/lib"
     (enableFeature withGUI "gui")
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24023,7 +24023,7 @@ with pkgs;
 
   minizip-ng = callPackage ../development/libraries/minizip-ng { };
 
-  mkvtoolnix = libsForQt5.callPackage ../applications/video/mkvtoolnix {
+  mkvtoolnix = qt6Packages.callPackage ../applications/video/mkvtoolnix {
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
   };
 


### PR DESCRIPTION
## Description of changes

We carry utf8cpp in nixpkgs so just use that.

Also build against qt6 as the next version of mkvtoolnix will drop qt5 support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
