### PR TITLE
python3Packages.wagtail: relax django-taggit dependency

### DIFF
--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -38,7 +38,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "beautifulsoup4>=4.8,<4.12" "beautifulsoup4>=4.8" \
       --replace "draftjs_exporter>=2.1.5,<3.0" "draftjs_exporter>=2.1.5,<6.0" \
-      --replace "django-taggit>=2.0,<5.0" "django-taggit>=2.0,<6.0"
+      --replace "django-taggit>=2.0,<5.0" "django-taggit>=2.0,<6.0" \
+      --replace "Willow[heif]>=1.6.2,<1.7" "Willow[heif]>=1.6.2,<2"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -37,7 +37,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "beautifulsoup4>=4.8,<4.12" "beautifulsoup4>=4.8" \
-      --replace "draftjs_exporter>=2.1.5,<3.0" "draftjs_exporter>=2.1.5,<6.0"
+      --replace "draftjs_exporter>=2.1.5,<3.0" "draftjs_exporter>=2.1.5,<6.0" \
+      --replace "django-taggit>=2.0,<5.0" "django-taggit>=2.0,<6.0"
   '';
 
   propagatedBuildInputs = [
@@ -64,7 +65,9 @@ buildPythonPackage rec {
   # on wagtail (wagtail-factories)
   doCheck = false;
 
-  passthru.tests.wagtail = callPackage ./tests.nix {};
+  passthru.tests.wagtail = callPackage ./tests.nix { };
+
+  pythonImportsCheck = [ "wagtail" ];
 
   meta = with lib; {
     description = "A Django content management system focused on flexibility and user experience";


### PR DESCRIPTION
## Description of changes

django-taggit was upgraded in 94aac108c6a7c26a0101cddd9104bd057484a36e, but this version is [not supported by Wagtail 5.2.2](https://github.com/wagtail/wagtail/blob/v5.2.2/setup.py#L25). I checked the django-taggit changelog, and the changes in 5.0 don’t have any impact on Wagtail (I’ve [opened a PR](https://github.com/wagtail/wagtail/pull/11363) to change this upstream) so it should be safe to relax the dependency.

I have no idea why the `python3Packages.wagtail` package can be built, and why building the `python3Packages.wagtail-localize` package (which depends on wagtail) fails.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
