### PR TITLE
backblaze-b2: add missing dependency setuptools

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -36,6 +36,7 @@ python3Packages.buildPythonApplication rec {
     tqdm
     platformdirs
     packaging
+    setuptools
   ];
 
   nativeCheckInputs = with python3Packages; [

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchPypi, installShellFiles }:
+{ lib, python3Packages, fetchPypi, installShellFiles, testers, backblaze-b2 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "backblaze-b2";
@@ -75,6 +75,15 @@ python3Packages.buildPythonApplication rec {
       --bash <(${python3Packages.argcomplete}/bin/register-python-argcomplete backblaze-b2) \
       --zsh <(${python3Packages.argcomplete}/bin/register-python-argcomplete backblaze-b2)
   '';
+
+  passthru.tests.version = (testers.testVersion {
+    package = backblaze-b2;
+    command = "backblaze-b2 version --short";
+  }).overrideAttrs (old: {
+    # workaround the error: Permission denied: '/homeless-shelter'
+    # backblaze-b2 fails to create a 'b2' directory under the XDG config path
+    HOME = "$(mktemp -d)";
+  });
 
   meta = with lib; {
     description = "Command-line tool for accessing the Backblaze B2 storage service";


### PR DESCRIPTION
## Description of changes

#274186 removed the input `setuptools` ([diff](https://github.com/NixOS/nixpkgs/pull/274186/files#diff-8276da915ad8fd63a703525ce27918b46c35a4c82c3f87d7455ab97423974ef5L33)), causing an error. Adding the dependency back fixes the error.

```console
$ nix run github:nixos/nixpkgs/pull/274186/head#backblaze-b2
Traceback (most recent call last):
  File "/nix/store/psn689pjsr8crngzb1sfl48b5044344z-backblaze-b2-3.15.0/bin/.backblaze-b2-wrapped", line 6, in <module>
    from b2.console_tool import main
  File "/nix/store/psn689pjsr8crngzb1sfl48b5044344z-backblaze-b2-3.15.0/lib/python3.11/site-packages/b2/console_tool.py", line 111, in <module>
    from class_registry import ClassRegistry
  File "/nix/store/wdkvzkhyyi2ng6syj56jrly3px4sn5vy-python3.11-class-registry-4.0.6/lib/python3.11/site-packages/class_registry/__init__.py", line 4, in <module>
    from .entry_points import *
  File "/nix/store/wdkvzkhyyi2ng6syj56jrly3px4sn5vy-python3.11-class-registry-4.0.6/lib/python3.11/site-packages/class_registry/entry_points.py", line 3, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
