### PR TITLE
glide-media-player: init at 0.6.1

### DIFF
--- a/pkgs/by-name/gl/glide-media-player/package.nix
+++ b/pkgs/by-name/gl/glide-media-player/package.nix
@@ -1,0 +1,84 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, meson
+, ninja
+, rustc
+, cargo
+, wrapGAppsHook4
+, python3
+, libadwaita
+, graphene
+, gst_all_1
+, glib-networking
+, darwin
+, libsoup_3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "glide-media-player";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "philn";
+    repo = "glide";
+    rev = version;
+    hash = "sha256-dIXuWaoTeyVBhzr6VWxYBsn+CnUYG/KzhzNJtLLdRuI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-azvxW40fuKuF/N0qwzofFk1bZiNxyTN6YBFU5qHQkCA=";
+  };
+
+  postPatch = ''
+    substituteInPlace scripts/meson_post_install.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+    patchShebangs --build scripts/meson_post_install.py
+  '' + lib.optionalString stdenv.isDarwin ''
+    sed -i "/wayland,x11egl,x11glx/d" meson.build
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+    wrapGAppsHook4
+    python3
+  ];
+
+  buildInputs = [
+    libadwaita
+    graphene
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-good
+    glib-networking
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.IOKit
+  ];
+
+  # FIXME: gst-plugins-good missing libsoup breaks streaming
+  # (https://github.com/nixos/nixpkgs/issues/271960)
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsoup_3 ]}")
+  '';
+
+  meta = with lib; {
+    description = "Linux/macOS media player based on GStreamer and GTK";
+    homepage = "https://philn.github.io/glide";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aleksana ];
+    mainProgram = "glide";
+    platforms = platforms.unix;
+    # error: could not find system library 'gstreamer-gl-1.0' required by the 'gstreamer-gl-sys' crate
+    broken = stdenv.isDarwin && stdenv.isx86_64;
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/163387

Build on darwin has not been tested yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
