### PR TITLE
snakemake: 7.32.4 -> 8.0.1

### DIFF
--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -1,19 +1,27 @@
 { lib
 , fetchFromGitHub
 , python3
+, runtimeShell
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "snakemake";
-  version = "7.32.4";
+  version = "8.0.1";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "snakemake";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-9KuMPqvM8ZCTuomc0R9MBxsK3KIpukDTrlwU6MHysK0=";
+    hash = "sha256-F4c/lgp7J6LLye+f3FpzaXz3zM7R+jXxTziPlVbxFxA=";
   };
+
+  postPatch = ''
+    patchShebangs --build tests/
+    patchShebangs --host snakemake/executors/jobscript.sh
+    substituteInPlace snakemake/shell.py \
+      --replace "/bin/sh" "${runtimeShell}"
+  '';
 
   propagatedBuildInputs = with python3.pkgs; [
     appdirs
@@ -23,6 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     docutils
     gitpython
     humanfriendly
+    immutables
     jinja2
     jsonschema
     nbformat
@@ -32,6 +41,9 @@ python3.pkgs.buildPythonApplication rec {
     requests
     reretry
     smart-open
+    snakemake-interface-executor-plugins
+    snakemake-interface-common
+    snakemake-interface-storage-plugins
     stopit
     tabulate
     throttler
@@ -46,30 +58,28 @@ python3.pkgs.buildPythonApplication rec {
   # setup.
 
   nativeCheckInputs = with python3.pkgs; [
+    numpy
     pandas
     pytestCheckHook
     requests-mock
-    pillow
+    snakemake-executor-plugin-cluster-generic
   ];
 
   disabledTestPaths = [
-    "tests/test_slurm.py"
-    "tests/test_tes.py"
-    "tests/test_tibanna.py"
-    "tests/test_linting.py"
-    "tests/test_google_lifesciences.py"
-    "tests/test_conda_python_script/test_script.py"
+    "tests/test_conda_python_3_7_script/test_script.py"
   ];
 
   disabledTests = [
-    # Tests require network access
-    "test_github_issue1396"
-    "test_github_issue1460"
+    "test_deploy_sources"
   ];
 
   pythonImportsCheck = [
     "snakemake"
   ];
+
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
 
   meta = with lib; {
     homepage = "https://snakemake.github.io";

--- a/pkgs/development/python-modules/snakemake-executor-plugin-cluster-generic/default.nix
+++ b/pkgs/development/python-modules/snakemake-executor-plugin-cluster-generic/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, snakemake-interface-executor-plugins
+, snakemake-interface-common
+}:
+
+buildPythonPackage rec {
+  pname = "snakemake-executor-plugin-cluster-generic";
+  version = "1.0.7";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-1W/8jf+R1798cu3sWI0LTSyVawtmFfwlAqRHwfmIAzU=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    snakemake-interface-executor-plugins
+    snakemake-interface-common
+  ];
+
+  pythonImportsCheck = [ "snakemake_executor_plugin_cluster_generic" ];
+
+  meta = with lib; {
+    description = "Generic cluster executor for Snakemake";
+    homepage = "https://github.com/snakemake/snakemake-executor-plugin-cluster-generic/tags";
+    license = licenses.mit;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/snakemake-interface-common/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-common/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, argparse-dataclass
+, ConfigArgParse
+}:
+
+buildPythonPackage rec {
+  pname = "snakemake-interface-common";
+  version = "1.15.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Rf2eMkRvkTCR2swB53ekjv8U8DzTPgjhIkBVrn6gTTI=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    argparse-dataclass
+    ConfigArgParse
+  ];
+
+  pythonImportsCheck = [ "snakemake_interface_common" ];
+
+  meta = with lib; {
+    description = "Common functions and classes for Snakemake and its plugins";
+    homepage = "https://github.com/snakemake/snakemake-interface-common";
+    license = licenses.mit;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/snakemake-interface-executor-plugins/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-executor-plugins/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, argparse-dataclass
+, throttler
+, snakemake-interface-common
+}:
+
+buildPythonPackage rec {
+  pname = "snakemake-interface-executor-plugins";
+  version = "8.1.3";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-QBLdqhR6WrO/zT0Ux5xcUtr5HbrDy91qiWuSjAA5c3E=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    argparse-dataclass
+    throttler
+    snakemake-interface-common
+  ];
+
+  pythonImportsCheck = [ "snakemake_interface_executor_plugins" ];
+
+  meta = with lib; {
+    description = "This package provides a stable interface for interactions between Snakemake and its executor plugins";
+    homepage = "https://github.com/snakemake/snakemake-interface-executor-plugins";
+    license = licenses.mit;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/snakemake-interface-storage-plugins/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-storage-plugins/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, reretry
+, snakemake-interface-common
+, throttler
+, wrapt
+, snakemake
+}:
+
+buildPythonPackage rec {
+  pname = "snakemake-interface-storage-plugins";
+  version = "3.0.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-MinqSMpBlp3pCgQxorkMdrJuO0GExJsO02kg2/mGsFw=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    reretry
+    snakemake-interface-common
+    throttler
+    wrapt
+  ];
+
+  pythonImportsCheck = [ "snakemake_interface_storage_plugins" ];
+
+  meta = with lib; {
+    description = "This package provides a stable interface for interactions between Snakemake and its storage plugins";
+    homepage = "https://github.com/snakemake/snakemake-interface-storage-plugins";
+    license = licenses.mit;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13278,6 +13278,8 @@ self: super: with self; {
 
   snakemake-interface-common = callPackage ../development/python-modules/snakemake-interface-common { };
 
+  snakemake-interface-executor-plugins = callPackage ../development/python-modules/snakemake-interface-executor-plugins { };
+
   snakebite = callPackage ../development/python-modules/snakebite { };
 
   snakeviz = callPackage ../development/python-modules/snakeviz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13276,6 +13276,8 @@ self: super: with self; {
     inherit (self) python;
   });
 
+  snakemake-interface-common = callPackage ../development/python-modules/snakemake-interface-common { };
+
   snakebite = callPackage ../development/python-modules/snakebite { };
 
   snakeviz = callPackage ../development/python-modules/snakeviz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13280,6 +13280,8 @@ self: super: with self; {
 
   snakemake-interface-executor-plugins = callPackage ../development/python-modules/snakemake-interface-executor-plugins { };
 
+  snakemake-interface-storage-plugins = callPackage ../development/python-modules/snakemake-interface-storage-plugins { };
+
   snakebite = callPackage ../development/python-modules/snakebite { };
 
   snakeviz = callPackage ../development/python-modules/snakeviz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13276,6 +13276,8 @@ self: super: with self; {
     inherit (self) python;
   });
 
+  snakemake-executor-plugin-cluster-generic = callPackage ../development/python-modules/snakemake-executor-plugin-cluster-generic { };
+
   snakemake-interface-common = callPackage ../development/python-modules/snakemake-interface-common { };
 
   snakemake-interface-executor-plugins = callPackage ../development/python-modules/snakemake-interface-executor-plugins { };


### PR DESCRIPTION
## Description of changes

New snakemake 8.x release that transitioned to a plugin architecture

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
