### PR TITLE
cudaPackages: replace the FHS paths in pkg-config files

### DIFF
--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -44,6 +44,7 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
 
   cuda_cudart = prev.cuda_cudart.overrideAttrs (
     prevAttrs: {
+      allowFHSReferences = false;
 
       # The libcuda stub's pkg-config doesn't follow the general pattern:
       postPatch = prevAttrs.postPatch or "" + ''

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -1,4 +1,4 @@
-{cudaVersion, lib}:
+{cudaVersion, lib, addDriverRunpath}:
 let
   inherit (lib) attrsets lists strings;
   # cudaVersionOlder : Version -> Boolean
@@ -41,6 +41,20 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
   libcusparse = addBuildInputs prev.libcusparse (
     lists.optionals (cudaVersionAtLeast "12.0") [final.libnvjitlink.lib]
   );
+
+  cuda_cudart = prev.cuda_cudart.overrideAttrs (
+    prevAttrs: {
+
+      # The libcuda stub's pkg-config doesn't follow the general pattern:
+      postPatch = prevAttrs.postPatch or "" + ''
+        while IFS= read -r -d $'\0' path ; do
+          sed -i \
+            -e "s|^libdir\s*=.*/lib\$|libdir=''${!outputLib}/lib/stubs|" \
+            -e "s|^Libs\s*:\(.*\)\$|Libs: \1 -Wl,-rpath,${addDriverRunpath.driverLink}/lib|" \
+            "$path"
+        done < <(find -iname 'cuda-*.pc' -print0)
+      '';
+    });
 
   cuda_compat = prev.cuda_compat.overrideAttrs (
     prevAttrs: {

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -115,7 +115,10 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
           moveToOutput "nvvm" "''${!outputBin}"
         '';
 
-      meta = (oldAttrs.meta or {}) // {
+      # The nvcc and cicc binaries contain hard-coded references to /usr
+      allowFHSReferences = true;
+
+      meta = (oldAttrs.meta or { }) // {
         mainProgram = "nvcc";
       };
     }

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -219,7 +219,7 @@ backendStdenv.mkDerivation (
       '';
 
     doInstallCheck = true;
-    allowFHSReferences = false;
+    allowFHSReferences = true; # TODO: Default to `false`
     postInstallCheck = ''
       echo "Executing postInstallCheck"
 


### PR DESCRIPTION
Cf. https://github.com/NixOS/nixpkgs/issues/224119

@NixOS/cuda-maintainers 

## Description of changes

- [x] Generically replace `libdir = /usr/local/whatever` with `libdir = ${!outputLib}`, etc
- [x] Test if any FHS references remained
  - [ ] See if any of the cudaPackages violate that test
- [x] Fix the libcuda pkg-config ad hoc

```bash
❯ nix build -f ./. --arg config '{ cudaSupport = true; cudaCapabilities = [ "8.6" ]; cudaEnableForwardCompat = false; allowUnfree = true; }' -L cudaPackages.cuda_cudart.dev
❯ cat result-dev/share/pkg-config/cuda-11.8.pc 
cudaroot=/nix/store/45366qi6nxycj2x195n7qshma0dkyq8j-cuda_cudart-11.8.89-dev
libdir=/nix/store/aqm4p2f28bas1zy2fk0kf4spmf29ywq8-cuda_cudart-11.8.89-lib/lib/stubs
includedir=/nix/store/45366qi6nxycj2x195n7qshma0dkyq8j-cuda_cudart-11.8.89-dev/include

Name: cuda
Description: CUDA Driver Library
Version: 11.8
Libs:  -L${libdir} -lcuda -Wl,-rpath,/run/opengl-driver/lib
Cflags: -I${includedir}
❯ cat result-dev/share/pkg-config/cudart-11.8.pc 
cudaroot=/nix/store/45366qi6nxycj2x195n7qshma0dkyq8j-cuda_cudart-11.8.89-dev
libdir=/nix/store/aqm4p2f28bas1zy2fk0kf4spmf29ywq8-cuda_cudart-11.8.89-lib/lib
includedir=/nix/store/45366qi6nxycj2x195n7qshma0dkyq8j-cuda_cudart-11.8.89-dev/include

Name: cudart
Description: CUDA Runtime Library
Version: 11.8
Libs: -L${libdir} -lcudart
Cflags: -I${includedir}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
