### PR TITLE
cmdstan: refactor

### DIFF
--- a/pkgs/development/compilers/cmdstan/default.nix
+++ b/pkgs/development/compilers/cmdstan/default.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, stanc, python3, buildPackages, runtimeShell }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, stanc
+, buildPackages
+, runtimeShell
+, runCommandCC
+, cmdstan
+}:
 
 stdenv.mkDerivation rec {
   pname = "cmdstan";
@@ -12,39 +21,43 @@ stdenv.mkDerivation rec {
     hash = "sha256-c+L/6PjW7YgmXHuKhKjiRofBRAhKYCzFCZ6BOX5AmC4=";
   };
 
-  nativeBuildInputs = [ stanc ];
-
-  buildFlags = [ "build" ];
-  enableParallelBuilding = true;
-
-  doCheck = true;
-  nativeCheckInputs = [ python3 ];
-
-  CXXFLAGS = lib.optionalString stdenv.isDarwin "-D_BOOST_LGAMMA";
-
   postPatch = ''
     substituteInPlace stan/lib/stan_math/make/libraries \
       --replace "/usr/bin/env bash" "bash"
-    patchShebangs .
-  '' + lib.optionalString stdenv.isAarch64 ''
-    sed -z -i "s/TEST(CommandStansummary, check_console_output).*TEST(CommandStansummary, check_csv_output)/TEST(CommandStansummary, check_csv_output)/" \
-      src/test/interface/stansummary_test.cpp
   '';
 
+  nativeBuildInputs = [
+    python3
+    stanc
+  ];
+
   preConfigure = ''
+    patchShebangs test-all.sh runCmdStanTests.py stan/
+  ''
+  # Fix inclusion of hardcoded paths in PCH files, by building in the store.
+  + ''
+    mkdir -p $out/opt
+    cp -R . $out/opt/cmdstan
+    cd $out/opt/cmdstan
     mkdir -p bin
     ln -s ${buildPackages.stanc}/bin/stanc bin/stanc
   '';
 
-  makeFlags = lib.optional stdenv.isDarwin "arch=${stdenv.hostPlatform.darwinArch}";
+  makeFlags = [
+    "build"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "arch=${stdenv.hostPlatform.darwinArch}"
+  ];
 
-  checkPhase = ''
-    ./runCmdStanTests.py -j$NIX_BUILD_CORES src/test/interface
-  '';
+  # Disable inclusion of timestamps in PCH files when using Clang.
+  env.CXXFLAGS = lib.optionalString stdenv.cc.isClang "-Xclang -fno-pch-timestamp";
+
+  enableParallelBuilding = true;
 
   installPhase = ''
-    mkdir -p $out/opt $out/bin
-    cp -r . $out/opt/cmdstan
+    runHook preInstall
+
+    mkdir -p $out/bin
     ln -s $out/opt/cmdstan/bin/stanc $out/bin/stanc
     ln -s $out/opt/cmdstan/bin/stansummary $out/bin/stansummary
     cat > $out/bin/stan <<EOF
@@ -52,10 +65,19 @@ stdenv.mkDerivation rec {
     make -C $out/opt/cmdstan "\$(realpath "\$1")"
     EOF
     chmod a+x $out/bin/stan
+
+    runHook postInstall
   '';
 
-  # Hack to ensure that patchelf --shrink-rpath get rids of a $TMPDIR reference.
-  preFixup = "rm -rf stan";
+  passthru.tests = {
+    test = runCommandCC "cmdstan-test" { } ''
+      cp -R ${cmdstan}/opt/cmdstan cmdstan
+      chmod -R +w cmdstan
+      cd cmdstan
+      ./runCmdStanTests.py -j$NIX_BUILD_CORES src/test/interface
+      touch $out
+    '';
+  };
 
   meta = with lib; {
     description = "Command-line interface to Stan";


### PR DESCRIPTION
## Description of changes

Also drops timestamps in PCH files on darwin, allowing the derivation to be used in `python311Packages.cmdstanpy` without modification.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
