### PR TITLE
julia.withPackages: add thomasjm as maintainer

### DIFF
--- a/pkgs/development/compilers/julia/1.6-bin.nix
+++ b/pkgs/development/compilers/julia/1.6-bin.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     homepage = "https://julialang.org";
     # Bundled and linked with various GPL code, although Julia itself is MIT.
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = with lib.maintainers; [ raskin thomasjm ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "julia";
   };

--- a/pkgs/development/compilers/julia/1.8-bin.nix
+++ b/pkgs/development/compilers/julia/1.8-bin.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     homepage = "https://julialang.org";
     # Bundled and linked with various GPL code, although Julia itself is MIT.
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ raskin nickcao wegank ];
+    maintainers = with lib.maintainers; [ raskin nickcao wegank thomasjm ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     mainProgram = "julia";
   };

--- a/pkgs/development/compilers/julia/1.8.nix
+++ b/pkgs/development/compilers/julia/1.8.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "https://julialang.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ nickcao ];
+    maintainers = with maintainers; [ nickcao thomasjm ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/development/compilers/julia/1.9-bin.nix
+++ b/pkgs/development/compilers/julia/1.9-bin.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
     homepage = "https://julialang.org";
     # Bundled and linked with various GPL code, although Julia itself is MIT.
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ raskin nickcao wegank ];
+    maintainers = with lib.maintainers; [ raskin nickcao wegank thomasjm ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     mainProgram = "julia";
   };

--- a/pkgs/development/compilers/julia/1.9.nix
+++ b/pkgs/development/compilers/julia/1.9.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "https://julialang.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ nickcao joshniemela ];
+    maintainers = with maintainers; [ nickcao joshniemela thomasjm ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -170,6 +170,7 @@ runCommand "julia-${julia.version}-env" {
 
   inherit julia;
   inherit juliaWrapped;
+  meta = julia.meta;
 
   # Expose the steps we used along the way in case the user wants to use them, for example to build
   # expressions and build them separately to avoid IFD.


### PR DESCRIPTION
## Description of changes

I wanted to add myself as maintainer for the `julia.withPackages` stuff. Hopefully this is a good way to do so. I tested it in the Nix repl for all the current Julia versions.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
