### PR TITLE
ocamlPackages.kqueue: init at 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/kqueue/default.nix
+++ b/pkgs/development/ocaml-modules/kqueue/default.nix
@@ -1,0 +1,39 @@
+{ buildDunePackage
+, dune-configurator
+, lib
+, fetchurl
+, ppx_expect
+, ppx_optcomp
+}:
+
+buildDunePackage rec {
+  pname = "kqueue";
+  version = "0.3.0";
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchurl {
+    url = "https://github.com/anuragsoni/kqueue-ml/releases/download/${version}/kqueue-${version}.tbz";
+    hash = "sha256-MKRCyN6q9euTEgHIhldGGH8FwuLblWYNG+SiCMWBP6Y=";
+  };
+
+  buildInputs = [
+    dune-configurator
+    ppx_optcomp
+  ];
+
+  checkInputs = [
+    ppx_expect
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "OCaml bindings for kqueue event notification interface";
+    homepage = "https://github.com/anuragsoni/kqueue-ml";
+    changelog = "https://github.com/anuragsoni/kqueue-ml/blob/${version}/CHANGES.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sixstring982 ];
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -891,6 +891,8 @@ let
 
     kicadsch = callPackage ../development/ocaml-modules/kicadsch { };
 
+    kqueue = callPackage ../development/ocaml-modules/kqueue { };
+
     ### L ###
 
     lablgl = callPackage ../development/ocaml-modules/lablgl { };


### PR DESCRIPTION
## Description of changes

This change initializes `ocamlPackages.kqueue` at `0.3.0`.

`kqueue` provides OCaml bindings for the `kqueue` BSD interface: https://en.wikipedia.org/wiki/Kqueue
This interface allows hooking into filesystem events, for e.g. polling changes to files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).