### PR TITLE
grub: 2.12-rc1 -> 2.12

### DIFF
--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -49,8 +49,8 @@ let
 
   src = fetchFromSavannah {
     repo = "grub";
-    rev = "grub-2.12-rc1";
-    hash = "sha256-DrNFzi2o7ZUfL3bMdG63xivZIjcTgv8RODJz7hLJ3WY=";
+    rev = "grub-2.12";
+    hash = "sha256-lathsBb2f7urh8R86ihpTdwo3h1hAHnRiHd5gCLVpBc=";
   };
 
   # HACK: the translations are stored on a different server,
@@ -61,7 +61,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-XpQ4tu5eNRARdbg95LOjqp+2RCVRj1qZWe+Sc0O5zNg=";
+    outputHash = "sha256-XzW2e7Xe7Pi297eV/fD2B/6uONEz9UjL2EHDCY0huTA=";
   }
   ''
     mkdir -p po
@@ -77,46 +77,12 @@ assert !(efiSupport && xenSupport);
 
 stdenv.mkDerivation rec {
   pname = "grub";
-  version = "2.12-rc1";
+  version = "2.12";
   inherit src;
 
   patches = [
     ./fix-bash-completion.patch
     ./add-hidden-menu-entries.patch
-
-    # Revert upstream commit that breaks reading XFS filesystems
-    # FIXME: remove when fixed upstream
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=ef7850c757fb3dd2462a512cfa0ff19c89fcc0b1";
-      revert = true;
-      hash = "sha256-p8Kcv9d7ri4eJU6Fgqyzdj0hV5MHSe50AF02FPDJx2Y=";
-    })
-
-    # Fixes for NTFS bugs (CVE-2023-4692 and CVE-2023-4693)
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=43651027d24e62a7a463254165e1e46e42aecdea";
-      hash = "sha256-/oudbfL8Ph7ZsgsFUI0YIddji+7okFRG12E/rDsgvNM=";
-    })
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=0ed2458cc4eff6d9a9199527e2a0b6d445802f94";
-      hash = "sha256-6EhLzVapN2n62Lgo+PnB4SRvDkYWFkrKNinCvArRUXk=";
-    })
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=7e5f031a6a6a3decc2360a7b0c71abbe598e7354";
-      hash = "sha256-R2vmVGidm1ZFxopt/71y2816z2i/vvPrthZE52oc4CI=";
-    })
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=7a5a116739fa6d8a625da7d6b9272c9a2462f967";
-      hash = "sha256-T1LglEcUl9GXQjJ6Y4fKuFyFAujNRbcAb9KoNkl6jXs=";
-    })
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1fe82c41e070385e273d7bb1cfb482627a3c28e8";
-      hash = "sha256-x/V7bmRaNxo8NNOUwVti59n9ST/2yTJ/blWjk3omdqE=";
-    })
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=e58b870ff926415e23fc386af41ff81b2f588763";
-      hash = "sha256-a0faNQafL+uRIglnILkLj64ROWxqmczQTQSu3VdklSk=";
-    })
   ];
 
   postPatch = if kbdcompSupport then ''


### PR DESCRIPTION
## Description of changes

The prophecy is fulfilled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
