### PR TITLE
cgal: 4.14.2 → 4.14.3 & default to version 5

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , cmake
 , boost
-, cgal_5
+, cgal
 , eigen
 , flann
 , gdal
@@ -41,7 +41,7 @@ mkDerivation rec {
 
   buildInputs = [
     boost
-    cgal_5
+    cgal
     flann
     gdal
     gmp

--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -14,7 +14,7 @@
 , levmar
 , qhull
 , cmake
-, cgal_5
+, cgal
 , boost179
 , mpfr
 , xercesc
@@ -45,7 +45,7 @@ mkDerivation rec {
     gmp
     levmar
     qhull
-    cgal_5
+    cgal
     boost179
     mpfr
     xercesc

--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -11,7 +11,7 @@
 , libGLU, libGL
 , glew
 , opencsg
-, cgal
+, cgal_4
 , mpfr
 , gmp
 , glib
@@ -60,7 +60,7 @@ mkDerivation rec {
   nativeBuildInputs = [ bison flex pkg-config gettext qmake ];
 
   buildInputs = [
-    eigen boost glew opencsg cgal mpfr gmp glib
+    eigen boost glew opencsg cgal_4 mpfr gmp glib
     harfbuzz lib3mf libzip double-conversion freetype fontconfig
     qtbase qtmultimedia qscintilla cairo
   ] ++ lib.optionals stdenv.isLinux [ libGLU libGL wayland wayland-protocols qtwayland ]

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -10,7 +10,7 @@
 , wrapGAppsHook
 , boost
 , cereal
-, cgal_5
+, cgal
 , curl
 , dbus
 , eigen
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     binutils
     boost
     cereal
-    cgal_5
+    cgal
     curl
     dbus
     eigen

--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -4,7 +4,7 @@
 , fparser
 , tinyxml
 , hdf5
-, cgal_5
+, cgal
 , vtk
 , boost
 , gmp
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   patches = [./searchPath.patch ];
 
   buildInputs = [
-    cgal_5
+    cgal
     boost
     gmp
     mpfr

--- a/pkgs/development/libraries/CGAL/4.nix
+++ b/pkgs/development/libraries/CGAL/4.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, boost, gmp, mpfr }:
+{ lib, stdenv, fetchurl, fetchpatch, cmake, boost, gmp, mpfr }:
 
 stdenv.mkDerivation rec {
-  version = "4.14.2";
+  version = "4.14.3";
   pname = "cgal";
 
-  src = fetchFromGitHub {
-    owner = "CGAL";
-    repo = "releases";
-    rev = "CGAL-${version}";
-    sha256 = "1p1xyws2s9h2c8hlkz1af4ix48qma160av24by6lcm8al1g44pca";
+  src = fetchurl {
+    url = "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-${version}/CGAL-${version}.tar.xz";
+    hash = "sha256-W6/nq+hDW+yhehCCBi02M2jsHj8NZYG7DaiwEPs4n+Q=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/gudhi/default.nix
+++ b/pkgs/development/python-modules/gudhi/default.nix
@@ -5,7 +5,7 @@
 , boost
 , eigen
 , gmp
-, cgal_5  # see https://github.com/NixOS/nixpkgs/pull/94875 about cgal
+, cgal  # see https://github.com/NixOS/nixpkgs/pull/94875 about cgal
 , mpfr
 , tbb
 , numpy
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   patches = [ ./remove_explicit_PYTHONPATH.patch ];
 
   nativeBuildInputs = [ cmake numpy cython pybind11 matplotlib ];
-  buildInputs = [ boost eigen gmp cgal_5 mpfr ]
+  buildInputs = [ boost eigen gmp cgal mpfr ]
     ++ lib.optionals enableTBB [ tbb ];
   propagatedBuildInputs = [ numpy scipy ];
   nativeCheckInputs = [ pytest ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20820,7 +20820,7 @@ with pkgs;
   # CGAL 5 has API changes
   cgal_4 = callPackage ../development/libraries/CGAL/4.nix { };
   cgal_5 = callPackage ../development/libraries/CGAL { };
-  cgal = cgal_4;
+  cgal = cgal_5;
 
   cgui = callPackage ../development/libraries/cgui { };
 


### PR DESCRIPTION
## Description of changes

Bug fix: https://www.cgal.org/2020/02/25/cgal4143/

Also default to the branch 5.x which is the one to be actively maintained.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
