### PR TITLE
soci: fix darwin build

### DIFF
--- a/pkgs/development/libraries/soci/default.nix
+++ b/pkgs/development/libraries/soci/default.nix
@@ -4,9 +4,12 @@
 , sqlite
 , postgresql
 , boost
+, darwin
 , lib, stdenv
 }:
-
+let
+  inherit (darwin.apple_sdk_11_0.frameworks) Kerberos;
+in
 stdenv.mkDerivation rec {
   pname = "soci";
   version = "4.0.2";
@@ -34,6 +37,8 @@ stdenv.mkDerivation rec {
     sqlite
     postgresql
     boost
+  ] ++ lib.optionals stdenv.isDarwin [
+    Kerberos
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This is a draft PR to fix current `soci` in nixpkgs for `aarch64-darwin`, which currently fails, with this message. I found this issue while working on a local branch to fix [nixpkgs rstudio](https://github.com/NixOS/nixpkgs/blob/54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6/pkgs/applications/editors/rstudio/default.nix#L102) for the same architecture. Please note this is my first PR. Happy to adapt according to your tips :-)

```sh
ld: file not found: /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos for architecture arm64
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Things done

- added `darwin.apple_sdk_11_0.frameworks` to `nativeBuildInputs`. 

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
