### PR TITLE
guile-chickadee: init at 0.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3246,6 +3246,13 @@
     githubId = 4526429;
     name = "Philipp Dargel";
   };
+  chito = {
+    email = "iamchito@protonmail.com";
+    github = "chitochi";
+    githubId = 153365419;
+    matrix = "@chito:nichijou.dev";
+    name = "Chito";
+  };
   chivay = {
     email = "hubert.jasudowicz@gmail.com";
     github = "chivay";

--- a/pkgs/by-name/gu/guile-chickadee/package.nix
+++ b/pkgs/by-name/gu/guile-chickadee/package.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, fetchurl
+, autoreconfHook
+, makeWrapper
+, testers
+, guile
+, pkg-config
+, texinfo
+, freetype
+, libjpeg_turbo
+, libpng
+, libvorbis
+, mpg123
+, openal
+, readline
+, guile-opengl
+, guile-sdl2
+, guile-chickadee
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "guile-chickadee";
+  version = "0.10.0";
+
+  src = fetchurl {
+    url = "https://files.dthompson.us/chickadee/chickadee-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Ey9TtuWaGlHG2cYYwqJIt2RX7XNUW28OGl/kuPUCD3U=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoreconfHook
+    guile
+    pkg-config
+    texinfo
+  ];
+
+  buildInputs = [
+    freetype
+    guile
+    libjpeg_turbo
+    libpng
+    libvorbis
+    mpg123
+    openal
+    readline
+  ];
+
+  propagatedBuildInputs = [
+    guile-opengl
+    guile-sdl2
+  ];
+
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/chickadee \
+      --prefix GUILE_LOAD_PATH : "$out/${guile.siteDir}:$GUILE_LOAD_PATH" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH"
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = guile-chickadee;
+    command = "chickadee -v";
+  };
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = with lib; {
+    description = "Game development toolkit for Guile Scheme with SDL2 and OpenGL";
+    homepage = "https://dthompson.us/projects/chickadee.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ chito ];
+    mainProgram = "chickadee";
+    platforms = guile.meta.platforms;
+    broken = stdenv.isDarwin;
+  };
+})


### PR DESCRIPTION
## Description of changes

This pull request adds the `guile-chickadee` package.

Chickadee is a game development toolkit for Guile Scheme built on top of SDL2 and OpenGL. Chickadee aims to provide all the features that parenthetically inclined game developers need to make 2D (and eventually 3D) games in Scheme, such as:
- extensible, fixed-timestep game loop
- OpenGL-based rendering engine
- keyboard, mouse, controller input
- REPL-driven development model

If you want to read more, here is the homepage of the project: https://dthompson.us/projects/chickadee.html.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
