### PR TITLE
doc: update the appimageTools section content and examples

### DIFF
--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -1,7 +1,7 @@
 # pkgs.appimageTools {#sec-pkgs-appimageTools}
 
 `pkgs.appimageTools` is a set of functions for extracting and wrapping [AppImage](https://appimage.org/) files.
-They are meant to be used if traditional packaging from source is infeasible, or it would take too long.
+They are meant to be used if traditional packaging from source is infeasible, or if it would take too long.
 To quickly run an AppImage file, `pkgs.appimage-run` can be used as well.
 
 ::: {.warning}
@@ -19,7 +19,7 @@ This means that you can pass the `extraInstallCommands` attribute, for example, 
 
 ::: {.note}
 In the past, `appimageTools` provided both `wrapType1` and `wrapType2`, to be used depending on the type of AppImage that was being wrapped.
-However, since [early 2020](https://github.com/NixOS/nixpkgs/pull/81833) those were unified, meaning that both `wrapType1` and `wrapType2` have the same behaviour now.
+However, [those were unified early 2020](https://github.com/NixOS/nixpkgs/pull/81833), meaning that both `wrapType1` and `wrapType2` have the same behaviour now.
 :::
 
 :::{.example #ex-wrapping-appimage-from-github}
@@ -82,7 +82,7 @@ This is usually used in Nixpkgs to install extra files in addition to [wrapping]
 
 ::: {.note}
 In the past, `appimageTools` provided both `extractType1` and `extractType2`, to be used depending on the type of AppImage that was being extracted.
-However, since [early 2020](https://github.com/NixOS/nixpkgs/pull/81572) those were unified, meaning that both `extractType1` and `extractType2` have the same behaviour as `extract` now.
+However, [those were unified early 2020](https://github.com/NixOS/nixpkgs/pull/81572), meaning that both `extractType1` and `extractType2` have the same behaviour as `extract` now.
 :::
 
 :::{.example #ex-extracting-appimage}

--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -1,48 +1,167 @@
 # pkgs.appimageTools {#sec-pkgs-appimageTools}
 
-`pkgs.appimageTools` is a set of functions for extracting and wrapping [AppImage](https://appimage.org/) files. They are meant to be used if traditional packaging from source is infeasible, or it would take too long. To quickly run an AppImage file, `pkgs.appimage-run` can be used as well.
+`pkgs.appimageTools` is a set of functions for extracting and wrapping [AppImage](https://appimage.org/) files.
+They are meant to be used if traditional packaging from source is infeasible, or it would take too long.
+To quickly run an AppImage file, `pkgs.appimage-run` can be used as well.
 
 ::: {.warning}
 The `appimageTools` API is unstable and may be subject to backwards-incompatible changes in the future.
 :::
 
-## AppImage formats {#ssec-pkgs-appimageTools-formats}
-
-There are different formats for AppImages, see [the specification](https://github.com/AppImage/AppImageSpec/blob/74ad9ca2f94bf864a4a0dac1f369dd4f00bd1c28/draft.md#image-format) for details.
-
-- Type 1 images are ISO 9660 files that are also ELF executables.
-- Type 2 images are ELF executables with an appended filesystem.
-
-They can be told apart with `file -k`:
-
-```ShellSession
-$ file -k type1.AppImage
-type1.AppImage: ELF 64-bit LSB executable, x86-64, version 1 (SYSV) ISO 9660 CD-ROM filesystem data 'AppImage' (Lepton 3.x), scale 0-0,
-spot sensor temperature 0.000000, unit celsius, color scheme 0, calibration: offset 0.000000, slope 0.000000, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.18, BuildID[sha1]=d629f6099d2344ad82818172add1d38c5e11bc6d, stripped\012- data
-
-$ file -k type2.AppImage
-type2.AppImage: ELF 64-bit LSB executable, x86-64, version 1 (SYSV) (Lepton 3.x), scale 232-60668, spot sensor temperature -4.187500, color scheme 15, show scale bar, calibration: offset -0.000000, slope 0.000000 (Lepton 2.x), scale 4111-45000, spot sensor temperature 412442.250000, color scheme 3, minimum point enabled, calibration: offset -75402534979642766821519867692934234112.000000, slope 5815371847733706829839455140374904832.000000, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.18, BuildID[sha1]=79dcc4e55a61c293c5e19edbd8d65b202842579f, stripped\012- data
-```
-
-Note how the type 1 AppImage is described as an `ISO 9660 CD-ROM filesystem`, and the type 2 AppImage is not.
-
 ## Wrapping {#ssec-pkgs-appimageTools-wrapping}
 
-Depending on the type of AppImage you're wrapping, you'll have to use `wrapType1` or `wrapType2`.
+Use `wrapType2` to wrap any AppImage.
+This will create a FHS environment with many packages [expected to exist](https://github.com/AppImage/pkg2appimage/blob/master/excludelist) for the AppImage to work.
+`wrapType2` expects an argument with the `src` attribute, and either a `name` attribute or `pname` and `version` attributes.
+
+It will eventually call into [`buildFHSEnv`](#sec-fhs-environments), and any extra attributes in the argument to `wrapType2` will be passed through to it.
+This means that you can pass the `extraInstallCommands` attribute, for example, and it will have the same effect as described in [`buildFHSEnv`](#sec-fhs-environments).
+
+::: {.note}
+In the past, `appimageTools` provided both `wrapType1` and `wrapType2`, to be used depending on the type of AppImage that was being wrapped.
+However, since [early 2020](https://github.com/NixOS/nixpkgs/pull/81833) those were unified, meaning that both `wrapType1` and `wrapType2` have the same behaviour now.
+:::
+
+:::{.example #ex-wrapping-appimage-from-github}
+
+# Wrapping an AppImage from GitHub
 
 ```nix
-appimageTools.wrapType2 { # or wrapType1
-  name = "patchwork";
+{ appimageTools, fetchurl }:
+let
+  pname = "nuclear";
+  version = "0.6.30";
+
   src = fetchurl {
-    url = "https://github.com/ssbc/patchwork/releases/download/v3.11.4/Patchwork-3.11.4-linux-x86_64.AppImage";
-    hash = "sha256-OqTitCeZ6xmWbqYTXp8sDrmVgTNjPZNW0hzUPW++mq4=";
+    url = "https://github.com/nukeop/nuclear/releases/download/v${version}/${pname}-v${version}.AppImage";
+    hash = "sha256-he1uGC1M/nFcKpMM9JKY4oeexJcnzV0ZRxhTjtJz6xw=";
   };
-  extraPkgs = pkgs: with pkgs; [ ];
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
 }
 ```
 
-- `name` specifies the name of the resulting image.
-- `src` specifies the AppImage file to extract.
-- `extraPkgs` allows you to pass a function to include additional packages inside the FHS environment your AppImage is going to run in. There are a few ways to learn which dependencies an application needs:
-  - Looking through the extracted AppImage files, reading its scripts and running `patchelf` and `ldd` on its executables. This can also be done in `appimage-run`, by setting `APPIMAGE_DEBUG_EXEC=bash`.
+:::
+
+The argument passed to `wrapType2` can also contain an `extraPkgs` attribute, which allows you to include additional packages inside the FHS environment your AppImage is going to run in.
+`extraPkgs` must be a function that returns a list of packages.
+There are a few ways to learn which dependencies an application needs:
+
+  - Looking through the extracted AppImage files, reading its scripts and running `patchelf` and `ldd` on its executables.
+    This can also be done in `appimage-run`, by setting `APPIMAGE_DEBUG_EXEC=bash`.
   - Running `strace -vfefile` on the wrapped executable, looking for libraries that can't be found.
+
+:::{.example #ex-wrapping-appimage-with-extrapkgs}
+
+# Wrapping an AppImage with extra packages
+
+```nix
+{ appimageTools, fetchurl }:
+let
+  pname = "irccloud";
+  version = "0.16.0";
+
+  src = fetchurl {
+    url = "https://github.com/irccloud/irccloud-desktop/releases/download/v${version}/IRCCloud-${version}-linux-x86_64.AppImage";
+    sha256 = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
+  };
+in appimageTools.wrapType2 {
+  inherit pname version src;
+  extraPkgs = pkgs: [ pkgs.at-spi2-core ];
+}
+```
+
+:::
+
+## Extracting {#ssec-pkgs-appimageTools-extracting}
+
+Use `extract` if you need to extract the contents of an AppImage.
+This is usually used in Nixpkgs to install extra files in addition to [wrapping](#ssec-pkgs-appimageTools-wrapping) the AppImage.
+`extract` expects an argument with the `src` attribute, and either a `name` attribute or `pname` and `version` attributes.
+
+::: {.note}
+In the past, `appimageTools` provided both `extractType1` and `extractType2`, to be used depending on the type of AppImage that was being extracted.
+However, since [early 2020](https://github.com/NixOS/nixpkgs/pull/81572) those were unified, meaning that both `extractType1` and `extractType2` have the same behaviour as `extract` now.
+:::
+
+:::{.example #ex-extracting-appimage}
+
+# Extracting an AppImage to install extra files
+
+This example was adapted from a real package in Nixpkgs to show how `extract` is usually used in combination with `wrapType2`.
+Note how `appimageContents` is used in `extraInstallCommands` to install additional files that were extracted from the AppImage.
+
+```nix
+{ appimageTools, fetchurl }:
+let
+  pname = "irccloud";
+  version = "0.16.0";
+
+  src = fetchurl {
+    url = "https://github.com/irccloud/irccloud-desktop/releases/download/v${version}/IRCCloud-${version}-linux-x86_64.AppImage";
+    sha256 = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+in appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [ pkgs.at-spi2-core ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
+      $out/share/icons/hicolor/512x512/apps/irccloud.png
+    substituteInPlace $out/share/applications/irccloud.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+}
+```
+
+:::
+
+The argument passed to `extract` can also contain a `postExtract` attribute, which allows you to execute additional commands after the files are extracted from the AppImage.
+`postExtract` must be a string with commands to run.
+
+:::{.example #ex-extracting-appimage-with-postextract}
+
+# Extracting an AppImage to install extra files, using `postExtract`
+
+This is a rewrite of [](#ex-extracting-appimage) to use `postExtract`.
+
+```nix
+{ appimageTools, fetchurl }:
+let
+  pname = "irccloud";
+  version = "0.16.0";
+
+  src = fetchurl {
+    url = "https://github.com/irccloud/irccloud-desktop/releases/download/v${version}/IRCCloud-${version}-linux-x86_64.AppImage";
+    sha256 = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      substituteInPlace $out/irccloud.desktop --replace 'Exec=AppRun' 'Exec=${pname}'
+    '';
+  };
+in appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [ pkgs.at-spi2-core ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
+      $out/share/icons/hicolor/512x512/apps/irccloud.png
+  '';
+}
+```
+
+:::


### PR DESCRIPTION
## Description of changes

The following changes are made:
- Document how `wrapType2` and `wrapType1` are the same thing.
- Expand on how `wrapType2` works and additional arguments it uses.
- Document `extract` and show how it's used in combination with `wrapType2`.
- Remove information on AppImage types, which isn't needed anymore.
- Provide full working examples using the new admonition syntax.
- Update the document to use one sentence per line.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
