### PR TITLE
junicode: 2.203 -> 2.206

### DIFF
--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,14 +2,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.205";
+  version = "2.206";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-/9vkc6Ic3xyfpKEE64dBpoVM/gcRsLnAcrZWie9lNa4=";
+    hash = "sha256-oOKg85Yz5/2/pvwjVqeQXE8xE7X+QJvPYwYN+E18oEc=";
   };
 
-  outputs = [ "out" "doc" "tex" "texdoc" ];
+  outputs = [ "out" "doc" "tex" ];
 
   patches = [ ./tex-font-path.patch ];
 
@@ -32,15 +32,6 @@ stdenvNoCC.mkDerivation rec {
 
     install -Dm 444 -t $tex/tex/latex/junicode TeX/junicode.sty
     install -Dm 444 -t $tex/tex/latex/junicodevf TeX/junicodevf.{sty,lua}
-
-    install -Dm 444 -t $texdoc/doc/tex/latex/junicode TeX/junicode-package.pdf
-    install -Dm 444 -t $texdoc/doc/tex/latex/junicodevf TeX/junicodevf-package.pdf
-
-    cat >$texdoc/doc/tex/latex/junicode/nix-font-note.txt <<EOF
-    The style file is patched to refer directly to the corresponding
-    font files; thus, contrary to the documentation, the fonts
-    do *not* have to be installed globally.
-    EOF
 
     runHook postInstall
   '';

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.204";
+  version = "2.205";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-n0buIXc+xjUuUue2Fu1jnlTc74YvmrDKanfmWtM4bFs=";
+    hash = "sha256-/9vkc6Ic3xyfpKEE64dBpoVM/gcRsLnAcrZWie9lNa4=";
   };
 
   outputs = [ "out" "doc" "tex" "texdoc" ];
@@ -14,8 +14,10 @@ stdenvNoCC.mkDerivation rec {
   patches = [ ./tex-font-path.patch ];
 
   postPatch = ''
-    substituteInPlace TeX/Junicode.sty \
+    substituteInPlace TeX/junicode.sty \
       --replace '@@@opentype_path@@@' "$out/share/fonts/opentype/" \
+      --replace '@@@truetype_path@@@' "$out/share/fonts/truetype/"
+    substituteInPlace TeX/junicodevf.sty \
       --replace '@@@truetype_path@@@' "$out/share/fonts/truetype/"
   '';
 
@@ -28,11 +30,13 @@ stdenvNoCC.mkDerivation rec {
 
     install -Dm 444 -t $doc/share/doc/${pname}-${version} docs/*.pdf
 
-    install -Dm 444 -t $tex/tex/latex/Junicode TeX/Junicode.sty
+    install -Dm 444 -t $tex/tex/latex/junicode TeX/junicode.sty
+    install -Dm 444 -t $tex/tex/latex/junicodevf TeX/junicodevf.{sty,lua}
 
-    install -Dm 444 -t $texdoc/doc/tex/latex/Junicode TeX/*.pdf
+    install -Dm 444 -t $texdoc/doc/tex/latex/junicode TeX/junicode-package.pdf
+    install -Dm 444 -t $texdoc/doc/tex/latex/junicodevf TeX/junicodevf-package.pdf
 
-    cat >$texdoc/doc/tex/latex/Junicode/nix-font-note.txt <<EOF
+    cat >$texdoc/doc/tex/latex/junicode/nix-font-note.txt <<EOF
     The style file is patched to refer directly to the corresponding
     font files; thus, contrary to the documentation, the fonts
     do *not* have to be installed globally.

--- a/pkgs/data/fonts/junicode/test-vf.tex
+++ b/pkgs/data/fonts/junicode/test-vf.tex
@@ -1,6 +1,6 @@
 \documentclass{article}
 
-\usepackage[fonttype=@fonttype@]{junicode}
+\usepackage{junicodevf}
 
 \begin{document}
 \begin{enumerate}
@@ -18,16 +18,16 @@
 \item {\jExpBoldItalic ExpBoldItalic}
 \item {\jExpMedium ExpMedium}
 \item {\jExpMediumItalic ExpMediumItalic}
-\item {\jExpSmBold ExpSmBold}
-\item {\jExpSmBoldItalic ExpSmBoldItalic}
+\item {\jExpSmbold ExpSmbold}
+\item {\jExpSmboldItalic ExpSmboldItalic}
 \item {\jItalic Italic}
 \item {\jLight Light}
 \item {\jLightItalic LightItalic}
 \item {\jMedium Medium}
 \item {\jMediumItalic MediumItalic}
 \item {\jRegular Regular}
-\item {\jSmBold SmBold}
-\item {\jSmBoldItalic SmBoldItalic}
+\item {\jSmbold Smbold}
+\item {\jSmboldItalic SmboldItalic}
 \item {\jSmCond SmCond}
 \item {\jSmCondItalic SmCondItalic}
 \item {\jSmCondLight SmCondLight}
@@ -40,7 +40,7 @@
 \item {\jSmExpBoldItalic SmExpBoldItalic}
 \item {\jSmExpMedium SmExpMedium}
 \item {\jSmExpMediumItalic SmExpMediumItalic}
-\item {\jSmExpSmBold SmExpSmBold}
-\item {\jSmExpSmBoldItalic SmExpSmBoldItalic}
+\item {\jSmExpSmbold SmExpSmbold}
+\item {\jSmExpSmboldItalic SmExpSmboldItalic}
 \end{enumerate}
 \end{document}

--- a/pkgs/data/fonts/junicode/test.tex
+++ b/pkgs/data/fonts/junicode/test.tex
@@ -1,0 +1,46 @@
+\documentclass{article}
+
+\usepackage[fonttype=@fonttype@]{Junicode}
+
+\begin{document}
+\begin{enumerate}
+\item {\jBold Bold}
+\item {\jBoldItalic BoldItalic}
+\item {\jCond Cond}
+\item {\jCondItalic CondItalic}
+\item {\jCondLight CondLight}
+\item {\jCondLightItalic CondLightItalic}
+\item {\jCondMedium CondMedium}
+\item {\jCondMediumItalic CondMediumItalic}
+\item {\jExp Exp}
+\item {\jExpItalic ExpItalic}
+\item {\jExpBold ExpBold}
+\item {\jExpBoldItalic ExpBoldItalic}
+\item {\jExpMedium ExpMedium}
+\item {\jExpMediumItalic ExpMediumItalic}
+\item {\jExpSmbold ExpSmbold}
+\item {\jExpSmboldItalic ExpSmboldItalic}
+\item {\jItalic Italic}
+\item {\jLight Light}
+\item {\jLightItalic LightItalic}
+\item {\jMedium Medium}
+\item {\jMediumItalic MediumItalic}
+\item {\jRegular Regular}
+\item {\jSmbold Smbold}
+\item {\jSmboldItalic SmboldItalic}
+\item {\jSmCond SmCond}
+\item {\jSmCondItalic SmCondItalic}
+\item {\jSmCondLight SmCondLight}
+\item {\jSmCondLightItalic SmCondLightItalic}
+\item {\jSmCondMedium SmCondMedium}
+\item {\jSmCondMediumItalic SmCondMediumItalic}
+\item {\jSmExp SmExp}
+\item {\jSmExpItalic SmExpItalic}
+\item {\jSmExpBold SmExpBold}
+\item {\jSmExpBoldItalic SmExpBoldItalic}
+\item {\jSmExpMedium SmExpMedium}
+\item {\jSmExpMediumItalic SmExpMediumItalic}
+\item {\jSmExpSmbold SmExpSmbold}
+\item {\jSmExpSmboldItalic SmExpSmboldItalic}
+\end{enumerate}
+\end{document}

--- a/pkgs/data/fonts/junicode/tests.nix
+++ b/pkgs/data/fonts/junicode/tests.nix
@@ -1,0 +1,23 @@
+{ lib, runCommand, junicode, texliveBasic }:
+let
+  texliveWithJunicode = texliveBasic.withPackages (p: [ p.xetex junicode ]);
+
+  texTest = { tex, fonttype }:
+    lib.attrsets.nameValuePair "${tex}-${fonttype}" (
+      runCommand "junicode-test-${tex}-${fonttype}.pdf" {
+          nativeBuildInputs = [ texliveWithJunicode ];
+          inherit tex fonttype;
+        } ''
+        substituteAll ${./test.tex} test.tex
+        HOME=$PWD $tex test.tex
+        cp test.pdf $out
+      '');
+in
+builtins.listToAttrs (
+  map
+    texTest
+    (lib.attrsets.cartesianProductOfSets {
+      tex = [ "xelatex" "lualatex" ];
+      fonttype = [ "ttf" "otf" ];
+    })
+)

--- a/pkgs/data/fonts/junicode/tests.nix
+++ b/pkgs/data/fonts/junicode/tests.nix
@@ -2,13 +2,14 @@
 let
   texliveWithJunicode = texliveBasic.withPackages (p: [ p.xetex junicode ]);
 
-  texTest = { tex, fonttype }:
-    lib.attrsets.nameValuePair "${tex}-${fonttype}" (
-      runCommand "junicode-test-${tex}-${fonttype}.pdf" {
+  texTest = { package, tex, fonttype, file }:
+    lib.attrsets.nameValuePair "${package}-${tex}-${fonttype}" (
+      runCommand "${package}-test-${tex}-${fonttype}.pdf"
+        {
           nativeBuildInputs = [ texliveWithJunicode ];
-          inherit tex fonttype;
+          inherit tex fonttype file;
         } ''
-        substituteAll ${./test.tex} test.tex
+        substituteAll $file test.tex
         HOME=$PWD $tex test.tex
         cp test.pdf $out
       '');
@@ -19,5 +20,16 @@ builtins.listToAttrs (
     (lib.attrsets.cartesianProductOfSets {
       tex = [ "xelatex" "lualatex" ];
       fonttype = [ "ttf" "otf" ];
+      package = [ "junicode" ];
+      file = [ ./test.tex ];
     })
+  ++
+  [
+    (texTest {
+      package = "junicodevf";
+      fonttype = "ttf";
+      tex = "lualatex";
+      file = ./test-vf.tex;
+    })
+  ]
 )

--- a/pkgs/data/fonts/junicode/tex-font-path.patch
+++ b/pkgs/data/fonts/junicode/tex-font-path.patch
@@ -1,0 +1,36 @@
+Upstream style file relies on font files being present on the system
+globally.  This is not quite how Nix usually does thing, so this patch
+changes the style file to instead look fonts up in hardcoded
+locations, which are later patched up to refer to the package outputs,
+thus ensuring the style always uses the fonts packaged with it.
+
+diff --git a/TeX/Junicode.sty b/TeX/Junicode.sty
+index f46b376..c73e6f8 100644
+--- a/TeX/Junicode.sty
++++ b/TeX/Junicode.sty
+@@ -136,8 +136,17 @@
+ \RequirePackage{fontspec}
+ \defaultfontfeatures{Ligatures=TeX, Extension=.\junicode@fonttype}
+ 
++\def\junicode@fonttype@otf{otf}
++
++\ifx\junicode@fonttype\junicode@fonttype@otf
++  \def\junicode@fontpath{@@@opentype_path@@@}
++\else
++  \def\junicode@fontpath{@@@truetype_path@@@}
++\fi
++
+ \setmainfont
+   [Renderer =          HarfBuzz,
++   Path =              \junicode@fontpath,
+    Numbers =           {\junicode@figurealign,\junicode@figurestyle},
+    SmallCapsFeatures = {Letters=SmallCaps},
+    UprightFont =       *-\junicode@regstylename,
+@@ -152,6 +161,7 @@
+ \newcommand{\junicode@newfont}[2]{
+     \newfontface#1{#2}[
+         Renderer =          HarfBuzz,
++        Path =              \junicode@fontpath,
+         Numbers =           {\junicode@figurealign,\junicode@figurestyle},
+         SmallCapsFeatures = {Letters=SmallCaps},
+     ]

--- a/pkgs/data/fonts/junicode/tex-font-path.patch
+++ b/pkgs/data/fonts/junicode/tex-font-path.patch
@@ -4,14 +4,16 @@ changes the style file to instead look fonts up in hardcoded
 locations, which are later patched up to refer to the package outputs,
 thus ensuring the style always uses the fonts packaged with it.
 
-diff --git a/TeX/Junicode.sty b/TeX/Junicode.sty
-index f46b376..c73e6f8 100644
---- a/TeX/Junicode.sty
-+++ b/TeX/Junicode.sty
-@@ -136,8 +136,17 @@
+diff --git a/TeX/junicode.sty b/TeX/junicode.sty
+index 83bd45d..8fe671c 100644
+--- a/TeX/junicode.sty
++++ b/TeX/junicode.sty
+@@ -208,7 +208,14 @@
+ 
  \RequirePackage{fontspec}
  \defaultfontfeatures{Ligatures=TeX, Extension=.\junicode@fonttype}
- 
+-\defaultfontfeatures{Ligatures=TeX}
++
 +\def\junicode@fonttype@otf{otf}
 +
 +\ifx\junicode@fonttype\junicode@fonttype@otf
@@ -19,18 +21,146 @@ index f46b376..c73e6f8 100644
 +\else
 +  \def\junicode@fontpath{@@@truetype_path@@@}
 +\fi
-+
- \setmainfont
-   [Renderer =          HarfBuzz,
+ 
+ \ifxetex
+ \typeout{\junicode@regstylename}
+@@ -219,6 +226,7 @@
+    ItalicFont =        *-\junicode@italstylename,
+    BoldFont =          *-\junicode@boldstylename,
+    BoldItalicFont =    *-\junicode@boldstylename Italic,
 +   Path =              \junicode@fontpath,
-    Numbers =           {\junicode@figurealign,\junicode@figurestyle},
-    SmallCapsFeatures = {Letters=SmallCaps},
-    UprightFont =       *-\junicode@regstylename,
-@@ -152,6 +161,7 @@
- \newcommand{\junicode@newfont}[2]{
-     \newfontface#1{#2}[
-         Renderer =          HarfBuzz,
-+        Path =              \junicode@fontpath,
+   ]{Junicode}
+ \fi
+ \ifluatex
+@@ -230,6 +238,7 @@
+    ItalicFont =        *-\junicode@italstylename,
+    BoldFont =          *-\junicode@boldstylename,
+    BoldItalicFont =    *-\junicode@boldstylename Italic,
++   Path =              \junicode@fontpath,
+   ]{Junicode}
+ \fi
+ 
+@@ -242,6 +251,7 @@
+         #3
          Numbers =           {\junicode@figurealign,\junicode@figurestyle},
          SmallCapsFeatures = {Letters=SmallCaps},
++        Path =              \junicode@fontpath,
      ]
+ }
+ \fi
+@@ -252,6 +262,7 @@
+         #3
+         Numbers =           {\junicode@figurealign,\junicode@figurestyle},
+         SmallCapsFeatures = {Letters=SmallCaps},
++        Path =              \junicode@fontpath,
+     ]
+ }
+ \fi
+diff --git a/TeX/junicodevf.lua b/TeX/junicodevf.lua
+index 7148668..acebe82 100644
+--- a/TeX/junicodevf.lua
++++ b/TeX/junicodevf.lua
+@@ -148,7 +148,7 @@ function mkfontcommands()
+          romfontcmd = "jRegular"
+          italfontcmd = "jItalic"
+       end
+-      tex.print("\\junicodevf@newfont{\\" .. romfontcmd .. "}{JunicodeVF}{\\" .. defcmd .. "}{\\" .. defsizecmd .. "}")
++      tex.print("\\junicodevf@newfont{\\" .. romfontcmd .. "}{JunicodeVF-Roman}{\\" .. defcmd .. "}{\\" .. defsizecmd .. "}")
+       tex.print("\\junicodevf@newfont{\\" .. italfontcmd .. "}{JunicodeVF-Italic}{\\" .. defcmd .. "}{\\" .. defsizecmd .. "}")
+    end
+ end
+diff --git a/TeX/junicodevf.sty b/TeX/junicodevf.sty
+index c01ccaf..07a99ad 100644
+--- a/TeX/junicodevf.sty
++++ b/TeX/junicodevf.sty
+@@ -168,11 +168,13 @@ mkwidthcommands(wdindex, adjustment)}}
+ 
+ % DECLARE THE FONTS
+ 
+-\setmainfont{Junicode VF}[
+-    ItalicFont =         {*-Italic},
+-    BoldFont =           {*},
+-    BoldItalicFont =     {*-Italic},
++\setmainfont{JunicodeVF-Roman}[
++    ItalicFont =         {JunicodeVF-Italic},
++    BoldFont =           {JunicodeVF-Roman},
++    BoldItalicFont =     {JunicodeVF-Italic},
+     Renderer =           HarfBuzz,
++    Extension =          .ttf,
++    Path =               @@@truetype_path@@@,
+     Numbers =            {\junicodevf@figurealign,\junicodevf@figurestyle},
+     \MainDef,
+     UprightFeatures =    {\MainRegDef
+@@ -188,6 +190,8 @@ mkwidthcommands(wdindex, adjustment)}}
+ \newcommand*{\junicodevf@newfont}[4]{
+     \setfontface#1{#2}[
+         Renderer =          HarfBuzz,
++        Extension =          .ttf,
++        Path =               @@@truetype_path@@@,
+         Numbers =           {\junicodevf@figurealign,\junicodevf@figurestyle},
+         SmallCapsFont =     {*},
+         SmallCapsFeatures = {Letters=SmallCaps},
+@@ -200,43 +204,59 @@ mkwidthcommands(wdindex, adjustment)}}
+ 
+ % ENLARGED FACES
+ 
+-\setfontface\EnlargedOne{JunicodeVF}[
++\setfontface\EnlargedOne{JunicodeVF-Roman}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLAOneSizeDef
+ ]
+ 
+ \setfontface\EnlargedOneItalic{JunicodeVF-Italic}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLAOneSizeDef
+ ]
+ 
+-\setfontface\EnlargedTwo{JunicodeVF}[
++\setfontface\EnlargedTwo{JunicodeVF-Roman}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLATwoSizeDef
+ ]
+ 
+ \setfontface\EnlargedTwoItalic{JunicodeVF-Italic}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLATwoSizeDef
+ ]
+ 
+-\setfontface\EnlargedThree{JunicodeVF}[
++\setfontface\EnlargedThree{JunicodeVF-Roman}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLAThreeSizeDef
+ ]
+ 
+ \setfontface\EnlargedThreeItalic{JunicodeVF-Italic}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLAThreeSizeDef
+ ]
+ 
+-\setfontface\EnlargedFour{JunicodeVF}[
++\setfontface\EnlargedFour{JunicodeVF-Roman}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLAFourSizeDef
+ ]
+ 
+ \setfontface\EnlargedFourItalic{JunicodeVF-Italic}[
+     Renderer = HarfBuzz,
++    Extension = .ttf,
++    Path = @@@truetype_path@@@,
+     \ENLAFourSizeDef
+ ]
+ 


### PR DESCRIPTION
Supersedes #274586 

## Description of changes

Changelog:
https://github.com/psb1558/Junicode-font/releases/tag/v2.204

In addition to the updated font itself, new version includes a TeX package for use with LuaLaTeX or XeLaTeX. Accordingly, the derivation is updated to expose it under the 'tex' output, and tests are added to ensure it works properly with texlive infrastructure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
