### PR TITLE
mattermost-desktop 5.5.0 -> 5.6.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchurl
-, electron_28
+, electron_27
 , makeWrapper
 }:
 
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/Mattermost.desktop \
       --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
 
-    makeWrapper ${electron_28}/bin/electron $out/bin/${pname} \
+    makeWrapper '${lib.getExe electron_27}' $out/bin/${pname} \
       --add-flags $out/share/${pname}/app.asar
 
     runHook postInstall

--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -1,24 +1,24 @@
 { lib
 , stdenv
 , fetchurl
-, electron_26
+, electron_28
 , makeWrapper
 }:
 
 let
 
   pname = "mattermost-desktop";
-  version = "5.5.1";
+  version = "5.6.0";
 
   srcs = {
     "x86_64-linux" = {
       url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-      hash = "sha256-bRiO5gYM7nrnkbHBP3B9zAK2YV5POkc3stEsbZJ48VA=";
+      hash = "sha256-KUF/zH18X+RS8AICBv53JTBpcaokzo92psyoQNmLF/Q=";
     };
 
     "aarch64-linux" = {
       url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-arm64.tar.gz";
-      hash = "sha256-Z4U6Jbwasra69QPHJ9/7WwMSxh0O9r4QIe/xC3WRf4w=";
+      hash = "sha256-Zl5PalAles39qSMtt1cytfu4Mheud4+8TTkt7Ohdf/o=";
     };
   };
 
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/Mattermost.desktop \
       --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
 
-    makeWrapper ${electron_26}/bin/electron $out/bin/${pname} \
+    makeWrapper ${electron_28}/bin/electron $out/bin/${pname} \
       --add-flags $out/share/${pname}/app.asar
 
     runHook postInstall


### PR DESCRIPTION
## Description of changes

Update mattermost-desktop to 5.6.0. [Changelog](https://docs.mattermost.com/deploy/desktop-app-changelog.html#release-v5-6).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Update mattermost-desktop
Update electron_26 -> electron_27

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
