### PR TITLE
[Backport release-23.05] {ungoogled-,}chromium: 120.0.6099.71 -> 120.0.6099.109

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -54,12 +54,12 @@
         version = "2023-10-23";
       };
       ungoogled-patches = {
-        rev = "120.0.6099.71-1";
-        sha256 = "1wl8ykvpcww399xi8p3i8bp78fq44hpcnvijlg42ikxmrpsashjb";
+        rev = "120.0.6099.109-1";
+        sha256 = "1hdl0yfmarr1sjj9zkrw095rjs5qb0ldz17b8hir2gnmw71va9f2";
       };
     };
-    sha256 = "0jpmrp6cgm8xbsdrl219h5hr7yi0dan2qrhbwrkx3xxn2wi1v1nq";
-    sha256bin64 = "15r1kx4jnbrcw7kfma528ks5ic17s4ydh1ncsb680himhln02z64";
-    version = "120.0.6099.71";
+    sha256 = "08rrkjd4xn8l8hbfc7jawjda85za9856i0fsimj9bg4zyg33rfk5";
+    sha256bin64 = "0arwmfj9wnwray0gq0mmlcnq4azka1mg0kni3qb5fqsz3x04kha9";
+    version = "120.0.6099.109";
   };
 }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -41,9 +41,9 @@
         version = "2023-10-23";
       };
     };
-    sha256 = "0jpmrp6cgm8xbsdrl219h5hr7yi0dan2qrhbwrkx3xxn2wi1v1nq";
-    sha256bin64 = "15r1kx4jnbrcw7kfma528ks5ic17s4ydh1ncsb680himhln02z64";
-    version = "120.0.6099.71";
+    sha256 = "08rrkjd4xn8l8hbfc7jawjda85za9856i0fsimj9bg4zyg33rfk5";
+    sha256bin64 = "0arwmfj9wnwray0gq0mmlcnq4azka1mg0kni3qb5fqsz3x04kha9";
+    version = "120.0.6099.109";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

Manual backport of #274298

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
