### PR TITLE
fstar: build with dune

### DIFF
--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     removeReferencesTo
   ];
 
-  propagatedBuildInputs = fstarDune.buildInputs;
+  inherit (fstarDune) propagatedBuildInputs;
 
   dontBuild = true;
 

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation {
     removeReferencesTo
   ];
 
+  propagatedBuildInputs = fstarDune.buildInputs;
+
   dontBuild = true;
 
   installPhase = ''

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -21,9 +21,9 @@ let
     hash = "sha256-ymoP5DvaLdrdwJcnhZnLEvwNxUFzhkICajPyK4lvacc=";
   };
 
-  fstarDune = ocamlPackages.callPackage ./dune.nix { inherit version src; };
+  fstar-dune = ocamlPackages.callPackage ./dune.nix { inherit version src; };
 
-  fstarLib = callPackage ./ulib.nix { inherit version src fstarDune z3; };
+  fstar-ulib = callPackage ./ulib.nix { inherit version src fstar-dune z3; };
 
 in
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     removeReferencesTo
   ];
 
-  inherit (fstarDune) propagatedBuildInputs;
+  inherit (fstar-dune) propagatedBuildInputs;
 
   dontBuild = true;
 
@@ -45,8 +45,8 @@ stdenv.mkDerivation {
     mkdir $out
 
     CP="cp -r --no-preserve=mode"
-    $CP ${fstarDune}/* $out
-    $CP ${fstarLib}/* $out
+    $CP ${fstar-dune}/* $out
+    $CP ${fstar-ulib}/* $out
 
     PREFIX=$out make -C src/ocaml-output install-sides
 
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
     remove-references-to -t '${ocamlPackages.ocaml}' $out/bin/fstar.exe
 
     substituteInPlace $out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/fstar/dune-package \
-      --replace ${fstarDune} $out
+      --replace ${fstar-dune} $out
 
     installShellCompletion --bash .completion/bash/fstar.exe.bash
     installShellCompletion --fish .completion/fish/fstar.exe.fish

--- a/pkgs/development/compilers/fstar/dune.nix
+++ b/pkgs/development/compilers/fstar/dune.nix
@@ -1,0 +1,50 @@
+{ batteries
+, buildDunePackage
+, memtrace
+, menhir
+, menhirLib
+, pprint
+, ppx_deriving
+, ppx_deriving_yojson
+, ppxlib
+, process
+, sedlex
+, src
+, stdint
+, version
+, yojson
+, zarith
+}:
+
+buildDunePackage {
+  pname = "fstar";
+  inherit version src;
+
+  duneVersion = "3";
+
+  postPatch = ''
+    patchShebangs ocaml/fstar-lib/make_fstar_version.sh
+    cd ocaml
+  '';
+
+  nativeBuildInputs = [
+    menhir
+  ];
+
+  buildInputs = [
+    batteries
+    memtrace
+    menhirLib
+    pprint
+    ppx_deriving
+    ppx_deriving_yojson
+    ppxlib
+    process
+    sedlex
+    stdint
+    yojson
+    zarith
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/compilers/fstar/dune.nix
+++ b/pkgs/development/compilers/fstar/dune.nix
@@ -20,8 +20,6 @@ buildDunePackage {
   pname = "fstar";
   inherit version src;
 
-  duneVersion = "3";
-
   postPatch = ''
     patchShebangs ocaml/fstar-lib/make_fstar_version.sh
     cd ocaml

--- a/pkgs/development/compilers/fstar/dune.nix
+++ b/pkgs/development/compilers/fstar/dune.nix
@@ -32,8 +32,11 @@ buildDunePackage {
   ];
 
   buildInputs = [
-    batteries
     memtrace
+  ];
+
+  propagatedBuildInputs = [
+    batteries
     menhirLib
     pprint
     ppx_deriving

--- a/pkgs/development/compilers/fstar/ulib.nix
+++ b/pkgs/development/compilers/fstar/ulib.nix
@@ -1,0 +1,26 @@
+{ fstarDune
+, src
+, stdenv
+, version
+, z3
+}:
+
+stdenv.mkDerivation {
+  pname = "fstar-ulib";
+  inherit version src;
+
+  nativeBuildInputs = [
+    z3
+  ];
+
+  postPatch = ''
+    mkdir -p bin
+    cp ${fstarDune}/bin/fstar.exe bin
+    patchShebangs ulib/install-ulib.sh
+    cd ulib
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/compilers/fstar/ulib.nix
+++ b/pkgs/development/compilers/fstar/ulib.nix
@@ -1,4 +1,4 @@
-{ fstarDune
+{ fstar-dune
 , src
 , stdenv
 , version
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     mkdir -p bin
-    cp ${fstarDune}/bin/fstar.exe bin
+    cp ${fstar-dune}/bin/fstar.exe bin
     patchShebangs ulib/install-ulib.sh
     cd ulib
   '';


### PR DESCRIPTION
## Description of changes

Build F* with Dune, reflecting changes to the F* build process from a few months ago.
This splits the build into three derivations, one for the F* binary, one for the library and one for the complete package.

Should fix #275866 

cc @W95Psp who helped rework the F* flake, does this look good to you?

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
