### PR TITLE
openvr: 1.26.7 -> 2.2.3, gamescope: 3.13.19 -> 3.14.1

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -13,6 +13,7 @@
 , glm
 , gbenchmark
 , libcap
+, libavif
 , SDL2
 , pipewire
 , pixman
@@ -40,14 +41,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.13.19";
+  version = "3.14.1";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     rev = "refs/tags/${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-WKQgVbuHvTbZnvTU5imV35AKZ4AF0EDsdESBZwVH7+M=";
+    hash = "sha256-lJt6JVolorQdrhumkW9yjyItxqpw6ZtEUbkjNqzHfb8=";
   };
 
   patches = [
@@ -109,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     xorg.libXres
     xorg.libXtst
     xorg.libXxf86vm
+    libavif
     libdrm
     libliftoff
     SDL2

--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -26,6 +26,7 @@
 , libdisplay-info
 , lib
 , makeBinaryWrapper
+, nix-update-script
 , enableExecutable ? true
 , enableWsi ? true
 }:
@@ -130,6 +131,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/gamescope/reshade
     cp -r ${joshShaders}/* $out/share/gamescope/reshade/
   '';
+
+  passthru.updateScript = nix-update-script {};
 
   meta = with lib; {
     description = "SteamOS session compositing window manager";

--- a/pkgs/development/libraries/openvr/default.nix
+++ b/pkgs/development/libraries/openvr/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvr";
-  version = "1.26.7";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "openvr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-verVIRyDdpF8lIjjjG8GllDJG7nhqByIfs/8O5TMOyc=";
+    hash = "sha256-Dpl88Te+EoVasoCtwERGrYt3xK8o03h15r8IVxxPPCw=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

https://github.com/ValveSoftware/openvr/compare/v1.26.7...v2.2.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
