### PR TITLE
maintainers-list.nix: allow maintainer contact using Discourse

### DIFF
--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -29,10 +29,10 @@ let
         id=$(jq -r '.id' <<< "$info")
         echo "The GitHub ID for GitHub user ${checkedAttrs.github} is $id:"
         echo -e "    githubId = $id;\n"
-      '' ++ lib.optional (checkedAttrs.email == null && checkedAttrs.github == null && checkedAttrs.matrix == null) ''
-        echo ${lib.escapeShellArg (lib.showOption prefix)}': At least one of `email`, `github` or `matrix` must be specified, so that users know how to reach you.'
+      '' ++ lib.optional (checkedAttrs.email == null && checkedAttrs.github == null && checkedAttrs.matrix == null && checkedAttrs.discourse == null) ''
+        echo ${lib.escapeShellArg (lib.showOption prefix)}': At least one of `email`, `discourse`, `github` or `matrix` must be specified, so that users know how to reach you.'
       '' ++ lib.optional (checkedAttrs.email != null && lib.hasSuffix "noreply.github.com" checkedAttrs.email) ''
-        echo ${lib.escapeShellArg (lib.showOption prefix)}': If an email address is given, it should allow people to reach you. If you do not want that, you can just provide `github` or `matrix` instead.'
+        echo ${lib.escapeShellArg (lib.showOption prefix)}': If an email address is given, it should allow people to reach you. If you do not want that, you can just provide `discourse`, `github` or `matrix` instead.'
       '';
     in lib.deepSeq checkedAttrs checks;
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4,9 +4,10 @@
       # Required
       name = "Your name";
 
-      # Optional, but at least one of email, matrix or githubId must be given
+      # Optional, but at least one of email, matrix, discourse or githubId must be given
       email = "address@example.org";
       matrix = "@user:example.org";
+      discourse = "DiscourseHandle";
       github = "GithubUsername";
       githubId = your-github-id;
 
@@ -22,6 +23,7 @@
     - `name` is a name that people would know and recognize you by,
     - `email` is your maintainer email address,
     - `matrix` is your Matrix user ID,
+    - `discourse` is your handle on https://discourse.nixos.org/
     - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
     - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
     - `keys` is a list of your PGP/GPG key fingerprints.


### PR DESCRIPTION
## Description of changes

Many maintainers are already registered on Discourse, and it's no less convenient than the other contact possibilities maintainers can currently supply. Additionally, since the Discourse server is ran under control of the NixOS foundation, it provides a platform that can be used for subsequent implementation of maintainer-related automation. Therefore, it seems reasonable to allow maintainers to move more of their maintainership-related communication to Discourse. This is made possible by this PR.

GDPR impact:

This must be taken into account (see https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix#L52) as long as EU citizens are expected to take part in the community. However, the suggested change only adds an optional field, so it won't lead to more processing of personal data than before. Additionally, if maintainers choose to provide a Discourse handle, they may even choose not to provide the other contact details. It remains important to make sure there will be no implicit pressure that would make optional fields mandatory without explicit declaration. But this is a responsibility that is already present with the current schema. Therefore, if the pre-PR situation was GDPR-compliant, so will be the situation afterwards.

## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
