### PR TITLE
hareThirdParty.hare-ev: init at unstable-2023-10-31

### DIFF
--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -5,7 +5,7 @@
 , unstableGitUpdater
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "hare-ev";
   version = "unstable-2023-10-31";
 

--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, lib
+, fetchFromSourcehut
+, hare
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hare-ev";
+  version = "unstable-2023-10-31";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-ev";
+    rev = "9bdbd02401334b7d762131a46e64ca2cd24846dc";
+    hash = "sha256-VY8nsy5kLDMScA2ig3Rgbkf6VQlCTnGWjzGvsI9OcaQ=";
+  };
+
+  nativeCheckInputs = [
+    hare
+  ];
+
+  makeFlags = [
+    "HARECACHE=.harecache"
+    "PREFIX=${builtins.placeholder "out"}"
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "Event loop for Hare programs";
+    homepage = "https://sr.ht/~sircmpwn/hare-ev";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ colinsane ];
+    inherit (hare.meta) platforms badPlatforms;
+  };
+}

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -7,5 +7,6 @@ in
 {
 
   hare-compress = callPackage ../development/hare-third-party/hare-compress { };
+  hare-ev = callPackage ../development/hare-third-party/hare-ev { };
   hare-json = callPackage ../development/hare-third-party/hare-json { };
 })


### PR DESCRIPTION
## Description of changes

hare-ev is Hare's "event loop" library, and a direct dependency of the outstanding [bonsai PR](https://github.com/NixOS/nixpkgs/pull/233892). initialized to a version known to be compatible with bonsai (and the harec in nixpkgs).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
