### PR TITLE
nixos-firewall-tool: add nftables support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15962,6 +15962,12 @@
     githubId = 141248;
     name = "Ramses";
   };
+  rvfg = {
+    email = "i@rvf6.com";
+    github = "duament";
+    githubId = 30264485;
+    name = "Rvfg";
+  };
   rvl = {
     email = "dev+nix@rodney.id.au";
     github = "rvl";

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -79,6 +79,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - The `hardware.pulseaudio` module now sets permission of pulse user home directory to 755 when running in "systemWide" mode. It fixes [issue 114399](https://github.com/NixOS/nixpkgs/issues/114399).
 
+- `nixos-firewall-tool` now supports nftables and is installed by default when NixOS firewall is enabled.
+
 - The `btrbk` module now automatically selects and provides required compression
   program depending on the configured `stream_compress` option. Since this
   replaces the need for the `extraPackages` option, this option will be

--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -301,7 +301,6 @@ in
       }
     ];
 
-    environment.systemPackages = [ pkgs.nixos-firewall-tool ];
     networking.firewall.checkReversePath = mkIf (!kernelHasRPFilter) (mkDefault false);
 
     systemd.services.firewall = {

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -1,8 +1,8 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 let
+
+  inherit (lib) mkIf mkOption types mdDoc optionalString concatStrings concatStringsSep hasPrefix mapAttrsToList;
 
   cfg = config.networking.firewall;
 
@@ -26,7 +26,7 @@ in
         type = types.lines;
         default = "";
         example = "ip6 saddr { fc00::/7, fe80::/10 } tcp dport 24800 accept";
-        description = lib.mdDoc ''
+        description = mdDoc ''
           Additional nftables rules to be appended to the input-allow
           chain.
 
@@ -38,7 +38,7 @@ in
         type = types.lines;
         default = "";
         example = "iifname wg0 accept";
-        description = lib.mdDoc ''
+        description = mdDoc ''
           Additional nftables rules to be appended to the forward-allow
           chain.
 

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.networking.firewall;
 
+  backend = if config.networking.nftables.enable then "nftables" else "iptables";
+
   canonicalizePortList =
     ports: lib.unique (builtins.sort builtins.lessThan ports);
 
@@ -277,7 +279,10 @@ in
 
     networking.firewall.trustedInterfaces = [ "lo" ];
 
-    environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages;
+    environment.systemPackages = [
+      cfg.package
+      (pkgs.nixos-firewall-tool.override { inherit backend; })
+    ] ++ cfg.extraPackages;
 
     boot.kernelModules = (optional cfg.autoLoadConntrackHelpers "nf_conntrack")
       ++ map (x: "nf_conntrack_${x}") cfg.connectionTrackingModules;

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -3,14 +3,31 @@
 import ./make-test-python.nix ( { pkgs, nftables, ... } : {
   name = "firewall" + pkgs.lib.optionalString nftables "-nftables";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ eelco ];
+    maintainers = [ eelco rvfg ];
   };
 
   nodes =
     { walled =
         { ... }:
-        { networking.firewall.enable = true;
-          networking.firewall.logRefusedPackets = true;
+        { networking.firewall = {
+            enable = true;
+            logRefusedPackets = true;
+            # Syntax smoke test, not actually verified otherwise
+            allowedTCPPorts = [ 25 993 8005 ];
+            allowedTCPPortRanges = [
+              { from = 980; to = 1000; }
+              { from = 990; to = 1010; }
+              { from = 8000; to = 8010; }
+            ];
+            interfaces.eth0 = {
+              allowedTCPPorts = [ 10003 ];
+              allowedTCPPortRanges = [ { from = 10000; to = 10005; } ];
+            };
+            interfaces.eth3 = {
+              allowedUDPPorts = [ 10003 ];
+              allowedUDPPortRanges = [ { from = 10000; to = 10005; } ];
+            };
+          };
           networking.nftables.enable = nftables;
           services.httpd.enable = true;
           services.httpd.adminAddr = "foo@example.org";
@@ -36,7 +53,7 @@ import ./make-test-python.nix ( { pkgs, nftables, ... } : {
     };
 
   testScript = { nodes, ... }: let
-    newSystem = nodes.walled2.config.system.build.toplevel;
+    newSystem = nodes.walled2.system.build.toplevel;
     unit = if nftables then "nftables" else "firewall";
   in ''
     start_all()
@@ -55,6 +72,14 @@ import ./make-test-python.nix ( { pkgs, nftables, ... } : {
     # Outgoing connections/pings should still work.
     walled.succeed("curl -v http://attacker/ >&2")
     walled.succeed("ping -c 1 attacker >&2")
+
+    # Open tcp port 80 at runtime
+    walled.succeed("nixos-firewall-tool open tcp 80")
+    attacker.succeed("curl -v http://walled/ >&2")
+
+    # Reset the firewall
+    walled.succeed("nixos-firewall-tool reset")
+    attacker.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
 
     # If we stop the firewall, then connections should succeed.
     walled.stop_job("${unit}")

--- a/pkgs/by-name/ni/nixos-firewall-tool/nixos-firewall-tool-nftables.sh
+++ b/pkgs/by-name/ni/nixos-firewall-tool/nixos-firewall-tool-nftables.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+show_help() {
+    echo "nixos-firewall-tool"
+    echo ""
+    echo "Can temporarily manipulate the NixOS firewall"
+    echo ""
+    echo "Open TCP port:"
+    echo " nixos-firewall-tool open tcp 8888"
+    echo ""
+    echo "Show all firewall rules:"
+    echo " nixos-firewall-tool show"
+    echo ""
+    echo "Open UDP port:"
+    echo " nixos-firewall-tool open udp 51820"
+    echo ""
+    echo "Reset firewall configuration to system settings:"
+    echo " nixos-firewall-tool reset"
+}
+
+if [[ -z ${1+x} ]]; then
+  show_help
+  exit 1
+fi
+
+case $1 in
+  "open")
+    protocol="$2"
+    port="$3"
+
+    nft add element inet nixos-fw "$protocol-ports" "{ $port }"
+  ;;
+  "show")
+    nft list table inet nixos-fw
+  ;;
+  "reset")
+    systemctl reload nftables.service
+  ;;
+  -h|--help|help)
+    show_help
+    exit 0
+  ;;
+  *)
+    show_help
+    exit 1
+  ;;
+esac

--- a/pkgs/by-name/ni/nixos-firewall-tool/package.nix
+++ b/pkgs/by-name/ni/nixos-firewall-tool/package.nix
@@ -1,15 +1,24 @@
-{ writeShellApplication, iptables, lib }:
+{ writeShellApplication, iptables, lib
+, nftables, backend ? "iptables"
+}:
 
-writeShellApplication {
+writeShellApplication ({
   name = "nixos-firewall-tool";
-  text = builtins.readFile ./nixos-firewall-tool.sh;
-  runtimeInputs = [
-    iptables
-  ];
 
   meta = with lib; {
     description = "Temporarily manipulate the NixOS firewall";
     license = licenses.mit;
-    maintainers = with maintainers; [ clerie ];
+    maintainers = with maintainers; [ clerie rvfg ];
   };
-}
+} // (
+  if backend == "iptables" then {
+    text = builtins.readFile ./nixos-firewall-tool.sh;
+    runtimeInputs = [ iptables ];
+
+  } else if backend == "nftables" then {
+    text = builtins.readFile ./nixos-firewall-tool-nftables.sh;
+    runtimeInputs = [ nftables ];
+
+  } else
+    throw "Unknown firewall backend."
+))


### PR DESCRIPTION
## Description of changes

Add nftables support in `nixos-firewall-tool` and enable it by default when NixOS firewall enables.

Also add some tests for `nixos-firewall-tool` in `nixosTests.firewall`.

Depends on #275371
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

ping @Atemu @clerie

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
