### PR TITLE
python3Packages.pdoc: 14.1.0 -> 14.2.0

### DIFF
--- a/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
+++ b/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, rustPlatform
+, cargo
+, rustc
+}:
+
+buildPythonPackage rec {
+  pname = "pdoc-pyo3-sample-library";
+  version = "1.0.11";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pdoc_pyo3_sample_library";
+    inherit version;
+    hash = "sha256-ZGMo7WgymkSDQu8tc4rTfWNsIWO0AlDPG0OzpKRq3oA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit pname version src;
+    hash = "sha256-KrEBr998AV/bKcIoq0tX72/QwPD9bQplrS0Zw+JiSMQ=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    cargo
+    rustc
+  ];
+
+  pythonImportsCheck = [ "pdoc_pyo3_sample_library" ];
+
+  # no tests
+  doCheck = false;
+
+  meta = {
+    description = "A sample PyO3 library used in pdoc tests";
+    homepage = "https://github.com/mitmproxy/pdoc-pyo3-sample-library";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.pbsds ];
+  };
+}

--- a/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
+++ b/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
@@ -1,9 +1,11 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , rustPlatform
 , cargo
 , rustc
+, libiconv
 }:
 
 buildPythonPackage rec {
@@ -27,6 +29,10 @@ buildPythonPackage rec {
     rustPlatform.maturinBuildHook
     cargo
     rustc
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
   ];
 
   pythonImportsCheck = [ "pdoc_pyo3_sample_library" ];

--- a/pkgs/development/python-modules/pdoc/default.nix
+++ b/pkgs/development/python-modules/pdoc/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , setuptools
 , jinja2
+, pdoc-pyo3-sample-library
 , pygments
 , markupsafe
 , astunparse
@@ -13,16 +14,16 @@
 
 buildPythonPackage rec {
   pname = "pdoc";
-  version = "14.1.0";
+  version = "14.2.0";
   disabled = pythonOlder "3.8";
 
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mitmproxy";
     repo = "pdoc";
     rev = "v${version}";
-    hash = "sha256-LQXhdzocw01URrmpDayK9rpsArvM/E44AE8Eok9DBwk=";
+    hash = "sha256-Mmmq4jqRQow+1jn5ZDVMtP1uxrYgHJK/IQrwFWNw8ag=";
   };
 
   nativeBuildInputs = [
@@ -38,6 +39,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     hypothesis
+    pdoc-pyo3-sample-library
   ];
   disabledTestPaths = [
     # "test_snapshots" tries to match generated output against stored snapshots,

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9028,6 +9028,8 @@ self: super: with self; {
 
   pdoc = callPackage ../development/python-modules/pdoc { };
 
+  pdoc-pyo3-sample-library = callPackage ../development/python-modules/pdoc-pyo3-sample-library { };
+
   pdoc3 = callPackage ../development/python-modules/pdoc3 { };
 
   peaqevcore = callPackage ../development/python-modules/peaqevcore { };


### PR DESCRIPTION
## Description of changes

* packages pdoc checkPhase dep https://github.com/mitmproxy/pdoc-pyo3-sample-library
* pdoc diff: https://github.com/mitmproxy/pdoc/compare/v14.1.0...v14.2.0
* pdoc changelog: https://github.com/mitmproxy/pdoc/blob/v14.2.0/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
