### PR TITLE
freeplane: 1.9.14 -> 1.11.8

### DIFF
--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -1,31 +1,46 @@
-{ stdenv, lib, fetchpatch, fetchFromGitHub, makeWrapper, writeText, runtimeShell, jdk11, perl, gradle_6, which }:
+{ stdenv
+, lib
+, fetchpatch
+, fetchFromGitHub
+, makeWrapper
+, makeDesktopItem
+, writeText
+, runtimeShell
+, jdk17
+, perl
+, gradle_7
+, which
+}:
 
 let
   pname = "freeplane";
-  version = "1.9.14";
+  version = "1.11.4";
 
-  src_sha256 = "UiXtGJs+hibB63BaDDLXgjt3INBs+NfMsKcX2Q/kxKw=";
-  deps_outputHash = "tHhRaMIQK8ERuzm+qB9tRe2XSesL0bN3rComB9/qWgg=";
-  emoji_outputHash = "w96or4lpKCRK8A5HaB4Eakr7oVSiQALJ9tCJvKZaM34=";
+  src_hash = "sha256-LuXvGNpnkinHuukZEYZjo5l7TiwumEFd2H06JcC9Qd8=";
+  deps_outputHash = "sha256-exiP37gFcJfxzcS2bNjVntb0Wthy8kPSgaHJF9cvmRU=";
 
-  jdk = jdk11;
-  gradle = gradle_6;
+  jdk = jdk17;
+  gradle = gradle_7;
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "release-${version}";
-    sha256 = src_sha256;
+    hash = src_hash;
   };
 
   deps = stdenv.mkDerivation {
     name = "${pname}-deps";
     inherit src;
 
-    nativeBuildInputs = [ jdk perl gradle ];
+    nativeBuildInputs = [
+      jdk
+      perl
+      gradle
+    ];
 
     buildPhase = ''
-      GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk} --no-daemon jar
+      GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk} --no-daemon build
     '';
 
     # Mavenize dependency paths
@@ -34,6 +49,12 @@ let
       find ./caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
         | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
         | sh
+    # com/squareup/okio/okio/2.10.0/okio-jvm-2.10.0.jar expected to exist under name okio-2.10.0.jar
+    while IFS="" read -r -d "" path; do
+      dir=''${path%/*}; file=''${path##*/}; dest=''${file//-jvm-/-}
+      [[ -e $dir/$dest ]] && continue
+      ln -s "$dir/$file" "$dir/$dest"
+    done < <(find "$out" -type f -name 'okio-jvm-*.jar' -print0)
     '';
 
     outputHashAlgo = "sha256";
@@ -43,72 +64,78 @@ let
 
   # Point to our local deps repo
   gradleInit = writeText "init.gradle" ''
-    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
-    gradle.projectsLoaded {
-      rootProject.allprojects {
-        buildscript {
-          repositories {
-            clear()
-            maven { url '${deps}' }
-          }
-        }
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
         repositories {
           clear()
           maven { url '${deps}' }
         }
       }
     }
-    settingsEvaluated { settings ->
-      settings.pluginManagement {
+    gradle.projectsLoaded {
+      rootProject.allprojects {
         repositories {
+          clear()
           maven { url '${deps}' }
         }
       }
     }
   '';
 
-  emoji = stdenv.mkDerivation rec {
-    name = "${pname}-emoji";
-    inherit src;
-
-    nativeBuildInputs = [ jdk gradle ];
-
-    buildPhase = ''
-      GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk} --no-daemon --offline --init-script ${gradleInit} :freeplane:downloadEmoji
-    '';
-
-    installPhase = ''
-      mkdir -p $out/emoji/txt $out/resources/images
-      cp freeplane/build/emoji/txt/emojilist.txt $out/emoji/txt
-      cp -r freeplane/build/emoji/resources/images/emoji/. $out/resources/images/emoji
-    '';
-
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = emoji_outputHash;
-  };
-
 in stdenv.mkDerivation rec {
   inherit pname version src;
 
-  nativeBuildInputs = [ makeWrapper jdk gradle ];
+  nativeBuildInputs = [
+    makeWrapper
+    jdk
+    gradle
+  ];
 
   buildPhase = ''
-    mkdir -p -- ./freeplane/build/emoji/{txt,resources/images}
-    cp ${emoji}/emoji/txt/emojilist.txt ./freeplane/build/emoji/txt/emojilist.txt
-    cp -r ${emoji}/resources/images/emoji ./freeplane/build/emoji/resources/images/emoji
-    GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk} --no-daemon --offline --init-script ${gradleInit} -x test -x :freeplane:downloadEmoji build
+    mkdir -p -- ./freeplane/build
+
+    GRADLE_USER_HOME=$PWD \
+      gradle -Dorg.gradle.java.home=${jdk} \
+      --no-daemon --offline --init-script ${gradleInit} \
+      -x test \
+      build
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "freeplane";
+      desktopName = "freeplane";
+      genericName = "Mind-mapper";
+      exec = "freeplane";
+      icon = "freeplane";
+      comment = meta.description;
+      mimeTypes = [
+        "application/x-freemind"
+        "application/x-freeplane"
+        "text/x-troff-mm"
+      ];
+      categories = [
+        "2DGraphics"
+        "Chart"
+        "Graphics"
+        "Office"
+      ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/share
 
-    cp -a ./BIN/. $out/share/${pname}
-    makeWrapper $out/share/${pname}/${pname}.sh $out/bin/${pname} \
-      --set FREEPLANE_BASE_DIR $out/share/${pname} \
+    mkdir -p $out/bin $out/share
+    cp -a ./BIN/. $out/share/freeplane
+
+    makeWrapper $out/share/freeplane/freeplane.sh $out/bin/freeplane \
+      --set FREEPLANE_BASE_DIR $out/share/freeplane \
       --set JAVA_HOME ${jdk} \
-      --prefix PATH : ${lib.makeBinPath [ jdk which ]}
+      --prefix PATH : ${lib.makeBinPath [ jdk which ]} \
+      --prefix _JAVA_AWT_WM_NONREPARENTING : 1 \
+      --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on"
+
     runHook postInstall
   '';
 
@@ -116,7 +143,9 @@ in stdenv.mkDerivation rec {
     description = "Mind-mapping software";
     homepage = "https://freeplane.org/";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ chaduffy ];
+    # platforms = platforms.linux;
+    maintainers = with maintainers; [
+      chaduffy
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

This builds on https://github.com/NixOS/nixpkgs/pull/244937 and adds another bump from 1.11.4 to 1.11.8 on top.

~~This PR still has open issues.~~ All open issues are resolved

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<details>
  <summary>outdated issue with this PR</summary>

## ~~Open issues~~ fived via https://github.com/NixOS/nixpkgs/pull/275479/commits/b444ec34ebcfe2ca00b825c81afeac4375adf855#diff-39091065f4ad22ac853cb58126f4841171696ed247b18e60a42d19ba4e0e0829R59-R60
it currently does not compile and the gradle build fails with:
```
FAILURE: Build failed with an exception.                                                                                                           
                                                                                                                                                   
* Where:                                                                                                                                           
Build file '/build/source/build.gradle' line: 186                                                                                                  
                                                                                                                                                   
* What went wrong:                                                                                                                                 
A problem occurred configuring project ':freeplane_plugin_script'.                                                                                 
> Could not resolve all files for configuration ':freeplane_plugin_script:lib'.                                                                    
   > Could not resolve info.picocli:picocli:4.7.4.                       
     Required by:                                                        
         project :freeplane_plugin_script > org.apache.groovy:groovy-all:4.0.13 > org.apache.groovy:groovy-cli-picocli:4.0.13
      > No cached version of info.picocli:picocli:4.7.4 available for offline mode.                                                                
      > No cached version of info.picocli:picocli:4.7.4 available for offline mode.                                                                
      > No cached version of info.picocli:picocli:4.7.4 available for offline mode.                                                                
      > No cached version of info.picocli:picocli:4.7.4 available for offline mode.
```
the dependency is in a weird path in the deps derivation:
```
> find /nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/ -iname '*picocli*'
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/org/apache/groovy/groovy-cli-picocli
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/org/apache/groovy/groovy-cli-picocli/4.0.13/groovy-cli-picocli-4.0.13.jar
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/org/apache/groovy/groovy-cli-picocli/4.0.13/groovy-cli-picocli-4.0.13.pom
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/share/info/picocli
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/share/info/picocli/picocli
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/share/info/picocli/picocli/4.7.4/picocli-4.7.4.jar
/nix/store/zgkwpv58w4jr7r3zgvr3sl8sf280jkpa-freeplane-deps-1.11.8/share/info/picocli/picocli/4.7.4/picocli-4.7.4.pom
```
the path instead of `.../share/info/picocli/picocli/...` should be `.../info/picocli/picocli/...` and a `mv "$out/share/info" "$out"` fixes the build.

<details>