### PR TITLE
lingua-franca: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/development/compilers/lingua-franca/default.nix
+++ b/pkgs/development/compilers/lingua-franca/default.nix
@@ -1,23 +1,17 @@
-{ lib, pkgs, stdenv, fetchzip, jdk17_headless }:
+{ lib, pkgs, stdenv, jdk17_headless }:
 
 stdenv.mkDerivation rec {
   pname = "lfc";
-  version = "0.4.0";
+  version = "0.5.1";
 
-  src = fetchzip {
-    url = "https://github.com/lf-lang/lingua-franca/releases/download/v${version}/lf-cli-${version}.zip";
-    sha256 = "sha256-LrAm77iPUlqVfRdYy2bZ4mim7DHIr5JxPdbrgxokGvc=";
+  src = builtins.fetchTarball {
+    url = "https://github.com/lf-lang/lingua-franca/releases/download/v${version}/lf-cli-${version}-Linux-x86_64.tar.gz";
+    sha256 = "110kph2di59wj32gx4ymh4237dvyd9m2daamnyxck89vw7la9sjp";
   };
 
   buildInputs = [ jdk17_headless ];
 
   _JAVA_HOME = "${jdk17_headless}/";
-
-  postPatch = ''
-    substituteInPlace bin/lfc \
-      --replace 'base=`dirname $(dirname ''${abs_path})`' "base='$out'" \
-      --replace "run_lfc_with_args" "${jdk17_headless}/bin/java -jar $out/lib/jars/org.lflang.lfc-${version}-all.jar"
-  '';
 
   installPhase = ''
     cp -r ./ $out/
@@ -31,7 +25,7 @@ stdenv.mkDerivation rec {
       and possibly time-sensitive applications ranging from low-level
       embedded code to distributed cloud and edge applications.
     '';
-    homepage = "https://github.com/lf-lang/lingua-franca";
+    homepage = "https://lf-lang.org";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.bsd2;
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes
Bumped the version from 0.4 to 0.5.1 and threw out some postPatch stuff that is not needed anymore. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
