### PR TITLE
Test `pkgs/by-name` ratchet check and remove unneeded definition in `all-packages.nix`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27431,8 +27431,6 @@ with pkgs;
 
   tailscale = callPackage ../servers/tailscale { };
 
-  tailscale-nginx-auth = callPackage ../by-name/ta/tailscale-nginx-auth/package.nix { };
-
   tailscale-systray = callPackage ../applications/misc/tailscale-systray { };
 
   tailspin = callPackage ../tools/misc/tailspin { };


### PR DESCRIPTION
## Description of changes

This PR does two things:
- It tests the new [ratchet check](https://github.com/NixOS/nixpkgs/tree/master/pkgs/test/nixpkgs-check-by-name#ratchet-checks) for `pkgs/by-name`, which disallows _new_ manual definitions of the form `callPackage ../by-name/... { }` (note the empty attribute set)
  - This is done with an initial commit that adds such a definition. CI should fail
- After confirming CI fails, and only for the new attribute, a commit is force pushed to remove the only existing attribute that uses such a definition. CI allows this, but future PR's won't be able to re-add it again.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
