### PR TITLE
bochs: 2.7 -> 2.7-unstable-2023-12-16

### DIFF
--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , SDL2
 , curl
 , darwin
@@ -19,24 +19,31 @@
 , wxGTK32
 , enableSDL2 ? true
 , enableTerm ? true
-, enableWx ? !stdenv.isDarwin
+, enableWx ? false # Too heavy
 , enableX11 ? !stdenv.isDarwin
 }:
 
+assert enableWx -> !stdenv.isDarwin;
 stdenv.mkDerivation (finalAttrs: {
   pname = "bochs";
-  version = "2.7";
+  version = "2.7-unstable-2023-12-16";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/bochs/bochs/${finalAttrs.version}/bochs-${finalAttrs.version}.tar.gz";
-    hash = "sha256-oBCrG/3HKsWgjS4kEs1HHA/r1mrx2TSbwNeWh53lsXo=";
+  src = fetchFromGitHub {
+    owner = "bochs-emu";
+    repo = "Bochs";
+    rev = "54831068df334989405f16f85117f7f46fef944d";
+    hash = "sha256-iZ3HN1Ysi8VAAL4rfDqS3YppdgkJ3soKy7ZAjesoyKE=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/bochs";
 
   nativeBuildInputs = [
     docbook_xml_dtd_45
     docbook_xsl
     libtool
     pkg-config
+  ] ++ lib.optionals enableSDL2 [
+    SDL2
   ];
 
   buildInputs = [
@@ -59,77 +66,81 @@ stdenv.mkDerivation (finalAttrs: {
     darwin.libobjc
   ];
 
+  outputs = [ "out" "lib" "man" ];
+
+  strictDeps = true;
+
   configureFlags = [
-    "--with-rfb=no"
-    "--with-vncsrv=no"
-    "--with-nogui"
+    (lib.withFeature false "rfb")
+    (lib.withFeature false "vncsrv")
+    (lib.withFeature false "nogui")
 
-    # These will always be "yes" on NixOS
-    "--enable-ltdl-install=yes"
-    "--enable-readline=yes"
-    "--enable-all-optimizations=yes"
-    "--enable-logging=yes"
-    "--enable-xpm=yes"
+    # These will always be "true" on NixOS
+    (lib.enableFeature true "ltdl-install")
+    (lib.enableFeature true "readline")
+    (lib.enableFeature true "all-optimizations")
+    (lib.enableFeature true "logging")
+    (lib.enableFeature true "xpm")
 
-    # ... whereas these, always "no"!
-    "--enable-cpp=no"
-    "--enable-instrumentation=no"
+    # ... whereas these, always "false"
+    (lib.enableFeature false "cpp")
+    (lib.enableFeature false "instrumentation")
 
-    "--enable-docbook=no" # Broken - it requires docbook2html
+    # Broken - it requires docbook2html
+    (lib.enableFeature false "docbook")
 
-    # Dangerous options - they are marked as "incomplete/experimental" on Bochs documentation
-    "--enable-3dnow=no"
-    "--enable-monitor-mwait=no"
-    "--enable-raw-serial=no"
+    # Dangerous options - they are marked as "incomplete/experimental" on Bochs
+    # documentation
+    (lib.enableFeature false "3dnow")
+    (lib.enableFeature false "monitor-mwait")
+    (lib.enableFeature false "raw-serial")
 
     # These are completely configurable, and they don't depend of external tools
-    "--enable-a20-pin"
-    "--enable-avx"
-    "--enable-busmouse"
-    "--enable-cdrom"
-    "--enable-clgd54xx"
-    "--enable-configurable-msrs"
-    "--enable-cpu-level=6" # from 3 to 6
-    "--enable-debugger" #conflicts with gdb-stub option
-    "--enable-debugger-gui"
-    "--enable-evex"
-    "--enable-fpu"
-    "--enable-gdb-stub=no" # conflicts with debugger option
-    "--enable-handlers-chaining"
-    "--enable-idle-hack"
-    "--enable-iodebug"
-    "--enable-large-ramfile"
-    "--enable-largefile"
-    "--enable-pci"
-    "--enable-repeat-speedups"
-    "--enable-show-ips"
-    "--enable-smp"
-    "--enable-vmx=2"
-    "--enable-svm"
-    "--enable-trace-linking"
-    "--enable-usb"
-    "--enable-usb-ehci"
-    "--enable-usb-ohci"
-    "--enable-usb-xhci"
-    "--enable-voodoo"
-    "--enable-x86-64"
-    "--enable-x86-debugger"
-  ] ++ lib.optionals enableSDL2 [
-    "--with-sdl2"
-  ] ++ lib.optionals enableTerm [
-    "--with-term"
-  ] ++ lib.optionals enableWx [
-    "--with-wx"
-  ] ++ lib.optionals enableX11 [
-    "--with-x"
-    "--with-x11"
-  ] ++ lib.optionals (!stdenv.isDarwin) [
-    "--enable-e1000"
-    "--enable-es1370"
-    "--enable-ne2000"
-    "--enable-plugins"
-    "--enable-pnic"
-    "--enable-sb16"
+    (lib.enableFeature true "a20-pin")
+    (lib.enableFeature true "avx")
+    (lib.enableFeature true "busmouse")
+    (lib.enableFeature true "cdrom")
+    (lib.enableFeature true "clgd54xx")
+    (lib.enableFeature true "configurable-msrs")
+    (lib.enableFeature true "debugger") # conflicts with gdb-stub option
+    (lib.enableFeature true "debugger-gui")
+    (lib.enableFeature true "evex")
+    (lib.enableFeature true "fpu")
+    (lib.enableFeature false "gdb-stub") # conflicts with debugger option
+    (lib.enableFeature true "handlers-chaining")
+    (lib.enableFeature true "idle-hack")
+    (lib.enableFeature true "iodebug")
+    (lib.enableFeature true "large-ramfile")
+    (lib.enableFeature true "largefile")
+    (lib.enableFeature true "pci")
+    (lib.enableFeature true "repeat-speedups")
+    (lib.enableFeature true "show-ips")
+    (lib.enableFeature true "smp")
+    (lib.enableFeature true "svm")
+    (lib.enableFeature true "trace-linking")
+    (lib.enableFeature true "usb")
+    (lib.enableFeature true "usb-ehci")
+    (lib.enableFeature true "usb-ohci")
+    (lib.enableFeature true "usb-xhci")
+    (lib.enableFeature true "voodoo")
+    (lib.enableFeature true "x86-64")
+    (lib.enableFeature true "x86-debugger")
+
+    (lib.enableFeature (!stdenv.isDarwin) "e1000")
+    (lib.enableFeature (!stdenv.isDarwin) "es1370")
+    (lib.enableFeature (!stdenv.isDarwin) "ne2000")
+    (lib.enableFeature (!stdenv.isDarwin) "plugins")
+    (lib.enableFeature (!stdenv.isDarwin) "pnic")
+    (lib.enableFeature (!stdenv.isDarwin) "sb16")
+
+    (lib.enableFeatureAs true "cpu-level" "6")
+    (lib.enableFeatureAs true "vmx" "2")
+
+    (lib.withFeature enableSDL2 "sdl2")
+    (lib.withFeature enableTerm "term")
+    (lib.withFeature enableWx "wx")
+    (lib.withFeature enableX11 "x")
+    (lib.withFeature enableX11 "x11")
   ];
 
   enableParallelBuilding = true;
@@ -142,10 +153,10 @@ stdenv.mkDerivation (finalAttrs: {
       in C++, that runs on most popular platforms. It includes emulation of the
       Intel x86 CPU, common I/O devices, and a custom BIOS.
     '';
-    license = lib.licenses.lgpl2Plus;
+    license = with lib.licenses; [ lgpl2Plus ];
+    mainProgram = "bochs";
     maintainers = with lib.maintainers; [ AndersonTorres ];
     platforms = lib.platforms.unix;
   };
 })
-# TODO: a better way to organize the options
 # TODO: docbook (docbook-tools from RedHat mirrors should help)


### PR DESCRIPTION
- `enableWx` false by default, since it pulls heavy dependencies
- fetch from GitHub instead of Sourceforge
- split outputs
- strictDeps
- use lib.* functions
- set `meta.mainProgram`

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
