### PR TITLE
gdal: call correct binaries in tests

### DIFF
--- a/pkgs/development/libraries/gdal/tests.nix
+++ b/pkgs/development/libraries/gdal/tests.nix
@@ -4,33 +4,31 @@ let
   inherit (gdal) pname version;
 
 in
-runCommand "${pname}-tests" {
-  nativeBuildInputs = [ gdal ];
-  meta.timeout = 60;
-} ''
+runCommand "${pname}-tests" { meta.timeout = 60; }
+  ''
     # test version
-    ogrinfo --version \
+    ${gdal}/bin/ogrinfo --version \
       | grep 'GDAL ${version}'
 
-    gdalinfo --version \
+    ${gdal}/bin/gdalinfo --version \
       | grep 'GDAL ${version}'
 
 
     # test formats
-    ogrinfo --formats \
+    ${gdal}/bin/ogrinfo --formats \
       | grep 'GPKG.*GeoPackage'
 
-    gdalinfo --formats \
+    ${gdal}/bin/gdalinfo --formats \
       | grep 'GTiff.*GeoTIFF'
 
 
     # test vector file
     echo -e "Latitude,Longitude,Name\n48.1,0.25,'Test point'" > test.csv
-    ogrinfo ./test.csv
+    ${gdal}/bin/ogrinfo ./test.csv
 
 
     # test raster file
-    gdal_create \
+    ${gdal}/bin/gdal_create \
       -a_srs "EPSG:4326" \
       -of GTiff \
       -ot UInt16 \
@@ -40,7 +38,7 @@ runCommand "${pname}-tests" {
       -co COMPRESS=LZW \
       test.tif
 
-    gdalinfo ./test.tif
+    ${gdal}/bin/gdalinfo ./test.tif
 
     touch $out
   ''


### PR DESCRIPTION
## Description of changes

Make sure we always call correct binaries in GDAL package tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
