### PR TITLE
gcc: extend crtn workaround to alpha target

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -249,6 +249,11 @@ let
     ++ lib.optionals (targetPlatform.isMips && targetPlatform.parsed.abi.name == "gnu" && lib.versions.major version == "12") [
       "--disable-libsanitizer"
     ]
+    ++ lib.optionals targetPlatform.isAlpha [
+      # Workaround build failures like:
+      #   cc1: error: fp software completion requires '-mtrap-precision=i' [-Werror]
+      "--disable-werror"
+    ]
   ;
 
 in configureFlags

--- a/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
@@ -48,6 +48,6 @@ in
   # https://www.openwall.com/lists/musl/2022/11/09/3
   #
   # 'parsed.cpu.family' won't be correct for every platform.
-+ lib.optionalString (stdenv.targetPlatform.isLoongArch64 || stdenv.targetPlatform.isS390) ''
++ lib.optionalString (stdenv.targetPlatform.isLoongArch64 || stdenv.targetPlatform.isS390 || stdenv.targetPlatform.isAlpha) ''
   touch libgcc/config/${stdenv.targetPlatform.parsed.cpu.family}/crt{i,n}.S
 ''


### PR DESCRIPTION
Without the change `alpha-unknown-linux-gnu` target is failing to build `gcc`:

```
$ NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix build -f ./. re2c --arg crossSystem '{ config = "alpha-unknown-linux-gnu"; }'
...
make[1]: *** No rule to make target '../../../gcc-12.3.0/libgcc/config/alpha/crti.S', needed by 'crti.o'.  Stop.
...
cc1: error: fp software completion requires '-mtrap-precision=i' [-Werror]
```

After the change it is able to produce working binaries:

```
$ NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix build -f ./. re2c --arg crossSystem '{ config = "alpha-unknown-linux-gnu"; }'
...
$ qemu-alpha ./result/bin/re2c --version
re2c 3.1

$ file result/bin/re2c
result/bin/re2c: ELF 64-bit LSB executable, Alpha (unofficial), version 1 (SYSV), dynamically linked, interpreter ...-glibc-alpha-unknown-linux-gnu-2.38-27/lib/ld-linux.so.2, for GNU/Linux 3.10.0, not stripped
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
