### PR TITLE
elixir-tools-nvim: fix credo-language-server

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -476,6 +476,12 @@ self: super: {
     '';
   });
 
+  elixir-tools-nvim = super.elixir-tools-nvim.overrideAttrs {
+    fixupPhase = ''
+      patchShebangs $(find $out/bin/ -type f -not -name credo-language-server)
+    '';
+  };
+
   executor-nvim = super.executor-nvim.overrideAttrs {
     dependencies = with self; [ nui-nvim ];
   };


### PR DESCRIPTION
## Description of changes

Credo language server gets broken by `patchShebangs` in its current form. It produces an error like this:

```
"/nix/store/zx8aqgdy735qzk81glfwil6mbi6ddqb1-coreutils-9.4/bin/env: unrecognized option '--sname'\nTry '/nix/store/zx8aqgdy735qzk81glfwil6mbi6ddqb1-coreutils-9.4/bin/env --help' for more information.\n"
```

`env -S` without a command in the path causes the 'elixir' part of this shebang to be removed. This is because the following line defaults to 'true', which produces a blank string:

https://github.com/NixOS/nixpkgs/blob/b0d1fe9a32113e0269fae0ea6dd00e5604ccf6a9/pkgs/build-support/setup-hooks/patch-shebangs.sh#L91

elixir-tools-nvim wants to use whichever `elixir` is currently on the path, so I believe not patching the [credo-language-server script](https://github.com/elixir-tools/elixir-tools.nvim/blob/main/bin/credo-language-server) is the correct thing to do here.

As an aside, I believe [the tests](https://github.com/NixOS/nixpkgs/blob/b0d1fe9a32113e0269fae0ea6dd00e5604ccf6a9/pkgs/test/stdenv/patch-shebangs.nix#L71) for `patchShebangs` don't cover the `env -S` case correctly - the assertion uses `grep -v`, which looks like an accident. Perhaps @Artturin can comment on this?

I considered a PR to patchShebangs, but [my attempted fix](https://github.com/code-supply/nixpkgs/commit/ded4029beddbabb959e6dd8bb2b8092794d1099d) caused issues with the many, many dependent packages when I ran `nixpkgs-review`.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
