### PR TITLE
update etcher version - will update to electron v25

### DIFF
--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -1,15 +1,15 @@
-{
-  lib,
-  stdenv,
-  fetchurl,
-  bash,
-  util-linux,
-  autoPatchelfHook,
-  dpkg,
-  makeWrapper,
-  udev,
-  electron_25,
+{ lib
+, stdenv
+, fetchurl
+, bash
+, util-linux
+, autoPatchelfHook
+, dpkg
+, makeWrapper
+, udev
+, electron_25
 }:
+
 stdenv.mkDerivation rec {
   pname = "etcher";
   version = "1.18.13"; # 1.18.13 uses electron 25
@@ -65,8 +65,8 @@ stdenv.mkDerivation rec {
     homepage = "https://etcher.io/";
     license = licenses.asl20;
     mainProgram = pname;
-    maintainers = with maintainers; [wegank];
-    platforms = ["x86_64-linux"];
-    sourceProvenance = with sourceTypes; [binaryNativeCode];
+    maintainers = with maintainers; [ wegank ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -12,7 +12,7 @@
 }:
 stdenv.mkDerivation rec {
   pname = "etcher";
-  version = "1.18.13";
+  version = "1.18.13"; # 1.18.13 uses electron 25
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher_${version}_amd64.deb";

--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -1,22 +1,22 @@
-{ lib
-, stdenv
-, fetchurl
-, bash
-, util-linux
-, autoPatchelfHook
-, dpkg
-, makeWrapper
-, udev
-, electron
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bash,
+  util-linux,
+  autoPatchelfHook,
+  dpkg,
+  makeWrapper,
+  udev,
+  electron,
 }:
-
 stdenv.mkDerivation rec {
   pname = "etcher";
-  version = "1.18.12";
+  version = "1.18.13";
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher_${version}_amd64.deb";
-    hash = "sha256-Ucs187xTpbRJ7P32hCl8cHPxO3HCs44ZneAas043FXk=";
+    hash = "sha512-84RlIwhcWLSE84JFvfUVINPdL3uVrfnySMmXGGeFe6P0/wRaFD5GNyPyLNV3PvUL7srzl9bHeFwaQBcP+uZwng==";
   };
 
   # sudo-prompt has hardcoded binary paths on Linux and we patch them here
@@ -65,8 +65,8 @@ stdenv.mkDerivation rec {
     homepage = "https://etcher.io/";
     license = licenses.asl20;
     mainProgram = pname;
-    maintainers = with maintainers; [ wegank ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [wegank];
+    platforms = ["x86_64-linux"];
+    sourceProvenance = with sourceTypes; [binaryNativeCode];
   };
 }

--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -8,11 +8,12 @@
   dpkg,
   makeWrapper,
   udev,
-  electron,
+  electron_25,
 }:
 stdenv.mkDerivation rec {
   pname = "etcher";
   version = "1.18.13";
+  electron = electron_25;
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher_${version}_amd64.deb";

--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -13,7 +13,6 @@
 stdenv.mkDerivation rec {
   pname = "etcher";
   version = "1.18.13";
-  electron = electron_25;
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher_${version}_amd64.deb";
@@ -52,7 +51,7 @@ stdenv.mkDerivation rec {
     cp -a usr/share/* $out/share
     cp -a opt/balenaEtcher/{locales,resources} $out/share/${pname}
 
-    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+    makeWrapper ${electron_25}/bin/electron $out/bin/${pname} \
       --add-flags $out/share/${pname}/resources/app
 
     substituteInPlace $out/share/applications/balena-etcher.desktop \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8032,9 +8032,7 @@ with pkgs;
 
   esshader = callPackage ../tools/graphics/esshader { };
 
-  etcher = callPackage ../tools/misc/etcher {
-    electron = electron_25;
-  };
+  etcher = callPackage ../tools/misc/etcher { };
 
   ethercalc = callPackage ../servers/web-apps/ethercalc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8033,7 +8033,7 @@ with pkgs;
   esshader = callPackage ../tools/graphics/esshader { };
 
   etcher = callPackage ../tools/misc/etcher {
-    electron = electron_19;
+    electron = electron_25;
   };
 
   ethercalc = callPackage ../servers/web-apps/ethercalc { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/balena-io/etcher/commit/f38bca290fe26121bed58d1131265e1aa350ddb5 (patch: upgrade to electron 25, 2023-08-30)
https://github.com/balena-io/etcher/commit/fb8ed5b529e22bc9e766bfe99c2b6955ed695b58 (patch: refactor scanner, loader and flasher out of gui + upgrade to electron 25, 2023-08-30)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

:+1:  - Security related update
cc @wegank