### PR TITLE
python311Packages.cached-ipaddress: init at 0.3.0,  python311Packages.aiodiscover: 1.5.1 -> 1.6.0 

### DIFF
--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -1,6 +1,7 @@
 { lib
 , async-timeout
 , buildPythonPackage
+, cached-ipaddress
 , dnspython
 , fetchFromGitHub
 , ifaddr
@@ -9,34 +10,40 @@
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "1.5.1";
-  format = "setuptools";
+  version = "1.6.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bdraco";
-    repo = pname;
+    repo = "aiodiscover";
     rev = "refs/tags/v${version}";
-    hash = "sha256-rFypv0gCj+Jskk+dlRNJ2ufj2sDud7AuJzj3cl4bB4Y=";
+    hash = "sha256-FbOqTUSqxSPSCn5zA4s47+M6OsVsqvUBZxTFvJ5PoHs=";
   };
-
-  propagatedBuildInputs = [
-    async-timeout
-    dnspython
-    netifaces
-    pyroute2
-    ifaddr
-  ];
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace '"pytest-runner>=5.2",' ""
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    async-timeout
+    cached-ipaddress
+    dnspython
+    netifaces
+    pyroute2
+    ifaddr
+  ];
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/cached-ipaddress/default.nix
+++ b/pkgs/development/python-modules/cached-ipaddress/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, cython_3
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "cached-ipaddress";
+  version = "0.3.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = "cached-ipaddress";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-iTQ1DSCZqjAzsf95nYUxnNj5YCb1Y4JIUW5VGIi7yoY=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov=cached_ipaddress --cov-report=term-missing:skip-covered" "" \
+      --replace "Cython>=3.0.5" "Cython"
+  '';
+
+  nativeBuildInputs = [
+    cython_3
+    poetry-core
+    setuptools
+    wheel
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "cached_ipaddress"
+  ];
+
+  meta = with lib; {
+    description = "Cache construction of ipaddress objects";
+    homepage = "https://github.com/bdraco/cached-ipaddress";
+    changelog = "https://github.com/bdraco/cached-ipaddress/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1747,6 +1747,8 @@ self: super: with self; {
 
   cachecontrol = callPackage ../development/python-modules/cachecontrol { };
 
+  cached-ipaddress = callPackage ../development/python-modules/cached-ipaddress { };
+
   cached-property = callPackage ../development/python-modules/cached-property { };
 
   cachelib = callPackage ../development/python-modules/cachelib { };


### PR DESCRIPTION
Diff: https://github.com/bdraco/aiodiscover/compare/refs/tags/v1.5.1...v1.6.0

Changelog: https://github.com/bdraco/aiodiscover/releases/tag/v1.6.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
