### PR TITLE
doc: add more details on testers.testVersion

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -30,37 +30,48 @@ meta.pkgConfigModules = [ "libfoo" ];
 
 ## `testVersion` {#tester-testVersion}
 
-Checks the command output contains the specified version
+Checks that the output from running a command contains the specified version string in it as a whole word.
 
-Although simplistic, this test assures that the main program
-can run. While there's no substitute for a real test case,
-it does catch dynamic linking errors and such. It also provides
-some protection against accidentally building the wrong version,
-for example when using an 'old' hash in a fixed-output derivation.
+Although simplistic, this test assures that the main program can run.
+While there's no substitute for a real test case, it does catch dynamic linking errors and such.
+It also provides some protection against accidentally building the wrong version, for example when using an "old" hash in a fixed-output derivation.
 
-Examples:
+By default, the command to be run will be inferred from the given `package` attribute:
+it will check `meta.mainProgram` first, and fall back to `pname` or `name`.
+The default argument to the command is `--version`, and the version to be checked will be inferred from the given `package` attribute as well.
+
+:::{.example #ex-testversion-hello}
+
+# Check a program version using all the default values
+
+This example will run the command `hello --version`, and then check that the version of the `hello` package is in the output of the command.
 
 ```nix
 passthru.tests.version = testers.testVersion { package = hello; };
+```
+
+:::
+
+:::{.example #ex-testversion-different-commandversion}
+
+# Check the program version using a specified command and expected version string
+
+This example will run the command `leetcode -V`, and then check that `leetcode 0.4.2` is in the output of the command as a whole word (separated by whitespaces).
+This means that an output like "leetcode 0.4.21" would fail the tests, and an output like "You're running leetcode 0.4.2" would pass the tests.
+
+A common usage of the `version` attribute is to specify `version = "v${version}"`.
+
+```nix
+version = "0.4.2";
 
 passthru.tests.version = testers.testVersion {
-  package = seaweedfs;
-  command = "weed version";
-};
-
-passthru.tests.version = testers.testVersion {
-  package = key;
-  command = "KeY --help";
-  # Wrong '2.5' version in the code. Drop on next version.
-  version = "2.5";
-};
-
-passthru.tests.version = testers.testVersion {
-  package = ghr;
-  # The output needs to contain the 'version' string without any prefix or suffix.
-  version = "v${version}";
+  package = leetcode-cli;
+  command = "leetcode -V";
+  version = "leetcode ${version}";
 };
 ```
+
+:::
 
 ## `testBuildFailure` {#tester-testBuildFailure}
 


### PR DESCRIPTION
## Description of changes

I recently had to figure out how `testers.testVersion` worked, and decided to capture some of the information on how it works in the manual. The information there didn't explain what it does by default.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
