### PR TITLE
xflr5: use fetchsvn instead of fetchzip

### DIFF
--- a/pkgs/applications/science/physics/xflr5/default.nix
+++ b/pkgs/applications/science/physics/xflr5/default.nix
@@ -1,11 +1,14 @@
-{ mkDerivation, lib, fetchzip, qmake }:
+{ mkDerivation, lib, qmake, fetchsvn }:
 
 mkDerivation rec {
   pname = "xflr5";
   version = "6.61";
-  src = fetchzip {
-    url = "https://sourceforge.net/code-snapshots/svn/x/xf/xflr5/code/xflr5-code-r1481-tags-v6.61-xflr5.zip";
-    sha256 = "sha256-voWnXiBo7+kBPiZLVpSiXyBsYJv/Phd3noA81SQ5Vtw=";
+
+  sourceRoot = "${src.name}/xflr5";
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/xflr5/code/trunk";
+    rev = "1480";
+    sha256 = "sha256-Uj6R15OT5i5tAJEYWqyFyN5Z51Wz5RjO26mWC3Y6QAI=";
   };
 
   nativeBuildInputs = [ qmake ];


### PR DESCRIPTION
## Description of changes
The Sourceforge ZIP URLs aren't stable. They (sometimes?) disappear and throw 404. Probably until someone requests the file to be generated from the UI. This made the build of xflr5 fail. By using the SVN checkout we should be on the safer side.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
