### PR TITLE
jj: init at 1.9.2

### DIFF
--- a/pkgs/by-name/jj/jj/package.nix
+++ b/pkgs/by-name/jj/jj/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nix-update-script
+, testers
+, writeText
+, runCommand
+, jj
+}:
+buildGoModule rec {
+  pname = "jj";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "tidwall";
+    repo = "jj";
+    rev = "v${version}";
+    hash = "sha256-Yijap5ZghTBe1ahkQgjjxuo++SriJWXgRqrNXIVQ0os=";
+  };
+
+  vendorHash = "sha256-39rA3jMGYhsh1nrGzI1vfHZzZDy4O6ooYWB8af654mM=";
+
+  subPackages = [ "cmd/jj" ];
+
+  CGO_ENABLED = "0";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = with testers; {
+      version = testVersion { package = jj; };
+      examples = testEqualContents {
+        assertion = "examples from projects README.md work";
+        actual = runCommand "actual" { nativeBuildInputs = [ jj ]; } ''
+          {
+            echo '{"name":{"first":"Tom","last":"Smith"}}' | jj name.last
+            echo '{"name":{"first":"Tom","last":"Smith"}}' | jj name
+            echo '{"name":{"first":"Tom","last":"Smith"}}' | jj -v Andy name.first
+            echo '{"friends":["Tom","Jane","Carol"]}' | jj -v Andy friends.-1
+            echo '{"age":46,"name":{"first":"Tom","last":"Smith"}}' | jj -D age
+          } > $out
+        '';
+        expected = writeText "expected" ''
+          Smith
+          {"first":"Tom","last":"Smith"}
+          {"name":{"first":"Andy","last":"Smith"}}
+          {"friends":["Tom","Jane","Carol","Andy"]}
+          {"name":{"first":"Tom","last":"Smith"}}
+        '';
+      };
+    };
+  };
+
+  meta = with lib; {
+    description = "JSON Stream Editor (command line utility)";
+    longDescription = ''
+      JJ is a command line utility that provides a fast and simple way to retrieve
+      or update values from JSON documents. It's powered by GJSON and SJSON under the hood.
+      It's fast because it avoids parsing irrelevant sections of json, skipping over values
+      that do not apply, and aborts as soon as the target value has been found or updated.
+    '';
+    homepage = "https://github.com/tidwall/jj";
+    changelog = "https://github.com/tidwall/jj/releases/tag/v${version}";
+    license = licenses.mit;
+    mainProgram = "jj";
+    maintainers = with maintainers; [ katexochen ];
+  };
+}


### PR DESCRIPTION
## Description of changes

a fast alternative to jq

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
