### PR TITLE
jiten: cherry-pick test fix from upstream

### DIFF
--- a/pkgs/applications/misc/jiten/cookie-fix.patch
+++ b/pkgs/applications/misc/jiten/cookie-fix.patch
@@ -1,0 +1,39 @@
+diff --git a/jiten/app.py b/jiten/app.py
+index 6d54020..f30a1d8 100644
+--- a/jiten/app.py
++++ b/jiten/app.py
+@@ -149,13 +149,22 @@ True
+ >>> d.index("JLPT N3") < d.index("歯", d.index("JLPT N5")) < d.index("JLPT N2")
+ True
+ 
+->>> sorted( (c.name, c.value) for c in client.cookie_jar )
++>>> def cookies():
++...   import importlib.metadata
++...   v = tuple(map(int, importlib.metadata.version("werkzeug").split(".")))
++...   if v < (2, 3):
++...     return sorted( (c.name, c.value) for c in client.cookie_jar )
++...   else:
++...     cookies = [ client.get_cookie(k) for k in PREFS ]
++...     return sorted( (c.key, c.value) for c in cookies if c is not None )
++
++>>> cookies()
+ []
+ >>> p = dict(dark = "yes", lang = "eng ger oops".split())
+ >>> r = client.post("/_save_prefs", data = p, follow_redirects = True)
+ >>> r.status
+ '200 OK'
+->>> sorted( (c.name, c.value) for c in client.cookie_jar )
++>>> cookies()
+ [('dark', 'yes'), ('lang', '"eng ger"'), ('large', 'no'), ('max', '50'), ('nogrid', 'no'), ('nor2h', 'no'), ('roma', 'no')]
+ 
+ """                                                             # }}}1
+@@ -168,8 +177,7 @@ import kanjidraw
+ import click, flask, jinja2, werkzeug
+ 
+ os.environ["FLASK_SKIP_DOTENV"] = "yes"                       #  FIXME
+-from flask import Flask, abort, escape, make_response, redirect, \
+-                  request, render_template, url_for
++from flask import Flask, abort, make_response, redirect, request, render_template, url_for
+ 
+ from .version import __version__, py_version
+ from .kana import kana2romaji

--- a/pkgs/applications/misc/jiten/default.nix
+++ b/pkgs/applications/misc/jiten/default.nix
@@ -27,6 +27,12 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "16sz8i0sw7ggy6kijcx4qyl2zr6xj789x4iav0yyllx12dfgp5b1";
   };
 
+  patches = [
+    # Potentially can be dropped after the next release
+    # https://github.com/NixOS/nixpkgs/issues/271600
+    ./cookie-fix.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ pcre sqlite ];
   propagatedBuildInputs = with python3.pkgs; [ click flask kanjidraw ];


### PR DESCRIPTION
## Description of changes

The build of jiten is broken due to a test failure.

This fixes https://github.com/NixOS/nixpkgs/issues/271600 by cherry-picking an unreleased patch from upstream, as discussed on the issue thread.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
