### PR TITLE
Add Ollama-webui package and service for Mixtral

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11273,6 +11273,11 @@
     githubId = 1780588;
     name = "Malte Poll";
   };
+  malteneuss = {
+    github = "malteneuss";
+    githubId = 5301202;
+    name = "Malte Neuss";
+  };
   malte-v = {
     email = "nixpkgs@mal.tc";
     github = "malte-v";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1320,6 +1320,7 @@
   ./services/web-apps/nexus.nix
   ./services/web-apps/nifi.nix
   ./services/web-apps/node-red.nix
+  ./services/web-apps/ollama-webui.nix
   ./services/web-apps/onlyoffice.nix
   ./services/web-apps/openvscode-server.nix
   ./services/web-apps/mobilizon.nix

--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -1,42 +1,106 @@
-{ config, lib, pkgs, ... }: let
+{ config, pkgs, lib, ... }:
 
-  cfg = config.services.ollama;
+with lib;
+
+let cfg = config.services.ollama;
 
 in {
-
   options = {
     services.ollama = {
-      enable = lib.mkEnableOption (
-        lib.mdDoc "Server for local large language models"
-      );
-      package = lib.mkPackageOption pkgs "ollama" { };
+      enable = mkEnableOption (lib.mdDoc ''
+        Ollama backend service.
+        Run state-of-the-art AI large language models (LLM) similar to ChatGPT locally with privacy
+        on your personal computer.
+
+        This module provides the `ollama serve` backend runner service so that you can run
+        `ollam run <model-name>` locally in a terminal; this will automatically download the
+        LLM model and open a chat. See <https://github.com/jmorganca/ollama#quickstart>.
+        The model names can be looked up on <https://ollama.ai/library> and are available in
+        varying sizes to fit your CPU, GPU, RAM and disk storage.
+        See <https://github.com/jmorganca/ollama#model-library>.
+
+        Optional: This module is intended to be run locally, but can be served from a (home) server,
+        ideally behind a secured reverse-proxy.
+        Look at <https://nixos.wiki/wiki/Nginx> or <https://nixos.wiki/wiki/Caddy>
+        on how to set up a reverse proxy.
+
+        Optional: This service doesn't persist any chats and is only available in the terminal.
+        For a convenient, graphical web app on top of it, take look at
+        <https://github.com/ollama-webui/ollama-webui>, also as `ollama-webui` in Nixpkgs.
+      '');
+
+      ollama-package = mkPackageOption pkgs "ollama" { };
+
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = lib.mdDoc ''
+          The host/domain name under which the Ollama backend service is reachable.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 11434;
+        description = lib.mdDoc "The port for the  Ollama backend service.";
+      };
+
+      cors_origins = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "https://myserver:8080,http://10.0.0.10:*";
+        description = lib.mdDoc ''
+          Allow access from web apps that are served under some (different) URL.
+          If a web app like Ollama-WebUI is available/served on `https://myserver:8080`,
+          then add this URL here. Otherwise the Ollama backend server will reject the
+          UIs request and return 403 forbidden due to CORS.
+          See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Open ports in the firewall for the Ollama backend service.";
+      };
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
+    systemd.services.ollama = {
+      description = "Ollama: A backend service for local large language models (LLM).";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
 
-    systemd = {
-      services.ollama = {
-        wantedBy = [ "multi-user.target" ];
-        description = "Server for local large language models";
-        after = [ "network.target" ];
-        environment = {
-          HOME = "%S/ollama";
-          OLLAMA_MODELS = "%S/ollama/models";
-        };
-        serviceConfig = {
-          ExecStart = "${lib.getExe cfg.package} serve";
-          WorkingDirectory = "/var/lib/ollama";
-          StateDirectory = [ "ollama" ];
-          DynamicUser = true;
-        };
+      environment = {
+        OLLAMA_HOST = "${cfg.host}:${toString cfg.port}";
+        OLLAMA_ORIGINS = cfg.cors_origins;
+        # Where to store LLM model files.
+        # Directory is managed by systemd DynamicUser feature, see below.
+        HOME = "%S/ollama";
+        OLLAMA_MODELS = "%S/ollama/models";
+      };
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.ollama-package} serve";
+        # Systemd takes care of username, user id, security & permissions
+        # See https://0pointer.net/blog/dynamic-users-with-systemd.html
+        # Almost nothing on the disk is readable for this dynamic user; only a few places writable:
+        # See https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=
+        DynamicUser = "true";
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = 3;
+        WorkingDirectory = "/var/lib/ollama";
+        # Persistent storage for model files, i.e. /var/lib/<StateDirectory>
+        StateDirectory = [ "ollama" ];
       };
     };
 
-    environment.systemPackages = [ cfg.package ];
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
 
   };
-
-  meta.maintainers = with lib.maintainers; [ onny ];
-
+  meta.maintainers = with lib.maintainers; [ onny malteneuss ];
 }

--- a/nixos/modules/services/web-apps/ollama-webui.nix
+++ b/nixos/modules/services/web-apps/ollama-webui.nix
@@ -1,0 +1,94 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let cfg = config.services.ollama-webui;
+
+in {
+  options = {
+    services.ollama-webui = {
+      enable = mkEnableOption (lib.mdDoc ''
+        Ollama-WebUI frontend service for the Ollama backend service.
+        It's a single page web application that integrates with Ollama to
+        run state-of-the-art AI large language models (LLM) locally with privacy
+        on your personal computer.
+        It's look and feel is similar to ChatGPT, supports different LLM models,
+        it stores chats (in the browser storage), supports image uploads,
+        Markdown and Latex rendering etc.See <https://github.com/ollama-webui/ollama-webui>.
+
+        The model names can be looked up on <https://ollama.ai/library> and are available in
+        varying sizes to fit your CPU, GPU, RAM and disk storage.
+
+        Required: This module requires the Ollama backend runner service that actually runs the
+        LLM models. The Ollama backend can be running locally or on a server; it's available
+        as a Nix package or a NixOS module.
+        The URL to the Ollama backend service can be set in this module, but overriden
+        later in the running Ollama-WebUI as well.
+
+        Optional: This module is configured to run locally, but can be served from a (home) server,
+        ideally behind a secured reverse-proxy.
+        Look at <https://nixos.wiki/wiki/Nginx> or <https://nixos.wiki/wiki/Caddy>
+        on how to set up a reverse proxy.
+      '');
+
+      ollama-webui-package = mkPackageOption pkgs "ollama-webui" { };
+
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = lib.mdDoc ''
+          The host/domain name under which the Ollama-WebUI service is reachable.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 8080;
+        description = lib.mdDoc "The port for the  Ollama-WebUI service.";
+      };
+
+      cors_origins = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "*,https://myserver:8080,http://10.0.0.10:*";
+        description = lib.mdDoc ''
+          Allow access from web apps that are served under some (different) URL.
+          If a web app like Ollama-WebUI is available/served on `https://myserver:8080`,
+          then add this URL here. Otherwise the Ollama frontend server will reject the
+          UIs request and return 403 forbidden due to CORS.
+          See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Open ports in the firewall for the Ollama-WebUI service.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.ollama-webui = {
+      description = "Ollama WebUI Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = let
+        cors-arg = if cfg.cors_origins == null then "" else "--cors='" + cfg.cors_origin +"'";
+      in {
+        ExecStart = "${cfg.ollama-webui-package}/bin/ollama-webui --port ${toString cfg.port} ${cors-arg}";
+        DynamicUser = "true";
+        Type = "simple";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+  };
+  meta.maintainers = with lib.maintainers; [ malteneuss ];
+}

--- a/pkgs/tools/misc/ollama-webui/default.nix
+++ b/pkgs/tools/misc/ollama-webui/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildNpmPackage
+, nodePackages
+, fetchFromGitHub
+, runtimeShell
+}:
+
+# We just package the JS frontend part, not the Python reverse-proxy backend.
+# NixOS can provide any another reverse proxy such as nginx.
+buildNpmPackage rec {
+  pname = "ollama-webui";
+  # ollama-webui doesn't tag versions yet.
+  version = "0.0.0-unstable-2023-12-22";
+
+  src = fetchFromGitHub {
+    owner = "ollama-webui";
+    repo = "ollama-webui";
+    rev = "77c1a77fccb04337ff95440030cd051fd16c2cd8";
+    hash = "sha256-u7h2tpHgtQwYXornslY3CZjKjigqBK2mHmaiK1EoEgk=";
+  };
+  # dependencies are downloaded into a separate node_modules Nix package
+  npmDepsHash = "sha256-SI2dPn1SwbGwl8093VBtcDsA2eHSxr3UUC+ta68w2t8=";
+
+  # We have to bake in the default URL it will use for ollama webserver here,
+  # but it can be overriden in the UI later.
+  PUBLIC_API_BASE_URL = "http://localhost:11434/api";
+
+  # The path '/ollama/api' will be redirected to the specified backend URL
+  OLLAMA_API_BASE_URL = PUBLIC_API_BASE_URL;
+  # "npm run build" creates a static page in the "build" folder.
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -R ./build/. $out/lib
+
+    mkdir -p $out/bin
+    cat <<EOF >>$out/bin/${pname}
+    #!${runtimeShell}
+    ${nodePackages.http-server}/bin/http-server $out/lib
+    EOF
+    chmod +x $out/bin/${pname}
+  '';
+
+  meta = with lib; {
+    description = "ChatGPT-Style Web Interface for Ollama";
+    longDescription = ''
+      Tools like Ollama make open-source large langue models (LLM) accessible and almost
+      trivial to download and run them locally on a consumer computer.
+      However, Ollama only runs in a terminal and doesn't store any chat history.
+      Ollama-WebUI is a web frontend on top of Ollama that looks and behaves similar to ChatGPT's web frontend.
+      You can have separate chats with different LLMs that are saved in your browser,
+      automatic Markdown and Latex rendering, upload files etc.
+      This package contains two parts:
+      - `<nix-store-package-path>/lib` The WebUI as a compiled, static html folder to bundle in your web server
+      - `<nix-store-package-path>/bin/${pname}` A runnable webserver the serves the WebUI for convenience.
+    '';
+    homepage = "https://github.com/ollama-webui/ollama-webui";
+    license = licenses.mit;
+    mainProgram = pname;
+    maintainers = with maintainers; [ malteneuss ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -863,6 +863,8 @@ with pkgs;
 
   ollama = callPackage ../tools/misc/ollama {  };
 
+  ollama-webui = callPackage ../tools/misc/ollama-webui {  };
+
   ots = callPackage ../tools/security/ots {  };
 
   credential-detector = callPackage ../tools/security/credential-detector { };


### PR DESCRIPTION
## Description of changes

Related to  #273556:
 
- Add [Ollama-WebUI](https://github.com/ollama-webui/ollama-webui) package that mimics ChatGPT's frontend and integrates nicely with existing Ollama package.
- Extend the Ollama service module for NixOS with options for home lab deployments
- Add Ollama-WebUI service module for NixOS

Background:
To make open-source large langue models (LLM) accessible there are projects like [Ollama](https://github.com/NixOS/nixpkgs/issues/ollama.ai) that make it almost trivial to download and run them locally on a consumer computer.
We already have [Ollama in Nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/tools/misc/ollama/default.nix), but that can only be run conveniently in a terminal (and doesn't store previous chats). What's missing is a web UI, e.g. [Ollama-WebUI](https://github.com/ollama-webui/ollama-webui) that mimics ChatGPT's frontend and integrates nicely with Ollama.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
