### PR TITLE
luaPackages.nvim-client: remove

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -96,7 +96,6 @@ middleclass,,,,,,
 mpack,,,,,,
 moonscript,https://github.com/leafo/moonscript.git,dev-1,,,,arobyn
 nui.nvim,,,,,,mrcjkb
-nvim-client,https://github.com/neovim/lua-client.git,,,,,
 nvim-cmp,https://github.com/hrsh7th/nvim-cmp,,,,,
 penlight,https://github.com/lunarmodules/Penlight.git,,,,,alerque
 plenary.nvim,https://github.com/nvim-lua/plenary.nvim.git,,,,5.1,

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -43,7 +43,6 @@ let
     luabitop
     mpack
   ] ++ lib.optionals doCheck [
-    nvim-client
     luv
     coxpcall
     busted

--- a/pkgs/development/lua-modules/aliases.nix
+++ b/pkgs/development/lua-modules/aliases.nix
@@ -42,4 +42,5 @@ mapAliases {
   lpty = throw "lpy was removed because broken and unmaintained "; # added 2023-10-14
   cyrussasl = throw "cyrussasl was removed because broken and unmaintained "; # added 2023-10-18
   nlua-nvim = throw "nlua-nvim was removed, use neodev-nvim instead"; # added 2023-12-16
+  nvim-client = throw "nvim-client was removed because it is now part of neovim"; # added 2023-12-17
 }

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -2755,26 +2755,6 @@ buildLuarocksPackage {
   };
 }) {};
 
-nvim-client = callPackage({ buildLuarocksPackage, coxpcall, fetchurl, lua, luaOlder, luv, mpack }:
-buildLuarocksPackage {
-  pname = "nvim-client";
-  version = "0.2.4-1";
-
-  src = fetchurl {
-    url    = "https://github.com/neovim/lua-client/archive/0.2.4-1.tar.gz";
-    sha256 = "0sk1lmj0r7pyj9k3p6n0wqjbd95br44ansz0ck3amp6ql8f9kprf";
-  };
-
-  disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ coxpcall lua luv mpack ];
-
-  meta = {
-    homepage = "https://github.com/neovim/lua-client";
-    description = "Lua client to Nvim";
-    license.fullName = "Apache";
-  };
-}) {};
-
 nvim-cmp = callPackage({ buildLuarocksPackage, fetchgit, lua, luaAtLeast, luaOlder }:
 buildLuarocksPackage {
   pname = "nvim-cmp";


### PR DESCRIPTION
## Description of changes

nvim-client (lua-client) [is now part of neovim core](https://github.com/neovim/lua-client).

The nix package is broken, and breaks the Neovim build when `doCheck = true`.

cc @teto 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
