### PR TITLE
vinegar: add segrevert patch for wine 9.0-rc1-staging

### DIFF
--- a/pkgs/by-name/vi/vinegar/package.nix
+++ b/pkgs/by-name/vi/vinegar/package.nix
@@ -1,54 +1,70 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, wine-staging
-, makeBinaryWrapper
-, pkg-config
-, libGL
-, libxkbcommon
-, xorg
-}:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  pkg-config,
+  libGL,
+  libxkbcommon,
+  xorg,
+  wineWowPackages,
+  fetchpatch,
+}: let
+  # wine-staging doesn't support overrideAttrs for now
+  wine = wineWowPackages.stagingFull.overrideDerivation (oldAttrs: {
+    patches =
+      (oldAttrs.patches or [])
+      ++ [
+        # upstream issue: https://bugs.winehq.org/show_bug.cgi?id=55604
+        # Here are the currently applied patches for Roblox to run under WINE:
+        (fetchpatch {
+          name = "vinegar-wine-segrevert.patch";
+          url = "https://raw.githubusercontent.com/flathub/org.vinegarhq.Vinegar/8fc153c492542a522d6cc2dff7d1af0e030a529a/patches/wine/temp.patch";
+          hash = "sha256-AnEBBhB8leKP0xCSr6UsQK7CN0NDbwqhe326tJ9dDjc=";
+        })
+      ];
+  });
+in
+  buildGoModule rec {
+    pname = "vinegar";
+    version = "1.5.9";
 
-buildGoModule rec {
-  pname = "vinegar";
-  version = "1.5.9";
+    src = fetchFromGitHub {
+      owner = "vinegarhq";
+      repo = "vinegar";
+      rev = "v${version}";
+      hash = "sha256-cLzQnNmQYyAIdTGygk/CNU/mxGgcgoFTg5G/0DNwpz4=";
+    };
 
-  src = fetchFromGitHub {
-    owner = "vinegarhq";
-    repo = "vinegar";
-    rev = "v${version}";
-    hash = "sha256-cLzQnNmQYyAIdTGygk/CNU/mxGgcgoFTg5G/0DNwpz4=";
-  };
+    vendorHash = "sha256-DZI4APnrldnwOmLZ9ucFBGQDxzPXTIi44eLu74WrSBI=";
 
-  vendorHash = "sha256-DZI4APnrldnwOmLZ9ucFBGQDxzPXTIi44eLu74WrSBI=";
+    nativeBuildInputs = [pkg-config makeBinaryWrapper];
+    buildInputs = [libGL libxkbcommon xorg.libX11 xorg.libXcursor xorg.libXfixes wine];
 
-  nativeBuildInputs = [ pkg-config makeBinaryWrapper ];
-  buildInputs = [ libGL libxkbcommon xorg.libX11 xorg.libXcursor xorg.libXfixes wine-staging ];
+    buildPhase = ''
+      runHook preBuild
+      make PREFIX=$out
+      runHook postBuild
+    '';
 
-  buildPhase = ''
-    runHook preBuild
-    make PREFIX=$out
-    runHook postBuild
-  '';
+    installPhase = ''
+      runHook preInstall
+      make PREFIX=$out install
+      runHook postInstall
+    '';
 
-  installPhase = ''
-    runHook preInstall
-    make PREFIX=$out install
-    runHook postInstall
-  '';
+    postInstall = ''
+      wrapProgram $out/bin/vinegar \
+        --prefix PATH : ${lib.makeBinPath [wine]}
+    '';
 
-  postInstall = ''
-    wrapProgram $out/bin/vinegar \
-      --prefix PATH : ${lib.makeBinPath [ wine-staging ]}
-  '';
-
-  meta = with lib; {
-    description = "An open-source, minimal, configurable, fast bootstrapper for running Roblox on Linux";
-    homepage = "https://github.com/vinegarhq/vinegar";
-    changelog = "https://github.com/vinegarhq/vinegar/releases/tag/v${version}";
-    mainProgram = "vinegar";
-    license = licenses.gpl3Only;
-    platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = with maintainers; [ nyanbinary ];
-  };
-}
+    meta = with lib; {
+      description = "An open-source, minimal, configurable, fast bootstrapper for running Roblox on Linux";
+      homepage = "https://github.com/vinegarhq/vinegar";
+      changelog = "https://github.com/vinegarhq/vinegar/releases/tag/v${version}";
+      mainProgram = "vinegar";
+      license = licenses.gpl3Only;
+      platforms = ["x86_64-linux" "i686-linux"];
+      maintainers = with maintainers; [nyanbinary];
+    };
+  }


### PR DESCRIPTION
## Description of changes

Added segrevert patch for wine, as without it Roblox is unplayable.

(note: I have opened this new PR because there were some technical difficulties with my fork of nixpkgs https://github.com/NixOS/nixpkgs/pull/273810)
## Things done

added new temp.patch for wine 9.0-rc1-staging

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).