### PR TITLE
shortcat: refactor into FOD

### DIFF
--- a/pkgs/os-specific/darwin/shortcat/default.nix
+++ b/pkgs/os-specific/darwin/shortcat/default.nix
@@ -1,21 +1,18 @@
-{ lib, stdenv, fetchurl, unzip, ... }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
+fetchzip rec {
   pname = "shortcat";
   version = "0.11.0";
 
-  src = fetchurl {
-    url = "https://files.shortcat.app/releases/v${version}/Shortcat.zip";
-    sha256 = "sha256-P8NQy9odWOD8wRHBTmaNH7OCXXvgQsMiI169KfsAABU=";
-  };
+  url = "https://files.shortcat.app/releases/v${version}/Shortcat.zip";
+  hash = "sha256-lEX+6/2EHKWf4GdsZj6vLRGAxbJUAuge8zCPSc/13rQ=";
 
-  sourceRoot = "Shortcat.app";
+  stripRoot = false;
 
-  nativeBuildInputs = [ unzip ];
-
-  installPhase = ''
-    mkdir -p $out/Applications/Shortcat.app
-    cp -R . $out/Applications/Shortcat.app
+  postFetch = ''
+    shopt -s extglob
+    mkdir $out/Applications
+    mv $out/!(Applications) $out/Applications
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Avoids unpacking a new copy to the nixpkgs cache every time stdenvNoCC is touched.
No cache savings on this one though, considering it is unfree...

Only tested on x86_64-linux with `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1`

Found with

```bash
rg 'fetchurl' -l pkgs/ | xargs rg unzip -l  | xargs rg /releases/ -l | xargs rg binaryNativeCode -l
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
