### PR TITLE
caper: init at 0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19719,6 +19719,15 @@
     githubId = 20464732;
     name = "Willi Butz";
   };
+  willow_ch = {
+    email = "nix@w.wolo.dev";
+    github = "spaghetus";
+    githubId = 28763739;
+    name = "Willow Carlson-Huber";
+    keys = [{
+      fingerprint = "FE21E0981CDFD50ADD086423C21A693BA4693A60";
+    }];
+  };
   willswats = {
     email = "williamstuwatson@gmail.com";
     github = "willswats";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19724,9 +19724,7 @@
     github = "spaghetus";
     githubId = 28763739;
     name = "Willow Carlson-Huber";
-    keys = [{
-      fingerprint = "FE21E0981CDFD50ADD086423C21A693BA4693A60";
-    }];
+    keys = [ { fingerprint = "FE21E0981CDFD50ADD086423C21A693BA4693A60"; } ];
   };
   willswats = {
     email = "williamstuwatson@gmail.com";

--- a/pkgs/by-name/ca/caper/package.nix
+++ b/pkgs/by-name/ca/caper/package.nix
@@ -1,0 +1,64 @@
+{
+  stdenv,
+  lib,
+  ocaml,
+  ocamlPackages,
+  gnum4,
+  fetchFromGitLab,
+}:
+stdenv.mkDerivation rec {
+  pname = "caper";
+  version = "0.9";
+
+  src = fetchFromGitLab {
+    owner = "niksu";
+    repo = "caper";
+    rev = "v${version}";
+    hash = "sha256-TSryjz0NrGdkc+6vmfBqsuVpV3N9FvteTFsVqpUcm0w=";
+  };
+
+  nativeBuildInputs = [
+    ocaml
+    ocamlPackages.ocamlbuild
+    ocamlPackages.findlib
+    ocamlPackages.menhir
+    gnum4
+  ];
+
+  buildInputs = [
+    ocamlPackages.angstrom
+  ];
+
+  strictDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+    CAPER_WITH_ENGLISH=yes bash build.sh caper.native
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp caper.native $out/bin/caper
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Tool for understanding and processing pcap (packet capture) expressions";
+    longDescription = ''
+      Caper is a tool for understanding and processing "pcap expressions" (also known as *tcpdump filters*) which are used for network packet analysis.
+      Caper can be used for:
+      * Expanding out pcap expressions "in full" to understand their implicit features.
+      * Reasoning about whether two expressions accept the same set of packets, or how their accepted packets differ.
+      * Converting pcap expressions into BPF programs.
+      * Converting between pcap expressions and English.
+
+      More info can be found in the Caper paper (https://www.nik.network/caper/pcap_semantics.pdf).
+    '';
+    homepage = "https://gitlab.com/niksu/caper";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ willow_ch ];
+    mainProgram = "caper";
+  };
+}


### PR DESCRIPTION
## Description of changes

Caper is a tool for understanding and processing "pcap expressions" (also known as *tcpdump filters*) which are used for network packet analysis.
Caper can be used for:
* Expanding out pcap expressions "in full" to understand their implicit features.
* Reasoning about whether two expressions accept the same set of packets, or how their accepted packets differ.
* Converting pcap expressions into BPF programs.
* Converting between pcap expressions and English.

More info can be found in the Caper paper (https://www.nik.network/caper/pcap_semantics.pdf).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
