### PR TITLE
workflows/check-by-name: Cancel on merge conflicts

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -8,8 +8,9 @@ on:
   # Using pull_request_target instead of pull_request avoids having to approve first time contributors
   pull_request_target
 
-# The tool doesn't need any permissions, it only outputs success or not based on the checkout
-permissions: {}
+permissions:
+  # We need this permission to cancel the workflow run if there's a merge conflict
+  actions: write
 
 jobs:
   check:
@@ -62,7 +63,14 @@ jobs:
           if [[ "$mergeable" == "true" ]]; then
             echo "The PR can be merged, checking the merge commit $mergedSha"
           else
-            echo "The PR cannot be merged, it has a merge conflict"
+            echo "The PR cannot be merged, it has a merge conflict, cancelling the workflow.."
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/"$GITHUB_REPOSITORY"/actions/runs/"$GITHUB_RUN_ID"/cancel
+            sleep 60
+            # If it's still not canceled after a minute, something probably went wrong, just exit
             exit 1
           fi
           echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Description of changes

Currently the `pkgs/by-name` CI check fails with a red cross when there's a merge conflict. This PR makes check be _canceled_ in such a case instead. Originally I didn't think this was possible, but after tinkering a bit I figured it out.

This means that the check won't be highlighted in red anymore. Furthermore it makes it possible to list actual `pkgs/by-name` check failures by going to https://github.com/NixOS/nixpkgs/actions/workflows/check-by-name.yml?query=is%3Afailure.

## Things done

- [x] Tested: https://github.com/tweag/nixpkgs/pull/79

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
