### PR TITLE
libsForQt5.qmltermwidget: Fetch patch to Lomiri's patch series

### DIFF
--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -38,6 +38,14 @@ stdenv.mkDerivation {
       hash = "sha256-1GjC2mdfP3NpePDWZaT8zvIq3vwWIZs+iQ9o01iQtD4=";
     })
 
+    # A fix to the above series of patches, to fix a crash in lomiri-terminal-app
+    # Remove (and update the above fetchpatch) when https://github.com/gber/qmltermwidget/pull/1 merged
+    (fetchpatch {
+      name = "0002-qmltermwidget-Mark-ColorSchemeManager-singleton-as-C++-owned.patch";
+      url = "https://github.com/gber/qmltermwidget/commit/f3050bda066575eebdcff70fc1c3a393799e1d6d.patch";
+      hash = "sha256-O8fEpVLYMze6q4ps7RDGbNukRmZZBjLwqmvRqpp+H+Y=";
+    })
+
     # Some files are copied twice to the output which makes the build fails
     ./do-not-copy-artifacts-twice.patch
   ];


### PR DESCRIPTION
...to fix a crash in lomiri-terminal-app.

## Description of changes

Working towards https://github.com/NixOS/nixpkgs/issues/99090.

A debugging of this issue can be found here: https://gitlab.com/ubports/development/apps/lomiri-terminal-app/-/issues/104#note_1662252236
I have submitted this to https://github.com/gber/qmltermwidget/pull/1, where it (or a variant of it) should hopefully find its way into the UBports/Lomiri patch series.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    Tested the tests/terminal-emulators.nix entry for [`lomiri.lomiri-terminal-app`](https://github.com/NixOS/nixpkgs/pull/247112) after removing the workaround for this issue there, doesn't crash on shutdown now
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  Current hardware doesn't have enough RAM for `nixpkgs-review`. I tested `cool-retro-term` (unaffected by this, but doesn't hurt I guess) and [`lomiri.lomiri-terminal-app`](https://github.com/NixOS/nixpkgs/pull/247112)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
