### PR TITLE
pushup: init at 0.2

### DIFF
--- a/pkgs/by-name/pu/pushup/package.nix
+++ b/pkgs/by-name/pu/pushup/package.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitHub, buildGoModule, lib, go, makeWrapper }:
+
+buildGoModule rec {
+  pname = "pushup";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "adhocteam";
+    repo = "pushup";
+    rev = "v${version}";
+    hash = "sha256-9ENXeVON2/Bt8oXnyVw+Vl0bPVPP7iFSyhxwc091ZIs=";
+  };
+
+  vendorHash = null;
+  subPackages = ".";
+  # Pushup doesn't need CGO so disable it.
+  CGO_ENABLED=0;
+  ldflags = [ "-s" "-w" ];
+  nativeBuildInputs = [ makeWrapper ];
+  # The Go compiler is a runtime dependency of Pushup.
+  allowGoReference = true;
+  postInstall = ''
+    wrapProgram $out/bin/${meta.mainProgram} --prefix PATH : ${
+      lib.makeBinPath [ go ]
+    }
+  '';
+
+  meta = with lib; {
+    description = "A web framework for Go";
+    homepage = "https://pushup.adhoc.dev/";
+    license = licenses.mit;
+    changelog = "https://github.com/adhocteam/pushup/blob/${src.rev}/CHANGELOG.md";
+    mainProgram = "pushup";
+    maintainers = with maintainers; [ paulsmith ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[Pushup](https://pushup.adhoc.dev/) is a new web framework tool for making page-oriented web apps using the Go programming language.

Pushup compiles a novel syntax that combines Go and HTML down to pure Go code. The Pushup binary builds self-contained, standalone web app executables. It features file-based routing and support for modern HTML-over-the-wire projects like HTMX.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
