### PR TITLE
`lib.converge`: Deprecate

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -92,15 +92,22 @@ rec {
     0
     ```
 
+    :::{.warning}
+    This function is deprecated, see <https://github.com/NixOS/nixpkgs/pull/275760> for alternatives.
+    :::
+
     Type: (a -> a) -> a -> a
   */
-  converge = f: x:
-    let
-      x' = f x;
-    in
-      if x' == x
-      then x
-      else converge f x';
+  converge =
+    lib.warn "lib.converge is deprecated, see https://github.com/NixOS/nixpkgs/pull/275760 for alternatives."
+    (f: x:
+      let
+        x' = f x;
+      in
+        if x' == x
+        then x
+        else converge f x'
+    );
 
   /*
     Modify the contents of an explicitly recursive attribute set in a way that

--- a/nixos/modules/services/search/opensearch.nix
+++ b/nixos/modules/services/search/opensearch.nix
@@ -114,7 +114,8 @@ in
     dataDir = lib.mkOption {
       type = lib.types.path;
       default = "/var/lib/opensearch";
-      apply = converge (removeSuffix "/");
+      # Remove all trailing `/`s
+      apply = str: head (builtins.split "/+$" str);
       description = lib.mdDoc ''
         Data directory for OpenSearch. If you change this, you need to
         manually create the directory. You also need to create the

--- a/pkgs/tools/admin/google-cloud-sdk/withExtraComponents.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/withExtraComponents.nix
@@ -11,9 +11,18 @@ let
     builtins.filter (drv: !(builtins.elem drv preInstalledComponents));
 
   # Recursively build a list of components with their dependencies
-  # TODO this could be made faster, it checks the dependencies too many times
-  findDepsRecursive = lib.converge
-    (drvs: lib.unique (drvs ++ (builtins.concatMap (drv: drv.dependencies) drvs)));
+  findDepsRecursive = drvs:
+    let
+      addKeys = map (drv: {
+        key = drv.outPath;
+        inherit drv;
+      });
+      closure = builtins.genericClosure {
+        startSet = addKeys drvs;
+        operator = value: addKeys value.drv.dependencies;
+      };
+    in
+    map (value: value.drv) closure;
 
   # Components to install by default
   defaultComponents = with components; [ alpha beta ];


### PR DESCRIPTION
> [!warning]
> This PR depends on https://github.com/NixOS/nixpkgs/pull/275753

## Description of changes

`lib.converge` is inefficient, there's always better approaches:
- If you used it with `filterAttrsRecursive`, see use `filterAttrsRecursiveBottomUp` instead, introduced in https://github.com/NixOS/nixpkgs/pull/275753.
- If you used it compute a closure of packages, use [`builtins.genericClosure`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-genericClosure) instead.

This PR deprecates the function.

## Things done

- [x] Removed all instances of `lib.converge` from Nixpkgs
- [x] Checked that the changes give the same result

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
