### PR TITLE
Add devcontainer CLI

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8997,6 +8997,12 @@
     github = "joshniemela";
     githubId = 88747315;
   };
+  joshspicer = {
+    name = "Josh Spicer";
+    email = "hello@joshspicer.com";
+    github = "joshspicer";
+    githubId = 23246594;
+  };
   joshuafern = {
     name = "Joshua Fern";
     email = "joshuafern@protonmail.com";

--- a/pkgs/by-name/de/devcontainer/package.nix
+++ b/pkgs/by-name/de/devcontainer/package.nix
@@ -1,0 +1,28 @@
+{ lib
+  , stdenv
+}:
+
+stdenv.mkDerivation rec {
+    name = "devcontainer";
+    version = "0.55.0";
+
+    src = fetchTarball {
+        url = "https://registry.npmjs.org/@devcontainers/cli/-/cli-${version}.tgz";
+        sha256 = "sha256:07vh9b77mphxzv2ayd0kbmc0mngk7fpkka3ly05zcnzi9qqyvmgr";
+    };
+
+    installPhase = ''
+        mkdir -p $out/bin
+        mkdir -p $out/lib
+        cp -r $src/* $out/lib
+        chmod +x $out/lib/devcontainer.js
+        ln -s $out/lib/devcontainer.js $out/bin/devcontainer
+    '';
+
+    meta = with lib; {
+        description = "Development container reference implementation";
+        homepage = "https://containers.dev";
+        license = licenses.mit;
+        maintainers = with maintainers; [ joshspicer ];
+    };
+}


### PR DESCRIPTION
## Description of changes

Adds the devcontainer CLI, an open specification development environment project started by Microsoft. 

The dev container specification is utilized by VS Code's 'Dev Containers' extension, GitHub Codespaces, and [more](https://containers.dev/supporting).

The source code for the project can be found on GitHub: https://github.com/devcontainers/cli.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
