### PR TITLE
mesa: backport patches to fix build on Darwin and 32-bit platforms

### DIFF
--- a/pkgs/development/libraries/mesa/backports/0001-dri-added-build-dependencies-for-systems-using-non-s.patch
+++ b/pkgs/development/libraries/mesa/backports/0001-dri-added-build-dependencies-for-systems-using-non-s.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "duncan.hopkins" <duncan.hopkins@foundry.com>
+Date: Tue, 17 Oct 2023 09:34:31 +0100
+Subject: [PATCH] dri: added build dependencies for systems using non-standard
+ prefixed X11 libs.
+
+To get MacOS to build, some extra dependencies need to be added to a couple of build targets.
+This mainly shows up when not installing the dependencies in the default prefix locations.
+On MacOS, this happens when using a custom build of brew to install the dependencies to 'odd' locations.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25992>
+---
+ src/gallium/targets/dri/meson.build | 2 +-
+ src/glx/meson.build                 | 2 +-
+ src/loader/meson.build              | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/gallium/targets/dri/meson.build b/src/gallium/targets/dri/meson.build
+index 66619bba0db..6d3ef197e74 100644
+--- a/src/gallium/targets/dri/meson.build
++++ b/src/gallium/targets/dri/meson.build
+@@ -49,7 +49,7 @@ libgallium_dri = shared_library(
+   link_depends : gallium_dri_link_depends,
+   link_with : [
+     libdri, libmesa, libgalliumvl,
+-    libgallium, libglapi, libpipe_loader_static, libws_null, libwsw, libswdri,
++    libgallium, libglapi, libloader, libpipe_loader_static, libws_null, libwsw, libswdri,
+     libswkmsdri,
+   ],
+   dependencies : [
+diff --git a/src/glx/meson.build b/src/glx/meson.build
+index 7ec3e3e0d88..1a5e9833956 100644
+--- a/src/glx/meson.build
++++ b/src/glx/meson.build
+@@ -136,7 +136,7 @@ libglx = static_library(
+   ],
+   dependencies : [
+     idep_mesautil, idep_xmlconfig,
+-    dep_libdrm, dep_dri2proto, dep_glproto, dep_x11, dep_glvnd, dep_xxf86vm, dep_xshmfence
++    dep_libdrm, dep_dri2proto, dep_glproto, dep_x11, dep_xext, dep_glvnd, dep_xxf86vm, dep_xshmfence
+   ],
+ )
+ 
+diff --git a/src/loader/meson.build b/src/loader/meson.build
+index 35f9991ba2f..043cc852112 100644
+--- a/src/loader/meson.build
++++ b/src/loader/meson.build
+@@ -47,6 +47,6 @@ libloader = static_library(
+   c_args : loader_c_args,
+   gnu_symbol_visibility : 'hidden',
+   include_directories : [inc_include, inc_src, inc_util],
+-  dependencies : [dep_libdrm, dep_thread, dep_xcb_xrandr],
++  dependencies : [dep_libdrm, dep_thread, dep_xcb, dep_xcb_xrandr],
+   build_by_default : false,
+ )

--- a/pkgs/development/libraries/mesa/backports/0002-util-Update-util-libdrm.h-stubs-to-allow-loader.c-to.patch
+++ b/pkgs/development/libraries/mesa/backports/0002-util-Update-util-libdrm.h-stubs-to-allow-loader.c-to.patch
@@ -1,0 +1,103 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "duncan.hopkins" <duncan.hopkins@foundry.com>
+Date: Tue, 17 Oct 2023 14:36:39 +0100
+Subject: [PATCH] util: Update util/libdrm.h stubs to allow loader.c to compile
+ on MacOS.
+
+MacOS does not have the libdrm libraries so is missing xf86drm.h.
+util/libdrm.h already has a collection of stubs for systems that do not support the libraries.
+
+A compile on MacOS will fail with the source that uses newer drm functions and structures.
+Update adds in missing items that MacOS code needs to compile and run.
+New code is copied from the public repository: https://gitlab.freedesktop.org/mesa/drm/-/blob/main/xf86drm.h
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25992>
+---
+ src/util/libdrm.h | 57 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 57 insertions(+)
+
+diff --git a/src/util/libdrm.h b/src/util/libdrm.h
+index cc153cf88ab..e3af494b8d1 100644
+--- a/src/util/libdrm.h
++++ b/src/util/libdrm.h
+@@ -44,22 +44,79 @@
+ #define DRM_BUS_PLATFORM  2
+ #define DRM_BUS_HOST1X    3
+ 
++typedef struct _drmPciDeviceInfo {
++    uint16_t vendor_id;
++    uint16_t device_id;
++    uint16_t subvendor_id;
++    uint16_t subdevice_id;
++    uint8_t revision_id;
++} drmPciDeviceInfo, *drmPciDeviceInfoPtr;
++
++#define DRM_PLATFORM_DEVICE_NAME_LEN 512
++
++typedef struct _drmPlatformBusInfo {
++    char fullname[DRM_PLATFORM_DEVICE_NAME_LEN];
++} drmPlatformBusInfo, *drmPlatformBusInfoPtr;
++
++typedef struct _drmPlatformDeviceInfo {
++    char **compatible; /* NULL terminated list of compatible strings */
++} drmPlatformDeviceInfo, *drmPlatformDeviceInfoPtr;
++
++#define DRM_HOST1X_DEVICE_NAME_LEN 512
++
++typedef struct _drmHost1xBusInfo {
++    char fullname[DRM_HOST1X_DEVICE_NAME_LEN];
++} drmHost1xBusInfo, *drmHost1xBusInfoPtr;
++
++typedef struct _drmPciBusInfo {
++   uint16_t domain;
++   uint8_t bus;
++   uint8_t dev;
++   uint8_t func;
++} drmPciBusInfo, *drmPciBusInfoPtr;
++
+ typedef struct _drmDevice {
+     char **nodes; /* DRM_NODE_MAX sized array */
+     int available_nodes; /* DRM_NODE_* bitmask */
+     int bustype;
++    union {
++       drmPciBusInfoPtr pci;
++       drmPlatformBusInfoPtr platform;
++       drmHost1xBusInfoPtr host1x;
++    } businfo;
++    union {
++        drmPciDeviceInfoPtr pci;
++    } deviceinfo;
+     /* ... */
+ } drmDevice, *drmDevicePtr;
+ 
++static inline int
++drmGetDevice2(int fd, uint32_t flags, drmDevicePtr *device)
++{
++   return -ENOENT;
++}
++
+ static inline int
+ drmGetDevices2(uint32_t flags, drmDevicePtr devices[], int max_devices)
+ {
+    return -ENOENT;
+ }
+ 
++static inline int
++drmGetDeviceFromDevId(dev_t dev_id, uint32_t flags, drmDevicePtr *device)
++{
++   return -ENOENT;
++}
++
++static inline void
++drmFreeDevice(drmDevicePtr *device) {}
++
+ static inline void
+ drmFreeDevices(drmDevicePtr devices[], int count) {}
+ 
++static inline char*
++drmGetDeviceNameFromFd2(int fd) { return NULL;}
++
+ typedef struct _drmVersion {
+     int     version_major;        /**< Major version */
+     int     version_minor;        /**< Minor version */

--- a/pkgs/development/libraries/mesa/backports/0003-glx-fix-automatic-zink-fallback-loading-between-hw-a.patch
+++ b/pkgs/development/libraries/mesa/backports/0003-glx-fix-automatic-zink-fallback-loading-between-hw-a.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "duncan.hopkins" <duncan.hopkins@foundry.com>
+Date: Wed, 1 Nov 2023 11:31:13 +0000
+Subject: [PATCH] glx: fix automatic zink fallback loading between hw and sw
+ drivers on MacOS
+
+The combination of defines used when compile the code on MacOS is hiding variables.
+Patch allows basic MacOS build to compile and run.
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25992>
+---
+ src/glx/glxext.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/glx/glxext.c b/src/glx/glxext.c
+index 7712e54c1d6..454f2c36a77 100644
+--- a/src/glx/glxext.c
++++ b/src/glx/glxext.c
+@@ -878,12 +878,16 @@ __glXInitialize(Display * dpy)
+ 
+    dpyPriv->glXDrawHash = __glxHashCreate();
+ 
++   Bool zink = False;
++   Bool try_zink = False;
++
+ #if defined(GLX_DIRECT_RENDERING) && !defined(GLX_USE_APPLEGL)
+    Bool glx_direct = !debug_get_bool_option("LIBGL_ALWAYS_INDIRECT", false);
+    Bool glx_accel = !debug_get_bool_option("LIBGL_ALWAYS_SOFTWARE", false);
+    const char *env = getenv("MESA_LOADER_DRIVER_OVERRIDE");
+-   Bool zink = env && !strcmp(env, "zink");
+-   Bool try_zink = False;
++
++   zink = env && !strcmp(env, "zink");
++   try_zink = False;
+ 
+    dpyPriv->drawHash = __glxHashCreate();
+ 
+@@ -928,12 +932,14 @@ __glXInitialize(Display * dpy)
+ 
+    if (!AllocAndFetchScreenConfigs(dpy, dpyPriv, zink | try_zink)) {
+       Bool fail = True;
++#if defined(GLX_DIRECT_RENDERING) && !defined(GLX_USE_APPLEGL)
+       if (try_zink) {
+          free(dpyPriv->screens);
+          dpyPriv->driswDisplay->destroyDisplay(dpyPriv->driswDisplay);
+          dpyPriv->driswDisplay = driswCreateDisplay(dpy, false);
+          fail = !AllocAndFetchScreenConfigs(dpy, dpyPriv, False);
+       }
++#endif
+       if (fail) {
+          free(dpyPriv);
+          return NULL;

--- a/pkgs/development/libraries/mesa/backports/0004-d3d12-Fix-AV1-video-encode-32-bits-build.patch
+++ b/pkgs/development/libraries/mesa/backports/0004-d3d12-Fix-AV1-video-encode-32-bits-build.patch
@@ -1,0 +1,270 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sil Vilerino <sivileri@microsoft.com>
+Date: Wed, 6 Dec 2023 20:09:44 -0500
+Subject: [PATCH] d3d12: Fix AV1 video encode 32 bits build
+
+Reviewed-by: Jesse Natalie <jenatali@microsoft.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/26573>
+---
+ .../drivers/d3d12/d3d12_video_enc_av1.cpp     | 58 +++++++++----------
+ ...12_video_encoder_bitstream_builder_av1.cpp | 10 ++--
+ ...2_video_encoder_references_manager_av1.cpp |  2 +-
+ 3 files changed, 35 insertions(+), 35 deletions(-)
+
+diff --git a/src/gallium/drivers/d3d12/d3d12_video_enc_av1.cpp b/src/gallium/drivers/d3d12/d3d12_video_enc_av1.cpp
+index 2c1964aa274..a5e2a2e3d39 100644
+--- a/src/gallium/drivers/d3d12/d3d12_video_enc_av1.cpp
++++ b/src/gallium/drivers/d3d12/d3d12_video_enc_av1.cpp
+@@ -2189,7 +2189,7 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+          writtenTemporalDelimBytes                      // Bytes Written AFTER placingPositionStart arg above
+       );
+       assert(pD3D12Enc->m_BitstreamHeadersBuffer.size() == writtenTemporalDelimBytes);
+-      debug_printf("Written OBU_TEMPORAL_DELIMITER bytes: %" PRIu64 "\n", writtenTemporalDelimBytes);
++      debug_printf("Written OBU_TEMPORAL_DELIMITER bytes: %" PRIu64 "\n", static_cast<uint64_t>(writtenTemporalDelimBytes));
+    }
+ 
+    size_t writtenSequenceBytes = 0;
+@@ -2208,7 +2208,7 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+          writtenSequenceBytes   // Bytes Written AFTER placingPositionStart arg above
+       );
+       assert(pD3D12Enc->m_BitstreamHeadersBuffer.size() == (writtenSequenceBytes + writtenTemporalDelimBytes));
+-      debug_printf("Written OBU_SEQUENCE_HEADER bytes: %" PRIu64 "\n", writtenSequenceBytes);
++      debug_printf("Written OBU_SEQUENCE_HEADER bytes: %" PRIu64 "\n", static_cast<uint64_t>(writtenSequenceBytes));
+    }
+ 
+    // Only supported bitstream format is with obu_size for now.
+@@ -2254,14 +2254,14 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+          writtenFrameBytes               // Bytes Written AFTER placingPositionStart arg above
+       );
+ 
+-      debug_printf("Written OBU_FRAME bytes: %" PRIu64 "\n", writtenFrameBytes);
++      debug_printf("Written OBU_FRAME bytes: %" PRIu64 "\n", static_cast<uint64_t>(writtenFrameBytes));
+ 
+       assert(pD3D12Enc->m_BitstreamHeadersBuffer.size() ==
+              (writtenSequenceBytes + writtenTemporalDelimBytes + writtenFrameBytes));
+ 
+       debug_printf("Uploading %" PRIu64
+                    " bytes from OBU sequence and/or picture headers to comp_bit_destination %p at offset 0\n",
+-                   pD3D12Enc->m_BitstreamHeadersBuffer.size(),
++                   static_cast<uint64_t>(pD3D12Enc->m_BitstreamHeadersBuffer.size()),
+                    associatedMetadata.comp_bit_destination);
+ 
+       // Upload headers to the finalized compressed bitstream buffer
+@@ -2330,13 +2330,13 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+                                                writtenFrameBytes   // Bytes Written AFTER placingPositionStart arg above
+       );
+ 
+-      debug_printf("Written OBU_FRAME_HEADER bytes: %" PRIu64 "\n", writtenFrameBytes);
++      debug_printf("Written OBU_FRAME_HEADER bytes: %" PRIu64 "\n", static_cast<uint64_t>(writtenFrameBytes));
+ 
+       assert(pD3D12Enc->m_BitstreamHeadersBuffer.size() ==
+              (writtenSequenceBytes + writtenTemporalDelimBytes + writtenFrameBytes));
+ 
+       debug_printf("Uploading %" PRIu64 " bytes from OBU headers to comp_bit_destination %p at offset 0\n",
+-                   pD3D12Enc->m_BitstreamHeadersBuffer.size(),
++                   static_cast<uint64_t>(pD3D12Enc->m_BitstreamHeadersBuffer.size()),
+                    associatedMetadata.comp_bit_destination);
+ 
+       // Upload headers to the finalized compressed bitstream buffer
+@@ -2361,7 +2361,7 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+          debug_printf("Uploading tile group %d to comp_bit_destination %p at offset %" PRIu64 "\n",
+                       tg_idx,
+                       associatedMetadata.comp_bit_destination,
+-                      comp_bitstream_offset);
++                      static_cast<uint64_t>(comp_bitstream_offset));
+ 
+          size_t tile_group_obu_size = 0;
+          size_t decode_tile_elements_size = 0;
+@@ -2387,9 +2387,9 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+ 
+          debug_printf("Written %" PRIu64 " bytes for OBU_TILE_GROUP open_bitstream_unit() prefix with obu_header() and "
+                       "obu_size to staging_bitstream_buffer %p at offset %" PRIu64 "\n",
+-                      writtenTileObuPrefixBytes,
++                      static_cast<uint64_t>(writtenTileObuPrefixBytes),
+                       associatedMetadata.m_StagingBitstreamConstruction.data(),
+-                      staging_bitstream_buffer_offset);
++                      static_cast<uint64_t>(staging_bitstream_buffer_offset));
+ 
+          writtenTileBytes += writtenTileObuPrefixBytes;
+ 
+@@ -2404,10 +2404,10 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+ 
+          debug_printf("Uploading %" PRIu64 " bytes for OBU_TILE_GROUP open_bitstream_unit() prefix with obu_header() "
+                       "and obu_size: %" PRIu64 " to comp_bit_destination %p at offset %" PRIu64 "\n",
+-                      writtenTileObuPrefixBytes,
+-                      tile_group_obu_size,
++                      static_cast<uint64_t>(writtenTileObuPrefixBytes),
++                      static_cast<uint64_t>(tile_group_obu_size),
+                       associatedMetadata.comp_bit_destination,
+-                      comp_bitstream_offset);
++                      static_cast<uint64_t>(comp_bitstream_offset));
+ 
+          staging_bitstream_buffer_offset += writtenTileObuPrefixBytes;
+ 
+@@ -2517,7 +2517,7 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+             // Add current pending frame being processed in the loop
+             extra_show_existing_frame_payload_bytes += writtenTemporalDelimBytes;
+ 
+-            debug_printf("Written OBU_TEMPORAL_DELIMITER bytes: %" PRIu64 "\n", writtenTemporalDelimBytes);
++            debug_printf("Written OBU_TEMPORAL_DELIMITER bytes: %" PRIu64 "\n", static_cast<uint64_t>(writtenTemporalDelimBytes));
+ 
+             size_t writtenShowExistingFrameBytes = 0;
+             av1_pic_header_t showExistingPicHdr = {};
+@@ -2561,7 +2561,7 @@ d3d12_video_encoder_build_post_encode_codec_bitstream_av1(struct d3d12_video_enc
+                          "in current frame ref_frame_idx[%" PRIu32 "]) bytes: %" PRIu64 "\n",
+                          *pendingFrameIt /*PictureIndex*/,
+                          showExistingPicHdr.frame_to_show_map_idx,
+-                         writtenShowExistingFrameBytes);
++                         static_cast<uint64_t>(writtenShowExistingFrameBytes));
+ 
+             // Remove it from the list of pending frames
+             pendingFrameIt =
+@@ -2628,7 +2628,7 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                 tileGroup.tg_start,
+                 tileGroup.tg_end,
+                 comp_bit_destination,
+-                comp_bit_destination_offset);
++                static_cast<uint64_t>(comp_bit_destination_offset));
+ 
+    debug_printf("[Tile group start %d to end %d] Using staging_bitstream_buffer %p at offset %" PRIu64
+                 " to write the tile_obu_group() prefix syntax: tile_start_and_end_present_flag, tg_start, tg_end and "
+@@ -2636,7 +2636,7 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                 tileGroup.tg_start,
+                 tileGroup.tg_end,
+                 staging_bitstream_buffer.data(),
+-                staging_bitstream_buffer_offset);
++                static_cast<uint64_t>(staging_bitstream_buffer_offset));
+ 
+    // Reserve space upfront in the scratch storage
+    // Do not modify anything before staging_bitstream_buffer_offset
+@@ -2673,9 +2673,9 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                 " for tile_obu_group() prefix syntax: tile_start_and_end_present_flag, tg_start, tg_end\n",
+                 tileGroup.tg_start,
+                 tileGroup.tg_end,
+-                bitstream_tile_group_obu_bytes,
++                static_cast<uint64_t>(bitstream_tile_group_obu_bytes),
+                 staging_bitstream_buffer.data(),
+-                staging_bitstream_buffer_offset);
++                static_cast<uint64_t>(staging_bitstream_buffer_offset));
+ 
+ 
+    // Save this to compare the final written destination byte size against the expected tile_group_obu_size
+@@ -2699,11 +2699,11 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                    " to comp_bit_destination %p at offset %" PRIu64 "\n",
+                    tileGroup.tg_start,
+                    tileGroup.tg_end,
+-                   bitstream_tile_group_obu_bytes,
++                   static_cast<uint64_t>(bitstream_tile_group_obu_bytes),
+                    staging_bitstream_buffer.data(),
+-                   staging_bitstream_buffer_offset,
++                   static_cast<uint64_t>(staging_bitstream_buffer_offset),
+                    comp_bit_destination,
+-                   comp_bit_destination_offset);
++                   static_cast<uint64_t>(comp_bit_destination_offset));
+ 
+       comp_bit_destination_offset += bitstream_tile_group_obu_bytes;
+       written_bytes_to_staging_bitstream_buffer += bitstream_tile_group_obu_bytes;
+@@ -2729,9 +2729,9 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                       tileGroup.tg_start,
+                       tileGroup.tg_end,
+                       TileIdx,
+-                      TileSizeBytes,
++                      static_cast<uint64_t>(TileSizeBytes),
+                       staging_bitstream_buffer.data(),
+-                      (written_bytes_to_staging_bitstream_buffer + staging_bitstream_buffer_offset));
++                      static_cast<uint64_t>(written_bytes_to_staging_bitstream_buffer + staging_bitstream_buffer_offset));
+ 
+          // Upload current tile_size_minus_1
+          // Note: The buffer_subdata is queued in pD3D12Enc->base.context but doesn't execute immediately
+@@ -2751,11 +2751,11 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                       tileGroup.tg_start,
+                       tileGroup.tg_end,
+                       TileIdx,
+-                      TileSizeBytes,
++                      static_cast<uint64_t>(TileSizeBytes),
+                       staging_bitstream_buffer.data(),
+-                      (written_bytes_to_staging_bitstream_buffer + staging_bitstream_buffer_offset),
++                      static_cast<uint64_t>(written_bytes_to_staging_bitstream_buffer + staging_bitstream_buffer_offset),
+                       comp_bit_destination,
+-                      comp_bit_destination_offset);
++                      static_cast<uint64_t>(comp_bit_destination_offset));
+ 
+          comp_bit_destination_offset += TileSizeBytes;
+          written_bytes_to_staging_bitstream_buffer += TileSizeBytes;
+@@ -2788,11 +2788,11 @@ upload_tile_group_obu(struct d3d12_video_encoder *pD3D12Enc,
+                    tileGroup.tg_start,
+                    tileGroup.tg_end,
+                    TileIdx,
+-                   tile_size,
++                   static_cast<uint64_t>(tile_size),
+                    src_driver_bitstream,
+-                   src_buf_tile_position,
++                   static_cast<uint64_t>(src_buf_tile_position),
+                    comp_bit_destination,
+-                   comp_bit_destination_offset);
++                   static_cast<uint64_t>(comp_bit_destination_offset));
+ 
+       comp_bit_destination_offset += tile_size;
+    }
+diff --git a/src/gallium/drivers/d3d12/d3d12_video_encoder_bitstream_builder_av1.cpp b/src/gallium/drivers/d3d12/d3d12_video_encoder_bitstream_builder_av1.cpp
+index 25550a2b4fb..96b7e32eb8e 100644
+--- a/src/gallium/drivers/d3d12/d3d12_video_encoder_bitstream_builder_av1.cpp
++++ b/src/gallium/drivers/d3d12/d3d12_video_encoder_bitstream_builder_av1.cpp
+@@ -153,7 +153,7 @@ d3d12_video_bitstream_builder_av1::write_temporal_delimiter_obu(std::vector<uint
+       write_obu_header(&bitstream_full_obu, OBU_TEMPORAL_DELIMITER, obu_extension_flag, temporal_id, spatial_id);
+ 
+       // Write the data size
+-      const size_t obu_size_in_bytes = 0;
++      const uint64_t obu_size_in_bytes = 0;
+       debug_printf("obu_size: %" PRIu64 " (temporal_delimiter_obu() has empty payload as per AV1 codec spec)\n",
+                    obu_size_in_bytes);
+       pack_obu_header_size(&bitstream_full_obu, obu_size_in_bytes);
+@@ -197,7 +197,7 @@ d3d12_video_bitstream_builder_av1::write_sequence_header(const av1_seq_header_t
+       write_obu_header(&bitstream_full_obu, OBU_SEQUENCE_HEADER, obu_extension_flag, temporal_id, spatial_id);
+ 
+       // Write the data size
+-      const size_t obu_size_in_bytes = static_cast<size_t>(bitstream_seq.get_byte_count());
++      const uint64_t obu_size_in_bytes = bitstream_seq.get_byte_count();
+       debug_printf("obu_size: %" PRIu64 "\n", obu_size_in_bytes);
+       pack_obu_header_size(&bitstream_full_obu, obu_size_in_bytes);
+ 
+@@ -802,7 +802,7 @@ d3d12_video_bitstream_builder_av1::write_frame_header(const av1_seq_header_t *pS
+       debug_printf("frame_header_obu() bytes (without OBU_FRAME nor OBU_FRAME_HEADER alignment padding): %" PRId32 "\n",
+                    bitstream_pic.get_byte_count());   // May be bit unaligned at this point (see padding below)
+       debug_printf("extra_obu_size_bytes (ie. tile_group_obu_size if writing OBU_FRAME ): %" PRIu64 "\n",
+-                   extra_obu_size_bytes);
++                   static_cast<uint64_t>(extra_obu_size_bytes));
+ 
+       // Write the obu_header
+       constexpr uint32_t obu_extension_flag = 0;
+@@ -825,7 +825,7 @@ d3d12_video_bitstream_builder_av1::write_frame_header(const av1_seq_header_t *pS
+       bitstream_pic.flush();
+ 
+       // Write the obu_size element
+-      const size_t obu_size_in_bytes = bitstream_pic.get_byte_count() + extra_obu_size_bytes;
++      const uint64_t obu_size_in_bytes = bitstream_pic.get_byte_count() + extra_obu_size_bytes;
+       debug_printf("obu_size: %" PRIu64 "\n", obu_size_in_bytes);
+       pack_obu_header_size(&bitstream_full_obu, obu_size_in_bytes);
+ 
+@@ -913,7 +913,7 @@ d3d12_video_bitstream_builder_av1::write_obu_tile_group_header(size_t tile_group
+ 
+    // Write the obu_size element
+    pack_obu_header_size(&bitstream_full_obu, tile_group_obu_size);
+-   debug_printf("obu_size: %" PRIu64 "\n", tile_group_obu_size);
++   debug_printf("obu_size: %" PRIu64 "\n", static_cast<uint64_t>(tile_group_obu_size));
+ 
+    bitstream_full_obu.flush();
+ 
+diff --git a/src/gallium/drivers/d3d12/d3d12_video_encoder_references_manager_av1.cpp b/src/gallium/drivers/d3d12/d3d12_video_encoder_references_manager_av1.cpp
+index 49892338984..2f4bcf0e1eb 100644
+--- a/src/gallium/drivers/d3d12/d3d12_video_encoder_references_manager_av1.cpp
++++ b/src/gallium/drivers/d3d12/d3d12_video_encoder_references_manager_av1.cpp
+@@ -213,7 +213,7 @@ d3d12_video_encoder_references_manager_av1::print_virtual_dpb_entries()
+                 "Number of DPB virtual entries is %" PRIu64 " entries for frame with OrderHint "
+                 "%d (PictureIndex %d) are: \n%s \n",
+                 m_PhysicalAllocationsStorage.get_number_of_pics_in_dpb(),
+-                m_CurrentFrameReferencesData.pVirtualDPBEntries.size(),
++                static_cast<uint64_t>(m_CurrentFrameReferencesData.pVirtualDPBEntries.size()),
+                 m_CurrentFramePicParams.OrderHint,
+                 m_CurrentFramePicParams.PictureIndex,
+                 dpbContents.c_str());

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -121,17 +121,17 @@ self = stdenv.mkDerivation {
 
     ./opencl.patch
     ./disk_cache-include-dri-driver-path-in-cache-key.patch
-  ] ++ lib.optionals stdenv.isDarwin [
+
+    # Backports to fix build
+    # FIXME: remove when applied upstream
+
     # Fix build on macOS
-    # Last two commits from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25992
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/c8b64452c076c1768beb23280de25faf2bcbe2c8.diff";
-      hash = "sha256-mqivdzyoLtkfkAb+r57gjPwg8d7whgFAahiUhGVOOvo=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/96d55d784cb4f047a4b58cd08330f42208641ea7.diff";
-      hash = "sha256-SkWdvqltfByFiKlhr9YILA6qWQxuyKz/YTanVp/NMzg=";
-    })
+    ./backports/0001-dri-added-build-dependencies-for-systems-using-non-s.patch
+    ./backports/0002-util-Update-util-libdrm.h-stubs-to-allow-loader.c-to.patch
+    ./backports/0003-glx-fix-automatic-zink-fallback-loading-between-hw-a.patch
+
+    # Fix build on i686
+    ./backports/0004-d3d12-Fix-AV1-video-encode-32-bits-build.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Fixes #274177 (hopefully). Also, made Darwin patches unconditional so we know when they don't apply (they didn't apply).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
