### PR TITLE
tmux-sessionizer: 0.2.3 -> 0.3.0

### DIFF
--- a/pkgs/tools/misc/tmux-sessionizer/default.nix
+++ b/pkgs/tools/misc/tmux-sessionizer/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tmux-sessionizer";
-  version = "0.2.3";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "jrmoulton";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-TTt4pEWlt1cL9SBM6C5dX88MqhBqr4Qt8INnWny8WL4=";
+    hash = "sha256-ZascTDIV9MqPPtK0CHSXUW5gIk/zjRhUB0xATcu7ICM=";
   };
 
-  cargoHash = "sha256-Jq4wpSKo5kq6xSr/qRPlMy9QREUHQ33oQgXrvKi25lM=";
+  cargoHash = "sha256-lZi72OJ+AnnLxf/zxwAERfy1oW8dE8bGF8hFwwrUXqE=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];

--- a/pkgs/tools/misc/tmux-sessionizer/default.nix
+++ b/pkgs/tools/misc/tmux-sessionizer/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     description = "The fastest way to manage projects as tmux sessions";
     homepage = "https://github.com/jrmoulton/tmux-sessionizer";
     license = licenses.mit;
-    maintainers = with maintainers; [ vinnymeller ];
+    maintainers = with maintainers; [ vinnymeller mrcjkb ];
     mainProgram = "tms";
   };
 }

--- a/pkgs/tools/misc/tmux-sessionizer/default.nix
+++ b/pkgs/tools/misc/tmux-sessionizer/default.nix
@@ -5,6 +5,8 @@
 , openssl
 , pkg-config
 , Security
+, testers
+, tmux-sessionizer
 }: let
 
   name = "tmux-sessionizer";
@@ -22,6 +24,10 @@ in rustPlatform.buildRustPackage {
   };
 
   cargoHash = "sha256-lZi72OJ+AnnLxf/zxwAERfy1oW8dE8bGF8hFwwrUXqE=";
+
+  passthru.tests.version = testers.testVersion {
+    package = tmux-sessionizer;
+  };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];

--- a/pkgs/tools/misc/tmux-sessionizer/default.nix
+++ b/pkgs/tools/misc/tmux-sessionizer/default.nix
@@ -5,15 +5,18 @@
 , openssl
 , pkg-config
 , Security
-}:
+}: let
 
-rustPlatform.buildRustPackage rec {
-  pname = "tmux-sessionizer";
+  name = "tmux-sessionizer";
   version = "0.3.0";
+
+in rustPlatform.buildRustPackage {
+  pname = name;
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "jrmoulton";
-    repo = pname;
+    repo = name;
     rev = "v${version}";
     hash = "sha256-ZascTDIV9MqPPtK0CHSXUW5gIk/zjRhUB0xATcu7ICM=";
   };


### PR DESCRIPTION
## Description of changes

- Bumps the version to `0.3.0`
- Adds a simple `passthrough.tests.version`
- Added `mrcjkb` to maintainers
- Replaced `rec` with `let... in` (Note: `buildRustPackage` doesn't accept a `finalAttrs: {}` function).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
