### PR TITLE
haskellPackages.postgrest: 10.1.1 -> 12.0.2 and fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2714,14 +2714,14 @@ self: super: {
   co-log-polysemy = doJailbreak super.co-log-polysemy;
   co-log-polysemy-formatting = doJailbreak super.co-log-polysemy-formatting;
 
-  # 2023-12-20: Needs newer postgrest package and extra dependencies
-  # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
-  # 2022-12-02: Too strict bounds: https://github.com/PostgREST/postgrest/issues/2580
+  # 2023-12-20: Needs newer hasql-pool package and extra dependencies
   postgrest = lib.pipe (super.postgrest.overrideScope (lself: lsuper: {
     hasql-pool = lself.hasql-pool_0_10;
   })) [
-    (addBuildDepends [ self.extra self.fuzzyset_0_2_4 ])
+    (addBuildDepends [ self.extra self.fuzzyset_0_2_4 self.cache self.timeit ])
+    # 2022-12-02: Too strict bounds: https://github.com/PostgREST/postgrest/issues/2580
     doJailbreak
+    # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
     (overrideSrc rec {
       version = "12.0.2";
       src = pkgs.fetchFromGitHub {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2714,19 +2714,24 @@ self: super: {
   co-log-polysemy = doJailbreak super.co-log-polysemy;
   co-log-polysemy-formatting = doJailbreak super.co-log-polysemy-formatting;
 
-  # 2022-12-02: Needs newer postgrest package
+  # 2023-12-20: Needs newer postgrest package and extra dependencies
   # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
   # 2022-12-02: Too strict bounds: https://github.com/PostgREST/postgrest/issues/2580
-  # 2022-12-02: Tests require running postresql server
-  postgrest = dontCheck (doJailbreak (overrideSrc rec {
-    version = "10.1.1";
-    src = pkgs.fetchFromGitHub {
-      owner = "PostgREST";
-      repo = "postgrest";
-      rev = "v${version}";
-      sha256 = "sha256-ceSPBH+lzGU1OwjolcaE1BCpkKCJrvMU5G8TPeaJesM=";
-    };
-  } super.postgrest));
+  postgrest = lib.pipe (super.postgrest.overrideScope (lself: lsuper: {
+    hasql-pool = lself.hasql-pool_0_10;
+  })) [
+    (addBuildDepends [ self.extra self.fuzzyset_0_2_4 ])
+    doJailbreak
+    (overrideSrc rec {
+      version = "11.2.2";
+      src = pkgs.fetchFromGitHub {
+        owner = "PostgREST";
+        repo = "postgrest";
+        rev = "v${version}";
+        hash = "sha256-6Nv0NSAiNUSg2T/cmWs7zGSInLSmF0WDA3E/KxlA7O8=";
+      };
+    })
+  ];
 
   html-charset = dontCheck super.html-charset;
 
@@ -2819,5 +2824,9 @@ self: super: {
     ipython-kernel = self.ipython-kernel_0_11_0_0;
     ghc-syntax-highlighter = self.ghc-syntax-highlighter_0_0_10_0;
   });
+
+  # 2024-01-01: Too strict bounds on megaparsec
+  # Fixed in 0.2.8: https://github.com/PostgREST/configurator-pg/pull/20
+  configurator-pg = doJailbreak super.configurator-pg;
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2723,12 +2723,12 @@ self: super: {
     (addBuildDepends [ self.extra self.fuzzyset_0_2_4 ])
     doJailbreak
     (overrideSrc rec {
-      version = "11.2.2";
+      version = "12.0.2";
       src = pkgs.fetchFromGitHub {
         owner = "PostgREST";
         repo = "postgrest";
         rev = "v${version}";
-        hash = "sha256-6Nv0NSAiNUSg2T/cmWs7zGSInLSmF0WDA3E/KxlA7O8=";
+        hash = "sha256-fpGeL8R6hziEtIgHUMfWLF7JAjo3FDYQw3xPSeQH+to=";
       };
     })
   ];

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -889,7 +889,6 @@ broken-packages:
   - config-parser # failure in job https://hydra.nixos.org/build/233206136 at 2023-09-02
   - Configurable # failure in job https://hydra.nixos.org/build/233200781 at 2023-09-02
   - configuration # failure in job https://hydra.nixos.org/build/233195399 at 2023-09-02
-  - configurator-pg # failure in job https://hydra.nixos.org/build/233219556 at 2023-09-02
   - config-value-getopt # failure in job https://hydra.nixos.org/build/233204566 at 2023-09-02
   - confsolve # failure in job https://hydra.nixos.org/build/233194913 at 2023-09-02
   - congruence-relation # failure in job https://hydra.nixos.org/build/233222125 at 2023-09-02
@@ -1749,7 +1748,6 @@ broken-packages:
   - future # failure in job https://hydra.nixos.org/build/233224844 at 2023-09-02
   - futures # failure in job https://hydra.nixos.org/build/233230206 at 2023-09-02
   - fuzzyfind # failure in job https://hydra.nixos.org/build/233206269 at 2023-09-02
-  - fuzzyset # failure in job https://hydra.nixos.org/build/233231726 at 2023-09-02
   - fuzzy-timings # failure in job https://hydra.nixos.org/build/233235765 at 2023-09-02
   - fvars # failure in job https://hydra.nixos.org/build/234461649 at 2023-09-13
   - fwgl # failure in job https://hydra.nixos.org/build/233246210 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -147,6 +147,7 @@ extra-packages:
   - shake-cabal < 0.2.2.3               # 2023-07-01: last version to support Cabal 3.6.*
   - unix-compat < 0.7                   # 2023-07-04: Need System.PosixCompat.User for git-annex
   - algebraic-graphs < 0.7              # 2023-08-14: Needed for building weeder < 2.6.0
+  - fuzzyset == 0.2.4                   # 2023-12-20: Needed for building postgrest > 10
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -3114,7 +3114,6 @@ dont-distribute-packages:
  - postgresql-tx-query
  - postgresql-tx-squeal
  - postgresql-tx-squeal-compat-simple
- - postgrest
  - postmark
  - potoki
  - potoki-cereal

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -422,7 +422,17 @@ self: super: builtins.intersectAttrs super {
   hasql-interpolate = dontCheck super.hasql-interpolate;
   hasql-notifications = dontCheck super.hasql-notifications;
   hasql-pool = dontCheck super.hasql-pool;
+  hasql-pool_0_10 = dontCheck super.hasql-pool_0_10;
   hasql-transaction = dontCheck super.hasql-transaction;
+
+  # Test suite requires a running postgresql server,
+  # avoid compiling twice by providing executable as a separate output (with small closure size),
+  # generate shell completion
+  postgrest = lib.pipe super.postgrest [
+    dontCheck
+    enableSeparateBinOutput
+    (self.generateOptparseApplicativeCompletions [ "postgrest" ])
+  ];
 
   # Tries to mess with extended POSIX attributes, but can't in our chroot environment.
   xattr = dontCheck super.xattr;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27128,6 +27128,8 @@ with pkgs;
 
   postgresqlTestHook = callPackage ../build-support/setup-hooks/postgresql-test-hook { };
 
+  postgrest = haskellPackages.postgrest.bin;
+
   redshift_jdbc = callPackage ../development/java-modules/redshift_jdbc { };
 
   liquibase_redshift_extension = callPackage ../development/java-modules/liquibase_redshift_extension { };


### PR DESCRIPTION
## Description of changes

Fixes #271868.

@maralorn : First attempt at fixing, please advise on improvements.

One issue that confused/surprised me is that the default `hasql-pool` package is the 0.9 version, while the newer 0.10 version that is on Hackage is `hasql-pool_0_10`. Does the stackage override take precedence?

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
