### PR TITLE
tigerbeetle: init at 0.14.171

### DIFF
--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, zig_0_11
+, testers
+, tigerbeetle
+, nix-update-script
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tigerbeetle";
+  version = "0.14.171";
+
+  src = fetchFromGitHub {
+    owner = "tigerbeetle";
+    repo = "tigerbeetle";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-MjsNQarRXsrWKJZ2aBi/Wc2HAYm3isLBNw81a75+nhc=";
+  };
+
+  nativeBuildInputs = [ zig_0_11.hook ];
+
+  zigBuildFlags = [
+    "-Dgit-commit=0000000000000000000000000000000000000000"
+    "-Dversion=${finalAttrs.version}"
+  ];
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = tigerbeetle;
+      command = "tigerbeetle version";
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://tigerbeetle.com/";
+    description = "A financial accounting database designed to be distributed and fast";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ danielsidhion ];
+    platforms = lib.platforms.unix;
+    mainProgram = "tigerbeetle";
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR packages the server binary for [tigerbeetle](https://tigerbeetle.com/). There are client libraries available on their website, but it's outside the scope of this contribution. Upstream also builds MacOS binaries, but I don't have access to any mac machine, so I only packaged for linux.

PS: there's another old draft PR to add the same binary (#194099), but it seems abandoned, so I created this new PR and am available to maintain the new package. It might be a good idea to close that PR if this one is merged.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
