### PR TITLE
tsm-client: 8.1.20.0 -> 8.1.21.0

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -22,7 +22,7 @@ let
   serverOptions = { name, config, ... }: {
     freeformType = attrsOf (either scalarType (listOf scalarType));
     # Client system-options file directives are explained here:
-    # https://www.ibm.com/docs/en/storage-protect/8.1.20?topic=commands-processing-options
+    # https://www.ibm.com/docs/en/storage-protect/8.1.21?topic=commands-processing-options
     options.servername = mkOption {
       type = servernameType;
       default = name;

--- a/nixos/modules/services/backup/tsm.nix
+++ b/nixos/modules/services/backup/tsm.nix
@@ -90,7 +90,7 @@ in
       environment.HOME = "/var/lib/tsm-backup";
       serviceConfig = {
         # for exit status description see
-        # https://www.ibm.com/docs/en/storage-protect/8.1.20?topic=clients-client-return-codes
+        # https://www.ibm.com/docs/en/storage-protect/8.1.21?topic=clients-client-return-codes
         SuccessExitStatus = "4 8";
         # The `-se` option must come after the command.
         # The `-optfile` option suppresses a `dsm.opt`-not-found warning.

--- a/nixos/tests/tsm-client-gui.nix
+++ b/nixos/tests/tsm-client-gui.nix
@@ -31,7 +31,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     machine.execute("DSM_LOG=/tmp dsmj -optfile=/dev/null >&2 &")
 
     # does it report the "TCP/IP connection failure" error code?
-    machine.wait_for_window("IBM Spectrum Protect")
+    machine.wait_for_window("IBM Storage Protect")
     machine.wait_for_text("ANS2610S")
     machine.send_key("esc")
 

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -45,7 +45,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/spectrum-protect/8.1.20?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/storage-protect/8.1.21?topic=solaris-set-api-environment-variables
 
 
 # The newest version of TSM client should be discoverable by
@@ -104,10 +104,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.20.0";
+    version = "8.1.21.0";
     src = fetchurl {
       url = mkSrcUrl version;
-      hash = "sha512-UZ5hRXGlB/1B4gZ8/i9OCHsxSuRkbAcp195zl/M75HtTi8o0rOfOh3LMmn4x4/M1V8d60ix7Tn4Mv8xkm7QXzw==";
+      hash = "sha512-iXkVYQsqbNhQJmrYl5a5433iSl6kg6YzlTlgCzpFGslMn+3ynSmYn8Rtxwitp931SwmV4a53tGctSuisz8pOCg==";
     };
     inherit meta passthru;
 


### PR DESCRIPTION
## Description of changes

"Update History" (release notes): https://www.ibm.com/support/pages/node/6998343

At the time of this writing, the "APAR" links of the "Update History" lead to 404.  However, the abstracts indicate that this update is not security critical.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Both tests derivations (cli and gui) build/pass. Also successfully tested with a real tsm-server (uploaded some files for backup without errors/problems).


## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc