### PR TITLE
dconf: enable cross compilation

### DIFF
--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchurl
 , meson
+, mesonEmulatorHook
 , ninja
 , python3
 , vala
@@ -13,16 +14,15 @@
 , gtk-doc
 , docbook-xsl-nons
 , docbook_xml_dtd_42
+, withDocs ? true
 }:
-let
-  isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
-in
+
 stdenv.mkDerivation rec {
   pname = "dconf";
   version = "0.40.0";
 
   outputs = [ "out" "lib" "dev" ]
-    ++ lib.optional (!isCross) "devdoc";
+    ++ lib.optional withDocs "devdoc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -38,19 +38,23 @@ stdenv.mkDerivation rec {
     glib
     docbook-xsl-nons
     docbook_xml_dtd_42
-  ] ++ lib.optional (!isCross) gtk-doc;
+    gtk-doc
+  ] ++ lib.optionals (withDocs && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook  # gtkdoc invokes the host binary to produce documentation
+  ];
+
 
   buildInputs = [
     glib
     bash-completion
     dbus
-  ] ++ lib.optional (!isCross) vala;
-  # Vala cross compilation is broken. For now, build dconf without vapi when cross-compiling.
+    vala
+  ];
 
   mesonFlags = [
     "--sysconfdir=/etc"
-    "-Dgtk_doc=${lib.boolToString (!isCross)}" # gtk-doc does do some gobject introspection, which doesn't yet cross-compile.
-  ] ++ lib.optional isCross "-Dvapi=false";
+    "-Dgtk_doc=${lib.boolToString withDocs}"
+  ];
 
   nativeCheckInputs = [
     dbus # for dbus-daemon


### PR DESCRIPTION
## Description of changes

combined with https://github.com/NixOS/nixpkgs/pull/267550, this enables `gnome.dconf-editor` to cross compile.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
