### PR TITLE
haskellPackages.{repa,hip}: Apply build fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -127,8 +127,13 @@ in {
     stylish-haskell
   ;
 
-  # Needs compat library for GHC < 9.6
-  indexed-traversable = addBuildDepends [
-    self.foldable1-classes-compat
-  ] super.indexed-traversable;
+  # Packages which need compat library for GHC < 9.6
+  inherit
+    (lib.mapAttrs
+      (_: addBuildDepends [ self.foldable1-classes-compat ])
+      super)
+    indexed-traversable
+    OneTuple
+    these
+  ;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -196,4 +196,8 @@ self: super: {
   # for these sorts of situations even on 9.2 and 9.4).
   # https://gitlab.haskell.org/ghc/ghc/-/issues/23746#note_525318
   tls = if pkgs.stdenv.hostPlatform.isAarch64 then self.forceLlvmCodegenBackend super.tls else super.tls;
+
+  # 2023-12-23: It needs this to build under ghc-9.6.3.
+  #   A factor of 100 is insufficent, 200 seems seems to work.
+  hip = appendConfigureFlag "--ghc-options=-fsimpl-tick-factor=200" super.hip;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -64,8 +64,11 @@ self: super: {
     hls-stylish-haskell-plugin = null;
   };
 
-  # Version upgrades
-  th-abstraction = doDistribute self.th-abstraction_0_6_0_0;
+  #
+  # Version deviations from Stackage LTS
+  #
+
+  th-abstraction = doDistribute self.th-abstraction_0_6_0_0;  # allows template-haskell-2.21
   ghc-lib-parser = doDistribute self.ghc-lib-parser_9_8_1_20231121;
   ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_8_0_0;
   ghc-lib = doDistribute self.ghc-lib_9_8_1_20231121;
@@ -75,18 +78,39 @@ self: super: {
   ormolu = doDistribute self.ormolu_0_7_3_0;
   fourmolu = doDistribute (dontCheck self.fourmolu_0_14_1_0);
 
+
+  #
   # Jailbreaks
-  commutative-semigroups = doJailbreak super.commutative-semigroups; # base < 4.19
-  ghc-trace-events = doJailbreak super.ghc-trace-events; # text < 2.1, bytestring < 0.12, base < 4.19
-  primitive-unlifted = doJailbreak super.primitive-unlifted; # bytestring < 0.12
-  newtype-generics = doJailbreak super.newtype-generics; # base < 4.19
-  hw-prim = doJailbreak super.hw-prim; # doctest < 0.22, ghc-prim < 0.11, hedgehog < 1.4
-  hw-fingertree = doJailbreak super.hw-fingertree; # deepseq <1.5, doctest < 0.22, hedgehog < 1.4
+  #
+
   # Too strict bound on base, believe it or not.
   # https://github.com/judah/terminfo/pull/55#issuecomment-1876894232
   terminfo_0_4_1_6 = doJailbreak super.terminfo_0_4_1_6;
 
+  inherit (pkgs.lib.mapAttrs (_: doJailbreak ) super)
+    active  # base <4.19
+    blaze-svg  # base <4.19
+    bmp  # bytestring <0.12
+    commutative-semigroups  # base < 4.19
+    diagrams-lib  # base <4.19, text <2.1
+    diagrams-postscript  # base <4.19, bytestring <0.12
+    diagrams-svg  # base <4.19, text <2.1
+    free  # Because we bumped the version of th-abstraction above.^
+    ghc-trace-events  # text < 2.1, bytestring < 0.12, base < 4.19
+    hw-fingertree  # deepseq <1.5, doctest < 0.22, hedgehog < 1.4
+    hw-prim  # doctest < 0.22, ghc-prim < 0.11, hedgehog < 1.4
+    newtype-generics  # base < 4.19
+    primitive-unlifted  # bytestring < 0.12
+    semigroupoids  # base <4.18
+    stack  # yaml >=0.10.4.0 && <0.11  https://github.com/commercialhaskell/stack/issues/4485
+    statestack  # base <4.19
+    svg-builder   # base <4.19, bytestring <0.12, text <2.1
+  ;
+
+  #
   # Test suite issues
+  #
+
   unordered-containers = dontCheck super.unordered-containers; # ChasingBottoms doesn't support base 4.20
   lifted-base = dontCheck super.lifted-base; # doesn't compile with transformers == 0.6.*
   # https://github.com/wz1000/HieDb/issues/64
@@ -95,4 +119,11 @@ self: super: {
       "--match" "!/hiedb/Command line/point-info/correctly prints type signatures/"
     ];
   }) super.hiedb;
+
+  #
+  # Build fixes
+  #
+
+  # 2023-12-23: Avoid "Simplifier ticks exhausted" error under ghc-9.8.1.
+  hip = appendConfigureFlag "--ghc-options=-fsimpl-tick-factor=200" super.hip;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -88,11 +88,8 @@ self: super: {
   terminfo_0_4_1_6 = doJailbreak super.terminfo_0_4_1_6;
 
   inherit (pkgs.lib.mapAttrs (_: doJailbreak ) super)
-    active  # base <4.19
-    blaze-svg  # base <4.19
-    bmp  # bytestring <0.12
-    commutative-semigroups  # base < 4.19
-    diagrams-lib  # base <4.19, text <2.1
+    blaze-svg  # base <4.19  https://github.com/diagrams/blaze-svg/pull/2
+    diagrams-lib  # base <4.19, text <2.1  https://github.com/diagrams/diagrams-lib/pull/364
     diagrams-postscript  # base <4.19, bytestring <0.12
     diagrams-svg  # base <4.19, text <2.1
     free  # Because we bumped the version of th-abstraction above.^
@@ -101,9 +98,7 @@ self: super: {
     hw-prim  # doctest < 0.22, ghc-prim < 0.11, hedgehog < 1.4
     newtype-generics  # base < 4.19
     primitive-unlifted  # bytestring < 0.12
-    semigroupoids  # base <4.18
-    stack  # yaml >=0.10.4.0 && <0.11  https://github.com/commercialhaskell/stack/issues/4485
-    statestack  # base <4.19
+    statestack  # base <4.19  https://github.com/diagrams/statestack/pull/11
     svg-builder   # base <4.19, bytestring <0.12, text <2.1
   ;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4655,7 +4655,6 @@ broken-packages:
   - reorderable # failure in job https://hydra.nixos.org/build/233256477 at 2023-09-02
   - reorder-expression # failure in job https://hydra.nixos.org/build/233215573 at 2023-09-02
   - repa-eval # failure in job https://hydra.nixos.org/build/233259486 at 2023-09-02
-  - repa # failure in job https://hydra.nixos.org/build/233219888 at 2023-09-02
   - repa-scalar # failure in job https://hydra.nixos.org/build/233213694 at 2023-09-02
   - repa-series # failure in job https://hydra.nixos.org/build/233200085 at 2023-09-02
   - ReplaceUmlaut # failure in job https://hydra.nixos.org/build/233228662 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -241,7 +241,6 @@ dont-distribute-packages:
  - JsContracts
  - JsonGrammar
  - JuPyTer-notebook
- - JuicyPixels-repa
  - JunkDB-driver-gdbm
  - JunkDB-driver-hashtables
  - KiCS
@@ -414,6 +413,7 @@ dont-distribute-packages:
  - WebCont
  - Wired
  - WordAlignment
+ - WringTwistree
  - WxGeneric
  - XML
  - XMPP
@@ -621,8 +621,6 @@ dont-distribute-packages:
  - battleships
  - bayes-stack
  - bbi
- - bcp47
- - bcp47-orphans
  - bdcs
  - bdcs-api
  - beam-automigrate
@@ -634,6 +632,7 @@ dont-distribute-packages:
  - belka
  - bff
  - bglib
+ - bhoogle
  - bifunctor
  - billboard-parser
  - billeksah-forms
@@ -703,7 +702,12 @@ dont-distribute-packages:
  - borel
  - both
  - breakout
- - brick_2_1_1
+ - brick
+ - brick-list-skip
+ - brick-skylighting
+ - brick-skylighting_0_3
+ - brick-tabular-list
+ - brick_2_3_1
  - bricks
  - bricks-internal-test
  - bricks-parsec
@@ -723,9 +727,7 @@ dont-distribute-packages:
  - bus-pirate
  - buster-gtk
  - buster-network
- - butterflies
  - bytable
- - bytehash
  - bytelog
  - bytestring-builder-varword
  - bytestring-read
@@ -733,8 +735,6 @@ dont-distribute-packages:
  - cabal-bounds
  - cabal-cache
  - cabal-cargs
- - cabal-flatpak
- - cabal-helper
  - cabal-query
  - cabal-test
  - cabal2arch
@@ -804,6 +804,7 @@ dont-distribute-packages:
  - chart-cli
  - chart-svg
  - chart-svg-various
+ - chart-svg_0_6_0_0
  - chart-unit
  - chassis
  - cheapskate-highlight
@@ -825,7 +826,6 @@ dont-distribute-packages:
  - chu2
  - chuchu
  - chunks
- - circle
  - citation-resolve
  - citeproc-hs-pandoc-filter
  - clac
@@ -981,8 +981,6 @@ dont-distribute-packages:
  - coroutine-iteratee
  - couch-simple
  - couchdb-enumerator
- - country
- - country_0_2_4_1
  - cpkg
  - cprng-aes-effect
  - cql-io-tinylog
@@ -1015,12 +1013,12 @@ dont-distribute-packages:
  - cryptol
  - cryptonite-cd
  - crystalfontz
- - csg
  - cspmchecker
  - csv-enumerator
  - ctpl
  - cube
  - curryer-rpc
+ - cursor-brick
  - cv-combinators
  - cypher
  - dahdit-network
@@ -1160,7 +1158,6 @@ dont-distribute-packages:
  - distribution-plot
  - dixi
  - dl-fedora
- - dl-fedora_1_0
  - dmenu-pkill
  - dmenu-pmount
  - dmenu-search
@@ -1191,8 +1188,6 @@ dont-distribute-packages:
  - dropbox-sdk
  - dropsolve
  - dsh-sql
- - dsmc
- - dsmc-tools
  - dtd
  - dvda
  - dynamic-cabal
@@ -1310,7 +1305,6 @@ dont-distribute-packages:
  - factual-api
  - fadno
  - fair
- - falling-turnip
  - fallingblocks
  - family-tree
  - fast-arithmetic
@@ -1342,7 +1336,6 @@ dont-distribute-packages:
  - feed2twitter
  - feedback
  - fei-base
- - fei-cocoapi
  - fei-dataiter
  - fei-datasets
  - fei-examples
@@ -1490,6 +1483,7 @@ dont-distribute-packages:
  - geodetic
  - geolite-csv
  - getemx
+ - ghc-debug-brick
  - ghc-dump-util
  - ghc-imported-from
  - ghc-instances
@@ -1510,6 +1504,7 @@ dont-distribute-packages:
  - gi-gstpbutils
  - gi-gtk-declarative-app-simple
  - gi-gtk_4_0_8
+ - git-brunch
  - git-config
  - git-fmt
  - git-gpush
@@ -1534,9 +1529,6 @@ dont-distribute-packages:
  - global-config
  - glome-hs
  - gloss-accelerate
- - gloss-devil
- - gloss-examples
- - gloss-raster
  - gloss-raster-accelerate
  - gloss-sodium
  - gltf-loader
@@ -1881,7 +1873,6 @@ dont-distribute-packages:
  - hascat-setup
  - hascat-system
  - hashable-accelerate
- - hasherize
  - hashflare
  - hask-home
  - haskanoid
@@ -1945,7 +1936,6 @@ dont-distribute-packages:
  - haskoin-bitcoind
  - haskoin-crypto
  - haskoin-node
- - haskoin-node_1_0_1
  - haskoin-protocol
  - haskoin-script
  - haskoon
@@ -2041,8 +2031,7 @@ dont-distribute-packages:
  - hesh
  - hesql
  - heterolist
- - hetzner
- - hetzner_0_6_0_0
+ - hevm
  - hevolisa
  - hevolisa-dph
  - hexpat-conduit
@@ -2071,7 +2060,6 @@ dont-distribute-packages:
  - hinduce-examples
  - hinvaders
  - hinze-streams
- - hip
  - hipbot
  - hipe
  - hipsql-client
@@ -2089,16 +2077,15 @@ dont-distribute-packages:
  - hjugement-cli
  - hlcm
  - hledger-api
+ - hledger-ui
  - hls
  - hls-exactprint-utils
  - hmark
- - hmatrix-repa
  - hmatrix-sundials
  - hmeap
  - hmeap-utils
  - hmep
  - hmt-diagrams
- - hnetcdf
  - hnormalise
  - hoauth2-demo
  - hoauth2-providers-tutorial
@@ -2174,7 +2161,6 @@ dont-distribute-packages:
  - hslogstash
  - hsparql
  - hspec-expectations-pretty
- - hspec-formatter-github
  - hspec-pg-transact
  - hspec-setup
  - hspec-shouldbe
@@ -2357,7 +2343,6 @@ dont-distribute-packages:
  - ix
  - ixset
  - iyql
- - j
  - j2hs
  - java-bridge-extras
  - java-character
@@ -2507,7 +2492,7 @@ dont-distribute-packages:
  - ldapply
  - leaky
  - lean
- - learn-physics_0_6_6
+ - learn-physics
  - learning-hmm
  - legion
  - legion-discovery
@@ -2612,7 +2597,6 @@ dont-distribute-packages:
  - lrucaching-haxl
  - ls-usb
  - lsystem
- - ltext
  - luachunk
  - lucid-colonnade
  - lucienne
@@ -2672,6 +2656,7 @@ dont-distribute-packages:
  - mathblog
  - mathlink
  - matsuri
+ - matterhorn
  - maxent
  - maxent-learner-hw-gui
  - maxsharing
@@ -2729,9 +2714,12 @@ dont-distribute-packages:
  - modular-prelude-classy
  - modularity
  - modulo
+ - moffy-samples-gtk3
+ - moffy-samples-gtk3-run
  - moffy-samples-gtk4
  - moffy-samples-gtk4-run
  - mole
+ - monad-bayes
  - monad-exception
  - monad-http
  - monad-metrics-extensible
@@ -2820,6 +2808,7 @@ dont-distribute-packages:
  - mxnet-examples
  - mxnet-nn
  - myTestlll
+ - myers-diff
  - mysnapsession
  - mysnapsession-example
  - mysql-haskell-nem
@@ -2870,11 +2859,11 @@ dont-distribute-packages:
  - neuron
  - newsletter-mailgun
  - newsynth
- - ngx-export-distribution
  - ngx-export-tools-extra
  - nikepub
  - nirum
  - nix-thunk
+ - nix-tree
  - nkjp
  - nlp-scores-scripts
  - nom
@@ -2885,6 +2874,8 @@ dont-distribute-packages:
  - nomyx-server
  - nonlinear-optimization-ad
  - nonlinear-optimization-backprop
+ - not-gloss
+ - not-gloss-examples
  - notmuch-web
  - now-haskell
  - nri-env-parser
@@ -2934,8 +2925,6 @@ dont-distribute-packages:
  - opc-xml-da-client
  - open-adt-tutorial
  - open-typerep
- - opencv
- - opencv-extra
  - openpgp-Crypto
  - openpgp-crypto-api
  - openssh-github-keys
@@ -2989,7 +2978,6 @@ dont-distribute-packages:
  - partage
  - passman-cli
  - patch-image
- - path-text-utf8_0_0_2_0
  - pathfindingcore
  - patterns
  - paypal-rest-client
@@ -3007,7 +2995,6 @@ dont-distribute-packages:
  - penny-lib
  - penrose
  - peparser
- - perceptual-hash
  - perdure
  - perf
  - perf-analysis
@@ -3164,7 +3151,6 @@ dont-distribute-packages:
  - prolog-graph-lib
  - prologue
  - prolude
- - propane
  - proplang
  - prosidyc
  - proto-lens-combinators
@@ -3201,7 +3187,6 @@ dont-distribute-packages:
  - qhs
  - qhull
  - qnap-decrypt
- - qr-repa
  - qtah-cpp-qt5
  - qtah-examples
  - qtah-generator
@@ -3219,7 +3204,6 @@ dont-distribute-packages:
  - quickcheck-poly
  - quickcheck-regex
  - quickcheck-relaxng
- - quickcheck-state-machine
  - quickcheck-state-machine-distributed
  - quicktest
  - quipper
@@ -3345,18 +3329,10 @@ dont-distribute-packages:
  - remote-json-client
  - remote-json-server
  - remotion
- - repa-algorithms
  - repa-array
- - repa-bytestring
  - repa-convert
- - repa-devil
- - repa-examples
- - repa-fftw
  - repa-flow
- - repa-io
- - repa-linear-algebra
  - repa-plugin
- - repa-sndfile
  - repa-stream
  - repa-v4l2
  - replicant
@@ -3465,7 +3441,12 @@ dont-distribute-packages:
  - samtools-conduit
  - samtools-enumerator
  - samtools-iteratee
- - sandwich_0_2_1_0
+ - sandwich
+ - sandwich-hedgehog
+ - sandwich-quickcheck
+ - sandwich-slack
+ - sandwich-webdriver
+ - sandwich_0_2_2_0
  - sarsi
  - sasha
  - sasl
@@ -3717,7 +3698,7 @@ dont-distribute-packages:
  - sparsebit
  - spartacon
  - spata
- - spatial-math_0_5_0_1
+ - spatial-math
  - specialize-th
  - spectral-clustering
  - speculation-transformers
@@ -3727,7 +3708,6 @@ dont-distribute-packages:
  - sphinx-cli
  - spice
  - spike
- - spline3
  - splines
  - sprinkles
  - sproxy
@@ -3861,11 +3841,11 @@ dont-distribute-packages:
  - tamarin-prover-theory
  - tar-bytestring
  - target
+ - tart
  - task
  - task-distribution
  - tasty-bdd
  - tasty-groundhog-converters
- - tasty-hspec_1_2_0_4
  - tasty-integrate
  - tasty-jenkins-xml
  - tasty-laws
@@ -3874,7 +3854,6 @@ dont-distribute-packages:
  - tateti-tateti
  - tbox
  - tccli
- - tcod-haskell
  - tdd-util
  - techlab
  - telegram-bot


### PR DESCRIPTION
This PR is for merging into #279413, cc @sternenseemann.

## Description of changes

One does not simply `import Graphics.Image.Processing`.

This fixes the build of the `hip` package under ghc94, ghc96, ghc98. Because `repa` is a dependency, that also gets a patch so that it builds.

## Things done

```
nix build --system x86_64-linux .#haskell.packages.ghc9{4,6,8}.{hip,repa-{io,algorithms}}
```

I haven't opened upstream issues/PRs yet.