### PR TITLE
nitter: unstable-2023-10-31 -> unstable-2023-12-03 (guest accounts support)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -39,6 +39,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `k9s` was updated to v0.29. There have been breaking changes in the config file format, check out the [changelog](https://github.com/derailed/k9s/releases/tag/v0.29.0) for details.
 
+- `nitter` requires a `guest_accounts.jsonl` to be provided as a path or loaded into the default location at `/var/lib/nitter/guest_accounts.jsonl`. See [Guest Account Branch Deployment](https://github.com/zedeus/nitter/wiki/Guest-Account-Branch-Deployment) for details.
+
 - Invidious has changed its default database username from `kemal` to `invidious`. Setups involving an externally provisioned database (i.e. `services.invidious.database.createLocally == false`) should adjust their configuration accordingly. The old `kemal` user will not be removed automatically even when the database is provisioned automatically.(https://github.com/NixOS/nixpkgs/pull/265857)
 
 - `mkosi` was updated to v19. Parts of the user interface have changed. Consult the

--- a/nixos/modules/services/misc/nitter.nix
+++ b/nixos/modules/services/misc/nitter.nix
@@ -304,6 +304,23 @@ in
         '';
       };
 
+      guestAccounts = mkOption {
+        type = types.path;
+        default = "/var/lib/nitter/guest_accounts.jsonl";
+        description = lib.mdDoc ''
+          Path to the guest accounts file.
+
+          This file contains a list of guest accounts that can be used to
+          access the instance without logging in. The file is in JSONL format,
+          where each line is a JSON object with the following fields:
+
+          {"oauth_token":"some_token","oauth_token_secret":"some_secret_key"}
+
+          See https://github.com/zedeus/nitter/wiki/Guest-Account-Branch-Deployment
+          for more information on guest accounts and how to generate them.
+        '';
+      };
+
       redisCreateLocally = mkOption {
         type = types.bool;
         default = true;
@@ -333,8 +350,12 @@ in
         after = [ "network-online.target" ];
         serviceConfig = {
           DynamicUser = true;
+          LoadCredential="guestAccountsFile:${cfg.guestAccounts}";
           StateDirectory = "nitter";
-          Environment = [ "NITTER_CONF_FILE=/var/lib/nitter/nitter.conf" ];
+          Environment = [
+            "NITTER_CONF_FILE=/var/lib/nitter/nitter.conf"
+            "NITTER_ACCOUNTS_FILE=%d/guestAccountsFile"
+          ];
           # Some parts of Nitter expect `public` folder in working directory,
           # see https://github.com/zedeus/nitter/issues/414
           WorkingDirectory = "${cfg.package}/share/nitter";

--- a/nixos/tests/nitter.nix
+++ b/nixos/tests/nitter.nix
@@ -1,13 +1,28 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 
+let
+  # In a real deployment this should naturally not common from the nix store
+  # and be seeded via agenix or as a non-nix managed file.
+  #
+  # These credentials are from the nitter wiki and are expired. We must provide
+  # credentials in the correct format, otherwise nitter fails to start. They
+  # must not be valid, as unauthorized errors are handled gracefully.
+  guestAccountFile = pkgs.writeText "guest_accounts.jsonl" ''
+    {"oauth_token":"1719213587296620928-BsXY2RIJEw7fjxoNwbBemgjJhueK0m","oauth_token_secret":"N0WB0xhL4ng6WTN44aZO82SUJjz7ssI3hHez2CUhTiYqy"}
+  '';
+in
 {
   name = "nitter";
   meta.maintainers = with pkgs.lib.maintainers; [ erdnaxe ];
 
   nodes.machine = {
-    services.nitter.enable = true;
-    # Test CAP_NET_BIND_SERVICE
-    services.nitter.server.port = 80;
+    services.nitter = {
+      enable = true;
+      # Test CAP_NET_BIND_SERVICE
+      server.port = 80;
+      # Provide dummy guest accounts
+      guestAccounts = guestAccountFile;
+    };
   };
 
   testScript = ''

--- a/pkgs/by-name/ni/nitter/lock.json
+++ b/pkgs/by-name/ni/nitter/lock.json
@@ -62,11 +62,11 @@
       "packages": [
         "jsony"
       ],
-      "path": "/nix/store/bzcq8q439rdsqhhihikzv3rsx4l4ybdm-source",
-      "rev": "ea811be",
-      "sha256": "1720iqsxjhqmhw1zhhs7d2ncdz25r8fqadls1p1iry1wfikjlnba",
+      "path": "/nix/store/l84av0wdc0s4r4alsvkaxcxhpd6j4bzg-source",
+      "rev": "1de1f08",
+      "sha256": "0rj205cs3v6g80h8ys9flbdq4wyd1csmkwdxv0lz21972zcsrcfh",
       "srcDir": "src",
-      "url": "https://github.com/treeform/jsony/archive/ea811be.tar.gz"
+      "url": "https://github.com/treeform/jsony/archive/1de1f08.tar.gz"
     },
     {
       "method": "fetchzip",
@@ -95,11 +95,22 @@
       "packages": [
         "nimcrypto"
       ],
-      "path": "/nix/store/dnj20qh97ylf57nka9wbxs735wbw7yxv-source",
-      "rev": "4014ef9",
-      "sha256": "1kgqr2lqaffglc1fgbanwcvhkqcbbd20d5b6w4lf0nksfl9c357a",
+      "path": "/nix/store/zyr8zwh7vaiycn1s4r8cxwc71f2k5l0h-source",
+      "rev": "a079df9",
+      "sha256": "1dmdmgb6b9m5f8dyxk781nnd61dsk3hdxqks7idk9ncnpj9fng65",
       "srcDir": "",
-      "url": "https://github.com/cheatfate/nimcrypto/archive/4014ef9.tar.gz"
+      "url": "https://github.com/cheatfate/nimcrypto/archive/a079df9.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "oauth"
+      ],
+      "path": "/nix/store/bwmrrzs6xpwizmww35461x3lqpgd0942-source",
+      "rev": "b8c163b",
+      "sha256": "0k5slyzjngbdr6g0b0dykhqmaf8r8n2klbkg2gpid4ckm8hg62v5",
+      "srcDir": "src",
+      "url": "https://github.com/CORDEA/oauth/archive/b8c163b.tar.gz"
     },
     {
       "method": "fetchzip",
@@ -155,6 +166,18 @@
       "sha256": "19d78787k97l5cis81800hxa9qjr0yzjshlzdp727gh6pn8kc8fj",
       "srcDir": "src",
       "url": "https://github.com/dom96/sass/archive/7dfdd03.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "sha1"
+      ],
+      "path": "/nix/store/a6a0ycxsaxpqks42aq9wicj8ars7z7ai-source",
+      "ref": "master",
+      "rev": "92ccc5800bb0ac4865b275a2ce3c1544e98b48bc",
+      "sha256": "00zvvd8ssy22srg74xzapknmgmi82v534npjdrk5805shswfhqdm",
+      "srcDir": "",
+      "url": "https://github.com/onionhammer/sha1/archive/92ccc5800bb0ac4865b275a2ce3c1544e98b48bc.tar.gz"
     },
     {
       "method": "fetchzip",

--- a/pkgs/by-name/ni/nitter/package.nix
+++ b/pkgs/by-name/ni/nitter/package.nix
@@ -8,13 +8,13 @@
 
 buildNimPackage (finalAttrs: prevAttrs: {
   pname = "nitter";
-  version = "unstable-2023-10-31";
+  version = "unstable-2023-12-03";
 
   src = fetchFromGitHub {
     owner = "zedeus";
     repo = "nitter";
-    rev = "b62d73dbd373f08af07c7a79efcd790d3bc1a49c";
-    hash = "sha256-yCD7FbqWZMY0fyFf9Q3Ka06nw5Ha7jYLpmPONAhEVIM=";
+    rev = "583c858cdf3486451ed6a0627640844f27009dbe";
+    hash = "sha256-3E6nfmOFhQ2bjwGMWdTmZ38Fg/SE36s6fxYDXwSJaTw=";
   };
 
   lockFile = ./lock.json;


### PR DESCRIPTION
## Description of changes

1. Updates nitter package to use the guest_accounts branch - master is no longer usable after Twitter's API changes, and all current deployments must be with guest accounts support
2. Updates the module and systemd service to load guest account credentials as required in [Guest Account Branch Deployment](https://github.com/zedeus/nitter/wiki/Guest-Account-Branch-Deployment)
3. Updates 24.05 release notes to reflect this new requirement

The updated implementation and package are being used to run a nitter instance on nitter.merklepath.com, which works as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
