### PR TITLE
treewide: remove isNull where it decreases readability and code understanding

### DIFF
--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -317,7 +317,7 @@ rec {
 
       # If all subtrees are fully excluded or empty directories, return null.
       # This takes advantage of the fact that empty directories can be represented as excluded directories
-      else if all (value: isNull value || value == "emptyDir") subtreeValues then
+      else if all (value: value == null || value == "emptyDir") subtreeValues then
         null
 
       # Mix of included and excluded entries

--- a/nixos/modules/config/ldso.nix
+++ b/nixos/modules/config/ldso.nix
@@ -32,20 +32,20 @@ in {
 
   config = {
     assertions = [
-      { assertion = isNull config.environment.ldso32 || pkgs.stdenv.isx86_64;
+      { assertion = config.environment.ldso32 == null || pkgs.stdenv.isx86_64;
         message = "Option environment.ldso32 currently only works on x86_64.";
       }
     ];
 
     systemd.tmpfiles.rules = (
-      if isNull config.environment.ldso then [
+      if config.environment.ldso == null then [
         "r /${libDir}/${ldsoBasename} - - - - -"
       ] else [
         "d /${libDir} 0755 root root - -"
         "L+ /${libDir}/${ldsoBasename} - - - - ${config.environment.ldso}"
       ]
     ) ++ optionals pkgs.stdenv.isx86_64 (
-      if isNull config.environment.ldso32 then [
+      if config.environment.ldso32 == null then [
         "r /${libDir32}/${ldsoBasename32} - - - - -"
       ] else [
         "d /${libDir32} 0755 root root - -"

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -160,7 +160,7 @@ in
           (value // {
             target = "xdg/nvim/${value.target}";
           })
-          (optionals (isNull value.source) [ "source" ]);
+          (optionals (value.source == null) [ "source" ]);
       })
       cfg.runtime));
 

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -61,7 +61,7 @@ let
       runHook preConfigure
 
       ${./mix-configure-hook.sh}
-      ${lib.optionalString (!isNull appConfigPath)
+      ${lib.optionalString (appConfigPath != null)
       # Due to https://hexdocs.pm/elixir/main/Config.html the config directory
       # of a library seems to be not considered, as config is always
       # application specific. So we can safely delete it.

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -97,7 +97,7 @@ buildDotnetModule rec {
                 'true'
   '';
 
-  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = isNull glibcLocales;
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = glibcLocales == null;
   LOCALE_ARCHIVE = lib.optionalString (!DOTNET_SYSTEM_GLOBALIZATION_INVARIANT) "${glibcLocales}/lib/locale/locale-archive";
 
   postConfigure = ''

--- a/pkgs/tools/networking/maubot/wrapper.nix
+++ b/pkgs/tools/networking/maubot/wrapper.nix
@@ -36,7 +36,7 @@ let wrapper = { pythonPackages ? (_: [ ]), plugins ? (_: [ ]), baseConfig ? null
           # XXX: would patching maubot be better? See:
           # https://github.com/maubot/maubot/blob/75879cfb9370aade6fa0e84e1dde47222625139a/maubot/server.py#L106
           server.override_resource_path =
-            if builtins.isNull (baseConfig.server.override_resource_path or null)
+            if (baseConfig.server.override_resource_path or null) == null
             then "${unwrapped}/${python3.sitePackages}/maubot/management/frontend/build"
             else baseConfig.server.override_resource_path;
         })} $out/${python3.sitePackages}/maubot/example-config.yaml


### PR DESCRIPTION
## Description of changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
