### PR TITLE
rustPlatform.importCargoLock: fix workspace_root detection

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -193,7 +193,7 @@ let
 
         if grep -q workspace "$out/Cargo.toml"; then
           chmod u+w "$out/Cargo.toml"
-          ${replaceWorkspaceValues} "$out/Cargo.toml" "${tree}/Cargo.toml"
+          ${replaceWorkspaceValues} "$out/Cargo.toml" "$(${cargo}/bin/cargo metadata --format-version 1 --no-deps --manifest-path $crateCargoTOML | ${jq}/bin/jq -r .workspace_root)/Cargo.toml"
         fi
 
         # Cargo is happy with empty metadata.


### PR DESCRIPTION
## Description of changes

Prior to this change, the `importCargoLock` git dependency builder assumed that the workspace root that needed to be passed to `replace-workspace-values` will always be the root directory of the git repository

This is not always the case as independent workspace roots may be used from subdirectories, and packages be referenced as dependencies via paths. An example of this is [in libcosmic](https://github.com/pop-os/libcosmic/blob/b8f1a366dd030b90ed72e50f521e3da1d6a676ce/Cargo.toml), where the `iced` subdirectory is its own independent workspace, and workspace values for packages within it should be pulled from the `iced` subdirectory as the workspace root, not from the top-level of the fetched repository

Given the derivation I changed is not a FOD, I just did a `nixpkgs-review` and compared with current Hydra failures to ensure there were no regressed builds

Closes #274490

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>python310Packages.dbt-bigquery</li>
    <li>python310Packages.dbt-bigquery.dist</li>
    <li>python311Packages.dbt-bigquery</li>
    <li>python311Packages.dbt-bigquery.dist</li>
  </ul>
</details>
<details>
  <summary>15 packages failed to build:</summary>
  <ul>
    <li>amazon-qldb-shell (<a href="https://hydra.nixos.org/build/244356603">failing in Hydra</a>)</li>
    <li>citations (<a href="https://hydra.nixos.org/build/244430114">failing in Hydra</a>)</li>
    <li>kdeltachat (<a href="https://hydra.nixos.org/build/244356271">failing in Hydra</a>)</li>
    <li>kord (<a href="https://hydra.nixos.org/build/244356863">failing in Hydra</a>)</li>
    <li>lnx (<a href="https://hydra.nixos.org/build/244355248">failing in Hydra</a>)</li>
    <li>popsicle (<a href="https://hydra.nixos.org/build/244355126">failing in Hydra</a>)</li>
    <li>pw-viz (<a href="https://hydra.nixos.org/build/244354911">failing in Hydra</a>)</li>
    <li>python310Packages.bytewax (<a href="https://hydra.nixos.org/build/244356978">failing in Hydra</a>)</li>
    <li>python310Packages.bytewax.dist (<a href="https://hydra.nixos.org/build/244356978">failing in Hydra</a>)</li>
    <li>python311Packages.bytewax (<a href="https://hydra.nixos.org/build/244354640">failing in Hydra</a>)</li>
    <li>python311Packages.bytewax.dist (<a href="https://hydra.nixos.org/build/244354640">failing in Hydra</a>)</li>
    <li>quickwit (<a href="https://hydra.nixos.org/build/244354916">failing in Hydra</a>)</li>
    <li>relibc (<a href="https://hydra.nixos.org/build/244356068">failing in Hydra</a>)</li>
    <li>rustplayer (<a href="https://hydra.nixos.org/build/244356587">failing in Hydra</a>)</li>
    <li>tremor-rs (<a href="https://hydra.nixos.org/build/244354504">failing in Hydra</a>)</li>
  </ul>
</details>
<details>
  <summary>335 packages built:</summary>
  <ul>
    <li>activitywatch</li>
    <li>airshipper</li>
    <li>ajour</li>
    <li>alfis</li>
    <li>alfis-nogui</li>
    <li>amdgpu_top</li>
    <li>anki</li>
    <li>anki-sync-server</li>
    <li>anki.dist</li>
    <li>anki.doc</li>
    <li>anki.man</li>
    <li>ankisyncd</li>
    <li>ante</li>
    <li>anup</li>
    <li>asciinema-agg</li>
    <li>asusctl</li>
    <li>aw-server-rust</li>
    <li>aw-watcher-window-wayland</li>
    <li>bandwhich</li>
    <li>bcachefs-tools</li>
    <li>cargo-edit</li>
    <li>cargo-lambda</li>
    <li>cargo-release</li>
    <li>cargo-shuttle</li>
    <li>catfs</li>
    <li>cfdyndns</li>
    <li>cicero-tui</li>
    <li>ciel</li>
    <li>cjdns</li>
    <li>cloud-hypervisor</li>
    <li>cloud-hypervisor.debug</li>
    <li>conceal</li>
    <li>cosmic-applets</li>
    <li>cosmic-comp</li>
    <li>cosmic-comp.debug</li>
    <li>cosmic-edit</li>
    <li>cosmic-greeter</li>
    <li>cosmic-osd</li>
    <li>cosmic-panel</li>
    <li>cosmic-settings</li>
    <li>cosmic-workspaces-epoch</li>
    <li>cosmic-workspaces-epoch.debug</li>
    <li>cotton</li>
    <li>cyme</li>
    <li>dbt (python311Packages.dbt-core)</li>
    <li>dbt.dist (python311Packages.dbt-core.dist)</li>
    <li>deltachat-cursed</li>
    <li>deltachat-cursed.dist</li>
    <li>deltachat-desktop</li>
    <li>deltachat-repl</li>
    <li>devpod-desktop</li>
    <li>difftastic</li>
    <li>dnspeep</li>
    <li>documenso</li>
    <li>dogdns</li>
    <li>dogdns.man</li>
    <li>done</li>
    <li>edgedb</li>
    <li>egglog</li>
    <li>emblem</li>
    <li>espanso</li>
    <li>espanso-wayland</li>
    <li>faircamp</li>
    <li>fedigroups</li>
    <li>findomain</li>
    <li>firmware-manager</li>
    <li>flare-floss</li>
    <li>flare-floss.dist</li>
    <li>flare-signal</li>
    <li>fractal</li>
    <li>framework-tool</li>
    <li>freshfetch</li>
    <li>gdrive3</li>
    <li>genemichaels</li>
    <li>geph.gui</li>
    <li>ghostie</li>
    <li>gifski</li>
    <li>gir-rs</li>
    <li>git-interactive-rebase-tool</li>
    <li>git-ps-rs</li>
    <li>gst_all_1.gst-plugins-rs</li>
    <li>gst_all_1.gst-plugins-rs.dev</li>
    <li>gurk-rs</li>
    <li>habitat</li>
    <li>halloy</li>
    <li>hebbot</li>
    <li>httm</li>
    <li>humility</li>
    <li>insulator2</li>
    <li>ion</li>
    <li>itm-tools</li>
    <li>jrsonnet</li>
    <li>jumpy</li>
    <li>kafka-delta-ingest</li>
    <li>kanidm</li>
    <li>kile-wl</li>
    <li>kubernix</li>
    <li>lapce</li>
    <li>lazymc</li>
    <li>liana</li>
    <li>libdeltachat</li>
    <li>lightdm-mobile-greeter</li>
    <li>lighthouse</li>
    <li>lighthouse-steamvr</li>
    <li>lipl</li>
    <li>lldap</li>
    <li>lychee</li>
    <li>materialize</li>
    <li>matrix-appservice-discord</li>
    <li>matrix-appservice-irc</li>
    <li>matrix-appservice-slack</li>
    <li>matrix-conduit</li>
    <li>matrix-hookshot</li>
    <li>matrix-sdk-crypto-nodejs</li>
    <li>matrix-sdk-crypto-nodejs-0_1_0-beta_3</li>
    <li>mchprs</li>
    <li>measureme</li>
    <li>meilisearch</li>
    <li>millet</li>
    <li>mission-center</li>
    <li>mitmproxy (python311Packages.mitmproxy)</li>
    <li>mitmproxy.dist (python311Packages.mitmproxy.dist)</li>
    <li>mitmproxy2swagger</li>
    <li>mitmproxy2swagger.dist</li>
    <li>mjolnir</li>
    <li>mnemosyne</li>
    <li>mnemosyne.dist</li>
    <li>moonfire-nvr</li>
    <li>mopidy</li>
    <li>mopidy-bandcamp</li>
    <li>mopidy-bandcamp.dist</li>
    <li>mopidy-iris</li>
    <li>mopidy-iris.dist</li>
    <li>mopidy-jellyfin</li>
    <li>mopidy-jellyfin.dist</li>
    <li>mopidy-local</li>
    <li>mopidy-local.dist</li>
    <li>mopidy-moped</li>
    <li>mopidy-moped.dist</li>
    <li>mopidy-mopify</li>
    <li>mopidy-mopify.dist</li>
    <li>mopidy-mpd</li>
    <li>mopidy-mpd.dist</li>
    <li>mopidy-mpris</li>
    <li>mopidy-mpris.dist</li>
    <li>mopidy-muse</li>
    <li>mopidy-muse.dist</li>
    <li>mopidy-musicbox-webclient</li>
    <li>mopidy-musicbox-webclient.dist</li>
    <li>mopidy-notify</li>
    <li>mopidy-notify.dist</li>
    <li>mopidy-podcast</li>
    <li>mopidy-podcast.dist</li>
    <li>mopidy-scrobbler</li>
    <li>mopidy-scrobbler.dist</li>
    <li>mopidy-somafm</li>
    <li>mopidy-somafm.dist</li>
    <li>mopidy-soundcloud</li>
    <li>mopidy-soundcloud.dist</li>
    <li>mopidy-spotify</li>
    <li>mopidy-spotify.dist</li>
    <li>mopidy-subidy</li>
    <li>mopidy-subidy.dist</li>
    <li>mopidy-tidal</li>
    <li>mopidy-tidal.dist</li>
    <li>mopidy-tunein</li>
    <li>mopidy-tunein.dist</li>
    <li>mopidy-youtube</li>
    <li>mopidy-youtube.dist</li>
    <li>mopidy-ytmusic</li>
    <li>mopidy-ytmusic.dist</li>
    <li>mopidy.dist</li>
    <li>mullvad</li>
    <li>muzika</li>
    <li>netease-cloud-music-gtk</li>
    <li>newsflash</li>
    <li>nickel</li>
    <li>nickel.nls</li>
    <li>nix-init</li>
    <li>nix-unit</li>
    <li>nls</li>
    <li>noaa-apt</li>
    <li>nurl</li>
    <li>nym</li>
    <li>onagre</li>
    <li>openethereum</li>
    <li>openobserve</li>
    <li>owmods-cli</li>
    <li>peek</li>
    <li>php81Extensions.datadog_trace</li>
    <li>php82Extensions.datadog_trace</li>
    <li>php83Extensions.datadog_trace</li>
    <li>pict-rs_0_3</li>
    <li>pls</li>
    <li>pods</li>
    <li>polaris</li>
    <li>polkadot</li>
    <li>pomsky</li>
    <li>pot</li>
    <li>prettypst</li>
    <li>prisma-engines</li>
    <li>psst</li>
    <li>pwvucontrol</li>
    <li>python310Packages.dbt-core</li>
    <li>python310Packages.dbt-core.dist</li>
    <li>python310Packages.dbt-extractor</li>
    <li>python310Packages.dbt-extractor.dist</li>
    <li>python310Packages.dbt-postgres</li>
    <li>python310Packages.dbt-postgres.dist</li>
    <li>python310Packages.dbt-redshift</li>
    <li>python310Packages.dbt-redshift.dist</li>
    <li>python310Packages.dbt-snowflake</li>
    <li>python310Packages.dbt-snowflake.dist</li>
    <li>python310Packages.deltachat</li>
    <li>python310Packages.deltachat.dist</li>
    <li>python310Packages.json-stream</li>
    <li>python310Packages.json-stream-rs-tokenizer</li>
    <li>python310Packages.json-stream-rs-tokenizer.dist</li>
    <li>python310Packages.json-stream.dist</li>
    <li>python310Packages.mitmproxy</li>
    <li>python310Packages.mitmproxy-rs</li>
    <li>python310Packages.mitmproxy-rs.dist</li>
    <li>python310Packages.mitmproxy.dist</li>
    <li>python310Packages.polars</li>
    <li>python310Packages.polars.dist</li>
    <li>python310Packages.python-flirt</li>
    <li>python310Packages.python-flirt.dist</li>
    <li>python310Packages.skytemple-ssb-debugger</li>
    <li>python310Packages.skytemple-ssb-debugger.dist</li>
    <li>python310Packages.skytemple-ssb-emulator</li>
    <li>python310Packages.skytemple-ssb-emulator.dist</li>
    <li>python311Packages.dbt-extractor</li>
    <li>python311Packages.dbt-extractor.dist</li>
    <li>python311Packages.dbt-postgres</li>
    <li>python311Packages.dbt-postgres.dist</li>
    <li>python311Packages.dbt-redshift</li>
    <li>python311Packages.dbt-redshift.dist</li>
    <li>python311Packages.dbt-snowflake</li>
    <li>python311Packages.dbt-snowflake.dist</li>
    <li>python311Packages.deltachat</li>
    <li>python311Packages.deltachat.dist</li>
    <li>python311Packages.json-stream</li>
    <li>python311Packages.json-stream-rs-tokenizer</li>
    <li>python311Packages.json-stream-rs-tokenizer.dist</li>
    <li>python311Packages.json-stream.dist</li>
    <li>python311Packages.mitmproxy-rs</li>
    <li>python311Packages.mitmproxy-rs.dist</li>
    <li>python311Packages.polars</li>
    <li>python311Packages.polars.dist</li>
    <li>python311Packages.python-flirt</li>
    <li>python311Packages.python-flirt.dist</li>
    <li>python311Packages.skytemple-ssb-debugger</li>
    <li>python311Packages.skytemple-ssb-debugger.dist</li>
    <li>python311Packages.skytemple-ssb-emulator</li>
    <li>python311Packages.skytemple-ssb-emulator.dist</li>
    <li>qdrant</li>
    <li>quill</li>
    <li>radicle-cli</li>
    <li>ripasso-cursive</li>
    <li>ripgrep-all</li>
    <li>rnote</li>
    <li>rqbit</li>
    <li>rtz</li>
    <li>ruffle</li>
    <li>rustdesk</li>
    <li>rustdesk-server</li>
    <li>rustpython</li>
    <li>rye</li>
    <li>salut</li>
    <li>sapling</li>
    <li>sapling.dist</li>
    <li>scryer-prolog</li>
    <li>silicon</li>
    <li>skytemple</li>
    <li>skytemple.dist</li>
    <li>spade</li>
    <li>sqld</li>
    <li>stalwart-mail</li>
    <li>stratisd</li>
    <li>stratisd.initrd</li>
    <li>surface-control</li>
    <li>svix-server</li>
    <li>symbolicator</li>
    <li>syncstorage-rs</li>
    <li>system-syzygy</li>
    <li>system76-firmware</li>
    <li>teleport</li>
    <li>teleport.client</li>
    <li>teleport_12</li>
    <li>teleport_12.client</li>
    <li>teleport_13</li>
    <li>teleport_13.client</li>
    <li>texture-synthesis</li>
    <li>topiary</li>
    <li>tunnelto</li>
    <li>typst</li>
    <li>typst-live</li>
    <li>typst-lsp</li>
    <li>typst-preview</li>
    <li>typstfmt</li>
    <li>ukmm</li>
    <li>unimap</li>
    <li>vector</li>
    <li>veilid</li>
    <li>veilid.dev</li>
    <li>veilid.lib</li>
    <li>vimPlugins.vim-clap</li>
    <li>vimPluginsUpdater</li>
    <li>volta</li>
    <li>vrc-get</li>
    <li>vscode-extensions.azdavis.millet</li>
    <li>vscode-extensions.mgt19937.typst-preview</li>
    <li>vscode-extensions.nvarner.typst-lsp</li>
    <li>wapiti</li>
    <li>wapiti.dist</li>
    <li>watchmate</li>
    <li>weylus</li>
    <li>wezterm</li>
    <li>wgpu-utils</li>
    <li>windmill</li>
    <li>wluma</li>
    <li>worker-build</li>
    <li>workstyle</li>
    <li>wpaperd</li>
    <li>xdg-desktop-portal-cosmic</li>
    <li>xdg-desktop-portal-cosmic.debug</li>
    <li>xplorer</li>
    <li>yabridgectl</li>
    <li>youtube-tui</li>
    <li>zenith</li>
    <li>zenith-nvidia</li>
    <li>zerotierone</li>
    <li>zerotierone.man</li>
    <li>zpool-auto-expand-partitions</li>
    <li>zz</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc