### PR TITLE
gdb: fix cross-compile with python

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -25,7 +25,7 @@
   sourceHighlight,
   libiconv,
 
-  pythonSupport ? stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin,
+  pythonSupport ? !stdenv.hostPlatform.isCygwin,
   python3 ? null,
   enableDebuginfod ? lib.meta.availableOn stdenv.hostPlatform elfutils,
   elfutils,
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
   patches =
     [
       ./debug-info-from-env.patch
+      ./fix-cross-compile-python.patch
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       ./darwin-target-match.patch
@@ -167,6 +168,7 @@ stdenv.mkDerivation rec {
       "--with-auto-load-safe-path=${builtins.concatStringsSep ":" safePaths}"
     ]
     ++ lib.optional (!pythonSupport) "--without-python"
+    ++ lib.optional pythonSupport "--with-python=${python3.pythonOnBuildForHost.interpreter}"
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-nls"
     ++ lib.optional stdenv.hostPlatform.isStatic "--disable-inprocess-agent"
     ++ lib.optional enableDebuginfod "--with-debuginfod=yes"

--- a/pkgs/development/tools/misc/gdb/fix-cross-compile-python.patch
+++ b/pkgs/development/tools/misc/gdb/fix-cross-compile-python.patch
@@ -1,0 +1,55 @@
+--- a/gdb/python/python-config.py	(revision fa93e88f754e10dfb60dd4c9bf9cef858d4c7e4a)
++++ b/gdb/python/python-config.py	(revision 1605cab3f0f578a75778efdc4c380bbb8463ad6f)
+@@ -1,6 +1,15 @@
+ # Program to fetch python compilation parameters.
+ # Copied from python-config of the 2.7 release.
+
++# In this script, we should only use the following to retrieve configuration values:
++# - `sysconfig.get_config_var`
++# - `sysconfig.get_platform`
++# This is because certain variables may return invalid data during cross-compilation, for example:
++# - sys.prefix -> Use sysconfig.get_config_var("prefix") instead.
++# - sysconfig.get_path("include") -> Don't use, it may return paths for native python, not our target python
++# - os.name -> Use sysconfig.get_platform() for platform detection.
++
++
+ import getopt
+ import os
+ import sys
+@@ -26,7 +35,7 @@
+
+ pyver = sysconfig.get_config_var("VERSION")
+ getvar = sysconfig.get_config_var
+-abiflags = getattr(sys, "abiflags", "")
++abiflags = getvar("ABIFLAGS")
+
+ opt_flags = [flag for (flag, val) in opts]
+
+@@ -49,15 +58,14 @@
+
+ for opt in opt_flags:
+     if opt == "--prefix":
+-        print(to_unix_path(os.path.normpath(sys.prefix)))
++        print(to_unix_path(os.path.normpath(getvar("prefix"))))
+
+     elif opt == "--exec-prefix":
+-        print(to_unix_path(os.path.normpath(sys.exec_prefix)))
++        print(to_unix_path(os.path.normpath(getvar("exec_prefix"))))
+
+     elif opt in ("--includes", "--cflags"):
+         flags = [
+-            "-I" + sysconfig.get_path("include"),
+-            "-I" + sysconfig.get_path("platinclude"),
++            "-I" + getvar("INCLUDEPY"),
+         ]
+         if opt == "--cflags":
+             flags.extend(getvar("CFLAGS").split())
+@@ -76,7 +84,7 @@
+                 if getvar("LIBPL") is not None:
+                     libs.insert(0, "-L" + getvar("LIBPL"))
+                 elif os.name == "nt":
+-                    libs.insert(0, "-L" + os.path.normpath(sys.prefix) + "/libs")
++                    libs.insert(0, "-L" + os.path.normpath(getvar("prefix")) + "/libs")
+             if getvar("LINKFORSHARED") is not None:
+                 libs.extend(getvar("LINKFORSHARED").split())
+         print(to_unix_path(" ".join(libs)))


### PR DESCRIPTION
## Description of changes

Python in gdb is very useful. I added patch for support cross compilation with python.

How to test:
```
nix-build . -A 'pkgsCross.riscv64.gdb'
```

Before:
```
$ ./result/bin/gdb --configuration | grep python
             --without-python
             --without-python-libdir
```

After:
```
$ ./result/bin/gdb --configuration | grep python
             --with-python=/nix/store/80nllrpfnd1an56x10cjn1wwnmm0m4m3-python3-riscv64-unknown-linux-gnu-3.11.6
             --with-python-libdir=/nix/store/80nllrpfnd1an56x10cjn1wwnmm0m4m3-python3-riscv64-unknown-linux-gnu-3.11.6/lib
```

cc: @trofi 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
