### PR TITLE
chromium: drop inactive maintainers, CODEOWNERS: init chromium

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,8 @@
 
 # Browsers
 /pkgs/applications/networking/browsers/firefox @mweinelt
+/pkgs/applications/networking/browsers/chromium @emilylange
+/nixos/tests/chromium.nix @emilylange
 
 # Certificate Authorities
 pkgs/data/misc/cacert/ @ajs124 @lukegb @mweinelt

--- a/pkgs/applications/networking/browsers/chromium/README.md
+++ b/pkgs/applications/networking/browsers/chromium/README.md
@@ -1,26 +1,18 @@
 # Maintainers
 
 - Note: We could always use more contributors, testers, etc. E.g.:
-  - A dedicated maintainer for the NixOS stable channel
+  - Dedicated maintainers for the NixOS stable channel
   - PRs with cleanups, improvements, fixes, etc. (but please try to make reviews
     as easy as possible)
   - People who handle stale issues/PRs
-- Primary maintainer (responsible for all updates): @primeos
-- Testers (test all stable channel updates)
-  - `nixos-unstable`:
-    - `x86_64`: @danielfullmer
-    - `aarch64`: @thefloweringash
-  - Stable channel:
-    - `x86_64`: @Frostman
+
 - Other relevant packages:
-  - `chromiumBeta` and `chromiumDev`: For testing purposes only (not build on
-    Hydra). We use these channels for testing and to fix build errors in advance
-    so that `chromium` updates are trivial and can be merged fast.
-  - `google-chrome`, `google-chrome-beta`, `google-chrome-dev`: Updated via
-    Chromium's `upstream-info.nix`
-  - `ungoogled-chromium`: @squalus
+  - `google-chrome`: Updated via Chromium's `upstream-info.nix`.
+  - `ungoogled-chromium`: A patch set for Chromium, that has its own entry in Chromium's `upstream-info.nix`.
   - `chromedriver`: Updated via Chromium's `upstream-info.nix` and not built
-    from source.
+    from source. Must match Chromium's major version.
+  - `electron-source`: Various version of electron that are built from source using Chromium's
+    `-unwrapped` derivation, due to electron being based on Chromium.
 
 # Upstream links
 

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -85,8 +85,8 @@ mkChromiumDerivation (base: rec {
       then "https://github.com/ungoogled-software/ungoogled-chromium"
       else "https://www.chromium.org/";
     maintainers = with lib.maintainers; if ungoogled
-      then [ squalus primeos michaeladler networkexception emilylange ]
-      else [ primeos thefloweringash networkexception emilylange ];
+      then [ networkexception emilylange ]
+      else [ networkexception emilylange ];
     license = if enableWideVine then lib.licenses.unfree else lib.licenses.bsd3;
     platforms = lib.platforms.linux;
     mainProgram = "chromium";


### PR DESCRIPTION
## Description of changes

Our [`./maintainers/README.md`](https://github.com/NixOS/nixpkgs/blob/67402e9e6654882bebe2c504bbff2fa3457568ab/maintainers/README.md#how-to-lose-maintainer-status) has a section titled "How to lose maintainer
status", which describes an "inactivity measure":

Maintainers how haven't reacted to "package-related notifications" for more than 3 months can be removed.

All those 4 maintainers (@primeos, @thefloweringash, @squalus, @michaeladler) that are getting dropped as part of this commit haven't responded to any such notifications (mostly review pings) for at least 3 months.

I'll wait at least 1 week, just as [`./maintainers/README.md`](https://github.com/NixOS/nixpkgs/blob/67402e9e6654882bebe2c504bbff2fa3457568ab/maintainers/README.md#how-to-lose-maintainer-status) recommends, before merging this.

This also adds me as the only GitHub CODEOWNER, a feature that requires write/commit access, for the package itself and the VM test (but not the nixos module), because ofborg pings are still somewhat unreliable.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
