### PR TITLE
python311Packages.aiohttp-zlib-ng: 0.1.1 -> 0.1.2, python311Packages.cpufeature: init at 0.2.1 

### DIFF
--- a/pkgs/development/python-modules/aiohttp-zlib-ng/default.nix
+++ b/pkgs/development/python-modules/aiohttp-zlib-ng/default.nix
@@ -1,22 +1,32 @@
 { lib
+, aiohttp
 , buildPythonPackage
+, cpufeature
 , fetchFromGitHub
 , poetry-core
-, aiohttp
+, pytestCheckHook
+, pythonOlder
 , zlib-ng
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp-zlib-ng";
-  version = "0.1.1";
+  version = "0.1.2";
   pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = "aiohttp-zlib-ng";
-    rev = "v${version}";
-    hash = "sha256-dTNwt4eX6ZQ8ySK2/9ziVbc3KFg2aL/EsiBWaJRC4x8=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-lSzBmEgYrWKthpgceFn9LjsNw/ByPOrdPwVI8WU0Cvo=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov=aiohttp_zlib_ng --cov-report=term-missing:skip-covered" ""
+  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -24,16 +34,23 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiohttp
+    cpufeature
     zlib-ng
   ];
 
-  pythonImportsCheck = [ "aiohttp_zlib_ng" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "aiohttp_zlib_ng"
+  ];
 
   meta = with lib; {
     description = "Enable zlib_ng on aiohttp";
     homepage = "https://github.com/bdraco/aiohttp-zlib-ng";
-    changelog = "https://github.com/bdraco/aiohttp-zlib-ng/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/bdraco/aiohttp-zlib-ng/blob/${version}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/cpufeature/default.nix
+++ b/pkgs/development/python-modules/cpufeature/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, unittestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "cpufeature";
+  version = "0.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "robbmcleod";
+    repo = "cpufeature";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dp569Tp8E5/avQpYvhPNPgS/A+q2e/ie+7BR7h2Ip+I=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "cpufeature"
+  ];
+
+  preCheck = ''
+    # Change into the test directory due to a relative resource path
+    cd cpufeature
+  '';
+
+  meta = with lib; {
+    description = "Python module for detection of CPU features";
+    homepage = "https://github.com/robbmcleod/cpufeature";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2380,6 +2380,8 @@ self: super: with self; {
 
   cppy = callPackage ../development/python-modules/cppy { };
 
+  cpufeature = callPackage ../development/python-modules/cpufeature { };
+
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
   cram = callPackage ../development/python-modules/cram { };


### PR DESCRIPTION
Diff: https://github.com/bdraco/aiohttp-zlib-ng/compare/v0.1.1...v0.1.2

Changelog: https://github.com/bdraco/aiohttp-zlib-ng/blob/v0.1.2/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
