### PR TITLE
mpvScripts.mpv-cheatsheet: init at 0.30.0.2

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -69,6 +69,7 @@ let
     cutter = callPackage ./cutter.nix { };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
     mpris = callPackage ./mpris.nix { };
+    mpv-cheatsheet = callPackage ./mpv-cheatsheet.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { };

--- a/pkgs/applications/video/mpv/scripts/mpv-cheatsheet.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-cheatsheet.nix
@@ -1,0 +1,42 @@
+{ lib, fetchFromGitHub, nodePackages, stdenvNoCC }:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mpv-cheatsheet";
+  version = "0.30.0.2";
+
+  src = fetchFromGitHub {
+    owner = "ento";
+    repo = "mpv-cheatsheet";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-MWK0CYto3zgn3fivmL43tvgZn6XrjPxKLp0lgTFdplM=";
+  };
+
+  nativeBuildInputs = [
+    nodePackages.browserify
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make dist/${finalAttrs.passthru.scriptName}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D dist/${finalAttrs.passthru.scriptName} $out/share/mpv/scripts/${finalAttrs.passthru.scriptName}
+
+    runHook postInstall
+  '';
+
+
+  passthru.scriptName = "cheatsheet.js";
+
+  meta = with lib; {
+    description = "mpv script for looking up keyboard shortcuts";
+    homepage = "https://github.com/ento/mpv-cheatsheet";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ambroisie ];
+  };
+})


### PR DESCRIPTION
## Description of changes

I tested it on a local overlay, it works fine.

Homepage: https://github.com/ento/mpv-cheatsheet/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
