### PR TITLE
deepin.deepin-voice-note: 6.0.13 -> 6.0.15

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-voice-note/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-voice-note/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , qttools
@@ -10,6 +9,7 @@
 , dtkwidget
 , qt5integration
 , qt5platform-plugins
+, qtsvg
 , dde-qt-dbus-factory
 , qtmultimedia
 , qtwebengine
@@ -20,27 +20,17 @@
 
 stdenv.mkDerivation rec {
   pname = "deepin-voice-note";
-  version = "6.0.13";
+  version = "6.0.15";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    hash = "sha256-yDlWyMGkSToGCN7tuZNR8Mz7MUOZ7355w4H0OzeHBrs=";
+    hash = "sha256-k6LFMs2/OQQyeGI5WXBGWkAAY4GeP8LaA8hTXFwbaCM=";
   };
 
   patches = [
     ./use_v23_dbus_interface.diff
-    (fetchpatch {
-      name = "Adjust-the-audio-port-available-range.patch";
-      url = "https://github.com/linuxdeepin/deepin-voice-note/commit/a876e4c4cf7d77e50071246f9fb6998aa62def77.patch";
-      hash = "sha256-J/PPdj1Am/v2Sw2Dv2XvZJAy/6Tf7OoTfrbOB9rc5m8=";
-    })
-    (fetchpatch {
-      name = "fix-build-error-with-new-dtk.patch";
-      url = "https://github.com/linuxdeepin/deepin-voice-note/commit/9ce211f603deaff21b881e1c4f43d53e33a85347.patch";
-      hash = "sha256-oP+AzMniONxjYIFust8fGaD8/UOjKr4yZiRUkdTMd5w=";
-    })
   ];
 
   postPatch = ''
@@ -59,8 +49,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     qtbase
+    qtsvg
     dtkwidget
-    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
     qtmultimedia
@@ -76,6 +66,11 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   cmakeFlags = [ "-DVERSION=${version}" ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
 
   preFixup = ''
     qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")


### PR DESCRIPTION
https://github.com/linuxdeepin/deepin-voice-note/compare/6.0.13...6.0.15

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
