### PR TITLE
hare: embed paths for cross-compilation toolchains

### DIFF
--- a/pkgs/by-name/ha/hare/cross-compilation-tests.nix
+++ b/pkgs/by-name/ha/hare/cross-compilation-tests.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPackages
+, hare
+, runCommandNoCC
+, stdenv
+, writeText
+}:
+let
+  inherit (stdenv.hostPlatform.uname) processor;
+  inherit (stdenv.hostPlatform) emulator;
+  mainDotHare = writeText "main.ha" ''
+    use fmt;
+    use os;
+    export fn main() void = {
+        const machine = os::machine();
+        if (machine == "${processor}") {
+            fmt::println("os::machine() matches ${processor}")!;
+        } else {
+            fmt::fatalf("os::machine() does not match ${processor}: {}", machine);
+        };
+    };
+  '';
+in
+runCommandNoCC "${hare.pname}-cross-compilation-test" { meta.timeout = 60; } ''
+  HARECACHE="$(mktemp -d --tmpdir harecache.XXXXXXXX)"
+  export HARECACHE
+  outbin="test-${processor}"
+  ${lib.getExe hare} build -q -a "${processor}" -o "$outbin" ${mainDotHare}
+  ${emulator buildPackages} "./$outbin"
+  : 1>$out
+''

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -8,7 +8,26 @@
 , scdoc
 , tzdata
 , substituteAll
+, callPackage
+, enableCrossCompilation ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.is64bit)
+, pkgsCross
+, x86_64PkgsCrossToolchain ? pkgsCross.gnu64
+, aarch64PkgsCrossToolchain ? pkgsCross.aarch64-multiplatform
+, riscv64PkgsCrossToolchain ? pkgsCross.riscv64
 }:
+
+# There's no support for `aarch64-freebsd` or `riscv64-freebsd` on nix.
+# See `lib.systems.doubles.aarch64` and `lib.systems.doubles.riscv64`.
+assert let
+  inherit (stdenv.hostPlatform) isLinux is64bit;
+  inherit (lib) intersectLists platforms concatStringsSep;
+  workingPlatforms = intersectLists platforms.linux (with platforms; x86_64 ++ aarch64 ++ riscv64);
+in
+(enableCrossCompilation -> !(isLinux && is64bit))
+  -> builtins.throw ''
+  The cross-compilation toolchains may only be enabled on the following platforms:
+  ${concatStringsSep "\n" workingPlatforms}
+'';
 
 let
   # We use harec's override of qbe until 1.2 is released, but the `qbe` argument
@@ -16,7 +35,28 @@ let
   qbe = harec.qbeUnstable;
   # https://harelang.org/platforms/
   arch = stdenv.hostPlatform.uname.processor;
-  platform = lib.strings.toLower stdenv.hostPlatform.uname.system;
+  platform = lib.toLower stdenv.hostPlatform.uname.system;
+  embeddedOnBinaryTools =
+    let
+      genToolsFromToolchain = toolchain:
+        let
+          crossTargetPrefix = toolchain.stdenv.cc.targetPrefix;
+          toolchainArch = toolchain.stdenv.hostPlatform.uname.processor;
+          absOrRelPath = toolDrv: toolBasename:
+            if arch == toolchainArch then toolBasename
+            else lib.getExe' toolDrv "${crossTargetPrefix}${toolBasename}";
+        in
+        {
+          "ld" = absOrRelPath toolchain.buildPackages.binutils "ld";
+          "as" = absOrRelPath toolchain.buildPackages.binutils "as";
+          "cc" = absOrRelPath toolchain.stdenv.cc "cc";
+        };
+    in
+    {
+      x86_64 = genToolsFromToolchain x86_64PkgsCrossToolchain;
+      aarch64 = genToolsFromToolchain aarch64PkgsCrossToolchain;
+      riscv64 = genToolsFromToolchain riscv64PkgsCrossToolchain;
+    };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare";
@@ -58,6 +98,19 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=${builtins.placeholder "out"}"
     "PLATFORM=${platform}"
     "ARCH=${arch}"
+    # Strip the variable of an empty $(SRCDIR)/hare/third-party, since nix does
+    # not follow the FHS.
+    "HAREPATH=$(SRCDIR)/hare/stdlib"
+  ] ++ lib.optionals enableCrossCompilation [
+    "RISCV64_AS=${embeddedOnBinaryTools.riscv64.as}"
+    "RISCV64_CC=${embeddedOnBinaryTools.riscv64.cc}"
+    "RISCV64_LD=${embeddedOnBinaryTools.riscv64.ld}"
+    "AARCH64_AS=${embeddedOnBinaryTools.aarch64.as}"
+    "AARCH64_CC=${embeddedOnBinaryTools.aarch64.cc}"
+    "AARCH64_LD=${embeddedOnBinaryTools.aarch64.ld}"
+    "x86_64_AS=${embeddedOnBinaryTools.x86_64.as}"
+    "x86_64_CC=${embeddedOnBinaryTools.x86_64.cc}"
+    "x86_64_LD=${embeddedOnBinaryTools.x86_64.ld}"
   ];
 
   enableParallelBuilding = true;
@@ -79,6 +132,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   setupHook = ./setup-hook.sh;
+
+  passthru = {
+    tests = lib.optionalAttrs enableCrossCompilation {
+      crossCompilation = callPackage ./cross-compilation-tests.nix {
+        hare = finalAttrs.finalPackage;
+      };
+    };
+  };
 
   meta = {
     homepage = "https://harelang.org/";


### PR DESCRIPTION
## Description of changes

Embed the needed paths on the `Hare` binary, so that it can cross-compile.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
