### PR TITLE
avogadro2: 1.97.0 -> 1.98.1

### DIFF
--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -6,19 +6,19 @@ let
   avogadroI18N = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadro-i18n";
-    rev = "3b8a86cc37e988b043d1503d2f11068389b0aca3";
-    sha256 = "9wLY7/EJyIZYnlUAMsViCwD5kGc1vCNbk8vUhb90LMQ=";
+    rev = "7eef0b83ded6221a3ddb85c0118cc26f9a35375c";
+    hash = "sha256-AR/y70zeYR9xBzWDB5JXjJdDM+NLOX6yxCQte2lYN/U=";
   };
 
 in stdenv.mkDerivation rec {
   pname = "avogadro2";
-  version = "1.97.0";
+  version = "1.98.1";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadroapp";
     rev = version;
-    hash = "sha256-gZpMgFSPz70QNfd8gH5Jb9RTxQfQalWx33LkgXLEqOQ=";
+    hash = "sha256-N35WGYZbgfjKnorzGKCnbBvlrlt9Vr04YIG2R3k+b8A=";
   };
 
   postUnpack = ''

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -21,13 +21,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "avogadrolibs";
-  version = "1.97.0";
+  version = "1.98.1";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = pname;
     rev = version;
-    hash = "sha256-ZGFyUlFyI403aw/6GVze/gronT67XlEOKuw5sfHeVy8=";
+    hash = "sha256-BuBMWW7N5Cu9tw5Vpwk+aoIaMWwHViRzLtIG7XDWjN4=";
   };
 
   postUnpack = ''
@@ -53,9 +53,13 @@ in stdenv.mkDerivation rec {
     qttools
   ];
 
-  postFixup = ''
+  # Fix the broken CMake files to use the correct paths
+  postInstall = ''
     substituteInPlace $out/lib/cmake/${pname}/AvogadroLibsConfig.cmake \
-      --replace "''${AvogadroLibs_INSTALL_PREFIX}/$out" "''${AvogadroLibs_INSTALL_PREFIX}"
+      --replace "$out/" ""
+
+    substituteInPlace $out/lib/cmake/${pname}/AvogadroLibsTargets.cmake \
+      --replace "_IMPORT_PREFIX}/$out" "_IMPORT_PREFIX}/"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/science/chemistry/mmtf-cpp/default.nix
+++ b/pkgs/development/libraries/science/chemistry/mmtf-cpp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mmtf-cpp";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub  {
     owner = "rcsb";
     repo = pname;
     rev = "v${version}";
-    sha256= "17ylramda69plf5w0v5hxbl4ggkdi5s15z55cv0pljl12yvyva8l";
+    hash = "sha256-8JrNobvekMggS8L/VORKA32DNUdXiDrYMObjd29wQmc=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/science/chemistry/molequeue/default.nix
+++ b/pkgs/development/libraries/science/chemistry/molequeue/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "OpenChemistry";
     repo = pname;
     rev = version;
-    sha256 = "+NoY8YVseFyBbxc3ttFWiQuHQyy1GN8zvV1jGFjmvLg=";
+    hash = "sha256-+NoY8YVseFyBbxc3ttFWiQuHQyy1GN8zvV1jGFjmvLg=";
   };
 
   nativeBuildInputs = [
@@ -18,9 +18,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qttools ];
 
-  postFixup = ''
-    substituteInPlace $out/lib/cmake/molequeue/MoleQueueConfig.cmake \
-      --replace "''${MoleQueue_INSTALL_PREFIX}/$out" "''${MoleQueue_INSTALL_PREFIX}"
+  # Fix the broken CMake files to use the correct paths
+  postInstall = ''
+    substituteInPlace $out/lib/cmake/${pname}/MoleQueueConfig.cmake \
+      --replace "$out/" ""
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Updates the avogadro2 package and its ecosystem to the latest release:

https://github.com/OpenChemistry/avogadrolibs/releases/tag/1.98.1
https://github.com/OpenChemistry/avogadroapp/releases/tag/1.98.1
https://github.com/rcsb/mmtf-cpp/releases/tag/v1.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
