### PR TITLE
vulkan-helper: fix build on aarch64

### DIFF
--- a/pkgs/tools/graphics/vulkan-helper/default.nix
+++ b/pkgs/tools/graphics/vulkan-helper/default.nix
@@ -22,6 +22,12 @@ rustPlatform.buildRustPackage rec {
     addOpenGLRunpath
   ];
 
+  patches = [
+    # Can be removed as soon as this PR is merged:
+    # https://github.com/imLinguin/vulkan-helper-rs/pull/3
+    ./fix-aarch64-build.patch
+  ];
+
   postFixup = ''
     patchelf --add-rpath ${vulkan-loader}/lib $out/bin/vulkan-helper
     addOpenGLRunpath $out/bin/vulkan-helper

--- a/pkgs/tools/graphics/vulkan-helper/fix-aarch64-build.patch
+++ b/pkgs/tools/graphics/vulkan-helper/fix-aarch64-build.patch
@@ -1,0 +1,48 @@
+From 577400410cb7da220ab2e91c3a5ba861ccf2feca Mon Sep 17 00:00:00 2001
+From: Manuel Frischknecht <manuel.frischknecht@gmail.com>
+Date: Thu, 21 Dec 2023 22:14:09 +0000
+Subject: [PATCH] Fix build on aarch64
+
+`ash::vk::ApplicationInfo` [1] actually uses `*const c_char` as a type
+for its string fields, and the underlying type of `libc::c_char` varies on
+different architectures.
+
+Because of this, the application currently builds fine on x64 (where
+`c_char` is `i8`) but fails on aarch64 (where `c_char` is `u8` instead).
+
+[1]: https://docs.rs/ash/latest/ash/vk/struct.ApplicationInfo.html
+---
+ src/main.rs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index a26ddef..59bb38e 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,7 +1,7 @@
+ use ash::{vk, Entry};
+ use clap::{Parser, Subcommand};
+ use serde::{Deserialize, Serialize};
+-use libc::{c_void, dlopen, dlinfo, RTLD_NOW, RTLD_DI_LINKMAP, dlerror, dlclose};
++use libc::{c_void, c_char, dlopen, dlinfo, RTLD_NOW, RTLD_DI_LINKMAP, dlerror, dlclose};
+ use std::ffi::{CString, CStr};
+ use std::ptr::null_mut;
+ use std::mem::transmute;
+@@ -19,7 +19,7 @@ struct Device {
+ #[repr(C)]
+ struct LinkMap {
+     l_addr: *mut c_void,
+-    l_name: *mut i8,
++    l_name: *mut c_char,
+     l_ld: *mut c_void,
+     l_next: *mut LinkMap,
+     l_prev: *mut LinkMap,
+@@ -42,7 +42,7 @@ fn get_physical_versions() -> Vec<Device> {
+     let entry = unsafe { Entry::load() }.expect("Failed to load vulkan");
+ 
+     let app_info = vk::ApplicationInfo {
+-        p_application_name: APP_NAME.as_ptr() as *const i8,
++        p_application_name: APP_NAME.as_ptr() as *const c_char,
+         application_version: vk::make_api_version(0, 1, 0, 0),
+         api_version: vk::make_api_version(0, 1, 3, 0),
+         ..Default::default()


### PR DESCRIPTION
`vulkan-helper` constructs a C string using an explicit `*const i8` pointer, which isn't correct for all architectures. While this builds fine for x64, on aarch64 `c_char` is defined as `u8`, causing compilation errors.

This change introduces a patch for this issue I have submitted as an upstream PR [^1] until said PR is hopefully accepted.

[^1]: https://github.com/imLinguin/vulkan-helper-rs/pull/3

## Description of changes

Add a patch fixing the type of a C string field that breaks aarcht64 builds.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
