### PR TITLE
nixos/top-level: pass activation scripts as files to avoid "Argument list too long" error

### DIFF
--- a/nixos/modules/system/activation/activatable-system.nix
+++ b/nixos/modules/system/activation/activatable-system.nix
@@ -13,6 +13,10 @@ let
     ;
 
   systemBuilderArgs = {
+    passAsFile = [
+      "activationScript"
+      "dryActivationScript"
+    ];
     activationScript = config.system.activationScripts.script;
     dryActivationScript = config.system.dryActivationScript;
   };
@@ -54,8 +58,8 @@ in
   };
   config = {
     system.activatableSystemBuilderCommands = ''
-      echo "$activationScript" > $out/activate
-      echo "$dryActivationScript" > $out/dry-activate
+      mv "$activationScriptPath" $out/activate
+      mv "$dryActivationScriptPath" $out/dry-activate
       substituteInPlace $out/activate --subst-var-by out ''${!toplevelVar}
       substituteInPlace $out/dry-activate --subst-var-by out ''${!toplevelVar}
       chmod u+x $out/activate $out/dry-activate

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -64,7 +64,6 @@ let
       name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
       preferLocalBuild = true;
       allowSubstitutes = false;
-      passAsFile = [ "extraDependencies" ];
       buildCommand = systemBuilder;
 
       systemd = config.systemd.package;
@@ -386,6 +385,11 @@ in
         # to the system closure, which defeats the purpose of the `system.checks`
         # option, as opposed to `system.extraDependencies`.
         passedChecks = concatStringsSep " " config.system.checks;
+
+        # Define `passAsFile` here, rather than in the body of `baseSystem`, so
+        # that it can be augmented with "activationScript" and
+        # "dryActivationScript" in `./activatable-system.nix`.
+        passAsFile = [ "extraDependencies" ];
       }
       // lib.optionalAttrs (config.system.forbiddenDependenciesRegexes != [ ]) {
         closureInfo = pkgs.closureInfo {


### PR DESCRIPTION
This stops Bash from complaining "Argument list too long" due to very large activation scripts.  Related: ryantm/agenix#227.

## Description of changes

This PR updates the activatable system derivation to pass `activationScript` and `dryActivationScripts` via files rather than via environment variables.  Activation scripts are liable to grow large enough to make Bash/Linux complain about illegally large argument lists; see the above-linked `agenix` issue for one such example.

Incidental change: move the `passAsFile` definition, previously in the body of the `baseSystem` system derivation definition, into `system.systemBuilderArgs`, making it possible to extend it with `[ "activationScript" "dryActivationScript" ]` elsewhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
