### PR TITLE
wrapRustcWith: allow --sysroot to be overridden

### DIFF
--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -1,8 +1,6 @@
 { lib
 , fetchFromGitHub
 , hostPlatform
-, cargo
-, rustc
 , lld
 }:
 
@@ -24,12 +22,7 @@ let
     };
   };
 
-  # inherit (cross) rustPlatform;
-  # ^ breaks because we are doing a no_std embedded build with a custom sysroot,
-  # but the fast_cross rustc wrapper already passes a sysroot argument
-  rustPlatform = cross.makeRustPlatform {
-    inherit rustc cargo;
-  };
+  inherit (cross) rustPlatform;
 
 in
 

--- a/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
+++ b/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
@@ -1,6 +1,19 @@
 #!@shell@
 
-extraBefore=(@sysroot@)
+defaultSysroot=(@sysroot@)
+
+for arg; do
+    case "$arg" in
+        --sysroot)
+            defaultSysroot=()
+            ;;
+        --)
+            break
+            ;;
+    esac
+done
+
+extraBefore=("${defaultSysroot[@]}")
 extraAfter=($NIX_RUSTFLAGS)
 
 # Optionally print debug info.


### PR DESCRIPTION
## Description of changes

It turns out that unlike a normal Unix program, if the --sysroot option is given more than once, rustc will error rather than using the last value given.  Therefore, we need to ensure we only add our default --sysroot argument if one hasn't been given explicitly on the wrapper's command line.

This fixes cross compilation of rustc.

Closes: https://github.com/NixOS/nixpkgs/issues/271736
Fixes: 8b51cdd3bea1 ("rustc: add a compiler wrapper")

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
