### PR TITLE
libck and sysbench cross-compilation fix

### DIFF
--- a/pkgs/development/libraries/libck/default.nix
+++ b/pkgs/development/libraries/libck/default.nix
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-HUC+8Vd0koAmumRZ8gS5u6LVa7fUfkIYRaxVv6/7Hgg=";
   };
 
+  postPatch = ''
+    substituteInPlace \
+      configure \
+        --replace \
+          'COMPILER=`./.1 2> /dev/null`' \
+          "COMPILER=gcc"
+  '';
+
+  configureFlags = ["--platform=${stdenv.hostPlatform.parsed.cpu.name}}"];
+
   dontDisableStatic = true;
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , libmysqlclient
 , libaio
+, libck
 , luajit
 # For testing:
 , testers
@@ -16,7 +17,8 @@ stdenv.mkDerivation rec {
   version = "1.0.20";
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libmysqlclient luajit ] ++ lib.optionals stdenv.isLinux [ libaio ];
+  buildInputs = [ libmysqlclient luajit libck ] ++ lib.optionals stdenv.isLinux [ libaio ];
+  depsBuildBuild = [ pkg-config ];
 
   src = fetchFromGitHub {
     owner = "akopytov";
@@ -31,6 +33,9 @@ stdenv.mkDerivation rec {
     # The bundled version does not build on aarch64-darwin:
     # https://github.com/akopytov/sysbench/issues/416
     "--with-system-luajit"
+    "--with-system-ck"
+    "--with-mysql-includes=${lib.getDev libmysqlclient}/include/mysql"
+    "--with-mysql-libs=${libmysqlclient}/lib/mysql"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

Fix cross-compilation of sysbench (and libck as transitive dependency).
Also modify sysbench, to use system libck.
(tested cross-build for aarch64-linux)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
