### PR TITLE
rsgain: init at 3.4 and added myself as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7859,6 +7859,12 @@
     githubId = 36667224;
     name = "Yingchi Long";
   };
+  incrediblelaser = {
+    email = "gereon.schomber@gmail.com";
+    github = "IncredibleLaser";
+    githubId = 45564436;
+    name = "Gereon Schomber";
+  };
   indexyz = {
     email = "indexyz@pm.me";
     github = "5aaee9";

--- a/pkgs/by-name/rs/rsgain/package.nix
+++ b/pkgs/by-name/rs/rsgain/package.nix
@@ -1,0 +1,35 @@
+{ lib
+  , stdenv
+  , cmake
+  , fetchFromGitHub
+  , libebur128
+  , taglib
+  , ffmpeg
+  , inih
+  , fmt
+  , pkg-config
+  , zlib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rsgain";
+  version = "3.4";
+
+  src = fetchFromGitHub {
+    owner = "complexlogic";
+    repo = finalAttrs.pname;
+    rev = "v" + finalAttrs.version;
+    hash = "sha256-AiNjsrwTF6emcwXo2TPMbs8mLavGS7NsvytAppMGKfY=";
+  };
+
+  buildInputs = [ ffmpeg inih taglib libebur128 zlib fmt ];
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = with lib; {
+    description = "A ReplayGain 2.0 command line utility";
+    homepage = "https://github.com/complexlogic/rsgain";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.incrediblelaser ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Created a derivation for https://github.com/complexlogic/rsgain and added myself as maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The resulting binary successfully analyzed an album and wrote the appropriate tags.

I have added myself as a maintainer to both this package and to `maintainer-list.nix`.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
