### PR TITLE
Cinnamon updates 2023-12-17

### DIFF
--- a/pkgs/desktops/cinnamon/folder-color-switcher/default.nix
+++ b/pkgs/desktops/cinnamon/folder-color-switcher/default.nix
@@ -7,14 +7,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "folder-color-switcher";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     # They don't really do tags, this is just a named commit.
-    rev = "826df0b71c7c3b686421437eac86883945dc5956";
-    sha256 = "sha256-WdOTyladZ0U39wbhqsXzg9l3mJ5UGV99yVg1PWscP2w=";
+    rev = "ebab2114649cc688a05e30857f6706f16fe82307";
+    sha256 = "sha256-/VbgFuSoeDIiJG4owXbn7yT0ILrAdKkkhSkScnnJa+8=";
   };
 
   nativeBuildInputs = [
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace usr/share/nemo-python/extensions/nemo-folder-color-switcher.py \
-      --replace "/usr/share/locale" "$out/share" \
+      --replace "/usr/share/locale" "$out/share/locale" \
       --replace "/usr/share/folder-color-switcher/colors.d" "/run/current-system/sw/share/folder-color-switcher/colors.d" \
       --replace "/usr/share/folder-color-switcher/color.svg" "$out/share/folder-color-switcher/color.svg"
 

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-emblems/default.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-emblems/default.nix
@@ -1,6 +1,7 @@
 { python3
 , lib
 , fetchFromGitHub
+, cinnamon-translations
 }:
 
 let
@@ -17,6 +18,9 @@ python3.pkgs.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "/usr/share" "share"
+
+    substituteInPlace nemo-extension/nemo-emblems.py \
+      --replace "/usr/share/locale" "${cinnamon-translations}/share/locale"
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-fileroller/default.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-fileroller/default.nix
@@ -8,6 +8,7 @@
 , gtk3
 , nemo
 , gnome
+, cinnamon-translations
 }:
 
 let
@@ -33,7 +34,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/nemo-fileroller.c \
-      --replace "file-roller" "${lib.getExe gnome.file-roller}"
+      --replace "file-roller" "${lib.getExe gnome.file-roller}" \
+      --replace "GNOMELOCALEDIR" "${cinnamon-translations}/share/locale"
   '';
 
   PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";

--- a/pkgs/desktops/cinnamon/nemo-extensions/srcs.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/srcs.nix
@@ -4,12 +4,12 @@ rec {
   # When you bump this, you should make sure all nemo-extensions
   # are actually using this file since we try to deal with tags
   # like nemo-fileroller-5.6.1 according to upstream's wishes.
-  version = "6.0.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
     rev = version;
-    sha256 = "sha256-M8ImntyfFfSL591UpqZosE7F8ydbpfrBhcLOBtW/sGQ=";
+    sha256 = "sha256-zuE0SO5VJ2kKjK7JgsSf+wJgfyffTHhfICslEoPKK8Q=";
   };
 }


### PR DESCRIPTION
Bump nemo extensions, also try to fix broken translations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
