### PR TITLE
Lazier license checks

### DIFF
--- a/pkgs/applications/science/machine-learning/sc2-headless/default.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/default.nix
@@ -6,14 +6,18 @@
 , licenseAccepted ? config.sc2-headless.accept_license or false
 }:
 
-if !licenseAccepted then throw ''
-    You must accept the Blizzard® Starcraft® II AI and Machine Learning License at
-    https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html
-    by setting nixpkgs config option 'sc2-headless.accept_license = true;'
-  ''
-else assert licenseAccepted;
 let maps = callPackage ./maps.nix {};
-in stdenv.mkDerivation rec {
+in
+# This will check the license only when evaluating drvPath or outPath
+lib.extendDerivation (
+  if !licenseAccepted then throw ''
+      You must accept the Blizzard® Starcraft® II AI and Machine Learning License at
+      https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html
+      by setting nixpkgs config option 'sc2-headless.accept_license = true;'
+    ''
+  else true
+) {}
+(stdenv.mkDerivation rec {
   version = "4.7.1";
   pname = "sc2-headless";
 
@@ -59,4 +63,4 @@ in stdenv.mkDerivation rec {
     };
     maintainers = with lib.maintainers; [ ];
   };
-}
+})

--- a/pkgs/development/mobile/androidenv/cmdline-tools.nix
+++ b/pkgs/development/mobile/androidenv/cmdline-tools.nix
@@ -1,6 +1,8 @@
-{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, stdenv, postInstall}:
+{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, stdenv, postInstall, licenseCheck}:
 
-deployAndroidPackage {
+# This will check the license only when evaluating drvPath or outPath
+lib.extendDerivation licenseCheck {}
+(deployAndroidPackage {
   name = "androidsdk";
   inherit package os;
   nativeBuildInputs = [ makeWrapper ]
@@ -36,4 +38,4 @@ deployAndroidPackage {
   '';
 
   meta.license = lib.licenses.unfree;
-}
+})

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -317,20 +317,23 @@ rec {
   cmdline-tools-package = check-version packages "cmdline-tools" cmdLineToolsVersion;
 
   # This derivation deploys the tools package and symlinks all the desired
-  # plugins that we want to use. If the license isn't accepted, prints all the licenses
-  # requested and throws.
-  androidsdk = if !licenseAccepted then throw ''
-    ${builtins.concatStringsSep "\n\n" (mkLicenseTexts licenseNames)}
+  # plugins that we want to use.
+  androidsdk = callPackage ./cmdline-tools.nix {
+    licenseCheck =
+      # If the license isn't accepted, prints all the licenses requested and throws.
+      if !licenseAccepted then throw ''
+        ${builtins.concatStringsSep "\n\n" (mkLicenseTexts licenseNames)}
 
-    You must accept the following licenses:
-    ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
+        You must accept the following licenses:
+        ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
 
-    a)
-      by setting nixpkgs config option 'android_sdk.accept_license = true;'.
-    b)
-      by an environment variable for a single invocation of the nix tools.
-        $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
-  '' else callPackage ./cmdline-tools.nix {
+        a)
+          by setting nixpkgs config option 'android_sdk.accept_license = true;'.
+        b)
+          by an environment variable for a single invocation of the nix tools.
+            $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
+      '' else true;
+
     inherit deployAndroidPackage os;
 
     package = cmdline-tools-package;

--- a/pkgs/development/tools/neoload/default.nix
+++ b/pkgs/development/tools/neoload/default.nix
@@ -5,12 +5,6 @@
 # This can be fixed by setting a different WM name:
 # http://www.haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#Using_SetWMName
 
-if !licenseAccepted then throw ''
-    You have to accept the neoload EULA at
-    https://www.neotys.com/documents/legal/eula/neoload/eula_en.html
-    by setting nixpkgs config option 'neoload.accept_license = true';
-  ''
-else assert licenseAccepted;
 
 # the installer is very picky and demands 1.7.0.07
 let dotInstall4j = path: writeTextFile { name = "dot-install4j"; text = ''
@@ -30,7 +24,17 @@ let dotInstall4j = path: writeTextFile { name = "dot-install4j"; text = ''
       sys.symlinkDir=INSTALLDIR/bin
     ''; };
 
-in stdenv.mkDerivation rec {
+in
+# This will check the license only when evaluating drvPath or outPath
+lib.extendDerivation (
+  if !licenseAccepted then throw ''
+      You have to accept the neoload EULA at
+      https://www.neotys.com/documents/legal/eula/neoload/eula_en.html
+      by setting nixpkgs config option 'neoload.accept_license = true';
+    ''
+  else true
+) {}
+(stdenv.mkDerivation rec {
   pname = "neoload";
   version = "4.1.4";
 
@@ -94,4 +98,4 @@ in stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.bluescreen303 ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/tools/misc/gams/default.nix
+++ b/pkgs/tools/misc/gams/default.nix
@@ -1,8 +1,10 @@
 { lib, stdenv, fetchurl, unzip, file, licenseFile ? null, optgamsFile ? null}:
 
-assert licenseFile != null;
-
-stdenv.mkDerivation rec {
+# This will check the license only when evaluating drvPath or outPath
+lib.extendDerivation (
+  assert licenseFile != null; true
+) {}
+(stdenv.mkDerivation rec {
   version = "25.0.2";
   pname = "gams";
   src = fetchurl {
@@ -48,5 +50,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.Scriptkiddi ];
     platforms = platforms.linux;
   };
-}
-
+})


### PR DESCRIPTION
## Description of changes

This makes certain top-level attributes evaluate by deferring license checks into `drvPath`/`outPath` using `lib.extendDerivation`:
- androidsdk_9_0
- gams
- neoload
- sc2-headless

## Things done
- [x] Checked that each attribute evaluates with `nix-instantiate --eval -A <attr>`, but fails with `nix-instantiate -A <attr>` (since this evaluates the `outPath`)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
