### PR TITLE
vikunja-frontend: refactor into a FOD

### DIFF
--- a/pkgs/servers/web-apps/vikunja/frontend.nix
+++ b/pkgs/servers/web-apps/vikunja/frontend.nix
@@ -1,26 +1,13 @@
-{ stdenv, lib, fetchurl, unzip, nixosTests, ... }:
+{ lib, fetchzip, nixosTests, ... }:
 
-stdenv.mkDerivation rec {
+fetchzip rec {
   pname = "vikunja-frontend";
   version = "0.22.0";
 
-  src = fetchurl {
-    url = "https://dl.vikunja.io/frontend/${pname}-${version}.zip";
-    hash = "sha256-LYU1IGAhSZOwMI44HW5IfcBKs9RkU/IXGVgPGDKnKAs=";
-  };
+  url = "https://dl.vikunja.io/frontend/${pname}-${version}.zip";
+  hash = "sha256-mMfK+58nN014ta09/mTbz/6BgQIBj6DqJSPaRtGZ3A8=";
 
-  nativeBuildInputs = [ unzip ];
-
-  sourceRoot = ".";
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/
-    cp -r * $out/
-
-    runHook postInstall
-  '';
+  stripRoot = false;
 
   passthru.tests.vikunja = nixosTests.vikunja;
 


### PR DESCRIPTION
## Description of changes

Not only did it unpack a new copy to the nixpkgs cache every time `stdenv` was touched, it also kept a reference to the whole build closure in its runtime closure:

```shell
$ rg /nix/store results/vikunja-frontend
results/vikunja-frontend/env-vars
4:declare -x CONFIG_SHELL="/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash"
8:declare -x HOST_PATH="/nix/store/zx8aqgdy735qzk81glfwil6mbi6ddqb1-coreutils-9.4/bin:/nix/store/sq0w0jchkjqbxl47h52kfwa33qp1adfh-findutils-4.9.0/bin:/nix/store/f3g84l92p0njh0gyk1z7cp2k4qnh91ha-diffutils-3.10/bin:/nix/store/7fqp73nc"
10:declare -x NIX_BINTOOLS="/nix/store/lwqnazddv8037sin49482dnzc9iwgg8l-binutils-wrapper-2.40"
14:declare -x NIX_CC="/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0"
20:declare -x NIX_LDFLAGS="-rpath /nix/store/v930zcf1lm50lv95fmaazn9j11927k9q-vikunja-frontend-0.22.0/lib "
23:declare -x NIX_STORE="/nix/store"
28:declare -x PATH="/nix/store/jqqhncz6kca515cwammz56w7l34z7wyb-unzip-6.0/bin:/nix/store/pyq6gyhgck1nkfyjs6842ysxkxzjxkaj-patchelf-0.15.0/bin:/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin:/nix/store/qfqjymymsd2x"
32:declare -x SHELL="/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash"
45:declare -x XDG_DATA_DIRS="/nix/store/jqqhncz6kca515cwammz56w7l34z7wyb-unzip-6.0/share:/nix/store/pyq6gyhgck1nkfyjs6842ysxkxzjxkaj-patchelf-0.15.0/share"
48:declare -x builder="/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash"
50:declare -x configureFlags="--prefix=/nix/store/v930zcf1lm50lv95fmaazn9j11927k9q-vikunja-frontend-0.22.0 "
65:declare -x nativeBuildInputs="/nix/store/jqqhncz6kca515cwammz56w7l34z7wyb-unzip-6.0"
66:declare -x out="/nix/store/v930zcf1lm50lv95fmaazn9j11927k9q-vikunja-frontend-0.22.0"
72:declare -x shell="/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash"
74:declare -x src="/nix/store/xlbv34x04aymrgzb4fz2ph1c1xlcsn74-vikunja-frontend-0.22.0.zip"
75:declare -x stdenv="/nix/store/d4jf1cbbk494zwgbqz31pxgigpsbh6w2-stdenv-linux"
```

This should fix both.

Discovered while reviewing #275602


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
