### PR TITLE
openmpi: 4.1.6 -> 5.0.3

### DIFF
--- a/pkgs/by-name/pr/prrte/package.nix
+++ b/pkgs/by-name/pr/prrte/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, removeReferencesTo
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, gitMinimal
+, perl
+, python3
+, flex
+, hwloc
+, libevent
+, zlib
+, pmix
+}:
+
+stdenv.mkDerivation rec {
+  pname = "prrte";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = "openpmix";
+    repo = "prrte";
+    rev = "v${version}";
+    sha256 = "sha256-RDxd4veLGbN+T7xCDnNp2lbOM7mwKKD+SKdPmExr1C8=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [ "out" "dev" ];
+
+  postPatch = ''
+    patchShebangs ./autogen.pl
+    patchShebangs ./config
+  '';
+
+  preConfigure = ''
+    ./autogen.pl
+  '';
+
+  postInstall = ''
+    moveToOutput "bin/prte_info" "''${!outputDev}"
+    moveToOutput "bin/pcc" "''${!outputDev}"
+
+    remove-references-to -t $dev $(readlink -f $out/lib/libprrte${stdenv.hostPlatform.extensions.library})
+  '';
+
+  nativeBuildInputs = [ removeReferencesTo perl python3 autoconf automake libtool flex gitMinimal ];
+
+  buildInputs = [ libevent hwloc zlib pmix ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "PMIx Reference Runtime Environment";
+    homepage = "https://docs.prrte.org/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchurl, removeReferencesTo, gfortran, perl, libnl
 , rdma-core, zlib, numactl, libevent, hwloc, targetPackages, symlinkJoin
-, libpsm2, libfabric, pmix, ucx, ucc, makeWrapper
+, libpsm2, libfabric, pmix, ucx, ucc, prrte, makeWrapper
 , config
+
 # Enable CUDA support
 , cudaSupport ? config.cudaSupport, cudaPackages
 
@@ -16,34 +17,56 @@
 
 # Enable Fortran support
 , fortranSupport ? true
+
+# AVX/SSE options
+# note that opempi fails to build with AVX disabled.
+# => everything up to AVX is enabled by default
+, enableSse3 ? true
+, enableSse4_1 ? true
+, enableAvx ? true
+, enableAvx2 ? stdenv.hostPlatform.avx2Support
+, enableAvx512 ? stdenv.hostPlatform.avx512Support
 }:
 
 stdenv.mkDerivation rec {
   pname = "openmpi";
-  version = "4.1.6";
+  version = "5.0.3";
 
   src = with lib.versions; fetchurl {
     url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-90CZRIVRbetjtTEa8SLCZRefUyig2FelZ7hdsAsR5BU=";
+    sha256 = "sha256-mQWC8gazqzLpOKoxu/B8Y5No5EBdyhlvq+fw927tqQs=";
   };
 
   postPatch = ''
     patchShebangs ./
 
-    # Ensure build is reproducible
-    ts=`date -d @$SOURCE_DATE_EPOCH`
-    sed -i 's/OPAL_CONFIGURE_USER=.*/OPAL_CONFIGURE_USER="nixbld"/' configure
-    sed -i 's/OPAL_CONFIGURE_HOST=.*/OPAL_CONFIGURE_HOST="localhost"/' configure
-    sed -i "s/OPAL_CONFIGURE_DATE=.*/OPAL_CONFIGURE_DATE=\"$ts\"/" configure
-    find -name "Makefile.in" -exec sed -i "s/\`date\`/$ts/" \{} \;
+    # This is dynamically detected. Configure does not provide fine grained options
+    # We just disable the check in the configure script for now
+    ${lib.optionalString (!enableSse3)
+      "substituteInPlace configure --replace-fail 'ompi_cv_op_avx_check_sse3=yes' 'ompi_cv_op_avx_check_sse3=no'"}
+    ${lib.optionalString (!enableSse4_1)
+      "substituteInPlace configure --replace-fail 'ompi_cv_op_avx_check_sse41=yes' 'ompi_cv_op_avx_check_sse41=no'"}
+    ${lib.optionalString (!enableAvx)
+      "substituteInPlace configure --replace-fail 'ompi_cv_op_avx_check_avx=yes' 'ompi_cv_op_avx_check_avx=no'"}
+    ${lib.optionalString (!enableAvx2)
+      "substituteInPlace configure --replace-fail 'ompi_cv_op_avx_check_avx2=yes' 'ompi_cv_op_avx_check_avx2=no'"}
+    ${lib.optionalString (!enableAvx512)
+      "substituteInPlace configure --replace-fail 'ompi_cv_op_avx_check_avx512=yes' 'ompi_cv_op_avx_check_av512=no'"}
+  '';
+
+  preConfigure = ''
+    # Ensure build is reproducible according to manual
+    # https://docs.open-mpi.org/en/v5.0.x/release-notes/general.html#general-notes
+    export USER=nixbld
+    export HOSTNAME=localhost
+    export SOURCE_DATE_EPOCH=0
   '';
 
   outputs = [ "out" "man" "dev" ];
 
-  buildInputs = [ zlib ]
-    ++ lib.optionals stdenv.isLinux [ libnl numactl pmix ucx ucc ]
+  buildInputs = [ zlib libevent hwloc ]
+    ++ lib.optionals stdenv.isLinux [ numactl pmix ucx ucc prrte ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
-    ++ [ libevent hwloc ]
     ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
     ++ lib.optionals fabricSupport [ libpsm2 libfabric ];
 
@@ -52,26 +75,26 @@ stdenv.mkDerivation rec {
     ++ lib.optionals fortranSupport [ gfortran ];
 
   configureFlags = lib.optional (!cudaSupport) "--disable-mca-dso"
+    ++ lib.optional stdenv.isLinux "--with-prrte=${lib.getBin prrte}"
     ++ lib.optional (!fortranSupport) "--disable-mpi-fortran"
-    ++ lib.optionals stdenv.isLinux  [
-      "--with-libnl=${lib.getDev libnl}"
-      "--with-pmix=${lib.getDev pmix}"
-      "--with-pmix-libdir=${pmix}/lib"
-      "--enable-mpi-cxx"
-    ] ++ lib.optional enableSGE "--with-sge"
+    ++ lib.optional enableSGE "--with-sge"
     ++ lib.optional enablePrefix "--enable-mpirun-prefix-by-default"
     # TODO: add UCX support, which is recommended to use with cuda for the most robust OpenMPI build
     # https://github.com/openucx/ucx
     # https://www.open-mpi.org/faq/?category=buildcuda
     ++ lib.optionals cudaSupport [ "--with-cuda=${cudaPackages.cuda_cudart}" "--enable-dlopen" ]
-    ++ lib.optionals fabricSupport [ "--with-psm2=${lib.getDev libpsm2}" "--with-libfabric=${lib.getDev libfabric}" ]
-    ;
+    ++ lib.optionals fabricSupport [
+      "--with-psm2=${lib.getDev libpsm2}"
+      "--with-libfabric=${lib.getDev libfabric}"
+      "--with-libfabric-libdir=${lib.getLib libfabric}/lib"
+    ];
 
   enableParallelBuilding = true;
 
   postInstall = ''
     find $out/lib/ -name "*.la" -exec rm -f \{} \;
 
+    # Move compiler wrappers to $dev
     for f in mpi shmem osh; do
       for i in f77 f90 CC c++ cxx cc fort; do
         moveToOutput "bin/$f$i" "''${!outputDev}"
@@ -88,34 +111,28 @@ stdenv.mkDerivation rec {
    '';
 
   postFixup = ''
-    remove-references-to -t $dev $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
-    remove-references-to -t $man $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+    # These reference are caused by hard coded "configure options"
+    remove-references-to -t $dev $out/bin/mpirun
+    remove-references-to -t $dev $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.library})
+    remove-references-to -t $man $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.library})
 
     # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
     wrapProgram $dev/bin/opal_wrapper \
       --set OPAL_INCLUDEDIR $dev/include \
       --set OPAL_PKGDATADIR $dev/share/openmpi
 
-    # default compilers should be indentical to the
-    # compilers at build time
-
-    echo "$dev/share/openmpi/mpicc-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-      $dev/share/openmpi/mpicc-wrapper-data.txt
-
-    echo "$dev/share/openmpi/ortecc-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-       $dev/share/openmpi/ortecc-wrapper-data.txt
-
-    echo "$dev/share/openmpi/mpic++-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
-       $dev/share/openmpi/mpic++-wrapper-data.txt
+    # default compilers should be identical to the compilers at build time
+    for api in mpi shmem; do
+      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
+        $dev/share/openmpi/''${api}cc-wrapper-data.txt
+      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
+        $dev/share/openmpi/''${api}c++-wrapper-data.txt
+    done
   '' + lib.optionalString fortranSupport ''
-
-    echo "$dev/share/openmpi/mpifort-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
-       $dev/share/openmpi/mpifort-wrapper-data.txt
-
+    for api in mpi shmem; do
+      sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
+        $dev/share/openmpi/''${api}fort-wrapper-data.txt
+    done
   '';
 
   doCheck = true;

--- a/pkgs/development/libraries/science/chemistry/plumed/default.nix
+++ b/pkgs/development/libraries/science/chemistry/plumed/default.nix
@@ -4,8 +4,6 @@
 , blas
 }:
 
-assert !blas.isILP64;
-
 stdenv.mkDerivation rec {
   pname = "plumed";
   version = "2.9.0";
@@ -20,6 +18,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs .
   '';
+
+  configureFlags = [] ++ lib.optional blas.isILP64 "--enable-ilp64";
 
   buildInputs = [ blas ];
 

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -26,6 +26,10 @@ buildPythonPackage rec {
     substituteInPlace test/test_spawn.py --replace \
                       "unittest.skipMPI('openmpi(<3.0.0)')" \
                       "unittest.skipMPI('openmpi')"
+
+    substituteInPlace test/test_dynproc.py --replace \
+                      "unittest.skipMPI('openmpi(<2.0.0)')" \
+                      "unittest.skipMPI('openmpi')" \
   '';
 
   configurePhase = "";


### PR DESCRIPTION
## Description of changes
This is a bigger update: https://docs.open-mpi.org/en/v5.0.x/release-notes/changelog/v5.0.x.html#open-mpi-version-5-0-0

* Openmpi now uses PRRTE
* Uses at least AVX now (required for building openmpi).


Closes #275792.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
