### PR TITLE
openmoji-color,openmoji-black: 14.0.0 -> 15.0.0

### DIFF
--- a/pkgs/data/fonts/openmoji/build.patch
+++ b/pkgs/data/fonts/openmoji/build.patch
@@ -1,0 +1,77 @@
+diff --git a/helpers/generate-fonts-runner.sh b/helpers/generate-fonts-runner.sh
+index 21267e50f..873b5c664 100755
+--- a/helpers/generate-fonts-runner.sh
++++ b/helpers/generate-fonts-runner.sh
+@@ -25,10 +25,10 @@ mkdir -p "$build_dir"
+ 
+ # Change these to enable/disable formats
+ # Remember to update font/README.md accordingly
+-methods_black=(glyf)
+-methods_color=(cbdt glyf_colr_0 glyf_colr_1 sbix picosvgz untouchedsvgz)
++#methods_black=(glyf)
++#methods_color=(cbdt glyf_colr_0 glyf_colr_1 sbix picosvgz untouchedsvgz)
+ 
+-saturations=(black color)
++#saturations=(black color)
+ for saturation in "${saturations[@]}"; do
+     case "$saturation" in
+     black)
+@@ -43,6 +43,7 @@ for saturation in "${saturations[@]}"; do
+     mkdir -p "$build_dir/$saturation"
+ 
+     for method in "${methods[@]}"; do
++        if [ -z "$method" ]; then continue; fi
+         cat >"$build_dir/$saturation/OpenMoji-$saturation-$method.toml" <<-EOF
+ output_file = "$build_dir/$saturation/OpenMoji-$saturation-$method.ttf"
+ color_format = "$method"
+@@ -55,10 +56,7 @@ default = 400
+ 
+ [master.regular]
+ style_name = "Regular"
+-
+-# To quickly check build reverse comments below
+-srcs = ["/mnt/$saturation/svg/*.svg"]
+-# srcs = ["/mnt/$saturation/svg/1F923.svg", "/mnt/$saturation/svg/1F1E9-1F1F0.svg"]
++srcs = ["$(pwd)/$saturation/svg/*.svg"]
+ 
+ [master.regular.position]
+ wght = 400
+@@ -71,7 +69,7 @@ EOF
+     for method in "${methods[@]}"; do
+         # Generate XML for font
+         sed "s/Color/${saturation^}/;" \
+-            /mnt/data/OpenMoji-Color.ttx \
++            data/OpenMoji-Color.ttx \
+             > "$build_dir/$saturation/OpenMoji-$saturation-$method.ttx"
+ 
+         # Add version to XML
+@@ -89,25 +87,21 @@ EOF
+ 
+         # Compress with WOFF2
+         woff2_compress "$build_dir/fonts/OpenMoji-$saturation-$method/OpenMoji-$saturation-$method.ttf"
+-
+-        # Generate font demo
+-        /mnt/helpers/generate-font-demo.js "OpenMoji-$saturation-$method.woff2" "$build_dir/fonts/OpenMoji-$saturation-$method"
+     done
+ done
+ 
+-for colr_version in 0 1; do
++for colr_version in "${maximumColorVersions[@]}"; do
++    if [ -z "$colr_version" ]; then continue; fi
+     # Make TTF with both COLR and SVG font data in it
+     mkdir -p "$build_dir/fonts/OpenMoji-color-colr${colr_version}_svg"
+ 
+-    maximum_color \
++    maximum_color --build_dir="$build_dir/color" \
+         "$build_dir/fonts/OpenMoji-color-glyf_colr_${colr_version}/OpenMoji-color-glyf_colr_${colr_version}.ttf"\
+         --output_file "$build_dir/fonts/OpenMoji-color-colr${colr_version}_svg/OpenMoji-color-colr${colr_version}_svg.ttf"
+ 
+     woff2_compress "$build_dir/fonts/OpenMoji-color-colr${colr_version}_svg/OpenMoji-color-colr${colr_version}_svg.ttf"
+ 
+-    /mnt/helpers/generate-font-demo.js\
+-        "OpenMoji-color-colr${colr_version}_svg.woff2"\
+-        "$build_dir/fonts/OpenMoji-color-colr${colr_version}_svg"
++    rm -rf "$build_dir/fonts/OpenMoji-color-glyf_colr_${colr_version}"
+ done
+ 
+ echo "Done building fonts!"

--- a/pkgs/data/fonts/openmoji/default.nix
+++ b/pkgs/data/fonts/openmoji/default.nix
@@ -1,93 +1,85 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
-, fetchpatch
-, scfbuild
-, fontforge
-, node-glob
-, libuninameslist
-, nodejs
-, nodePackages
+, nanoemoji
 , python3Packages
-, variant ? "color" # "color" or "black"
+, woff2
+, xmlstarlet
+  # available color formats: ["cbdt" "glyf_colr_0" "glyf_colr_1" "sbix" "picosvgz" "untouchedsvgz"]
+  # available black formats: ["glyf"]
+, fontFormats ? [ "glyf" "cbdt" "glyf_colr_0" "glyf_colr_1" ]
+  # when at least one of the glyf_colr_0/1 formats is specified, whether to build maximum color fonts
+  # "none" to not build any, "svg" to build colr+svg, "bitmap" to build cbdt+colr+svg fonts
+, buildMaximumColorFonts ? "bitmap"
 }:
-
 let
-  filename = builtins.replaceStrings
-    [ "color"              "black"              ]
-    [ "OpenMoji-Color.ttf" "OpenMoji-Black.ttf" ]
-    variant;
+  # all available methods
+  methods = {
+    black = [ "glyf" ];
+    color = [ "cbdt" "glyf_colr_0" "glyf_colr_1" "sbix" "picosvgz" "untouchedsvgz" ];
+  };
+in
 
-  # With newer fontforge the build hangs, see
-  # https://github.com/NixOS/nixpkgs/issues/167869
-  # Patches etc taken from
-  # https://github.com/NixOS/nixpkgs/commit/69da642a5a9bb433138ba1b13c8d56fb5bb6ec05
-  fontforge-20201107 = fontforge.overrideAttrs (old: rec {
-    version = "20201107";
-    src = fetchFromGitHub {
-      owner = "fontforge";
-      repo = "fontforge";
-      rev = version;
-      sha256 = "sha256-Rl/5lbXaPgIndANaD0IakaDus6T53FjiBb45FIuGrvc=";
-    };
-    patches = [
-      (fetchpatch {
-        url = "https://salsa.debian.org/fonts-team/fontforge/raw/76bffe6ccf8ab20a0c81476a80a87ad245e2fd1c/debian/patches/0001-add-extra-cmake-install-rules.patch";
-        sha256 = "u3D9od2xLECNEHhZ+8dkuv9818tPkdP6y/Tvd9CADJg=";
-      })
-      (fetchpatch {
-        url = "https://github.com/fontforge/fontforge/commit/69e263b2aff29ad22f97f13935cfa97a1eabf207.patch";
-        sha256 = "06yyf90605aq6ppfiz83mqkdmnaq5418axp9jgsjyjq78b00xb29";
-      })
-    ];
-    buildInputs = old.buildInputs ++ [ libuninameslist ];
-  });
-  scfbuild-with-fontforge-20201107 = scfbuild.override (old: {
-    fontforge = fontforge-20201107;
-  });
+assert lib.asserts.assertEachOneOf "fontFormats" fontFormats (methods.black ++ methods.color);
+assert lib.asserts.assertOneOf "buildMaximumColorFonts" buildMaximumColorFonts [ "none" "bitmap" "svg" ];
 
-in stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "openmoji";
-  version = "14.0.0";
+  version = "15.0.0";
 
   src = fetchFromGitHub {
     owner = "hfg-gmuend";
     repo = pname;
     rev = version;
-    sha256 = "sha256-XnSRSlWXOMeSaO6dKaOloRg3+sWS4BSaro4bPqOyKmE=";
+    hash = "sha256-659ONkHU45Z2789ay0yLero9j5nFWhslpJad++4oNN8=";
   };
 
-  nativeBuildInputs = [
-    scfbuild-with-fontforge-20201107
-    nodejs
-    node-glob
-    nodePackages.lodash
+  patches = [
+    # fix paths and variables for nix build and skip generating font demos
+    ./build.patch
   ];
 
-  postPatch = ''
-    # this is API change in glob >9
-    substituteInPlace helpers/generate-font-glyphs.js \
-      --replace "require('glob').sync" "require('glob').globSync"
+  nativeBuildInputs = [
+    nanoemoji
+    python3Packages.fonttools
+    woff2
+    xmlstarlet
+  ];
+
+  methods_black = builtins.filter (m: builtins.elem m fontFormats) methods.black;
+  methods_color = builtins.filter (m: builtins.elem m fontFormats) methods.color;
+  saturations = lib.optional (methods_black != [ ]) "black" ++ lib.optional (methods_color != [ ]) "color";
+  maximumColorVersions = lib.optionals (buildMaximumColorFonts != "none") (
+    lib.optional (builtins.elem "glyf_colr_0" fontFormats) "0"
+    ++ lib.optional (builtins.elem "glyf_colr_1" fontFormats) "1"
+  );
+
+  postPatch = lib.optionalString (buildMaximumColorFonts == "bitmap") ''
+    substituteInPlace helpers/generate-fonts-runner.sh \
+      --replace 'maximum_color' 'maximum_color --bitmaps'
   '';
 
   buildPhase = ''
     runHook preBuild
 
-    node helpers/generate-font-glyphs.js
-
-    cd font
-    scfbuild -c scfbuild-${variant}.yml
+    bash helpers/generate-fonts-runner.sh "$(pwd)/build" "${version}"
 
     runHook postBuild
   '';
 
   installPhase = ''
-    install -Dm644 ${filename} $out/share/fonts/truetype/${filename}
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype $out/share/fonts/woff2
+    cp build/fonts/*/*.ttf $out/share/fonts/truetype/
+    cp build/fonts/*/*.woff2 $out/share/fonts/woff2/
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     license = licenses.cc-by-sa-40;
-    maintainers = with maintainers; [ fgaz ];
+    maintainers = with maintainers; [ _999eagle fgaz ];
     platforms = platforms.all;
     homepage = "https://openmoji.org/";
     downloadPage = "https://github.com/hfg-gmuend/openmoji/releases";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29816,9 +29816,9 @@ with pkgs;
 
   open-sans = callPackage ../data/fonts/open-sans { };
 
-  openmoji-color = callPackage ../data/fonts/openmoji { variant = "color"; };
+  openmoji-color = callPackage ../data/fonts/openmoji { fontFormats = ["glyf_colr_0"]; };
 
-  openmoji-black = callPackage ../data/fonts/openmoji { variant = "black"; };
+  openmoji-black = callPackage ../data/fonts/openmoji { fontFormats = ["glyf"]; };
 
   openzone-cursors = callPackage ../data/themes/openzone { };
 


### PR DESCRIPTION
## Description of changes

Release Notes: https://github.com/hfg-gmuend/openmoji/releases/tag/15.0.0

The build system has changed completely between 14.0.0 and 15.0.0 and generating all font formats upstream builds takes a *very* long time. I've experimented with the available fonts and `colr1_svg` (built from `glyf_colr_1` using `maximum_color`) seems to have the best support across font renderers, so that's what I've chosen for `openmoji-color` by default.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
