### PR TITLE
k3s_1_29: init at 1.29.0

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_29/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/chart-versions.nix
@@ -1,0 +1,10 @@
+{
+    traefik-crd  = {
+        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
+        sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
+    };
+    traefik = {
+        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
+        sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
+    };
+}

--- a/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
@@ -1,0 +1,14 @@
+{
+  k3sVersion = "1.29.0+k3s1";
+  k3sCommit = "3190a5faa28d7a0d428c756d67adcab7eb11e6a5";
+  k3sRepoSha256 = "1g75a7kz9nnv0vagzhggkw0zqigykimdwsmibgssa8vyjpg7idda";
+  k3sVendorHash = "sha256-iHmPVjYR/ZLH9UZ5yNEApyuGQsEwtxVbQw7Pu7WrpaQ=";
+  chartVersions = import ./chart-versions.nix;
+  k3sRootVersion = "0.12.2";
+  k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
+  k3sCNIVersion = "1.3.0-k3s1";
+  k3sCNISha256 = "0zma9g4wvdnhs9igs03xlx15bk2nq56j73zns9xgqmfiixd9c9av";
+  containerdVersion = "1.7.11-k3s2";
+  containerdSha256 = "0279sil02wz7310xhrgmdbc0r2qibj9lafy0i9k24jdrh74icmib";
+  criCtlVersion = "1.29.0-k3s1";
+}

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -25,4 +25,9 @@ in
   k3s_1_28 = common ((import ./1_28/versions.nix) // {
     updateScript = [ ./update-script.sh "28" ];
   }) extraArgs;
+
+  # 1_29 can be built with the same builder as 1_26
+  k3s_1_29 = common ((import ./1_29/versions.nix) // {
+    updateScript = [ ./update-script.sh "29" ];
+  }) extraArgs;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33013,6 +33013,8 @@ with pkgs;
   inherit (callPackage ../applications/networking/cluster/k3s {
     buildGoModule = buildGo120Module;
   }) k3s_1_26 k3s_1_27 k3s_1_28;
+  inherit (callPackage ../applications/networking/cluster/k3s { }) k3s_1_29;
+
   k3s = k3s_1_27;
 
   k3sup = callPackage ../applications/networking/cluster/k3sup { };


### PR DESCRIPTION
## Description of changes

This PR initializes the k3s series with a version 1.29 branch, starting with 1.29.0. The 1.29 line will be EOL in 02/2025. Current version matrix now being:  

| version | EOL |
| ---------- | ------------ |
| 1.24      | 07/2023  |
| 1.25      | 10/2023  |
| 1.26      | 02/2024  |
| 1.27      | 06/2024  |
| 1.28      | 10/2024  |
| 1.29      | 02/2025  |

Update script was used to generate all the SHAs for the new 1_29 package.

nixpkgs-review rev HEAD
```
1 package added:
k3s_1_29 (init at 1.29.0+k3s1)

1 package built:
k3s_1_29
```

Also ran single and multi-node tests via the commands below with no apparent failures: 

```
nix build '.#k3s_1_29.tests.single-node'
nix build '.#k3s_1_29.tests.multi-node'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - nix build '.#k3s_1_29.tests.single-node'
  - nix build '.#k3s_1_29.tests.multi-node'
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc