### PR TITLE
kaidan: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/kaidan/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kaidan/default.nix
@@ -8,8 +8,11 @@
 , qtmultimedia
 , qtlocation
 , qqc2-desktop-style
+, kirigami-addons
 , kirigami2
+, kio
 , knotifications
+, kquickimageedit
 , zxing-cpp
 , qxmpp
 , sonnet
@@ -18,14 +21,14 @@
 
 mkDerivation rec {
   pname = "kaidan";
-  version = "0.8.0";
+  version = "0.9.1";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "network";
     repo = pname;
     rev = "v${version}";
-    sha256 = "070njci5zyzahmz3nqyp660chxnqx1mxp31w17syfllvrw403qmg";
+    hash = "sha256-F5GhN9hAF2e8b0T3peUnLk8CVd+nq4YR8k52x6ZOoLM=";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkg-config ];
@@ -35,8 +38,11 @@ mkDerivation rec {
     qtmultimedia
     qtlocation
     qqc2-desktop-style
+    kirigami-addons
     kirigami2
+    kio
     knotifications
+    kquickimageedit
     zxing-cpp
     qxmpp
     sonnet

--- a/pkgs/by-name/li/libomemo-c/package.nix
+++ b/pkgs/by-name/li/libomemo-c/package.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libomemo-c";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "dino";
+    repo = "libomemo-c";
+    rev = "v${version}";
+    hash = "sha256-GvHMp0FWoApbYLMhKfNxSBel1xxWWF3TZ4lnkLvu2s4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildsInputs = [ openssl ];
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  meta = with lib; {
+    description = "Fork of libsignal-protocol-c adding support for OMEMO XEP-0384 0.5.0+";
+    homepage = "https://github.com/dino/libomemo-c";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.astro ];
+  };
+}

--- a/pkgs/development/libraries/qxmpp/default.nix
+++ b/pkgs/development/libraries/qxmpp/default.nix
@@ -5,6 +5,9 @@
 , pkg-config
 , withGstreamer ? true
 , gst_all_1
+, withOmemo ? true
+, qca-qt5
+, libomemo-c
 }:
 
 mkDerivation rec {
@@ -20,7 +23,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-  ] ++ lib.optionals withGstreamer [
+  ] ++ lib.optionals (withGstreamer || withOmemo) [
     pkg-config
   ];
   buildInputs = lib.optionals withGstreamer (with gst_all_1; [
@@ -28,12 +31,17 @@ mkDerivation rec {
     gst-plugins-bad
     gst-plugins-base
     gst-plugins-good
-  ]);
+  ]) ++ lib.optionals withOmemo [
+    qca-qt5
+    libomemo-c
+  ];
   cmakeFlags = [
     "-DBUILD_EXAMPLES=false"
     "-DBUILD_TESTS=false"
   ] ++ lib.optionals withGstreamer [
     "-DWITH_GSTREAMER=ON"
+  ] ++ lib.optionals withOmemo [
+    "-DBUILD_OMEMO=ON"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Fixes #274285 

Kaidan supports OMEMO now!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
