### PR TITLE
cpp-redis: init at 4.3.1

### DIFF
--- a/pkgs/by-name/cp/cpp-redis/01-fix-sleep_for.patch
+++ b/pkgs/by-name/cp/cpp-redis/01-fix-sleep_for.patch
@@ -1,0 +1,12 @@
+diff --git a/sources/core/client.cpp b/sources/core/client.cpp
+index 7ea20e2..c5d2c40 100644
+--- a/sources/core/client.cpp
++++ b/sources/core/client.cpp
+@@ -23,6 +23,7 @@
+ #include <cpp_redis/core/client.hpp>
+ #include <cpp_redis/misc/error.hpp>
+ #include <cpp_redis/misc/macro.hpp>
++#include <thread>
+ 
+ namespace cpp_redis {
+ 

--- a/pkgs/by-name/cp/cpp-redis/package.nix
+++ b/pkgs/by-name/cp/cpp-redis/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cpp-redis";
+  version = "4.3.1";
+
+  src = fetchFromGitHub {
+    owner = "cpp-redis";
+    repo = "cpp_redis";
+    rev = version;
+    hash = "sha256-dLAnxgldylWWKO3WIyx+F7ylOpRH+0nD7NZjWSOxuwQ=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  CFLAGS = "-D_GLIBCXX_USE_NANOSLEEP";
+  patches = [
+    ./01-fix-sleep_for.patch
+  ];
+
+  meta = with lib; {
+    description = "C++11 Lightweight Redis client: async, thread-safe, no dependency, pipelining, multi-platform";
+    homepage = "https://github.com/cpp-redis/cpp_redis";
+    changelog = "https://github.com/cpp-redis/cpp_redis/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ poelzi ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds cpp redis library required for ceph 19.x

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
