### PR TITLE
stig: fix build, close #275914

### DIFF
--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -10,13 +10,13 @@ python3Packages.buildPythonApplication rec {
   pname = "stig";
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
-  version = "0.12.5a0";
+  version = "0.12.8a0";
 
   src = fetchFromGitHub {
     owner = "rndusr";
     repo = "stig";
     rev = "v${version}";
-    sha256 = "sha256-e27DBzing38llFxPIsMGkZJXp2q7jjFlQdtfsqLXNHw=";
+    sha256 = "sha256-vfmuA6DqWvAygcS6N+qX1h+Ag+P4eOwm41DhAFZR3r8=";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -1,12 +1,12 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, python3Packages
+, python310Packages
 , testers
 , stig
 }:
 
-python3Packages.buildPythonApplication rec {
+python310Packages.buildPythonApplication rec {
   pname = "stig";
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-vfmuA6DqWvAygcS6N+qX1h+Ag+P4eOwm41DhAFZR3r8=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python310Packages; [
     urwid
     urwidtrees
     aiohttp
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec {
     setproctitle
   ];
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = with python310Packages; [
     asynctest
     pytestCheckHook
   ];
@@ -41,16 +41,15 @@ python3Packages.buildPythonApplication rec {
     export LC_ALL=C
   '';
 
-  pytestFlagsArray = [
-    "tests"
-    # TestScrollBarWithScrollable.test_wrapping_bug fails
-    "--deselect=tests/tui_test/scroll_test.py::TestScrollBarWithScrollable::test_wrapping_bug"
-    # https://github.com/rndusr/stig/issues/214
-    "--deselect=tests/completion_test/classes_test.py::TestCandidates::test_candidates_are_sorted_case_insensitively"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "--deselect=tests/client_test/ttypes_test.py::TestTimestamp::test_string__month_day_hour_minute_second"
-    "--deselect=tests/client_test/aiotransmission_test/api_torrent_test.py"
-    "--deselect=tests/client_test/aiotransmission_test/rpc_test.py"
+  disabledTestPaths = [
+    # Almost all tests fail in this file, it is reported upstream in:
+    # https://github.com/rndusr/stig/issues/214 , and upstream fails to
+    # reproduce the issue unfortunately.
+    "tests/client_test/aiotransmission_test/api_settings_test.py"
+  ];
+  disabledTests = [
+    # Another failure with similar circumstances to the above
+    "test_candidates_are_sorted_case_insensitively"
   ];
 
   passthru.tests = testers.testVersion {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
