### PR TITLE
cudaPackages.cuda_nvcc: patch nvcc.profile

### DIFF
--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -64,6 +64,15 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
 
       outputs = oldAttrs.outputs ++ [ "lib" ];
 
+      # Patch the nvcc.profile.
+      # Syntax:
+      # - `=` for assignment,
+      # - `?=` for conditional assignment,
+      # - `+=` to "prepend",
+      # - `=+` to "append".
+
+      # Cf. https://web.archive.org/web/20230308044351/https://arcb.csc.ncsu.edu/~mueller/cluster/nvidia/2.0/nvcc_2.0.pdf
+
       postPatch =
         (oldAttrs.postPatch or "")
         + ''

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -73,17 +73,37 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
 
       # Cf. https://web.archive.org/web/20230308044351/https://arcb.csc.ncsu.edu/~mueller/cluster/nvidia/2.0/nvcc_2.0.pdf
 
+      # We set all variables with the lowest priority (=+), but we do force
+      # nvcc to use the fixed backend toolchain. Cf. comments in
+      # backend-stdenv.nix
+
       postPatch =
         (oldAttrs.postPatch or "")
         + ''
           substituteInPlace bin/nvcc.profile \
             --replace \
               '$(TOP)/lib' \
-              "''${!outputLib}/lib"
+              "''${!outputLib}/lib" \
+            --replace \
+              '$(TOP)/$(_NVVM_BRANCH_)' \
+              "''${!outputBin}/nvvm" \
+            --replace \
+              '$(TOP)/$(_TARGET_DIR_)/include' \
+              "''${!outputDev}/include"
 
           cat << EOF >> bin/nvcc.profile
-          LIBRARIES +=  "-L''${!outputBin}/nvvm/lib" "-L$static/lib" "-L${final.cuda_cudart.lib}/lib" "-L${final.cuda_cudart.lib}/lib/stubs"
-          INCLUDES += "-I''${!outputDev}/include" "-I''${!outputBin}/nvvm/include" "-I${final.cuda_cudart.dev}/include"
+
+          # Fix a compatible backend compiler
+          PATH += ${lib.getBin final.backendStdenv.cc}/bin:
+          LIBRARIES += "-L${lib.getLib final.backendStdenv.nixpkgsCompatibleLibstdcxx}/lib"
+
+          # Expose the split-out nvvm
+          LIBRARIES =+ -L''${!outputBin}/nvvm/lib
+          INCLUDES =+ -I''${!outputBin}/nvvm/include
+
+          # Expose cudart and the libcuda stubs
+          LIBRARIES =+ -L$static/lib" "-L${final.cuda_cudart.lib}/lib -L${final.cuda_cudart.lib}/lib/stubs
+          INCLUDES =+ -I${final.cuda_cudart.dev}/include
           EOF
         '';
 

--- a/pkgs/development/cuda-modules/saxpy/default.nix
+++ b/pkgs/development/cuda-modules/saxpy/default.nix
@@ -14,6 +14,7 @@ let
     cudaVersion
     flags
     libcublas
+    setupCudaHook
     ;
 in
 backendStdenv.mkDerivation {

--- a/pkgs/development/cuda-modules/setup-hooks/setup-cuda-hook.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/setup-cuda-hook.sh
@@ -93,26 +93,6 @@ setupCUDAToolkitCompilers() {
     if [[ -z "${dontCompressFatbin-}" ]]; then
         export NVCC_PREPEND_FLAGS+=" -Xfatbin=-compress-all"
     fi
-
-    # CMake's enable_language(CUDA) runs a compiler test and it doesn't account for
-    # CUDAToolkit_ROOT. We have to help it locate libcudart
-    if [[ -z "${nvccDontPrependCudartFlags-}" ]] ; then
-        if [[ ! -v cudaOutputToPath["cuda_cudart-out"] ]] ; then
-            echo "setupCUDAToolkitCompilers: missing cudaPackages.cuda_cudart. This may become an an error in the future" >&2
-            # exit 1
-        fi
-        for pkg in "${!cudaOutputToPath[@]}" ; do
-            [[ ! "$pkg" = cuda_cudart* ]] && continue
-
-            local path="${cudaOutputToPath[$pkg]}"
-            if [[ -d "$path/include" ]] ; then
-                export NVCC_PREPEND_FLAGS+=" -I$path/include"
-            fi
-            if [[ -d "$path/lib" ]] ; then
-                export NVCC_PREPEND_FLAGS+=" -L$path/lib"
-            fi
-        done
-    fi
 }
 preConfigureHooks+=(setupCUDAToolkitCompilers)
 


### PR DESCRIPTION
let nvcc know about cudart and the stub drivers; this way we do not need to search for cudart in the setupCudaHook. This shouldn't (I hope) matter for `cudaPackages.cudatoolkit` because it's got its merged layout

@NixOS/cuda-maintainers 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
