### PR TITLE
pyxel: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/pyxel/default.nix
+++ b/pkgs/development/python-modules/pyxel/default.nix
@@ -1,0 +1,57 @@
+{ buildPythonPackage
+, pythonOlder
+, fetchPypi
+, SDL2
+, autoPatchelfHook
+, lib
+, stdenv
+}:
+
+let
+  mk-src = sys: hash: {
+    platform = "manylinux_2_17_${sys}.manylinux2014_${sys}";
+    inherit hash;
+  };
+
+  sources = {
+    "x86_64-linux" = mk-src "x86_64"
+      "sha256-ejxb74E35i/jtye9Xfokk32byJ2kp1Ri4Yf6W6GzKRg=";
+
+    "i686-linux" = mk-src "i686"
+      "sha256-g28prnsXPhaR8yw++Ww8QcFF6LpsIrb9KjBKTujY1Dw=";
+
+    "aarch64-linux" = mk-src "aarch64"
+      "sha256-kX4UksaIxTvromqG8wU/1vDONuWmaKf32HeYB29hUPQ=";
+  };
+in
+buildPythonPackage rec {
+  pname = "pyxel";
+  format = "wheel";
+  version = "2.0.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version format;
+
+    hash = sources.${stdenv.system}.hash;
+    python = "cp37";
+    dist = "cp37";
+    abi = "abi3";
+    platform = sources.${stdenv.system}.platform;
+  };
+
+  buildInputs = [ SDL2 ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "pyxel" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kitao/pyxel";
+    description = "Pyxel is a retro game engine for Python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sigmanificient ];
+    changelog = "https://github.com/kitao/pyxel/tree/v${version}/CHANGELOG.md";
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12078,6 +12078,8 @@ self: super: with self; {
 
   pyxbe = callPackage ../development/python-modules/pyxbe { };
 
+  pyxel = callPackage ../development/python-modules/pyxel { };
+
   pyxdg = callPackage ../development/python-modules/pyxdg { };
 
   pyxeoma = callPackage ../development/python-modules/pyxeoma { };


### PR DESCRIPTION
## Description of changes

Pyxel is a retro game engine for Python.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
