### PR TITLE
aacgain: Use vendored version of `faad2`

### DIFF
--- a/pkgs/applications/audio/aacgain/default.nix
+++ b/pkgs/applications/audio/aacgain/default.nix
@@ -5,7 +5,6 @@
 , autoconf
 , automake
 , libtool
-, faad2
 , mp4v2
 }:
 
@@ -17,11 +16,12 @@ stdenv.mkDerivation rec {
     owner = "dgilman";
     repo = pname;
     rev = version;
-    sha256 = "sha256-9Y23Zh7q3oB4ha17Fpm1Hu2+wtQOA1llj6WDUAO2ARU=";
+    hash = "sha256-842+ueBSrTRs/e14d2LUd+uFi2qgJOYv+dswpC0lgIo=";
+    fetchSubmodules = true;
   };
 
   postPatch = ''
-    cp -R ${faad2.src}/* 3rdparty/faad2
+    rm -rf 3rdparty/mp4v2/*
     cp -R ${mp4v2.src}/* 3rdparty/mp4v2
     chmod -R +w 3rdparty
   '';


### PR DESCRIPTION
Recent upstream versions of `faad2` have switched away from autoconf [^1], but the `aacgain` project's CMake build instructions haven't been adjusted accordingly [^2], as the project vendors its dependencies [^3].

This change switches to fetching the sources via Git, including the submodules for the vendored dependencies. In the patch phase, the (still working) `mp4v2` dependency then gets replaced with the sources from `mp4v2` derivation, while `faad2` sources remain at the commit it was vendored with.

I had tried to achieve this by keeping the `fetchFromGitHub` function and adding `fetchSubmodules = true;` (introduced here [^4]), but that still didn't seem to initialize the submodules properly on my machine. Because of that, I switched the package to `fetchgit` instead (for which `fetchSubmodules` seems to work properly).

[^1]: https://github.com/knik0/faad2/commit/ab4d54e8cdc9cad15e6cbf1fa4dc3e07862db15a
[^2]: https://github.com/dgilman/aacgain/blob/master/3rdparty/CMakeLists.txt#L9
[^3]: https://github.com/dgilman/aacgain/tree/9f9ae95a20197d1072994dbd89672bba2904bdb5/3rdparty
[^4]: https://github.com/NixOS/nixpkgs/commit/e8bb0a5ef7e0f0d94bdb96ece9da8fffa25fe9cf

EDIT: closes #273907.

## Description of changes

- Switch from packaged version of `faad2` to the version vendored upstream.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
