### PR TITLE
deepin.dde-appearance: 1.1.6 -> 1.1.8

### DIFF
--- a/pkgs/desktops/deepin/core/dde-appearance/default.nix
+++ b/pkgs/desktops/deepin/core/dde-appearance/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dde-appearance";
-  version = "1.1.6";
+  version = "1.1.8";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    hash = "sha256-7oRbydLXw8yRzi9L1GH/q0cjMY/DLyWbj4RUSyNpVNM=";
+    hash = "sha256-x503HhaF+cH+/KLve/aKp5H5TldOWg74gzCOPkp4I00=";
   };
 
   patches = [

--- a/pkgs/desktops/deepin/core/dde-appearance/fix-custom-wallpapers-path.diff
+++ b/pkgs/desktops/deepin/core/dde-appearance/fix-custom-wallpapers-path.diff
@@ -49,7 +49,7 @@ index 360ca6f..6db93ab 100644
              wallpaper = bg.getId();
          } else {
 -            wallpaper = "file:///usr/share/wallpapers/deepin/desktop.jpg";
-+            wallpaper = "file:///run/current-system/sw/wallpapers/deepin/desktop.jpg";
++            wallpaper = "file:///run/current-system/sw/share/wallpapers/deepin/desktop.jpg";
          }
  
          PhaseWallPaper::setWallpaperUri(index, monitorName, wallpaper);
@@ -62,7 +62,7 @@ index bf739a5..1076d59 100644
  #include <QDBusReply>
  
 -QStringList Backgrounds::systemWallpapersDir = { "/usr/share/wallpapers/deepin" };
-+QStringList Backgrounds::systemWallpapersDir = { "/run/current-system/sw/wallpapers/deepin" };
++QStringList Backgrounds::systemWallpapersDir = { "/run/current-system/sw/share/wallpapers/deepin" };
  QStringList Backgrounds::uiSupportedFormats = { "jpeg", "png", "bmp", "tiff", "gif" };
  
  Backgrounds::Backgrounds(QObject *parent)


### PR DESCRIPTION
https://github.com/linuxdeepin/dde-appearance/compare/1.1.6...1.1.8

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
