### PR TITLE
asterisk_18: 18.17.1 -> 18.20.1, asterisk_20: 20.2.1 -> 20.5.1

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -36,25 +36,6 @@
 }:
 
 let
-  # remove when upgrading to pjsip >2.13
-  pjsip_2_13_patches = [
-    (fetchpatch {
-      name = "CVE-2022-23537.patch";
-      url = "https://github.com/pjsip/pjproject/commit/d8440f4d711a654b511f50f79c0445b26f9dd1e1.patch";
-      sha256 = "sha256-7ueQCHIiJ7MLaWtR4+GmBc/oKaP+jmEajVnEYqiwLRA=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-23547.patch";
-      url = "https://github.com/pjsip/pjproject/commit/bc4812d31a67d5e2f973fbfaf950d6118226cf36.patch";
-      sha256 = "sha256-bpc8e8VAQpfyl5PX96G++6fzkFpw3Or1PJKNPKl7N5k=";
-    })
-    (fetchpatch {
-      name = "CVE-2023-27585.patch";
-      url = "https://github.com/pjsip/pjproject/commit/d1c5e4da5bae7f220bc30719888bb389c905c0c5.patch";
-      hash = "sha256-+yyKKTKG2FnfyLWnc4S80vYtDzmiu9yRmuqb5eIulPg=";
-    })
-  ];
-
   common = { version, sha256, externals, pjsip_patches ? [ ] }: stdenv.mkDerivation {
     inherit version;
     pname = "asterisk"
@@ -161,12 +142,12 @@ let
     };
   };
 
-  pjproject_2_13 = fetchurl
+  pjproject_2_13_1 = fetchurl
     {
-      url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.13/pjproject-2.13.tar.bz2";
-      hash = "sha256-Zj93PUAct13KVR5taOWEbQdKq76wicaBTNHpHC0rICY=";
+      url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.13.1/pjproject-2.13.1.tar.bz2";
+      hash = "sha256-cOBRvO+B9fGt4UVYAHQQwBsc2cUF7Pu1GRsjAF7BE1g=";
     } // {
-    pjsip_patches = pjsip_2_13_patches;
+    pjsip_patches = [ ];
   };
 
   mp3-202 = fetchsvn {
@@ -187,7 +168,7 @@ let
   versions = lib.mapAttrs
     (_: { version, sha256 }:
       let
-        pjsip = pjproject_2_13;
+        pjsip = pjproject_2_13_1;
       in
       common {
         inherit version sha256;

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,18 +1,14 @@
 {
-  "asterisk_16": {
-    "sha256": "f8448e8784df7fac019e459bf7c82529d80afe64ae97d73d40e6aa0e4fb39724",
-    "version": "16.30.0"
-  },
   "asterisk_18": {
-    "sha256": "66f0e55d84f9e5bf4e79a56255d35a034448acce00d219c3bf4930b1ebb0e88e",
-    "version": "18.17.1"
-  },
-  "asterisk_19": {
-    "sha256": "f0c56d1f8e39e0427455edfe25d24ff088c756bdc32dd1278c9f7a320815cbaa",
-    "version": "19.8.0"
+    "sha256": "ad7d01f58e5c5266e5b23cc385e6a3d32a656b93c1d4b4fb0082f3300012bd02",
+    "version": "18.20.1"
   },
   "asterisk_20": {
-    "sha256": "df12e47000fbac42bb780bb06172aa8bb8ac26faf77cc9f95184695b0cec69c3",
-    "version": "20.2.1"
+    "sha256": "7d128f2a164e36fae4875058120ff026e7cd73f7701429fee4fa293f4fba4336",
+    "version": "20.5.1"
+  },
+  "asterisk_21": {
+    "sha256": "8e7db886b70e808ade38ad060ccbbb49353031e4c2fa6dc4435bfbd79f082956",
+    "version": "21.0.1"
   }
 }


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-49294, CVE-2023-49786,  CVE-2022-23537.

Changelogs:
https://github.com/asterisk/asterisk/releases/tag/18.20.1
https://github.com/asterisk/asterisk/releases/tag/18.20.0
https://github.com/asterisk/asterisk/releases/tag/18.19.0
https://github.com/asterisk/asterisk/releases/tag/18.18.1
https://github.com/asterisk/asterisk/releases/tag/18.18.0
https://github.com/asterisk/asterisk/releases/tag/20.5.0
https://github.com/asterisk/asterisk/releases/tag/20.4.0
https://github.com/asterisk/asterisk/releases/tag/20.3.1
https://github.com/asterisk/asterisk/releases/tag/20.3.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>asterisk (asterisk-stable ,asterisk_20)</li>
    <li>asterisk-ldap</li>
    <li>asterisk_18 (asterisk-lts)</li>
    <li>asterisk-module-sccp</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
