### PR TITLE
rstudio: 2023.09.0+463 -> 2023.12.0+369

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -7,7 +7,7 @@
 , makeDesktopItem
 , copyDesktopItems
 , cmake
-, boost
+, boost183
 , zlib
 , openssl
 , R

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -51,7 +51,7 @@ let
     owner = "rstudio";
     repo = "rstudio";
     rev = "v${version}";
-    hash = "";
+    hash = "sha256-dJBnUsGUshzPwl9Ns8lTdIiQGjeLExAywUuTpBNSKEM=";
   };
 
   mathJaxSrc = fetchurl {

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -62,8 +62,8 @@ let
   rsconnectSrc = fetchFromGitHub {
     owner = "rstudio";
     repo = "rsconnect";
-    rev = "5175a927a41acfd9a21d9fdecb705ea3292109f2";
-    hash = "sha256-c1fFcN6KAfxXv8bv4WnIqQKg1wcNP2AywhEmIbyzaBA=";
+    rev = "872b53e3d39a43c543498f437587fd7fb7fdca59";
+    hash = "sha256-ghRz4Frd+I9ShRNNOE/kdk9KjRCj0Z1mPnThueriiUY=";
   };
 
   # Ideally, rev should match the rstudio release name.

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -43,15 +43,15 @@ let
   version =
   "${RSTUDIO_VERSION_MAJOR}.${RSTUDIO_VERSION_MINOR}.${RSTUDIO_VERSION_PATCH}${RSTUDIO_VERSION_SUFFIX}";
   RSTUDIO_VERSION_MAJOR  = "2023";
-  RSTUDIO_VERSION_MINOR  = "09";
+  RSTUDIO_VERSION_MINOR  = "12";
   RSTUDIO_VERSION_PATCH  = "0";
-  RSTUDIO_VERSION_SUFFIX = "+463";
+  RSTUDIO_VERSION_SUFFIX = "+369";
 
   src = fetchFromGitHub {
     owner = "rstudio";
     repo = "rstudio";
     rev = "v${version}";
-    hash = "sha256-FwNuU2rbE3GEhuwphvZISUMhvSZJ6FjjaZ1oQ9F8NWc=";
+    hash = "";
   };
 
   mathJaxSrc = fetchurl {

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -93,7 +93,7 @@ in
     ];
 
     buildInputs = [
-      boost
+      boost183
       zlib
       openssl
       R

--- a/pkgs/applications/editors/rstudio/use-system-node.patch
+++ b/pkgs/applications/editors/rstudio/use-system-node.patch
@@ -32,7 +32,7 @@ index 033d605..f1ee63d 100644
 +++ b/src/gwt/build.xml
 @@ -87,29 +87,7 @@
     <!-- ensure version matches RSTUDIO_NODE_VERSION -->
-    <property name="node.version" value="16.14.0"/>
+    <property name="node.version" value="18.18.2"/>
     <property name="node.dir" value="../../dependencies/common/node/${node.version}"/>
 -   <!-- use yarn from system but will prefer yarn from dependencies if available -->
 -   <condition property="yarn.bin" value="yarn">

--- a/pkgs/applications/editors/rstudio/use-system-node.patch
+++ b/pkgs/applications/editors/rstudio/use-system-node.patch
@@ -6,7 +6,7 @@ index d18362b..98cdd4c 100644
  external-pandoc-path=${RSTUDIO_DEPENDENCIES_PANDOC_DIR}
  external-quarto-path=${RSTUDIO_DEPENDENCIES_QUARTO_DIR}
  external-libclang-path=${RSTUDIO_DEPENDENCIES_DIR}/common/libclang
--external-node-path=${RSTUDIO_DEPENDENCIES_DIR}/common/node/16.14.0/bin/node
+-external-node-path=${RSTUDIO_DEPENDENCIES_DIR}/common/node/18.18.2/bin/node
 +external-node-path=@node@/bin/node
  
  # enable copilot

--- a/pkgs/applications/editors/rstudio/use-system-node.patch
+++ b/pkgs/applications/editors/rstudio/use-system-node.patch
@@ -58,15 +58,18 @@ index 033d605..f1ee63d 100644
 -      value="c:\rstudio-tools\dependencies\common\node\${node.version}\node_modules\yarn\bin\yarn.cmd"
 -      file="c:\rstudio-tools\dependencies\common\node\${node.version}\node_modules\yarn\bin\yarn.cmd"/>
 +   <property name="node.bin" value="@node@/bin/node"/>
- 
+
     <property name="panmirror.dir" value="./lib/quarto/apps/panmirror"/>
     <property name="panmirror.build.dir" value="./www/js/panmirror"/>
-@@ -126,21 +104,11 @@
-       file="c:\rstudio-tools\src\gwt\lib\quarto\apps\panmirror"/>
- 
-    <target name="panmirror" description="Compile panmirror library">
+@@ -133,28 +111,11 @@
+             <isset property="panmirror.minify" />
+          </not>
+       </condition>
+-
 -      <echo message="yarn location: ${yarn.bin}"/>
 -      <echo message="panmirror location: ${panmirror.dir}"/>
+-      <echo message="panmirror minify: ${panmirror.minify}"/>
+-
        <mkdir dir="${panmirror.build.dir}"/>
 -      <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
 -         <arg value="install"/>
@@ -75,14 +78,19 @@ index 033d605..f1ee63d 100644
 -      </exec>
 -      <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
 -         <arg value="build"/>
+-         <arg value="--minify"/>
+-         <arg value="${panmirror.minify}"/>
+-         <arg value="--sourcemap"/>
+-         <arg value="true"/>
 -         <env key="PANMIRROR_OUTDIR" value="dist-rstudio"/>
-+      <exec executable="${node.bin}" dir="${panmirror.dir}" spawn="${panmirror.spawn}">
-+         <arg value="fuse"/>
-+         <arg value="${panmirror.target}"/>
++     <exec executable="${node.bin}" dir="${panmirror.dir}" spawn="${panmirror.spawn}">
++          <arg value="fuse"/>
++          <arg value="${panmirror.target}"/>
        </exec>
 -      <copy todir="${panmirror.build.dir}">
 -         <fileset dir="${panmirror.dir}/dist-rstudio"/>
 -      </copy>
     </target>
- 
+
     <target name="javac" description="Compile java source">
+    


### PR DESCRIPTION
## Description of changes

This is a draft PR because I tried upgrading to the latest version of RStudio, but there seems to be an issue with CMake. See next message with the error message.

- Upgraded to current version (2023.12.0+369 "Ocean Storm"): commits https://github.com/b-rodrigues/nixpkgs/commit/6919a0a7295a6795c9ac0e20ec434b747fdba217 and https://github.com/b-rodrigues/nixpkgs/commit/1f1623bc18b9f946c0dcb7e0bd0d529c6909ccb5
- Upgraded boost version (from 1.81 to 1.83): commits https://github.com/b-rodrigues/nixpkgs/commit/5a9439f74a50196f3cf256d9af176b202a3880ca and https://github.com/b-rodrigues/nixpkgs/commit/872395a585473a0415b0a74262e60af309ba4537  This was needed because using boost at version 1.81 resulted in error indicating that this release of boost was too old.
- Updated use-system-node-patch: commits https://github.com/b-rodrigues/nixpkgs/commit/03ba137ae564eed4c8517bb66187d79687ff19eb , https://github.com/b-rodrigues/nixpkgs/commit/d66f51d9db7d9e0cf88a5ec8af6dde8d0da85df7 and https://github.com/b-rodrigues/nixpkgs/commit/123bd723cfd9e90c3fced89fc228445a5fac3368

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
