### PR TITLE
init redistimeseries at 1.10.10 and add redisModules

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1034,6 +1034,12 @@ in mkLicense lset) ({
     url = "https://qwt.sourceforge.io/qwtlicense.html";
   };
 
+  rsal2 = {
+    fullName = "Redis Source Available License 2.0";
+    url = "https://redis.com/legal/rsalv2-agreement";
+    free = false;
+  };
+
   ruby = {
     spdxId = "Ruby";
     fullName = "Ruby License";

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, lua, jemalloc, pkg-config, nixosTests
 , tcl, which, ps, getconf
+, callPackage
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 # dependency ordering is broken at the moment when building with openssl
 , tlsSupport ? !stdenv.hostPlatform.isStatic, openssl
@@ -85,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.tests.redis = nixosTests.redis;
+  passthru.modules = callPackage ./modules {};
 
   meta = with lib; {
     homepage = "https://redis.io";

--- a/pkgs/servers/nosql/redis/modules/default.nix
+++ b/pkgs/servers/nosql/redis/modules/default.nix
@@ -1,0 +1,3 @@
+{ callPackage }: {
+  redistimeseries = callPackage ./redistimeseries.nix {};
+}

--- a/pkgs/servers/nosql/redis/modules/redistimeseries.nix
+++ b/pkgs/servers/nosql/redis/modules/redistimeseries.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, cmake
+, libtool
+, openssl
+, pkg-config
+, python3
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "RedisTimeSeries";
+  version = "1.10.10";
+
+  src = fetchFromGitHub {
+    owner = "RedisTimeSeries";
+    repo = "RedisTimeSeries";
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-XarGPmHvht4MUxLHMr0Dm+cCQLABC205xMeGyRI5ZW8=";
+  };
+
+  # Neuter getpy3 setup script as it tries too hard to be clever.
+  postPatch = ''
+    sed -i '2i exit 0' deps/readies/bin/getpy3
+    patchShebangs deps/readies/bin
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib"
+    cp bin/*/*.so "$out/lib"
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    cmake
+    libtool
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  meta = with lib; {
+    description = "Time Series data structure for Redis";
+    homepage = "https://redis.io/docs/data-types/timeseries";
+    license = [ licenses.rsal2 licenses.sspl ];
+    maintainers = teams.deshaw.members;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26982,6 +26982,8 @@ with pkgs;
 
   redis = callPackage ../servers/nosql/redis { };
 
+  redisModules = recurseIntoAttrs redis.modules;
+
   redli = callPackage ../tools/networking/redli { };
 
   redstore = callPackage ../servers/http/redstore { };


### PR DESCRIPTION
## Description of changes

Adds [redistimeseries](https://redis.io/docs/data-types/timeseries/), the RSALv2 license that it uses, and a new redisModules top-level attribute to collect this and other redis modules. I could imagine a `redis.withModules` function at some point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
