### PR TITLE
livekit: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/by-name/li/livekit/package.nix
+++ b/pkgs/by-name/li/livekit/package.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "livekit";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "livekit";
     repo = "livekit";
     rev = "v${version}";
-    hash = "sha256-3KRES/2mGO6b1ZZEGx29Yu5wgEG4NOJ7/J0xPvQiNWk=";
+    hash = "sha256-Z1N6iYXd3HswRJql3YZMot5fdkdFFbJuxyGDgLsbtQI=";
   };
 
-  vendorHash = "sha256-5wByIkMs3321u4/2vPpsZ/L5zlcgrZo0b+NjeMR1RWE=";
+  vendorHash = "sha256-O0rlezMdhoRHdK37BGKW3CHLpYfkFC1d83o5u54LQ8k=";
 
   subPackages = [ "cmd/server" ];
 


### PR DESCRIPTION
## Description of changes
Updates livekit to `v1.5.2`. [Changelog available here](https://github.com/livekit/livekit/releases/tag/v1.5.2)

## Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).