### PR TITLE
goat-cli: init at 1.1.0

### DIFF
--- a/pkgs/by-name/go/goat-cli/mock-fix.patch
+++ b/pkgs/by-name/go/goat-cli/mock-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/goatfile/unmarshal_test.go b/pkg/goatfile/unmarshal_test.go
+index 089e89f..5b4191b 100644
+--- a/pkg/goatfile/unmarshal_test.go
++++ b/pkg/goatfile/unmarshal_test.go
+@@ -8,7 +8,6 @@ import (
+ 
+ 	"github.com/golang/mock/gomock"
+ 	"github.com/stretchr/testify/assert"
+-	"github.com/studio-b12/goat/mocks"
+ 	"github.com/studio-b12/goat/pkg/set"
+ )
+ 

--- a/pkgs/by-name/go/goat-cli/package.nix
+++ b/pkgs/by-name/go/goat-cli/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  fetchpatch,
+}:
+
+buildGoModule rec {
+  pname = "goat-cli";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    repo = "goat";
+    owner = "studio-b12";
+    rev = "v${version}";
+    hash = "sha256-H7ea3XOBfQ7bIX5SbxPd+fcSlMurSWXGXe+/LsqSc0A=";
+  };
+
+  vendorHash = "sha256-DtEXgGYSkWO876so6LEOkhVwDt/zrflDZdY4O2lz1mw=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/studio-b12/goat/internal/version.Version=${version}"
+    "-X github.com/studio-b12/goat/internal/version.CommitHash=${src.rev}"
+  ];
+
+  patches = [
+    ./mock-fix.patch
+  ];
+
+  # Checks currently fail because of an issue with github.com/studio-b12/goat/mocks
+  doCheck = false;
+
+  meta = {
+    description = "Integration testing tool for HTTP APIs using a simple script language";
+    homepage = "https://studio-b12.github.io/goat/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "goat";
+  };
+
+}


### PR DESCRIPTION
## Description of changes

https://github.com/studio-b12/goat
https://github.com/studio-b12/goat/releases/tag/v1.1.0

An integration testing tool for HTTP APIs uisng a simple script language. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
