### PR TITLE
ustream-ssl-wolfssl: add missing openssl dependency

### DIFF
--- a/pkgs/development/libraries/ustream-ssl/default.nix
+++ b/pkgs/development/libraries/ustream-ssl/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, lib, fetchgit, cmake, pkg-config, libubox-nossl, ssl_implementation }:
+{ stdenv
+, lib
+, fetchgit
+, cmake
+, pkg-config
+, libubox-nossl
+, ssl_implementation
+, additional_buildInputs ? [ ]
+}:
 
 stdenv.mkDerivation {
   pname = "ustream-ssl";
@@ -21,7 +29,7 @@ stdenv.mkDerivation {
   cmakeFlags = [ "-D${lib.toUpper ssl_implementation.pname}=ON" ];
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ ssl_implementation ];
+  buildInputs = [ ssl_implementation ] ++ additional_buildInputs;
 
   passthru = {
     inherit ssl_implementation;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20955,7 +20955,7 @@ with pkgs;
 
   ustream-ssl = callPackage ../development/libraries/ustream-ssl { ssl_implementation = openssl; };
 
-  ustream-ssl-wolfssl = callPackage ../development/libraries/ustream-ssl { ssl_implementation = wolfssl; };
+  ustream-ssl-wolfssl = callPackage ../development/libraries/ustream-ssl { ssl_implementation = wolfssl; additional_buildInputs = [ openssl ]; };
 
   ustream-ssl-mbedtls = callPackage ../development/libraries/ustream-ssl { ssl_implementation = mbedtls_2; };
 


### PR DESCRIPTION
`ustream-ssl` still needs `openssl` as a build input if it is built against `wolfssl` (see [^1]). I haven't deciphered the build setup entirely, but from the respective CMake declarations, it looks like the library still won't be linked against `openssl` if it is built against `wolfssl` (see the `SET(SSL_LIB ...)` declarations), so I guess `openssl` is solely needed for some header definitions.

[^1]: https://git.openwrt.org/?p=project/ustream-ssl.git;a=blob;f=CMakeLists.txt;h=2de65905a40d8893155877a2b0894bcedec56f39;hb=HEAD#l24

## Description of changes

- Add `openssl` as a build input if `ustream-ssl` is built against `wolfssl`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
