### PR TITLE
neondb: init at 4459

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -902,8 +902,46 @@ rec {
     _type = "lua-inline";
     inherit expr;
   };
-}
-// {
+
+  ## -- SHELL ARGUMENT GENERATORS --
+
+  mkShellArgument = {prefix ? "--", sep ? " ", enablePrefix? "", disablePrefix ? null, ...}: k: v:
+    let
+      err = t: v: abort
+        ("generators.mkShellArguments: " +
+         "${t} not supported: ${toPretty {} v}");
+    in if isInt v then "${prefix}${k}${sep}${toString v}"
+    else if lib.isDerivation v then "${prefix}${k}${sep}${toString v}"
+    else if lib.isString v then "${prefix}${k}${sep}${v}"
+    else if lib.isBool v then (
+      if disablePrefix == null then "${prefix}${k}${sep}${if v then "true" else "false"}"
+      else "${prefix}${if v then enablePrefix else disablePrefix}${k}"
+    )
+    else if null == v then ""
+    else if isAttrs v then err "attrsets" v
+    else if isFunction v then err "functions" v
+    else if isFloat v then floatToString v
+    else err "this value is" (toString v);
+
+  /* Generate a bash arguments line, where every argument is prefixed with prefix,
+   * arguments will be delimited by argSep, and every argument consists of key k and value v, separated
+   * by sep.
+   *
+   * If disablePrefix is null, then boolean values will be passed literally:
+   * mkShellArguments {} { arg = true; }
+   * > --arg true
+   *
+   * If not, then true argument will be passed literally, and false will be prefixed:
+   * mkShellArguments {} { a = true; b = false, disablePrefix = "disable-" }
+   * > --a --disable-b
+   */
+  mkShellArguments = {argSep ? " ", ...} @ opts:
+  let mkArgument' = k: v:
+    if lib.isList v then (map (mkShellArgument opts k) v)
+    else [(mkShellArgument opts k v)];
+  in attrs:
+    concatStringsSep argSep (lib.concatLists (mapAttrsToList (mkArgument') attrs));
+} // {
   /**
     Generates JSON from an arbitrary (non-function) value.
     For more information see the documentation of the builtin.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -552,6 +552,7 @@
   ./services/databases/mongodb.nix
   ./services/databases/mysql.nix
   ./services/databases/neo4j.nix
+  ./services/databases/neondb.nix
   ./services/databases/openldap.nix
   ./services/databases/opentsdb.nix
   ./services/databases/pgbouncer.nix

--- a/nixos/modules/services/databases/neondb.nix
+++ b/nixos/modules/services/databases/neondb.nix
@@ -1,0 +1,183 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+with lib; let
+  cfg = config.services.neondb;
+  settingsFormat = pkgs.formats.toml {};
+  argumentsFormat = pkgs.formats.shellArgs {disablePrefix = "disable-";};
+  pageserverOpts = {config, ...}: {
+    options = let
+      name = config._module.args.name;
+    in {
+      settings = mkOption {
+        description = ''
+          Pageserver settings, converted and passed as TOML config file.
+          Overriden by `configFile`.
+
+          For available params, see: <https://github.com/neondatabase/neon/blob/master/docs/settings.md>
+        '';
+        type = types.submodule {
+          freeformType = settingsFormat.type;
+        };
+      };
+      configFile = mkOption {
+        description = ''
+          Pageserver config file.
+          Overrides any values set using `settings`.
+        '';
+        type = types.path;
+        default =
+          settingsFormat.generate
+          "pageserver-${name}.toml"
+          config.settings;
+        defaultText = literalMD "TOML file generated from {option}`services.neondb.pageservers.<pageserver>.settings`";
+      };
+    };
+  };
+  safekeeperOpts = {...}: {
+    options = {
+      settings = mkOption {
+        description = ''
+          Safekeeper settings, passed as arguments
+        '';
+        type = types.submodule {
+          freeformType = argumentsFormat.type;
+        };
+      };
+    };
+  };
+  generatePageserverUnit = name: pageserver:
+    let
+      identityFile = settingsFormat.generate "identity-${name}.toml" {
+        id = pageserver.settings.id;
+      };
+    in {
+      name = "neondb-pageserver@${name}";
+      value = {
+        wantedBy = ["multi-user.target"];
+        serviceConfig = {
+          ExecStartPre = [
+            "${pkgs.coreutils}/bin/ln -sf ${pageserver.configFile} ./pageserver.toml"
+            "${pkgs.coreutils}/bin/ln -sf ${identityFile} ./identity.toml"
+          ];
+        };
+        overrideStrategy = "asDropin";
+      };
+    };
+  generateSafekeeperUnit = name: safekeeper: {
+    name = "neondb-safekeeper@${name}";
+    value = {
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/safekeeper -D . \
+            ${argumentsFormat.generateSystemd safekeeper.settings}
+        '';
+      };
+      overrideStrategy = "asDropin";
+    };
+  };
+in {
+  options.services.neondb = {
+    dataDir = mkOption {
+      description = ''
+        Default parent directory for all neondb components.
+      '';
+      type = types.path;
+      default = "/var/lib/neondb";
+    };
+    pageservers = mkOption {
+      description = "Neondb pageservers.";
+      default = {};
+      type = with types; attrsOf (submodule pageserverOpts);
+    };
+    safekeepers = mkOption {
+      description = "Neondb safekeepers.";
+      default = {};
+      type = with types; attrsOf (submodule safekeeperOpts);
+    };
+    storageController = {
+      enable = mkEnableOption "NeonDB Storage Controller";
+      settings = mkOption {
+        description = ''
+          Storage controller settings, passed as CLI arguments.
+        '';
+        type = types.submodule {
+          freeformType = argumentsFormat.type;
+        };
+        default = {};
+      };
+    };
+    package = mkPackageOption pkgs "neondb" {};
+    storageBrokerListenAddr = mkOption {
+      description = "Listen address for the storage broker.";
+      type = types.str;
+      default = "127.0.0.1:50051";
+    };
+  };
+  config = mkIf (cfg.pageservers != {} || cfg.safekeepers != {} || cfg.storageController.enable) {
+    systemd.services =
+      {
+        "neondb-pageserver@" = {
+          description = "NeonDB Pageserver %I";
+          after = ["network.target"];
+          serviceConfig = {
+            ExecStart = "${cfg.package}/bin/pageserver -D .";
+            StateDirectory = "neondb/pageserver/%i";
+            WorkingDirectory = "/var/lib/neondb/pageserver/%i";
+            DynamicUser = true;
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+        "neondb-safekeeper@" = {
+          description = "NeonDB Safekeeper %I";
+          after = ["network.target"];
+          serviceConfig = {
+            StateDirectory = "neondb/safekeeper/%i";
+            WorkingDirectory = "/var/lib/neondb/safekeeper/%i";
+            DynamicUser = true;
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+        "neondb-storage-broker" = {
+          description = "NeonDB Storage Broker";
+          after = ["network.target"];
+          wantedBy = ["multi-user.target"];
+          serviceConfig = {
+            ExecStart = "${cfg.package}/bin/storage_broker --listen-addr ${cfg.storageBrokerListenAddr}";
+            StateDirectory = "neondb/storage-broker";
+            WorkingDirectory = "/var/lib/neondb/storage-broker";
+            DynamicUser = true;
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+      }
+      // (mapAttrs' generatePageserverUnit cfg.pageservers)
+      // (mapAttrs' generateSafekeeperUnit cfg.safekeepers)
+      // optionalAttrs cfg.storageController.enable {
+        "neondb-storage-controller" = {
+          description = "NeonDB Storage Controller";
+          after = ["network.target" "postgresql.service"];
+          requires = ["postgresql.service"];
+          wantedBy = ["multi-user.target"];
+          serviceConfig = {
+            ExecStart = ''
+              ${cfg.package}/bin/storage_controller \
+                ${argumentsFormat.generateSystemd cfg.storageController.settings}
+            '';
+            StateDirectory = "neondb/storage-controller";
+            WorkingDirectory = "/var/lib/neondb/storage-controller";
+            DynamicUser = true;
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+      };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1132,6 +1132,7 @@ in
   nebula.connectivity = runTest ./nebula/connectivity.nix;
   nebula.reload = runTest ./nebula/reload.nix;
   neo4j = runTest ./neo4j.nix;
+  neondb = handleTest ./neondb.nix { };
   netbird = runTest ./netbird.nix;
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;
   netbox_4_4 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_4; };

--- a/nixos/tests/neondb.nix
+++ b/nixos/tests/neondb.nix
@@ -1,0 +1,70 @@
+import ./make-test-python.nix ({pkgs, lib, ...}: {
+  name = "neondb";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [lach];
+  };
+
+  nodes.machine = {pkgs, ...}: {
+    services.postgresql = {
+      enable = true;
+      enableTCPIP = true;
+      ensureDatabases = ["neondb"];
+      ensureUsers = [{
+        name = "neondb";
+        ensureDBOwnership = true;
+      }];
+      authentication = ''
+        hostssl neondb neondb 127.0.0.1/32 trust
+      '';
+      settings = {
+        ssl = true;
+        ssl_cert_file = "/var/lib/postgresql/server.crt";
+        ssl_key_file = "/var/lib/postgresql/server.key";
+      };
+    };
+    systemd.services.postgresql.preStart = lib.mkBefore ''
+      if [ ! -f /var/lib/postgresql/server.key ]; then
+        ${pkgs.openssl}/bin/openssl req -new -x509 -days 365 -nodes \
+          -out /var/lib/postgresql/server.crt \
+          -keyout /var/lib/postgresql/server.key \
+          -subj "/CN=localhost"
+        chmod 600 /var/lib/postgresql/server.key
+      fi
+    '';
+
+    services.neondb = {
+      storageController = {
+        enable = true;
+        settings = {
+          listen = "127.0.0.1:1234";
+          dev = true;
+          database-url = "postgresql://neondb@127.0.0.1/neondb";
+        };
+      };
+      pageservers.test.settings = {
+        id = 1;
+        control_plane_api = "http://127.0.0.1:1234/upcall/v1";
+        remote_storage = {
+          local_path = "/var/lib/neondb/pageserver/test/remote_storage";
+        };
+      };
+      safekeepers.test.settings = {
+        id = 1;
+        listen-pg = "127.0.0.1:5454";
+        listen-http = "127.0.0.1:7676";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("postgresql")
+    machine.wait_for_unit("neondb-storage-broker")
+    machine.wait_for_unit("neondb-storage-controller")
+    machine.wait_for_unit("neondb-pageserver@test")
+    machine.wait_for_unit("neondb-safekeeper@test")
+
+    machine.succeed("curl -sf http://127.0.0.1:1234/status")
+    machine.succeed("curl -sf http://127.0.0.1:9898/v1/status")
+    machine.succeed("curl -sf http://127.0.0.1:7676/v1/status")
+  '';
+})

--- a/pkgs/by-name/ne/neondb-pg-ext/package.nix
+++ b/pkgs/by-name/ne/neondb-pg-ext/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  cargo,
+  rustc,
+  pkg-config,
+  protobuf,
+  llvmPackages,
+  curl,
+  openssl,
+  postgresql_17_neon,
+  postgresql_neon ? postgresql_17_neon,
+}:
+
+let
+  version = "9129";
+  src = fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "neon";
+    rev = "release-${version}";
+    hash = "sha256-n5o4mHs6JJHTDTY0TnzRg3lKpSQKzYEe1nIXFGkRJJw=";
+  };
+  pgConfig = "${postgresql_neon.pg_config}/bin/pg_config";
+  clangBin = lib.getExe' llvmPackages.clang "clang";
+in
+
+stdenv.mkDerivation {
+  pname = "neondb-pg-ext-${lib.versions.major postgresql_neon.version}";
+  inherit version src;
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-C9EatnwZr+QjIzGa44bZPjMJptKLrpjCL2ZXJ+jpAeU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    rustPlatform.bindgenHook
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    postgresql_neon
+    curl
+    openssl
+  ];
+
+  # Make clang available for cc-rs without overriding stdenv's CC
+  postPatch = ''
+    mkdir -p .bin
+    ln -s ${clangBin} .bin/clang
+    ln -s ${clangBin} .bin/clang++
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    export PATH="$PWD/.bin:$PATH"
+    for ext in neon neon_rmgr neon_utils neon_test_utils neon_walredo; do
+      make -C pgxn/$ext \
+        PG_CONFIG=${pgConfig} \
+        NEON_CARGO_ARTIFACT_TARGET_DIR=$PWD/target/release \
+        CARGO_PROFILE=--release
+    done
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    export PATH="$PWD/.bin:$PATH"
+    for ext in neon neon_rmgr neon_utils neon_test_utils neon_walredo; do
+      make -C pgxn/$ext \
+        PG_CONFIG=${pgConfig} \
+        NEON_CARGO_ARTIFACT_TARGET_DIR=$PWD/target/release \
+        install DESTDIR=$out
+    done
+
+    if [[ -d "$out${postgresql_neon}" ]]; then
+      cp -alt "$out" "$out${postgresql_neon}"/*
+      rm -r "$out${postgresql_neon}"
+    fi
+    if [[ -d "$out${postgresql_neon.dev}" ]]; then
+      cp -alt "$out" "$out${postgresql_neon.dev}"/*
+      rm -r "$out${postgresql_neon.dev}"
+    fi
+    if [[ -d "$out${postgresql_neon.lib}" ]]; then
+      cp -alt "$out" "$out${postgresql_neon.lib}"/*
+      rm -r "$out${postgresql_neon.lib}"
+    fi
+    if [[ -d "$out/nix/store" ]]; then
+      rmdir --ignore-fail-on-non-empty "$out/nix/store" "$out/nix" || true
+    fi
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://neon.tech/";
+    description = "PostgreSQL extensions for Neon serverless database";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lach ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/ne/neondb/package.nix
+++ b/pkgs/by-name/ne/neondb/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  symlinkJoin,
+
+  pkg-config,
+  protobuf,
+  postgresql_14_neon,
+  postgresql_15_neon,
+  postgresql_16_neon,
+  postgresql_17_neon,
+
+  openssl,
+}:
+
+let
+  version = "9129";
+  mergePg = name: pg: symlinkJoin { inherit name; paths = [ pg pg.dev pg.pg_config ]; };
+  pg14 = mergePg "pg-neon-v14" postgresql_14_neon;
+  pg15 = mergePg "pg-neon-v15" postgresql_15_neon;
+  pg16 = mergePg "pg-neon-v16" postgresql_16_neon;
+  pg17 = mergePg "pg-neon-v17" postgresql_17_neon;
+in
+
+rustPlatform.buildRustPackage {
+  pname = "neondb";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "neon";
+    rev = "release-${version}";
+    hash = "sha256-n5o4mHs6JJHTDTY0TnzRg3lKpSQKzYEe1nIXFGkRJJw=";
+  };
+
+  cargoHash = "sha256-C9EatnwZr+QjIzGa44bZPjMJptKLrpjCL2ZXJ+jpAeU=";
+
+  # walproposer wants only postgresql_16, and generates some platform-dependent
+  # code, based on platforms ABI. I have no idea how to make it work with crosscompilation.
+  #
+  # postgres-ffi generates code for v14, v15 and v16, I think we don't need all of them,
+  # but in the time being we have dependency on 3 of them. Upstream changes are needed.
+  # Generated code should be platform-independent, bindgen emits isize for size_t etc,
+  # and postgres functions are the same between platforms.
+  #
+  # walproposer also wants to see libpgport.a at libs/walproposer-lib path for some reason.
+  postPatch = ''
+    mkdir pg_install
+    ln -s ${pg14} pg_install/v14
+    ln -s ${pg15} pg_install/v15
+    ln -s ${pg16} pg_install/v16
+    ln -s ${pg17} pg_install/v17
+    mkdir -p pg_install/build/walproposer-lib
+    ln -s ${pg17}/lib/lib{walproposer,pg{common,port}}.a pg_install/build/walproposer-lib/
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+  cargoBuildFlags = [
+    "--bin"
+    "pg_sni_router"
+    "--bin"
+    "proxy"
+    "--bin"
+    "pageserver"
+    "--bin"
+    "pagectl"
+    "--bin"
+    "safekeeper"
+    "--bin"
+    "storage_broker"
+    "--bin"
+    "storage_controller"
+    "--bin"
+    "storage_scrubber"
+    "--bin"
+    "storcon_cli"
+    "--bin"
+    "pagectl"
+    "--bin"
+    "compute_ctl"
+  ];
+
+  # Required setup is too complicated.
+  doCheck = false;
+
+  meta = {
+    homepage = "https://neon.tech/";
+    description = "Neon is a serverless open-source alternative to AWS Aurora Postgres. It separates storage and compute and substitutes the PostgreSQL storage layer by redistributing data across a cluster of nodes.";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lach ];
+    platforms = lib.platforms.unix;
+
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+  };
+}

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1110,4 +1110,22 @@ optionalAttrs allowAliases aliases
       generate = name: value: jsonFormat.generate name (mapAttrs (_: transform) value);
     };
 
+  # It doesn't require any of pkgs, but still uses nix module type system.
+  shellArgs = opts: {
+    type = let
+      singleValue = [
+        bool
+        float
+        int
+        path
+        str
+      ];
+      valueType = oneOf (singleValue ++ [
+        (listOf (oneOf singleValue))
+      ]) // {
+        description = "Shell argument value";
+      };
+    in attrsOf valueType;
+    generateSystemd = attrs: lib.generators.mkShellArguments (opts // {argSep = "\\\n";}) attrs;
+  };
 }

--- a/pkgs/servers/sql/postgresql/14_neon.nix
+++ b/pkgs/servers/sql/postgresql/14_neon.nix
@@ -1,0 +1,19 @@
+let
+  neonRev = "2155cb165d05f617eb2c8ad7e43367189b627703";
+  base = import ./generic.nix {
+    version = "14.18";
+    rev = neonRev;
+    hash = "";
+  };
+in
+{ self, ... }@args:
+(base (args // { jitSupport = false; })).overrideAttrs (prev: {
+  pname = "postgresql-neon";
+  src = self.fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "postgres";
+    rev = neonRev;
+    hash = "sha256-bPAHFkkNB0J9fimYJ2RYflN1zOGsAcOD0VHGfMEex7g=";
+  };
+  doInstallCheck = false;
+})

--- a/pkgs/servers/sql/postgresql/15_neon.nix
+++ b/pkgs/servers/sql/postgresql/15_neon.nix
@@ -1,0 +1,19 @@
+let
+  neonRev = "2aaab3bb4a13557aae05bb2ae0ef0a132d0c4f85";
+  base = import ./generic.nix {
+    version = "15.13";
+    rev = neonRev;
+    hash = "";
+  };
+in
+{ self, ... }@args:
+(base (args // { jitSupport = false; })).overrideAttrs (prev: {
+  pname = "postgresql-neon";
+  src = self.fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "postgres";
+    rev = neonRev;
+    hash = "sha256-E+a7OsB7doDqGs9dwWhmD+fO1dgYB1nDvB33EDGl7gc=";
+  };
+  doInstallCheck = false;
+})

--- a/pkgs/servers/sql/postgresql/16_neon.nix
+++ b/pkgs/servers/sql/postgresql/16_neon.nix
@@ -1,0 +1,19 @@
+let
+  neonRev = "a42351fcd41ea01edede1daed65f651e838988fc";
+  base = import ./generic.nix {
+    version = "16.9";
+    rev = neonRev;
+    hash = "";
+  };
+in
+{ self, ... }@args:
+(base (args // { jitSupport = false; })).overrideAttrs (prev: {
+  pname = "postgresql-neon";
+  src = self.fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "postgres";
+    rev = neonRev;
+    hash = "sha256-G1FsFBeVFxUotk4b6oAYPz/DCjXCnirXQBZA77eaeIg=";
+  };
+  doInstallCheck = false;
+})

--- a/pkgs/servers/sql/postgresql/17_neon.nix
+++ b/pkgs/servers/sql/postgresql/17_neon.nix
@@ -1,0 +1,19 @@
+let
+  neonRev = "1e01fcea2a6b38180021aa83e0051d95286d9096";
+  base = import ./generic.nix {
+    version = "17.5";
+    rev = neonRev;
+    hash = "";
+  };
+in
+{ self, ... }@args:
+(base (args // { jitSupport = false; })).overrideAttrs (prev: {
+  pname = "postgresql-neon";
+  src = self.fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "postgres";
+    rev = neonRev;
+    hash = "sha256-/IjOnB8PUYpwqTmPPXhihSulIZsUf7uBx8HXSIlArM0=";
+  };
+  doInstallCheck = false;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7584,6 +7584,11 @@ with pkgs;
     postgresql_19
     ;
 
+  postgresql_14_neon = import ../servers/sql/postgresql/14_neon.nix { self = pkgs; };
+  postgresql_15_neon = import ../servers/sql/postgresql/15_neon.nix { self = pkgs; };
+  postgresql_16_neon = import ../servers/sql/postgresql/16_neon.nix { self = pkgs; };
+  postgresql_17_neon = import ../servers/sql/postgresql/17_neon.nix { self = pkgs; };
+
   inherit (postgresqlJitVersions)
     postgresql_14_jit
     postgresql_15_jit


### PR DESCRIPTION
## Description of changes

Neon is a serverless open-source alternative to AWS Aurora Postgres. It separates storage and compute and substitutes the PostgreSQL storage layer by redistributing data across a cluster of nodes.

https://neon.tech/

Note that neondb will not work with standard postgresql included in nixpkgs, neondb-specific postgres fork and extensions will be added in further PRs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Fixes: https://github.com/NixOS/nixpkgs/issues/256202

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
