### PR TITLE
ocamlPackages.poll: init at 0.3.1

### DIFF
--- a/pkgs/development/ocaml-modules/poll/default.nix
+++ b/pkgs/development/ocaml-modules/poll/default.nix
@@ -1,0 +1,43 @@
+{ buildDunePackage
+, dune-configurator
+, fetchurl
+, kqueue
+, lib
+, ppx_expect
+, ppx_optcomp
+}:
+
+buildDunePackage rec {
+  pname = "poll";
+  version = "0.3.1";
+
+  minimalOCamlVersion = "4.13";
+
+  src = fetchurl {
+    url = "https://github.com/anuragsoni/poll/releases/download/${version}/poll-${version}.tbz";
+    hash = "sha256-IX6SivK/IMQaGgMgWiIsNgUSMHP6z1E/TSB0miaQ8pw=";
+  };
+
+  buildInputs = [
+    dune-configurator
+    ppx_optcomp
+  ];
+
+  propagatedBuildInputs = [
+    kqueue
+  ];
+
+  checkInputs = [
+    ppx_expect
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Portable OCaml interface to macOS/Linux/Windows native IO event notification mechanisms";
+    homepage = "https://github.com/anuragsoni/poll";
+    changelog = "https://github.com/anuragsoni/poll/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sixstring982 ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1443,6 +1443,8 @@ let
       inherit (pkgs) coreutils imagemagick;
     };
 
+    poll = callPackage ../development/ocaml-modules/poll { };
+
     polynomial = callPackage ../development/ocaml-modules/polynomial { };
 
     portaudio = callPackage ../development/ocaml-modules/portaudio {


### PR DESCRIPTION
## Description of changes

This change initializes `ocamlPackages.poll` at `0.3.1`.

`poll` provides cross-platform support for the IO event notifications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).