### PR TITLE
`filterAttrsRecursive` improvements, `filterAttrsRecursiveTopDown` and  `filterAttrsRecursiveBottomUp`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -419,16 +419,33 @@ rec {
     set:
     listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
 
+  /*
+    Filter an attribute set recursively by removing all attributes for which the given predicate returns `false`.
 
-  /* Filter an attribute set recursively by removing all attributes for
-     which the given predicate return false.
+    More precisely, for each attribute:
+    - Only include the attribute if the predicate returns `true` for this attribute.
+    - If the attribute is included and its value is an attribute set itself,
+      replace it with the result of calling `filterAttrsRecursive` on it.
 
-     Example:
-       filterAttrsRecursive (n: v: v != null) { foo = { bar = null; }; }
-       => { foo = {}; }
+    Example:
+      filterAttrsRecursive (n: v: v != null && v != {}) {
+        foo = null;
+        bar = {
+          baz = null;
+          qux = {
+            quux = null;
+            corge = { };
+          };
+        };
+      }
+      => {
+        bar = {
+          qux = { };
+        };
+      }
 
-     Type:
-       filterAttrsRecursive :: (String -> Any -> Bool) -> AttrSet -> AttrSet
+    Type:
+      filterAttrsRecursive :: (String -> Any -> Bool) -> AttrSet -> AttrSet
   */
   filterAttrsRecursive =
     # Predicate taking an attribute name and an attribute value, which returns `true` to include the attribute, or `false` to exclude the attribute.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -420,15 +420,20 @@ rec {
     listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
 
   /*
+    An alias for [`filterAttrsRecursiveTopDown`](#function-library-lib.attrsets.filterAttrsRecursiveTopDown).
+  */
+  filterAttrsRecursive = filterAttrsRecursiveTopDown;
+
+  /*
     Filter an attribute set recursively by removing all attributes for which the given predicate returns `false`.
 
     More precisely, for each attribute:
     - Only include the attribute if the predicate returns `true` for this attribute.
     - If the attribute is included and its value is an attribute set itself,
-      replace it with the result of calling `filterAttrsRecursive` on it.
+      replace it with the result of calling `filterAttrsRecursiveTopDown` on it.
 
     Example:
-      filterAttrsRecursive (n: v: v != null && v != {}) {
+      filterAttrsRecursiveTopDown (n: v: v != null && v != {}) {
         foo = null;
         bar = {
           baz = null;
@@ -445,9 +450,9 @@ rec {
       }
 
     Type:
-      filterAttrsRecursive :: (String -> Any -> Bool) -> AttrSet -> AttrSet
+      filterAttrsRecursiveTopDown :: (String -> Any -> Bool) -> AttrSet -> AttrSet
   */
-  filterAttrsRecursive =
+  filterAttrsRecursiveTopDown =
     # Predicate taking an attribute name and an attribute value, which returns `true` to include the attribute, or `false` to exclude the attribute.
     pred:
     # The attribute set to filter
@@ -457,7 +462,7 @@ rec {
         let v = set.${name}; in
         if pred name v then [
           (nameValuePair name (
-            if isAttrs v then filterAttrsRecursive pred v
+            if isAttrs v then filterAttrsRecursiveTopDown pred v
             else v
           ))
         ] else []

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,8 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
+      filterAttrsRecursive filterAttrsRecursiveTopDown
+      foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,7 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive filterAttrsRecursiveTopDown
+      filterAttrsRecursive filterAttrsRecursiveTopDown filterAttrsRecursiveBottomUp
       foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -25,6 +25,7 @@ let
     expected = true;
   };
   testingDeepThrow = expr: testingThrow (builtins.deepSeq expr expr);
+  testingDeepEval = expr: testingEval (builtins.deepSeq expr expr);
 
   testSanitizeDerivationName = { name, expected }:
   let
@@ -876,6 +877,37 @@ runTests {
       expr = attrsets.mergeAttrsList list;
       expected = foldl' mergeAttrs { } list;
     };
+
+  testFilterAttrsRecursiveExample = {
+    expr = attrsets.filterAttrsRecursive (n: v: v != null && v != {}) {
+      foo = null;
+      bar = {
+        baz = null;
+        qux = {
+          quux = null;
+          corge = { };
+        };
+      };
+    };
+    expected = {
+      bar = {
+        qux = { };
+      };
+    };
+  };
+
+  testFilterAttrsRecursiveLazy = testingDeepEval (
+    attrsets.filterAttrsRecursive (n: v: v.keep or true) {
+      foo = {
+        keep = false;
+        error = throw "This should not be evaluated";
+      };
+      bar.baz = {
+        keep = false;
+        error = throw "This should not be evaluated";
+      };
+    }
+  );
 
   # code from the example
   testRecursiveUpdateUntil = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -878,8 +878,8 @@ runTests {
       expected = foldl' mergeAttrs { } list;
     };
 
-  testFilterAttrsRecursiveExample = {
-    expr = attrsets.filterAttrsRecursive (n: v: v != null && v != {}) {
+  testFilterAttrsRecursiveTopDownExample = {
+    expr = attrsets.filterAttrsRecursiveTopDown (n: v: v != null && v != {}) {
       foo = null;
       bar = {
         baz = null;
@@ -896,8 +896,8 @@ runTests {
     };
   };
 
-  testFilterAttrsRecursiveLazy = testingDeepEval (
-    attrsets.filterAttrsRecursive (n: v: v.keep or true) {
+  testFilterAttrsRecursiveTopDownLazy = testingDeepEval (
+    attrsets.filterAttrsRecursiveTopDown (n: v: v.keep or true) {
       foo = {
         keep = false;
         error = throw "This should not be evaluated";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -909,6 +909,29 @@ runTests {
     }
   );
 
+  testFilterAttrsRecursiveBottomUpExample = {
+    expr = attrsets.filterAttrsRecursiveBottomUp (n: v: v != null && v != {}) {
+      foo = null;
+      bar = {
+        baz = null;
+        qux = {
+          quux = null;
+          corge = { };
+        };
+      };
+    };
+    expected = { };
+  };
+
+  testFilterAttrsRecursiveBottomUpStrict = testingDeepThrow (
+    attrsets.filterAttrsRecursiveBottomUp (n: v: v.keep or true) {
+      foo = {
+        keep = false;
+        error = throw "This should be evaluated";
+      };
+    }
+  );
+
   # code from the example
   testRecursiveUpdateUntil = {
     expr = recursiveUpdateUntil (path: l: r: path == ["foo"]) {

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -11,7 +11,7 @@ let
   # options shown in settings.
   # We post-process the result to add support for YAML functions, like secrets or includes, see e.g.
   # https://www.home-assistant.io/docs/configuration/secrets/
-  filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [ null ])) (lib.recursiveUpdate customLovelaceModulesResources (cfg.config or {}));
+  filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: v != null) (lib.recursiveUpdate customLovelaceModulesResources (cfg.config or {}));
   configFile = pkgs.runCommandLocal "configuration.yaml" { } ''
     cp ${format.generate "configuration.yaml" filteredConfig} $out
     sed -i -e "s/'\!\([a-z_]\+\) \(.*\)'/\!\1 \2/;s/^\!\!/\!/;" $out

--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -470,7 +470,7 @@ in
         # lists, empty attrsets and null. This makes it possible to
         # list interesting options in `settings` without them always
         # ending up in the resulting config.
-        filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [ null [] {} ])) cfg.settings;
+        filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: ! elem v [ null [] {} ]) cfg.settings;
 
         # Extract secrets (attributes set to an attrset with a
         # "_secret" key) from the settings and generate the commands

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -8,7 +8,7 @@ let
   defaultUser = "syncthing";
   defaultGroup = defaultUser;
   settingsFormat = pkgs.formats.json { };
-  cleanedConfig = converge (filterAttrsRecursive (_: v: v != null && v != {})) cfg.settings;
+  cleanedConfig = filterAttrsRecursiveBottomUp (_: v: v != null && v != {}) cfg.settings;
 
   isUnixGui = (builtins.substring 0 1 cfg.guiAddress) == "/";
 

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -3,7 +3,7 @@ let
   cfg = config.services.kanidm;
   settingsFormat = pkgs.formats.toml { };
   # Remove null values, so we can document optional values that don't end up in the generated TOML file.
-  filterConfig = lib.converge (lib.filterAttrsRecursive (_: v: v != null));
+  filterConfig = lib.filterAttrsRecursiveBottomUp (_: v: v != null);
   serverConfigFile = settingsFormat.generate "server.toml" (filterConfig cfg.serverSettings);
   clientConfigFile = settingsFormat.generate "kanidm-config.toml" (filterConfig cfg.clientSettings);
   unixConfigFile = settingsFormat.generate "kanidm-unixd.toml" (filterConfig cfg.unixSettings);

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -19,7 +19,7 @@ let
 
   format = pkgs.formats.yaml {};
 
-  filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! lib.elem v [ null ])) cfg.settings;
+  filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: v != null) cfg.settings;
 
   cameraFormat = with types; submodule {
     freeformType = format.type;

--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -391,7 +391,7 @@ in {
             replace-secret ${escapeShellArgs [ (builtins.hashString "sha256" file) file "${cfg.dataDir}/.env" ]}
           '';
           secretReplacements = lib.concatMapStrings mkSecretReplacement secretPaths;
-          filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [ {} null ])) cfg.config;
+          filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: ! elem v [ {} null ]) cfg.config;
           bookstackEnv = pkgs.writeText "bookstack.env" (bookstackEnvVars filteredConfig);
         in ''
         # error handling

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -462,7 +462,7 @@ in
       };
 
       isSecret = v: isAttrs v && v ? _secret && isString v._secret;
-      filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [{ } null])) cfg.settings;
+      filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: ! elem v [{ } null]) cfg.settings;
       confFile = pkgs.writeText "keycloak.conf" (keycloakConfig filteredConfig);
       keycloakBuild = cfg.package.override {
         inherit confFile;

--- a/nixos/modules/services/web-apps/monica.nix
+++ b/nixos/modules/services/web-apps/monica.nix
@@ -405,7 +405,7 @@ in {
           replace-secret ${escapeShellArgs [(builtins.hashString "sha256" file) file "${cfg.dataDir}/.env"]}
         '';
         secretReplacements = lib.concatMapStrings mkSecretReplacement secretPaths;
-        filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [{} null])) cfg.config;
+        filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: ! elem v [{} null]) cfg.config;
         monicaEnv = pkgs.writeText "monica.env" (monicaEnvVars filteredConfig);
       in ''
         # error handling

--- a/nixos/modules/services/web-apps/snipe-it.nix
+++ b/nixos/modules/services/web-apps/snipe-it.nix
@@ -431,7 +431,7 @@ in {
             ]}
           '';
           secretReplacements = lib.concatMapStrings mkSecretReplacement secretPaths;
-          filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [ {} null ])) cfg.config;
+          filteredConfig = lib.filterAttrsRecursiveBottomUp (_: v: ! elem v [ {} null ]) cfg.config;
           snipeITEnv = pkgs.writeText "snipeIT.env" (snipeITEnvVars filteredConfig);
         in ''
           # error handling

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -58,8 +58,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
         ldapBaseDN = builtins.concatStringsSep "," (map (s: "dc=" + s) (pkgs.lib.splitString "." serverDomain));
 
         # We need access to the config file in the test script.
-        filteredConfig = pkgs.lib.converge
-          (pkgs.lib.filterAttrsRecursive (_: v: v != null))
+        filteredConfig =
+          (pkgs.lib.filterAttrsRecursiveBottomUp (_: v: v != null))
           nodes.server.services.kanidm.serverSettings;
         serverConfigFile = (pkgs.formats.toml { }).generate "server.toml" filteredConfig;
 


### PR DESCRIPTION
## Context

Especially with [RFC 42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md), there's sometimes a desired to filter both `null` and `{}` values, such that you end up with none in the result.

Unfortunately a `lib.filterAttrsRecursive (_: v: v != null && v != {})` doesn't work:
```nix
nix-repl> :p filterAttrsRecursive (_: v: v != null && v != {}) {
            foo.bar = null;                                      
          }                                                      
{ foo = { }; }
```

Instead what has somewhat established itself is to (ab)use `converge` to iteratively call `filterAttrsRecursive` as many times as is necessary for the result to not change anymore:

```nix
nix-repl> :p converge (filterAttrsRecursive (_: v: v != null && v != {})) {
            foo.bar = null;                                                 
          }                                                                 
{ }
```

This _works_, but it's inefficient, because it recurses into the value many times.


## Description of changes

To address this, this PR introduces a variant of `filterAttrsRecursive` that has the expected behavior`:
```nix
nix-repl> :p filterAttrsRecursiveBottomUp (_: v: v != null && v != {}) {  
            foo.bar = null;                                               
          }                                                               
{ }
```

Furthermore, the previous `filterAttrsRecursive` gets aliased to `filterAttrsRecursiveTopDown`

And finally, all instances of `converge . filterAttrsRecursive` are replaced with `filterAttrsRecursiveBottomUp`, bringing us a step closer towards deprecating `converge`

## Things done

- [x] Tests
- [x] Documentation
- [x] Checked that all changed modules still evaluate to the same using
  ```
  $ nix-instantiate nixos --arg configuration ./configuration.nix -A system --show-trace
  ```
  
  <details>
  <summary>configuration.nix</summary>
  
  ```nix
  {
    boot.loader.grub.device = "nodev";
    fileSystems."/".device = "/devst";
    system.stateVersion = "23.11";
  
    services.home-assistant.enable = true;
    services.home-assistant.config = {};
  
    services.parsedmarc.enable = true;
    services.parsedmarc = {
      provision = {
        localMail = {
          enable = true;
          hostname = "monitoring.example.com";
        };
        geoIp = false;
      };
      # Needed because the module has a bug..
      settings.smtp.to = [];
    };
  
    services.syncthing.enable = true;
    services.kanidm.enableClient = true;
    services.kanidm.clientSettings.uri = "";
    services.frigate.enable = true;
    services.frigate.hostname = "";
    services.frigate.settings.cameras = {};
    services.bookstack.enable = true;
    services.bookstack.appKeyFile = "/";
    services.keycloak.enable = true;
    services.keycloak.settings.hostname = "";
    services.keycloak.database.passwordFile = "/";
    services.monica.enable = true;
    services.monica.hostname = "monica";
    services.monica.appKeyFile = "/";
    services.snipe-it.enable = true;
    services.snipe-it.hostName = "snipe";
    services.snipe-it.appKeyFile = "/";
  
    nixpkgs.config.permittedInsecurePackages = [
      "openssl-1.1.1w"
    ];
    nixpkgs.config.allowUnfree = true;
  }
  ```
  </details>

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
