### PR TITLE
clipcat: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/applications/misc/clipcat/default.nix
+++ b/pkgs/applications/misc/clipcat/default.nix
@@ -2,41 +2,32 @@
 , fetchFromGitHub
 , rustPlatform
 , protobuf
-, xvfb-run
 , installShellFiles
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "clipcat";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "xrelkd";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-Q9uGufIfqRLk3YJjaEEyu29JP8vSwUCe4ch9tf6Vz9g=";
+    hash = "sha256-NuljH6cqgdtTJDkNv4w44s1UM4/R1gmpVyWpCzCJ3DU=";
   };
 
-  cargoHash = "sha256-9TPj4W+BSpHlOWkbiV7jNgjiYJjjw9j2c3o8vesrJeI=";
+  cargoHash = "sha256-5+qa9/QGZyZBaO2kbvpP7Ybs1EXIO1MlPFm0PDTNqCQ=";
 
   nativeBuildInputs = [
     protobuf
     installShellFiles
   ];
 
-  nativeCheckInputs = [
-    xvfb-run
+  checkFlags = [
+    # Some test cases interact with X11, skip them
+    "--skip=test_x11_clipboard"
+    "--skip=test_x11_primary"
   ];
-
-  useNextest = true;
-
-  # cargo-nextest help us retry the failed test cases
-  NEXTEST_RETRIES = 5;
-
-  # Some test cases interact with X11, we use xvfb-run here
-  checkPhase = ''
-    xvfb-run --auto-servernum cargo nextest run --release --workspace --no-fail-fast --no-capture
-  '';
 
   postInstall = ''
     for cmd in clipcatd clipcatctl clipcat-menu clipcat-notify; do


### PR DESCRIPTION

## Description of changes
Update `clipcat` to the latest release.

- https://github.com/xrelkd/clipcat/releases/tag/v0.15.0
Diff: https://github.com/xrelkd/clipcat/compare/v0.14.0...v0.15.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
