### PR TITLE
nixos/kubernetes: fix pki's mkSpec function

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -220,7 +220,6 @@ in
             inherit (cert) action;
             authority = {
               inherit remote;
-              file.path = cert.caCert;
               root_ca = cert.caCert;
               profile = "default";
               auth_key_file = certmgrAPITokenPath;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

On nixos-unstable, the kubernetes deployment currently fails with `services.kubernetes.easyCerts = true`, due to the certmgr service failing with the following log:

```
Dec 21 21:20:52 default certmgr[1731]: time="2023-12-21T21:20:52+01:00" level=fatal msg="certmgr: while loading spec /nix/store/mgds21pm444v1ff8hs44f15q3rnqm3p6-certmgr.d/apiServer.json: pathway /var/lib/kubernetes/secrets/ca.pem is already managed by spec /nix/store/mgds21pm444v1ff8hs44f15q3rnqm3p6-certmgr.d/addonManager.json
```

Removing the `authority.file.path` field for all specs resolvs this issue. The `authority.file.path` field of a cert spec is [defined as follows](https://github.com/cloudflare/certmgr/tree/v3.0.3#pki-specs):

> if this is included, the CA certificate will be saved here. It follows the same file specification format above. Use this if you want to save your CA cert to disk.

So certmgr fails, because each certmgr spec (apiserver, addonManager, ...) wants to manage the file at the `cert.caCert` location. However, the `authority.file.path` field is not needed for generating a certificate, as the certificate is generated by the CA, which is reachable at `authority.remote` (e.g. https://localhost:8888 with `easyCerts = true`). The `authority.file.path` field just saves the certificate of the CA to disk, which is already known and passed to certmgr using the `authority.root_ca` field.

I also ran the nixosTests with this patch and they all went throught. I also ran the tests with the current nixos-unstable branch, and the kube-* systemd services are continuously failing without recovering, because certmgr is continuously failing.