### PR TITLE
enigma: cleanup; use `finalAttrs` pattern

### DIFF
--- a/pkgs/by-name/en/enigma/package.nix
+++ b/pkgs/by-name/en/enigma/package.nix
@@ -1,11 +1,12 @@
 { lib, stdenv, fetchurl, fetchpatch, makeWrapper, pkg-config, gettext, imagemagick, curl, libpng, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, xercesc, xdg-utils, hicolor-icon-theme }:
 stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "enigma";
   version = "1.30";
 
   src = fetchurl {
-    url = "https://github.com/Enigma-Game/Enigma/releases/download/${version}/Enigma-${version}-src.tar.gz";
-    sha256 = "rmS5H7wrEJcAcdDXjtW07enuOGjeLm6VaVRvxYQ3+K8=";
+    url = "https://github.com/Enigma-Game/Enigma/releases/download/${finalAttrs.version}/Enigma-${finalAttrs.version}-src.tar.gz";
+    hash = "sha256-rmS5H7wrEJcAcdDXjtW07enuOGjeLm6VaVRvxYQ3+K8=";
   };
 
   patches = [
@@ -44,4 +45,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ iblech ];
     homepage = "https://www.nongnu.org/enigma/";
   };
-}
+})

--- a/pkgs/by-name/en/enigma/package.nix
+++ b/pkgs/by-name/en/enigma/package.nix
@@ -1,5 +1,22 @@
-{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, pkg-config, gettext, imagemagick, curl, libpng, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, xercesc, xdg-utils, hicolor-icon-theme }:
-stdenv.mkDerivation rec {
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  makeWrapper,
+  pkg-config,
+  gettext,
+  imagemagick,
+  curl,
+  libpng,
+  SDL2,
+  SDL2_image,
+  SDL2_mixer,
+  SDL2_ttf,
+  xercesc,
+  xdg-utils,
+}:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "enigma";
   version = "1.30";
@@ -13,12 +30,26 @@ stdenv.mkDerivation (finalAttrs: {
     # fix format string security warning (turned into error)
     (fetchpatch {
       url = "https://github.com/Enigma-Game/Enigma/pull/70/commits/d25051eb6228c885e779a9674f8ee3979da30663.patch";
-      sha256 = "L5C4NCZDDUKji9Tg4geKaiw3CkSY6rCoawqGKqR4dFM=";
+      hash = "sha256-L5C4NCZDDUKji9Tg4geKaiw3CkSY6rCoawqGKqR4dFM=";
     })
   ];
 
-  nativeBuildInputs = [ pkg-config gettext makeWrapper imagemagick ];
-  buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf libpng xercesc curl xdg-utils ];
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    makeWrapper
+    imagemagick
+  ];
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+    SDL2_ttf
+    libpng
+    xercesc
+    curl
+    xdg-utils
+  ];
 
   # The configure script of enigma uses pkg-config to determine the header
   # directories of SDL2. However, pkg-config only returns the path to the core
@@ -39,7 +70,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Puzzle game inspired by Oxyd on the Atari ST and Rock'n'Roll on the Amiga";
     mainProgram = "enigma";
-    license = with licenses; [ gpl2Plus free ]; # source + bundles libs + art
+    license = with licenses; [
+      gpl2
+      free
+    ]; # source + bundles libs + art
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
     maintainers = with maintainers; [ iblech ];


### PR DESCRIPTION
## Description of changes

switch derivation to `finalAttrs` pattern
cleaned up some of the derivation as parts of it are getting a bit long
swapped `sha256` hash usages to `hash`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
