### PR TITLE
step-ca: 0.25.0 -> 0.25.2

### DIFF
--- a/pkgs/tools/security/step-ca/default.nix
+++ b/pkgs/tools/security/step-ca/default.nix
@@ -12,20 +12,24 @@
 
 buildGoModule rec {
   pname = "step-ca";
-  version = "0.25.0";
+  version = "0.25.2";
 
   src = fetchFromGitHub {
     owner = "smallstep";
     repo = "certificates";
     rev = "refs/tags/v${version}";
-    hash = "sha256-CO9Qjx4D6qNGjOdva88KRCJOQq85r5U5nwmXC1G94dY=";
+    hash = "sha256-cP3QypBNWGbr7R7lJLfaoBh6C37ubGuaxnxWlZ1Z000=";
   };
 
-  vendorHash = "sha256-Weq8sS+8gsfdoVSBDm8E2DCrngfNsolqQR2/yd9etPo=";
+  vendorHash = "sha256-AXMMpzXEhdKSGeVg/KK2NEgalxIXP6DUTcoxOQVqow4=";
 
-  ldflags = [ "-buildid=" ];
+  ldflags = [
+    "-buildid="
+  ];
 
-  nativeBuildInputs = lib.optionals hsmSupport [ pkg-config ];
+  nativeBuildInputs = lib.optionals hsmSupport [
+    pkg-config
+  ];
 
   buildInputs =
     lib.optionals (hsmSupport && stdenv.isLinux) [ pcsclite ]
@@ -43,9 +47,14 @@ buildGoModule rec {
     install -Dm444 -t $out/lib/systemd/system systemd/step-ca.service
   '';
 
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
   # Tests start http servers which need to bind to local addresses:
   # panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
   __darwinAllowLocalNetworking = true;
+
   # Tests need to run in a reproducible order, otherwise they run unreliably on
   # (at least) x86_64-linux.
   checkFlags = [ "-p 1" ];


### PR DESCRIPTION
Diff: https://github.com/smallstep/certificates/compare/refs/tags/v0.25.0...v0.25.2

Changelog: https://github.com/smallstep/certificates/releases/tag/v0.25.2

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
