### PR TITLE
git: re-enable some tests and fix update script path

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -315,11 +315,17 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace t/test-lib.sh \
       --replace "test_set_prereq POSIXPERM" ""
     # TODO: Investigate while these still fail (without POSIXPERM):
+    # Tested to fail: 2.43.0
     disable_test t0001-init 'shared overrides system'
+    # Tested to fail: 2.43.0
     disable_test t0001-init 'init honors global core.sharedRepository'
+    # Tested to fail: 2.43.0
     disable_test t1301-shared-repo
+    # Tested to fail: 2.43.0
     # git-completion.bash: line 405: compgen: command not found:
     disable_test t9902-completion 'option aliases are shown with GIT_COMPLETION_SHOW_ALL'
+    # Tested to fail: 2.43.0
+    disable_test t9902-completion "sourcing the completion script clears cached --options"
 
     # Our patched gettext never fallbacks
     disable_test t0201-gettext-fallbacks
@@ -329,28 +335,12 @@ stdenv.mkDerivation (finalAttrs: {
       disable_test t9001-send-email
     ''}
 
-    # XXX: I failed to understand why this one fails.
-    # Could someone try to re-enable it on the next release ?
-    # Tested to fail: 2.18.0 and 2.19.0
-    disable_test t1700-split-index "null sha1"
-
-    # Tested to fail: 2.18.0
-    disable_test t9902-completion "sourcing the completion script clears cached --options"
-
     # Flaky tests:
-    disable_test t5319-multi-pack-index
     disable_test t6421-merge-partial-clone
 
     # Fails reproducibly on ZFS on Linux with formD normalization
     disable_test t0021-conversion
     disable_test t3910-mac-os-precompose
-
-    ${lib.optionalString (!perlSupport) ''
-      # request-pull is a Bash script that invokes Perl, so it is not available
-      # when NO_PERL=1, and the test should be skipped, but the test suite does
-      # not check for the Perl prerequisite.
-      disable_test t5150-request-pull
-    ''}
   '' + lib.optionalString stdenv.isDarwin ''
     # XXX: Some tests added in 2.24.0 fail.
     # Please try to re-enable on the next release.

--- a/pkgs/applications/version-management/git/update.sh
+++ b/pkgs/applications/version-management/git/update.sh
@@ -10,7 +10,7 @@ targetVersion="${1:-$latestTag}"
 if [ ! "${oldVersion}" = "${targetVersion}" ]; then
   update-source-version git "${targetVersion}"
   nixpkgs="$(git rev-parse --show-toplevel)"
-  default_nix="$nixpkgs/pkgs/applications/version-management/git-and-tools/git/default.nix"
+  default_nix="$nixpkgs/pkgs/applications/version-management/git/default.nix"
   nix-build -A git
   git add "${default_nix}"
   git commit -m "git: ${oldVersion} -> ${targetVersion}"


### PR DESCRIPTION
## Description of changes

When fiddeling a bit with the git source-code I realized that the following tests have been fixed upstream and can be reenabled here:
- t5150: now has the proper perl prerequisite check: https://git.kernel.org/pub/scm/git/git.git/tree/t/t5150-request-pull.sh?h=v2.43.0#n10
- t5319: flake was fixed: https://git.kernel.org/pub/scm/git/git.git/commit/?id=152923b132d57e1dbd693a8cb9a8bc1827405674
- t1700: no idea what did the fix, but it is working again

Also fixed the path in the update script. Since it has been broken for quite a while, it does not really seem to be used, so is it still needed?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Maintainers: @primeos @wmertens @globin @kashw2

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
