### PR TITLE
luarocks-packages-updater: silence some warnings

### DIFF
--- a/pkgs/development/lua-modules/updater/.flake8
+++ b/pkgs/development/lua-modules/updater/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# E111 => 4 spaces tabs
+# don't let spaces else it is not recognized
+# E123 buggy
+ignore =
+	E501,E265,E402

--- a/pkgs/development/lua-modules/updater/default.nix
+++ b/pkgs/development/lua-modules/updater/default.nix
@@ -6,10 +6,24 @@
 # , nix-prefetch-git
 , nix-prefetch-scripts
 , luarocks-nix
+, lua5_1
+, lua5_2
+, lua5_3
+, lua5_4
 }:
 let
 
-    path = lib.makeBinPath [ nix nix-prefetch-scripts luarocks-nix ];
+  path = lib.makeBinPath [
+    nix nix-prefetch-scripts luarocks-nix
+  ];
+
+  luaversions = [
+    lua5_1
+    lua5_2
+    lua5_3
+    lua5_4
+  ];
+
 in
 buildPythonApplication {
   pname = "luarocks-packages-updater";
@@ -34,7 +48,12 @@ buildPythonApplication {
     cp ${../../../../maintainers/scripts/pluginupdate.py} $out/lib/pluginupdate.py
 
     # wrap python scripts
-    makeWrapperArgs+=( --prefix PATH : "${path}" --prefix PYTHONPATH : "$out/lib" )
+    makeWrapperArgs+=( --prefix PATH : "${path}" --prefix PYTHONPATH : "$out/lib" \
+      --set LUA_51 ${lua5_1} \
+      --set LUA_52 ${lua5_2} \
+      --set LUA_53 ${lua5_3} \
+      --set LUA_54 ${lua5_4}
+    )
     wrapPythonProgramsIn "$out"
   '';
 

--- a/pkgs/development/lua-modules/updater/updater.py
+++ b/pkgs/development/lua-modules/updater/updater.py
@@ -16,6 +16,8 @@ import csv
 import logging
 import textwrap
 from multiprocessing.dummy import Pool
+import pluginupdate
+from pluginupdate import update_plugins, FetchConfig
 
 from typing import List, Tuple, Optional
 from pathlib import Path
@@ -24,8 +26,6 @@ log = logging.getLogger()
 log.addHandler(logging.StreamHandler())
 
 ROOT = Path(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))).parent.parent  # type: ignore
-import pluginupdate
-from pluginupdate import update_plugins, FetchConfig, CleanEnvironment
 
 PKG_LIST = "maintainers/scripts/luarocks-packages.csv"
 TMP_FILE = "$(mktemp)"
@@ -171,7 +171,6 @@ def generate_pkg_nix(plug: LuaPlugin):
     if plug.maintainers:
         cmd.append(f"--maintainers={plug.maintainers}")
 
-    # if plug.server == "src":
     if plug.src != "":
         if plug.src is None:
             msg = (
@@ -193,6 +192,9 @@ def generate_pkg_nix(plug: LuaPlugin):
 
     if plug.luaversion:
         cmd.append(f"--lua-version={plug.luaversion}")
+        luaver = plug.luaversion.replace('.', '')
+        if luaver := os.getenv(f"LUA_{luaver}"):
+            cmd.append(f"--lua-dir={luaver}")
 
     log.debug("running %s", " ".join(cmd))
 


### PR DESCRIPTION
The script used to output:

```
Warning: Lua 5.1 interpreter not found at /nix/store/w577gc82dg7r1p480pp1kjbq7i32lhh2-lua-5.2.4
```
not sure why luarocks outputs since since it works nevertheless

added .flake8 so that the editor can pick it up too.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
