### PR TITLE
ocamlPackages.riot: 0.0.2 → 0.0.5

### DIFF
--- a/pkgs/development/ocaml-modules/riot/default.nix
+++ b/pkgs/development/ocaml-modules/riot/default.nix
@@ -4,24 +4,26 @@
 , fetchurl
 , iomux
 , ptime
+, telemetry
 , uri
 }:
 
 buildDunePackage rec {
   pname = "riot";
-  version = "0.0.2";
+  version = "0.0.5";
 
   minimalOCamlVersion = "5.1";
 
   src = fetchurl {
     url = "https://github.com/leostera/riot/releases/download/${version}/riot-${version}.tbz";
-    hash = "sha256-ck/tr5o0nKF4WNgjPODHg1/tlaKv1JtuYgqYfIIZ78Q=";
+    hash = "sha256-Abe4LMxlaxK3MVlg2d8X60aCuPGvaOn+4zFx/uH5z4g=";
   };
 
   propagatedBuildInputs = [
     bigstringaf
     iomux
     ptime
+    telemetry
     uri
   ];
 

--- a/pkgs/development/ocaml-modules/telemetry/default.nix
+++ b/pkgs/development/ocaml-modules/telemetry/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl }:
+
+buildDunePackage rec {
+  pname = "telemetry";
+  version = "0.0.1";
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchurl {
+    url = "https://github.com/leostera/telemetry/releases/download/${version}/telemetry-${version}.tbz";
+    hash = "sha256-YEf7zC/F2zJBtQNfyJ2OznKmoFo1Ms9O2WgiOFkhp28=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "A lightweight library for dispatching and handling events, with a focus on metrics and instrumentation";
+    homepage = "https://github.com/leostera/telemetry";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1733,6 +1733,8 @@ let
 
     telegraml = callPackage ../development/ocaml-modules/telegraml { };
 
+    telemetry = callPackage ../development/ocaml-modules/telemetry { };
+
     terminal = callPackage ../development/ocaml-modules/terminal { };
 
     terminal_size = callPackage ../development/ocaml-modules/terminal_size { };


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/leostera/riot/0.0.5/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
