### PR TITLE
tracetest: init at 0.15.3

### DIFF
--- a/pkgs/by-name/tr/tracetest/package.nix
+++ b/pkgs/by-name/tr/tracetest/package.nix
@@ -1,0 +1,98 @@
+{ lib
+, buildNpmPackage
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, testers
+, tracetest
+}:
+
+let
+  pname = "tracetest";
+  version = "0.15.4";
+  src = fetchFromGitHub {
+    owner = "kubeshop";
+    repo = "tracetest";
+    rev = "v${version}";
+    hash = "sha256-JOzQvG/10VL8s7D1X1M/lM+QUJlY+6z6NhUIhUhEsWA=";
+  };
+  ui = buildNpmPackage {
+    inherit pname version src;
+
+    sourceRoot = "source/web";
+
+    npmDepsHash = "sha256-2FhPXNyDBDvRlHawYOF3VRdp9nqacZMi01gboHCkxns=";
+
+    npmPackFlags = [ "--ignore-scripts" ];
+
+    env.CYPRESS_INSTALL_BINARY = 0;
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r build $out
+
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule rec {
+  inherit pname version src;
+
+  vendorHash = "sha256-tB2arEMG0RCGuPR4QH73wDrAIZxdD0zEvOERoM/FTrw=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  subPackages = [ "cli" "server" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/kubeshop/tracetest/server/version.Version=${version}"
+    "-X github.com/kubeshop/tracetest/cli/version.Version=${version}"
+  ];
+
+  preBuild = ''
+    cp -r ${ui} web/build
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp $GOPATH/bin/cli $out/bin/tracetest
+    cp $GOPATH/bin/server $out/bin/tracetest-server
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd tracetest \
+      --bash <($out/bin/tracetest completion bash) \
+      --fish <($out/bin/tracetest completion fish) \
+      --zsh <($out/bin/tracetest completion zsh)
+
+    installShellCompletion --cmd tracetest-server \
+      --bash <($out/bin/tracetest-server completion bash) \
+      --fish <($out/bin/tracetest-server completion fish) \
+      --zsh <($out/bin/tracetest-server completion zsh)
+  '';
+
+  passthru = {
+    inherit ui;
+    tests.version = testers.testVersion {
+      package = tracetest;
+      # tracetest CLI requires server to be setup
+      command = "tracetest-server version";
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/kubeshop/tracetest/releases/tag/v${version}";
+    description = "Build integration and end-to-end tests in minutes using OpenTelemetry and trace-based testing";
+    homepage = "https://github.com/kubeshop/tracetest";
+    license = licenses.mit;
+    mainProgram = "tracetest";
+    maintainers = with maintainers; [ gaelreyrol ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds the package tracetest: https://github.com/kubeshop/tracetest

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
