### PR TITLE
update hardened profile to new recommendations

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -39,14 +39,17 @@ with lib;
   security.apparmor.killUnconfinedConfinables = mkDefault true;
 
   boot.kernelParams = [
-    # Slab/slub sanity checks, redzoning, and poisoning
-    "slub_debug=FZP"
+    # Don't merge slabs
+    "slab_nomerge"
 
-    # Overwrite free'd memory
+    # Overwrite free'd pages
     "page_poison=1"
 
     # Enable page allocator randomization
     "page_alloc.shuffle=1"
+
+    # Disable debugfs
+    "debugfs=off"
   ];
 
   boot.blacklistedKernelModules = [

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -39,20 +39,32 @@ assert (versionAtLeast version "4.9");
   DEBUG_PI_LIST         = whenOlder "5.2" yes; # doesn't BUG()
   DEBUG_PLIST           = whenAtLeast "5.2" yes;
   DEBUG_SG              = yes;
+  DEBUG_VIRTUAL         = yes;
   SCHED_STACK_END_CHECK = yes;
 
   REFCOUNT_FULL = whenOlder "5.4.208" yes;
 
+  # tell EFI to wipe memory during reset
+  # https://lwn.net/Articles/730006/
+  RESET_ATTACK_MITIGATION = yes;
+
+  # restricts loading of line disciplines via TIOCSETD ioctl to CAP_SYS_MODULE
+  CONFIG_LDISC_AUTOLOAD = option no;
+
   # Randomize page allocator when page_alloc.shuffle=1
   SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;
-
-  # Allow enabling slub/slab free poisoning with slub_debug=P
-  SLUB_DEBUG = yes;
 
   # Wipe higher-level memory allocations on free() with page_poison=1
   PAGE_POISONING           = yes;
   PAGE_POISONING_NO_SANITY = whenOlder "5.11" yes;
   PAGE_POISONING_ZERO      = whenOlder "5.11" yes;
+
+  # Enable init_on_alloc and init_on_free by default
+  INIT_ON_ALLOC_DEFAULT_ON = yes;
+  INIT_ON_FREE_DEFAULT_ON  = yes;
+
+  # Wipe all caller-used registers on exit from a function
+  ZERO_CALL_USED_REGS = yes;
 
   # Enable the SafeSetId LSM
   SECURITY_SAFESETID = whenAtLeast "5.1" yes;
@@ -69,6 +81,16 @@ assert (versionAtLeast version "4.9");
   GCC_PLUGIN_STACKLEAK = whenAtLeast "4.20" yes; # A port of the PaX stackleak plugin
   GCC_PLUGIN_RANDSTRUCT = whenOlder "5.19" yes; # A port of the PaX randstruct plugin
   GCC_PLUGIN_RANDSTRUCT_PERFORMANCE = whenOlder "5.19" yes;
+
+  # Runtime undefined behaviour checks
+  # https://www.kernel.org/doc/html/latest/dev-tools/ubsan.html
+  # https://developers.redhat.com/blog/2014/10/16/gcc-undefined-behavior-sanitizer-ubsan
+  UBSAN      = yes;
+  UBSAN_TRAP = yes;
+  UBSAN_BOUNDS = yes;
+  UBSAN_SANITIZE_ALL = yes;
+  UBSAN_LOCAL_BOUNDS = option yes; # clang only
+  CFI_CLANG = option yes; # clang only Control Flow Integrity since 6.1
 
   # Same as GCC_PLUGIN_RANDSTRUCT*, but has been renamed to `RANDSTRUCT*` in 5.19.
   RANDSTRUCT = whenAtLeast "5.19" yes;
@@ -97,4 +119,15 @@ assert (versionAtLeast version "4.9");
   # CONFIG_DEVMEM=n causes these to not exist anymore.
   STRICT_DEVMEM    = option no;
   IO_STRICT_DEVMEM = option no;
+
+  # stricter IOMMU TLB invalidation
+  IOMMU_DEFAULT_DMA_STRICT = option yes;
+  IOMMU_DEFAULT_DMA_LAZY = option no;
+
+  # not needed for less than a decade old glibc versions
+  LEGACY_VSYSCALL_NONE = yes;
+
+  # Straight-Line-Speculation
+  # https://lwn.net/Articles/877845/
+  SLS = option yes;
 }


### PR DESCRIPTION
## Description of changes

Update the hardened profile to be up-to-date with current Linux kernel patches and arguments:

- remove SLAB_DEBUG options that would leak kernel pointers, remove SLAB_DEBUG from the kernel
- enable zeroing of all SLAB / SLUB allocations just as is the case on the Android kernel
- disable vsyscall and debugfs

Most changes are in the command line parameters only to allow runtime changes if desired.

Proposals from https://madaidans-insecurities.github.io/guides/linux-hardening.html?#boot-parameters were taken and evaluated. I read the kernel documentaion and mailing list discussions for each change.

Please read the detailed commit message.

Addresses issue #90704 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux -> Booted a non-graphical machine with running software
  - [ ] aarch64-linux -> no but most devices have their own kernel images anyway. the hardened profile was always x86_64 focused. (comment if you have ideas on how to change this)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files. Booted the kernel with the configuration
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
