### PR TITLE
forgejo: 1.21.2-1 -> 1.21.3-0

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -24,7 +24,7 @@ let
     pname = "forgejo-frontend";
     inherit (forgejo) src version;
 
-    npmDepsHash = "sha256-7ruJczJ2cE51UmoER8C3JsGm0p3RTwfqKx0eErB7LZs=";
+    npmDepsHash = "sha256-bxgkJODph88aXYYj50gNNP4gpsd18uOj0dQEX6GqEsc=";
 
     patches = [
       ./package-json-npm-build-frontend.patch
@@ -39,17 +39,17 @@ let
 in
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.21.2-1";
+  version = "1.21.3-0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "forgejo";
     repo = "forgejo";
     rev = "v${version}";
-    hash = "sha256-2dkl8QI82URhPV2f4cOUZfpAhlGwU197ZkLD9KitIiA=";
+    hash = "sha256-iBZIn2VGagG1RMBKm9qyg4RRscStr+PsdxOpprrInyo=";
   };
 
-  vendorHash = "sha256-+/wOEF44dSqy7ZThZyd66xyI3wVnFwZbsAd4ujyVku8=";
+  vendorHash = "sha256-+ukS9+SxymwnMSnr/BaL4lhc83wYC6+4BWYTbBTrWy8=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
## Description of changes

https://codeberg.org/forgejo/forgejo/releases/tag/v1.21.3-0
https://codeberg.org/forgejo/forgejo/src/commit/e75783cb4f185fa9a780f6450e03025c84be1ebe/RELEASE-NOTES.md#1-21-3-0

Fixes CVE-2023-48795 (for the integrated golang ssh server, which most probably don't use on NixOS).

There will soon be another release for the forgejo `1.20.x` series (for `nixos-23.11`) as well[^1] (tomorrow?).

[^1]: Message in "Forgejo Development" Matrix Chat: https://matrix.to/#/!zpNKWqkiEOyljSMQDK:matrix.org/$w9KZ20nq5DUQm-Xwi2mxJucYcA6_1jdepTM__mQH67c?via=exozy.me&via=matrix.org&via=aria-net.org

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
