### PR TITLE
python311Packages.gflanguages: 0.5.10 → 0.5.13

### DIFF
--- a/pkgs/development/python-modules/gflanguages/default.nix
+++ b/pkgs/development/python-modules/gflanguages/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "gflanguages";
-  version = "0.5.10";
+  version = "0.5.13";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-JVeI7TlJjbKCa+gGmjylbNiEhX3qmpbLXiH3VpFqgXc=";
+    hash = "sha256-LoppJHzX0dOpHnwMCyS1ACdIO4cqwb370ksvsXDFHzQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/gflanguages/default.nix
+++ b/pkgs/development/python-modules/gflanguages/default.nix
@@ -2,9 +2,10 @@
 , buildPythonPackage
 , fetchPypi
 , protobuf
-, setuptools-scm
-, pythonRelaxDepsHook
 , pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, setuptools-scm
 , uharfbuzz
 , youseedee
 }:
@@ -14,19 +15,29 @@ buildPythonPackage rec {
   version = "0.5.13";
   format = "setuptools";
 
+  disabled = pythonOlder "3.7";
+
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-LoppJHzX0dOpHnwMCyS1ACdIO4cqwb370ksvsXDFHzQ=";
   };
 
-  propagatedBuildInputs = [
-    protobuf
+  # Relax the dependency on protobuf 3. Other packages in the Google Fonts
+  # ecosystem have begun upgrading from protobuf 3 to protobuf 4,
+  # so we need to use protobuf 4 here as well to avoid a conflict
+  # in the closure of fontbakery. It seems to be compatible enough.
+  pythonRelaxDeps = [
+    "protobuf"
   ];
+
   nativeBuildInputs = [
     setuptools-scm
   ];
 
-  doCheck = true;
+  propagatedBuildInputs = [
+    protobuf
+  ];
+
   nativeCheckInputs = [
     pythonRelaxDepsHook
     pytestCheckHook
@@ -34,15 +45,10 @@ buildPythonPackage rec {
     youseedee
   ];
 
-  # Relax the dependency on protobuf 3. Other packages in the Google Fonts
-  # ecosystem have begun upgrading from protobuf 3 to protobuf 4,
-  # so we need to use protobuf 4 here as well to avoid a conflict
-  # in the closure of fontbakery. It seems to be compatible enough.
-  pythonRelaxDeps = [ "protobuf" ];
-
   meta = with lib; {
     description = "Python library for Google Fonts language metadata";
     homepage = "https://github.com/googlefonts/lang";
+    changelog = "https://github.com/googlefonts/lang/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ danc86 ];
   };


### PR DESCRIPTION
## Description of changes

Contains only backwards-compatible data changes:
https://github.com/googlefonts/lang/releases/tag/v0.5.13
https://github.com/googlefonts/lang/releases/tag/v0.5.12
https://github.com/googlefonts/lang/releases/tag/v0.5.11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- ~[ ] Tested basic functionality of all binary files (usually in `./result/bin/`)~
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
