### PR TITLE
home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: unstable-2023-12-06 -> unstable-2023-12-16

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/default.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/default.nix
@@ -6,20 +6,20 @@
 
 mkYarnPackage rec {
   pname = "zigbee2mqtt-networkmap";
-  version = "unstable-2023-12-06";
+  version = "unstable-2023-12-16";
 
   src = fetchFromGitHub {
     owner = "azuwis";
     repo = "zigbee2mqtt-networkmap";
-    rev = "d5f1002118ba5881c6bdc27cb0f67642575c414f";
-    hash = "sha256-ITqzMjom2XN7+ICDH0Z5YJWY5GNUXzaqSuEzXekhw9I=";
+    rev = "7851357d78ebc0d1cc3cb5c661267a1e8b4c09e3";
+    hash = "sha256-x7RVy0stWT6+8f0/0VORVBgGpBbsbyJBC38xIxXhzos=";
   };
 
   packageJSON = ./package.json;
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-uPhD6UQ1KI7y6bqqQF7InT9eKU9VWGf2D60Lo5Mwcf8=";
+    hash = "sha256-s+vnyUeJKkkA5G0AmsfIG0Zh4bYdDc2B5MSNvdwhjgs=";
   };
 
   configurePhase = ''

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.json
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "vue": "^3.3.4"
+    "vue": "^2.7.15"
   },
   "devDependencies": {
     "@material/mwc-button": "^0.27.0",


### PR DESCRIPTION
## Description of changes

Upstream changelog:

> Downgrade vue to 2.7.15
>
> Fix error `Cannot read properties of undefined (reading 'component')`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
