### PR TITLE
amphetype: init at 1.0.0

### DIFF
--- a/pkgs/by-name/am/amphetype/package.nix
+++ b/pkgs/by-name/am/amphetype/package.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitLab, lib, python3Packages, qt5 }:
+
+let
+  pname = "amphetype";
+  version = "1.0.0";
+in python3Packages.buildPythonApplication {
+  inherit pname version;
+
+  src = fetchFromGitLab {
+    owner = "franksh";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-pve2f+XMfFokMCtW3KdeOJ9Ey330Gwv/dk1+WBtrBEQ=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    editdistance
+    pyqt5
+    translitcodec
+  ];
+
+  doCheck = false;
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+  meta = with lib; {
+    description = "An advanced typing practice program";
+    homepage = "https://gitlab.com/franksh/amphetype";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ rycee ];
+  };
+}

--- a/pkgs/development/python-modules/translitcodec/default.nix
+++ b/pkgs/development/python-modules/translitcodec/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, pythonOlder }:
+
+let
+  pname = "translitcodec";
+  version = "0.7.0";
+in buildPythonPackage {
+  inherit pname version;
+
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "claudep";
+    repo = pname;
+    rev = "version-${version}";
+    hash = "sha256-/EKquTchx9i3fZqJ6AMzHYP9yCORvwbuUQ95WJQOQbI=";
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    description = "Unicode to 8-bit charset transliteration codec";
+    homepage = "https://github.com/claudep/translitcodec";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ rycee ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14453,6 +14453,8 @@ self: super: with self; {
 
   translationstring = callPackage ../development/python-modules/translationstring { };
 
+  translitcodec = callPackage ../development/python-modules/translitcodec { };
+
   transmission-rpc = callPackage ../development/python-modules/transmission-rpc { };
 
   transmissionrpc = callPackage ../development/python-modules/transmissionrpc { };


### PR DESCRIPTION
## Description of changes

Add [amphetype](https://gitlab.com/franksh/amphetype), a typing trainer, and [translitcodec](https://github.com/claudep/translitcodec), a dependency of amphetype.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
