### PR TITLE
ocamlPackages.minttea: init at 0.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/minttea/default.nix
+++ b/pkgs/development/ocaml-modules/minttea/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, riot
+, tty
+}:
+
+buildDunePackage rec {
+  pname = "minttea";
+  version = "0.0.1";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchurl {
+    url = "https://github.com/leostera/minttea/releases/download/${version}/minttea-${version}.tbz";
+    hash = "sha256-+4nVeYKx2A2i2nll/PbStcEa+Dvxd0T7e/KsdJqY4bI=";
+  };
+
+  propagatedBuildInputs = [
+    riot
+    tty
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A fun, functional, and stateful way to build terminal apps in OCaml heavily inspired by Go's BubbleTea";
+    homepage = "https://github.com/leostera/minttea";
+    changelog = "https://github.com/leostera/minttea/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sixstring982 ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1074,6 +1074,8 @@ let
 
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
+    minttea = callPackage ../development/ocaml-modules/minttea { };
+
     mirage = callPackage ../development/ocaml-modules/mirage { };
 
     mirage-block = callPackage ../development/ocaml-modules/mirage-block { };


### PR DESCRIPTION
## Description of changes

Adding ocaml-ng.ocamlPackages_5_1.minttea, which is built from v0.0.1: https://github.com/leostera/minttea/releases/tag/0.0.1

`minttea` is a TUI builder for OCaml, written by @leostera:
https://github.com/leostera/minttea

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
