### PR TITLE
claws-mail: ensure latest plugins are used

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -107,6 +107,7 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./mime.patch
+    ./plugin-load-in-default-dir.patch
   ];
 
   preConfigure = ''

--- a/pkgs/applications/networking/mailreaders/claws-mail/plugin-load-in-default-dir.patch
+++ b/pkgs/applications/networking/mailreaders/claws-mail/plugin-load-in-default-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/plugin.c b/src/common/plugin.c
+index 47557d735..03471e805 100644
+--- a/src/common/plugin.c
++++ b/src/common/plugin.c
+@@ -617,7 +617,7 @@ void plugin_load_all(const gchar *type)
+ 		g_strstrip(buf);
+ 		replace_old_plugin_name(buf);
+ 
+-		if ((buf[0] != '\0') && (plugin_load(buf, &error) == NULL)) {
++		if ((buf[0] != '\0') && (plugin_load_in_default_dir(buf, &error) == NULL)) {
+ 			g_warning("plugin loading error: %s", error);
+ 			g_free(error);
+ 		}							


### PR DESCRIPTION
## Description of changes
Our claws-mail package contains all built plugins next to the (already wrapped) claws-mail binary.

The user's `~/.claws-mail/clawsrc` configuration file is being generated through Claws Mail's GUI and might references the loaded plugins by their full path. Please note, older versions of Claws Mail seems to have
written only the plugin's basename to the config.

After a package update, the new claws-mail binary will be used, but the configuration might still points to the old plugins by their absolute path. This will result in either outdated and potentially vulnerable plugins being loaded or Claws Mail complaining about their absence after the Nix Store was cleaned by its Garbage Collection.

This patch uses the already implemented `plugin_load_in_default_dir` function from Claws Mail when loading
the plugins from the configuration file. By doing so, Claws Mail looks for a plugin with the basename from
the configuration in the current plugin directory.

Testing this with different configurations seems to work.

Loading the valid plugin `pgpcore.so` specified in any of the following variants succeeded with the same debug log below.
- Base name- `pgpcore.so`
- Correct absolute path: `/nix/store/rk7yfmmsac6lll1qdl6vlxyamhnl9cpy-claws-mail-4.2.0/lib/claws-mail/plugins/pgpcore.so`
- Outdated absolute path: `/nix/store/2wkg13m98n59sh5m9x8757x5c3ka49cn-claws-mail-4.2.0/lib/claws-mail/plugins/pgpcore.so`
- Invalid absolute path: `/nix/store/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-claws-mail-4.2.0/lib/claws-mail/plugins/pgpcore.so`

The debug output was always:
> plugin.c:390:trying to load pgpcore.so in default plugin directory /nix/store/rk7yfmmsac6lll1qdl6vlxyamhnl9cpy-claws-mail-4.2.0/lib/claws-mail/plugins/
> plugin.c:454:trying to load `/nix/store/rk7yfmmsac6lll1qdl6vlxyamhnl9cpy-claws-mail-4.2.0/lib/claws-mail/plugins/pgpcore.so'
> [...]
> plugin.c:528:Plugin PGP/Core (from file /nix/store/rk7yfmmsac6lll1qdl6vlxyamhnl9cpy-claws-mail-4.2.0/lib/claws-mail/plugins/pgpcore.so) loaded

However, specifying an absent plugin, e.g., `pgpgore.so`, will result in silently aborting the loading procedure, as Claws Mail would do without the patch.

Closes #271741.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
