### PR TITLE
Support spaces in substitute wrapper replacements

### DIFF
--- a/pkgs/build-support/substitute/substitute.nix
+++ b/pkgs/build-support/substitute/substitute.nix
@@ -11,4 +11,5 @@ stdenvNoCC.mkDerivation ({
   inherit (args) src;
   preferLocalBuild = true;
   allowSubstitutes = false;
+  __structuredAttrs = true;
 } // args // { replacements = args.replacements; })

--- a/pkgs/build-support/substitute/substitute.sh
+++ b/pkgs/build-support/substitute/substitute.sh
@@ -1,17 +1,18 @@
+source $NIX_ATTRS_SH_FILE
 source $stdenv/setup
 
 args=
 
-target=$out
+target="$out"
 if test -n "$dir"; then
-    target=$out/$dir/$name
-    mkdir -p $out/$dir
+    target="$out/$dir/$name"
+    mkdir -p "$out/$dir"
 fi
 
-substitute $src $target $replacements
+substitute "$src" "$target" "${replacements[@]}"
 
 if test -n "$isExecutable"; then
-    chmod +x $target
+    chmod +x "$target"
 fi
 
 eval "$postInstall"


### PR DESCRIPTION
## Description of changes

Prior to this change, spaces would result in "Invalid command line
argument" errors for the subsequent words due to substituteStream
expecting flags such as "--replace". This change aligns the behaviour
between the substitute wrapper and substituteInPlace command in stdenv.

Fixes #178438

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
