### PR TITLE
ocamlPackages.tty: init at 0.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/tty/default.nix
+++ b/pkgs/development/ocaml-modules/tty/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, uutf
+}:
+
+buildDunePackage rec {
+  pname = "tty";
+  version = "0.0.2";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchurl {
+    url = "https://github.com/leostera/tty/releases/download/${version}/tty-${version}.tbz";
+    hash = "sha256-eeD5Y+/QXZzFoEHvOSZj2Q74V8BK5j3Lu3Zsrj2YUUs=";
+  };
+
+  propagatedBuildInputs = [
+    uutf
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A library for interacting with teletype and terminal emulators";
+    homepage = "https://github.com/leostera/tty";
+    changelog = "https://github.com/leostera/tty/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sixstring982 ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1783,6 +1783,8 @@ let
 
     tsort = callPackage ../development/ocaml-modules/tsort { };
 
+    tty = callPackage ../development/ocaml-modules/tty { };
+
     tuntap = callPackage ../development/ocaml-modules/tuntap { };
 
     twt = callPackage ../development/ocaml-modules/twt { };


### PR DESCRIPTION
## Description of changes

Adding `ocaml-ng.ocamlPackages_5_1.tty`, which is built from v0.0.2: https://github.com/leostera/tty/releases/tag/0.0.2

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
