### PR TITLE
nixos/profiles: add xen-guest profile

### DIFF
--- a/nixos/modules/profiles/xen-guest.nix
+++ b/nixos/modules/profiles/xen-guest.nix
@@ -1,0 +1,30 @@
+# Common configuration for virtual machines running under Xen
+{lib, ...}: {
+  # Kernel modules used during the boot process
+  boot.initrd.availableKernelModules = [
+    "xen_blkfront"  # disks
+    "xen_netfront"  # network
+    "xen_pcifront"  # PCI for PV guests
+    "xen_scsifront" # SCSI passthrough
+    "xen_hcd" # usb passthrough
+    # "hvc_xen"          # console                                  # builtin enabled by HVC_XEN_FRONTEND
+    # "xen_pvh"          # Support for running as a PVH guest       # builtin enabled by XEN_PVH
+    # "xen_platform_pci" # Support running as a Xen PVHVM guest     # builtin enabled by XEN_PVHVM_GUEST
+    # "sys-hypervisor"   # Create xen entries under /sys/hypervisor # builtin enabled by XEN_SYS_HYEPRVISOR
+  ];
+  # Kernel modules used in the running system
+  boot.kernelModules = [
+    "xen_wdt"       # watchdog, Xen >= 4.0
+    "xen_balloon"   # memory balloon
+    "xen_fbfront"   # framebuffer
+    "drm_xen_front" # Direct Rendering Manager frontend
+    "xen_kbdfront"  # keyboard/mouse/pointer/multi-touch
+    "xen_tpmfront"  # TPM
+    "snd_xen_front" # sound
+    "xenfs"         # Xen filesystem
+    "9pnet_xen"     # 9P Xen Transport
+  ];
+
+  # Don't run ntpd, since we should get the correct time from Dom0.
+  services.timesyncd.enable = lib.mkDefault false;
+}


### PR DESCRIPTION
## Description of changes

Added a new profile for Xen guests, inspired by `nixpkgs/nixos/modules/profiles/qemu-guest.nix`.

The list of modules is based on the results of https://www.kernelconfig.io/search?q=xen&kernelversion=6.6.7&arch=x86

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).