### PR TITLE
aws-kms-pkcs11: init at 0.0.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7738,6 +7738,12 @@
     githubId = 25505957;
     name = "Ilian";
   };
+  iliana = {
+    email = "iliana@buttslol.net";
+    github = "iliana";
+    githubId = 52814;
+    name = "iliana etaoin";
+  };
   iliayar = {
     email = "iliayar3@gmail.com";
     github = "iliayar";

--- a/pkgs/by-name/aw/aws-kms-pkcs11/fix-up-includes.patch
+++ b/pkgs/by-name/aw/aws-kms-pkcs11/fix-up-includes.patch
@@ -1,0 +1,13 @@
+diff --git a/pkcs11_compat.h b/pkcs11_compat.h
+index 485c4e0..638eae7 100644
+--- a/pkcs11_compat.h
++++ b/pkcs11_compat.h
+@@ -9,7 +9,7 @@
+ #define __PKCS11_COMPAT_H__
+ 
+ #include <stdbool.h>
+-#include <pkcs11.h>
++#include <p11-kit/pkcs11.h>
+ 
+ #ifndef CK_NULL_PTR
+ #define CK_NULL_PTR NULL

--- a/pkgs/by-name/aw/aws-kms-pkcs11/package.nix
+++ b/pkgs/by-name/aw/aws-kms-pkcs11/package.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, aws-sdk-cpp
+, json_c
+, openssl
+, p11-kit
+, pkg-config
+}:
+stdenv.mkDerivation rec {
+  pname = "aws-kms-pkcs11";
+  version = "0.0.11";
+
+  src = fetchFromGitHub {
+    owner = "JackOfMostTrades";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-diQl1UzrL4fRIY+eEwusScAgO2d7Pp1jsY4F//RyXik=";
+  };
+  patches = [ ./fix-up-includes.patch ];
+
+  buildInputs = [ aws-sdk-cpp json_c openssl p11-kit pkg-config ];
+  buildPhase = ''
+    g++ -g -shared -fPIC -Wall -o aws_kms_pkcs11.so \
+      attributes.cpp aws_kms_pkcs11.cpp certificates.cpp unsupported.cpp debug.cpp aws_kms_slot.cpp \
+      $(pkg-config --cflags --libs aws-cpp-sdk-core aws-cpp-sdk-kms aws-cpp-sdk-acm-pca json-c openssl p11-kit-1)
+  '';
+  installPhase = ''
+    install -Dm 0755 aws_kms_pkcs11.so $out/lib/pkcs11/aws_kms_pkcs11.so
+  '';
+
+  meta = with lib; {
+    description = "PKCS#11 provider using AWS KMS";
+    homepage = "https://github.com/JackOfMostTrades/aws-kms-pkcs11";
+    license = licenses.mit;
+    maintainers = with maintainers; [ iliana ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

[aws-kms-pkcs11](https://github.com/JackOfMostTrades/aws-kms-pkcs11) is a PKCS#11 provider that allows using AWS Key Management Service like a smartcard.

Upstream's hand-written Makefile makes a number of assumptions that are wrong in Nixpkgs; instead of trying to patch it I found that ignoring it was a better use of my time. Also unfortunately upstream's test assumes an environment that can access and has credentials for KMS, so no `checkPhase`.

As with most things PKCS#11 in Nixpkgs, usage is a little rough. What works for me is writing out an `openssl.conf` pointing to the PKCS#11 engine in `pkgs.libp11` as suggested at https://github.com/OpenSC/libp11/blob/dd0a8c63c0311674cabfd781753e8374ff531409/README.md#using-the-engine-from-the-command-line:

```nix
let
  opensslConf = pkgs.writeText "openssl.conf" ''
    openssl_conf = openssl_init

    [openssl_init]
    engines=engine_section

    [engine_section]
    pkcs11 = pkcs11_section

    [pkcs11_section]
    engine_id = pkcs11
    dynamic_path = ${pkgs.libp11}/lib/engines/libpkcs11.so
    init = 0
  '';
in
  ...
```

then setting `OPENSSL_CONF` to that output, and `PKCS11_MODULE_PATH=result/lib/pkcs11/aws_kms_pkcs11.so` (or wherever it is on the Nix store).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
