### PR TITLE
gnuradio.unwrapped: 3.10.7.0 -> 3.10.8.0

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -276,7 +276,7 @@ stdenv.mkDerivation (finalAttrs: (shared // {
   '';
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
-    ./modtool-newmod-permissions.patch
+    ./modtool-newmod-permissions.3_9.patch
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overridden and are used inside GR plugins - the same version must

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -45,11 +45,11 @@
 # If one wishes to use a different src or name for a very custom build
 , overrideSrc ? {}
 , pname ? "gnuradio"
-, version ? "3.10.7.0"
+, version ? "3.10.8.0"
 }:
 
 let
-  sourceSha256 = "sha256-7fIQMcx90wI4mAZmR26/rkBKPKhNxgu3oWpJTV3C+Ek=";
+  sourceSha256 = "sha256-4BoJciL3ffd9Dgk3HxXCOOwnGHqCEVuo+a1AtzJG4IY=";
   featuresInfo = {
     # Needed always
     basic = {
@@ -291,12 +291,6 @@ stdenv.mkDerivation (finalAttrs: (shared // {
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.patch
-    # https://github.com/gnuradio/gnuradio/pull/6808
-    (fetchpatch {
-      name = "gnuradio-fmt10.1.patch";
-      url = "https://github.com/gnuradio/gnuradio/commit/9357c17721a27cc0aae3fe809af140c84e492f37.patch";
-      hash = "sha256-w3b22PTqoORyYQ3RKRG+2htQWbITzQiOdSDyuejUtHQ=";
-    })
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overridden and are used inside GR plugins - the same version must

--- a/pkgs/applications/radio/gnuradio/modtool-newmod-permissions.3_9.patch
+++ b/pkgs/applications/radio/gnuradio/modtool-newmod-permissions.3_9.patch
@@ -1,0 +1,15 @@
+diff --git c/gr-utils/modtool/core/newmod.py w/gr-utils/modtool/core/newmod.py
+index babebfcde..9a02f663e 100644
+--- c/gr-utils/modtool/core/newmod.py
++++ w/gr-utils/modtool/core/newmod.py
+@@ -62,7 +62,9 @@ class ModToolNewModule(ModTool):
+         self._setup_scm(mode='new')
+         logger.info(f"Creating out-of-tree module in {self.dir}...")
+         try:
+-            shutil.copytree(self.srcdir, self.dir)
++            # https://stackoverflow.com/a/17022146/4935114
++            shutil.copystat = lambda x, y: x
++            shutil.copytree(self.srcdir, self.dir, copy_function=shutil.copyfile)
+             try:
+               shutil.copyfile(os.path.join(gr.prefix(), 'share', 'gnuradio', 'clang-format.conf'),
+                               os.path.join(self.dir, '.clang-format'))

--- a/pkgs/applications/radio/gnuradio/modtool-newmod-permissions.patch
+++ b/pkgs/applications/radio/gnuradio/modtool-newmod-permissions.patch
@@ -1,8 +1,8 @@
-diff --git c/gr-utils/modtool/core/newmod.py w/gr-utils/modtool/core/newmod.py
-index babebfcde..9a02f663e 100644
---- c/gr-utils/modtool/core/newmod.py
+diff --git i/gr-utils/modtool/core/newmod.py w/gr-utils/modtool/core/newmod.py
+index 8b222473f..c82fcd538 100644
+--- i/gr-utils/modtool/core/newmod.py
 +++ w/gr-utils/modtool/core/newmod.py
-@@ -62,7 +62,9 @@ class ModToolNewModule(ModTool):
+@@ -66,7 +66,9 @@ class ModToolNewModule(ModTool):
          self._setup_scm(mode='new')
          logger.info(f"Creating out-of-tree module in {self.dir}...")
          try:
@@ -10,6 +10,6 @@ index babebfcde..9a02f663e 100644
 +            # https://stackoverflow.com/a/17022146/4935114
 +            shutil.copystat = lambda x, y: x
 +            shutil.copytree(self.srcdir, self.dir, copy_function=shutil.copyfile)
-             try:
-               shutil.copyfile(os.path.join(gr.prefix(), 'share', 'gnuradio', 'clang-format.conf'),
-                               os.path.join(self.dir, '.clang-format'))
+             source_dir = os.path.join(gr.prefix(), "share", "gnuradio")
+             for source_name, target_name in (
+                     ("clang-format.conf", ".clang-format"),


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
