### PR TITLE
photoqt: 3.4 -> 4.0.1

### DIFF
--- a/pkgs/applications/graphics/photoqt/default.nix
+++ b/pkgs/applications/graphics/photoqt/default.nix
@@ -7,39 +7,30 @@
 , wrapQtAppsHook
 , exiv2
 , graphicsmagick
-, kimageformats
 , libarchive
 , libraw
 , mpv
 , poppler
 , pugixml
 , qtbase
+, qtcharts
 , qtdeclarative
-, qtgraphicaleffects
+, qtimageformats
+, qtlocation
 , qtmultimedia
-, qtquickcontrols
-, qtquickcontrols2
+, qtpositioning
+, qtsvg
+, qtwayland
 }:
 
 stdenv.mkDerivation rec {
   pname = "photoqt";
-  version = "3.4";
+  version = "4.0.1";
 
   src = fetchurl {
     url = "https://photoqt.org/pkgs/photoqt-${version}.tar.gz";
-    hash = "sha256-kVf9+zI9rtEMmS0N4qrN673T/1fnqfcV3hQPnMXMLas=";
+    hash = "sha256-nmEipzatselwtBR//ayajqgmhaUnAMKW7JBLKdzutHg=";
   };
-
-  postPatch = ''
-    # exiv2 0.28.1
-    substituteInPlace CMakeLists.txt \
-      --replace "exiv2lib" "exiv2"
-  ''
-  # error: no member named 'setlocale' in namespace 'std'; did you mean simply 'setlocale'?
-  + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace cplusplus/main.cpp \
-      --replace "std::setlocale" "setlocale"
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -51,18 +42,21 @@ stdenv.mkDerivation rec {
   buildInputs = [
     exiv2
     graphicsmagick
-    kimageformats
     libarchive
     libraw
     mpv
     poppler
     pugixml
     qtbase
+    qtcharts
     qtdeclarative
-    qtgraphicaleffects
+    qtimageformats
+    qtlocation
     qtmultimedia
-    qtquickcontrols
-    qtquickcontrols2
+    qtpositioning
+    qtsvg
+  ] ++ lib.optionals stdenv.isLinux [
+    qtwayland
   ];
 
   cmakeFlags = [
@@ -74,6 +68,12 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export MAGICK_LOCATION="${graphicsmagick}/include/GraphicsMagick"
+  '';
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/bin/photoqt.app $out/Applications
+    makeWrapper $out/{Applications/photoqt.app/Contents/MacOS,bin}/photoqt
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34667,7 +34667,7 @@ with pkgs;
 
   phantomsocks = callPackage ../tools/networking/phantomsocks { };
 
-  photoqt = libsForQt5.callPackage ../applications/graphics/photoqt { };
+  photoqt = qt6Packages.callPackage ../applications/graphics/photoqt { };
 
   photoflare = libsForQt5.callPackage ../applications/graphics/photoflare { };
 


### PR DESCRIPTION
## Description of changes

https://photoqt.org/news/photoqt-4.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
