### PR TITLE
mlkit: add necessary patch until fixed upstream.

### DIFF
--- a/pkgs/development/compilers/mlkit/default.nix
+++ b/pkgs/development/compilers/mlkit/default.nix
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
 
   buildFlags = [ "mlkit" "mlkit_libs" ];
 
+  checkPhase = ''
+    touch empty.sml
+    mlkit -o empty empty.sml
+    ./empty
+  '';
+
+  patches = [ ./install-df.patch ];
+
   meta = with lib; {
     description = "Standard ML Compiler and Toolkit";
     homepage = "https://elsman.com/mlkit/";

--- a/pkgs/development/compilers/mlkit/install-df.patch
+++ b/pkgs/development/compilers/mlkit/install-df.patch
@@ -1,0 +1,28 @@
+diff --git a/Makefile.in b/Makefile.in
+index 55ab82a1..326abe2a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -96,7 +96,7 @@ install_smltojs_basislibs:
+ 	$(MKDIR) $(LIBDIR)/basis
+ 	$(INSTALLDATA) -p js/basis/*.{sml,sig,mlb} $(LIBDIR)/basis
+ 	$(MKDIR) $(LIBDIR)/basis/MLB/Js/
+-	$(INSTALLDATA) -p js/basis/MLB/Js/*.{d,eb,eb1,lnk,js} $(LIBDIR)/basis/MLB/Js
++	$(INSTALLDATA) -p js/basis/MLB/Js/*.{d,eb,eb1,lnk,js,df} $(LIBDIR)/basis/MLB/Js
+ 
+ .PHONY: install_mlkit_basislibs
+ install_mlkit_basislibs:
+@@ -110,10 +110,10 @@ install_mlkit_basislibs:
+ 	$(MKDIR) $(LIBDIR)/basis/io/MLB/RI_GC
+ 	$(MKDIR) $(LIBDIR)/basis/io/MLB/RI_GC_PROF
+ 	$(MKDIR) $(LIBDIR)/basis/io/MLB/RI_PROF
+-	$(INSTALLDATA) -p basis/MLB/RI/*.{d,eb,eb1,lnk,o} $(LIBDIR)/basis/MLB/RI
+-	$(INSTALLDATA) -p basis/MLB/RI_GC/*.{d,eb,eb1,lnk,o} $(LIBDIR)/basis/MLB/RI_GC
+-	$(INSTALLDATA) -p basis/MLB/RI_PROF/*.{d,eb,eb1,lnk,o,rev} $(LIBDIR)/basis/MLB/RI_PROF
+-	$(INSTALLDATA) -p basis/MLB/RI_GC_PROF/*.{d,eb,eb1,lnk,o,rev} $(LIBDIR)/basis/MLB/RI_GC_PROF
++	$(INSTALLDATA) -p basis/MLB/RI/*.{d,eb,eb1,lnk,o,df} $(LIBDIR)/basis/MLB/RI
++	$(INSTALLDATA) -p basis/MLB/RI_GC/*.{d,eb,eb1,lnk,o,df} $(LIBDIR)/basis/MLB/RI_GC
++	$(INSTALLDATA) -p basis/MLB/RI_PROF/*.{d,eb,eb1,lnk,o,rev,df} $(LIBDIR)/basis/MLB/RI_PROF
++	$(INSTALLDATA) -p basis/MLB/RI_GC_PROF/*.{d,eb,eb1,lnk,o,rev,df} $(LIBDIR)/basis/MLB/RI_GC_PROF
+ 	$(INSTALLDATA) -p basis/io/MLB/RI/*.{d,eb,eb1,lnk,o} $(LIBDIR)/basis/io/MLB/RI
+ 	$(INSTALLDATA) -p basis/io/MLB/RI_GC/*.{d,eb,eb1,lnk,o} $(LIBDIR)/basis/io/MLB/RI_GC
+ 	$(INSTALLDATA) -p basis/io/MLB/RI_PROF/*.{d,eb,eb1,lnk,o,rev} $(LIBDIR)/basis/io/MLB/RI_PROF


### PR DESCRIPTION
## Description of changes

Add-hoc patch to copy missing files.  Without this patch, the derivation simply does not work.

The 'install' target forgets to copy some .df files that are necessary when MLKit is installed in a read-only location.

Also adds a checkPhase so issues like this will not go undetected next time.

I have been in contact with the MLKit maintainer who is working on fixing the problem upstream, so hopefully this patch is a temporary measure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
