### PR TITLE
fable: 4.5.0 -> 4.9.0, added updateScript

### DIFF
--- a/pkgs/development/tools/fable/default.nix
+++ b/pkgs/development/tools/fable/default.nix
@@ -2,9 +2,10 @@
 
 buildDotnetGlobalTool {
   pname = "fable";
-  version = "4.5.0";
+  version = "4.9.0";
 
-  nugetSha256 = "sha256-KeNkS2fuZFnI8WVqSpIRjo2eA+XKuHLLpMIzDzgqXdg=";
+  nugetSha256 = "sha256-BB3jCsIz6Y9LjBhoEBzYLXttwLOBb4n1EpqJwImjo9A=";
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Fable is an F# to JavaScript compiler";

--- a/pkgs/development/tools/fable/update.sh
+++ b/pkgs/development/tools/fable/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
+
+set -euo pipefail
+URL="https://github.com/fable-compiler/fable"
+PKG="Fable"
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/default.nix"
+if [ ! -f "$NIX_DRV" ]; then
+  echo "ERROR: cannot find default.nix in $ROOT"
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+clean_up() {
+    rm -rf "$TMP"
+}
+trap clean_up EXIT SIGINT SIGTERM
+PACKAGES="$TMP/packages"
+SRC_RW="$TMP/src"
+
+mkdir -p $SRC_RW
+mkdir -p $PACKAGES
+
+
+VER=$(curl -s "https://api.github.com/repos/fable-compiler/fable/releases/latest" | jq -r .tag_name | grep -oP '\d+\.\d+\.\d+' )
+
+CURRENT_VER=$(grep -oP '(?<=version = ")[^"]+' "$NIX_DRV")
+if [[ "$CURRENT_VER" == "$VER" ]]; then
+    echo "$PKG is already up to date: $CURRENT_VER"
+    exit
+fi
+
+
+NUGET_URL="$(curl -f "https://api.nuget.org/v3/index.json" | jq --raw-output '.resources[] | select(."@type" == "PackageBaseAddress/3.0.0")."@id"')$PKG/$VER/$PKG.$VER.nupkg"
+HASH=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$NUGET_URL")")
+
+sed -i "s/version = \".*\"/version = \"$VER\"/" "$NIX_DRV"
+sed -i "s#nugetSha256 = \"sha256-.\{44\}\"#nugetSha256 = \"$HASH\"#" "$NIX_DRV"


### PR DESCRIPTION
## Description of changes
Added update script for Fable compiler 

https://github.com/fable-compiler/Fable/releases/tag/4.6.0

https://github.com/fable-compiler/Fable/releases/tag/4.7.0

https://github.com/fable-compiler/Fable/releases/tag/4.8.0

https://github.com/fable-compiler/Fable/releases/tag/4.8.1

https://github.com/fable-compiler/Fable/releases/tag/4.9.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
