### PR TITLE
ovn/ovn-lts: init at 23.09.1/22.03.5, openvswitch*: improve checks

### DIFF
--- a/pkgs/by-name/ov/ovn/generic.nix
+++ b/pkgs/by-name/ov/ovn/generic.nix
@@ -1,0 +1,96 @@
+{
+  version,
+  hash,
+  updateScriptArgs ? "",
+}:
+
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  gnused,
+  libbpf,
+  libcap_ng,
+  numactl,
+  openssl,
+  pkg-config,
+  procps,
+  python3,
+  unbound,
+  xdp-tools,
+  writeScript,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ovn";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "ovn-org";
+    repo = "ovn";
+    rev = "refs/tags/v${version}";
+    inherit hash;
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    libbpf
+    libcap_ng
+    numactl
+    openssl
+    unbound
+    xdp-tools
+  ];
+
+  # need to build the ovs submodule first
+  preConfigure = ''
+    pushd ovs
+    ./boot.sh
+    ./configure
+    make -j $NIX_BUILD_CORES
+    popd
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    gnused
+    procps
+  ];
+
+  # https://docs.ovn.org/en/latest/topics/testing.html
+  preCheck = ''
+    export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
+    # allow rechecks to retry flaky tests
+    export RECHECK=yes
+
+    # hack to stop tests from trying to read /etc/resolv.conf
+    export OVS_RESOLV_CONF="$PWD/resolv.conf"
+    touch $OVS_RESOLV_CONF
+  '';
+
+  passthru.updateScript = writeScript "ovs-update.nu" ''
+    ${./update.nu} ${updateScriptArgs}
+  '';
+
+  meta = with lib; {
+    description = "Open Virtual Network";
+    longDescription = ''
+      OVN (Open Virtual Network) is a series of daemons that translates virtual network configuration into OpenFlow, and installs them into Open vSwitch.
+    '';
+    homepage = "https://github.com/ovn-org/ovn";
+    changelog = "https://github.com/ovn-org/ovn/blob/${src.rev}/NEWS";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ adamcstephens ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/ov/ovn/lts.nix
+++ b/pkgs/by-name/ov/ovn/lts.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  version = "22.03.5";
+  hash = "sha256-DMDWR7Dbgak0azPcVqDdFHGovTbLX8byp+jQ3rYvvX4=";
+  updateScriptArgs = "--lts=true --regex '22.03.*'";
+}

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "23.09.1";
+  hash = "sha256-t4DtV0wW/jQX7/TpsLFoDzzSPROrhUHHG09r9+lsdaQ=";
+}

--- a/pkgs/by-name/ov/ovn/update.nu
+++ b/pkgs/by-name/ov/ovn/update.nu
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p nushell common-updater-scripts
+
+def main [--lts: bool = false, --regex: string] {
+  let tags = list-git-tags --url=https://github.com/ovn-org/ovn | lines | sort --natural | str replace v ''
+
+  let latest_tag = if $regex == null { $tags } else { $tags | find --regex $regex } | last
+  let current_version = nix eval --raw -f default.nix $"ovn(if $lts {"-lts"}).version" | str trim
+
+  if $latest_tag != $current_version {
+    if $lts {
+      update-source-version ovn-lts $latest_tag $"--file=(pwd)/pkgs/by-name/ov/ovn/lts.nix"
+    } else {
+      update-source-version ovn $latest_tag $"--file=(pwd)/pkgs/by-name/ov/ovn/package.nix"
+    }
+  }
+
+  {"lts?": $lts, before: $current_version, after: $latest_tag}
+}

--- a/pkgs/os-specific/linux/openvswitch/generic.nix
+++ b/pkgs/os-specific/linux/openvswitch/generic.nix
@@ -96,6 +96,8 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
   preCheck = ''
+    export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
+
     patchShebangs tests/
   '';
 

--- a/pkgs/os-specific/linux/openvswitch/generic.nix
+++ b/pkgs/os-specific/linux/openvswitch/generic.nix
@@ -97,6 +97,7 @@ in stdenv.mkDerivation rec {
   doCheck = true;
   preCheck = ''
     export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
+    export RECHECK=yes
 
     patchShebangs tests/
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11750,6 +11750,8 @@ with pkgs;
 
   openvswitch-lts = callPackage ../os-specific/linux/openvswitch/lts.nix { };
 
+  ovn-lts = callPackage ../by-name/ov/ovn/lts.nix { };
+
   optifinePackages = callPackage ../tools/games/minecraft/optifine { };
 
   optifine = optifinePackages.optifine-latest;


### PR DESCRIPTION
## Description of changes

https://www.ovn.org/en/

Followed the openvswitch pattern since these two projects are intertwined.

- ovn/ovn-lts: init at 23.09.1/22.03.5
- openvswitch*: run tests in parallel for significant speedup
- openvswitch*: enable RECHECK to rerun failed tests

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
