### PR TITLE
julia.withPackages: update registry to fix missing hash for FiniteDiff.jl

### DIFF
--- a/pkgs/development/julia-modules/python/sources_nix.py
+++ b/pkgs/development/julia-modules/python/sources_nix.py
@@ -45,9 +45,13 @@ with open(out_path, "w") as f:
       path = registry_info["path"]
       packageToml = toml.load(registry_path / path / "Package.toml")
 
-      all_versions = toml.load(registry_path / path / "Versions.toml")
+      versions_toml = registry_path / path / "Versions.toml"
+      all_versions = toml.load(versions_toml)
       if not pkg["version"] in all_versions: continue
       version_to_use = all_versions[pkg["version"]]
+
+      if not "nix-sha256" in version_to_use:
+        raise KeyError(f"""Couldn't find nix-sha256 hash for {pkg["name"]} {pkg["version"]} in {versions_toml}. This might indicate that we failed to prefetch the hash when computing the augmented registry. Was there a relevant failure in {registry_path / "failures.yml"}?""")
 
       repo = packageToml["repo"]
       f.write(f"""  "{uuid}" = {{

--- a/pkgs/development/julia-modules/registry.nix
+++ b/pkgs/development/julia-modules/registry.nix
@@ -3,7 +3,7 @@
 fetchFromGitHub {
   owner = "CodeDownIO";
   repo = "General";
-  rev = "baf9e22ecdf97b6424a611ac4a565c6ee60d3f44";
-  sha256 = "1nd3x2z8r6578149pbpkx9qw2ajln1kfy7w5kjsnv56v180h0ddf";
-  # date = "2023-12-14T12:20:00+00:00";
+  rev = "de80ad56e87f222ca6a7a517c69039d35437ab42";
+  sha256 = "0pz1jmmcb2vn854w8w0zlpnihi470649cd8djh1wzgq2i2fy83bl";
+  # date = "2023-12-22T03:28:12+00:00";
 }


### PR DESCRIPTION
## Description of changes

This fixes #275802 by picking up an updated augmented registry. The previous one had failed to prefetch hashes for the `FiniteDiff.jl` package, which was needed by `DFTK.jl`.

This also adds an improved error message to point users to the source of missing hash problems.

CC @kilianar 

## Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
