### PR TITLE
certificate-ripper: init at 2.2.0

### DIFF
--- a/pkgs/by-name/ce/certificate-ripper/fix-test-temp-dir-path.patch
+++ b/pkgs/by-name/ce/certificate-ripper/fix-test-temp-dir-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/test/java/nl/altindag/crip/command/FileBaseTest.java b/src/test/java/nl/altindag/crip/command/FileBaseTest.java
+index 674ca10..f140601 100644
+--- a/src/test/java/nl/altindag/crip/command/FileBaseTest.java
++++ b/src/test/java/nl/altindag/crip/command/FileBaseTest.java
+@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
+ 
+ public class FileBaseTest extends BaseTest {
+ 
+-    protected static final Path TEMP_DIRECTORY = Paths.get(System.getProperty("user.home"), "certificate-ripper-temp");
++    protected static final Path TEMP_DIRECTORY = Paths.get(System.getenv("TMP"), "certificate-ripper-temp");
+ 
+     @BeforeEach
+     void createTempDirAndClearConsoleCaptor() throws IOException {

--- a/pkgs/by-name/ce/certificate-ripper/make-deterministic.patch
+++ b/pkgs/by-name/ce/certificate-ripper/make-deterministic.patch
@@ -1,0 +1,68 @@
+diff --git a/pom.xml b/pom.xml
+index dd0075d..46ac184 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -46,6 +46,7 @@
+         <version.license-maven-plugin>4.2.rc3</version.license-maven-plugin>
+         <license.git.copyrightYears>2021</license.git.copyrightYears>
+         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
++        <project.build.outputTimestamp>1980-01-01T00:00:02Z</project.build.outputTimestamp>
+     </properties>
+ 
+     <scm>
+@@ -103,6 +104,55 @@
+ 
+     <build>
+         <plugins>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-enforcer-plugin</artifactId>
++                <version>3.4.1</version>
++                <executions>
++                    <execution>
++                        <id>enforce-plugin-versions</id>
++                        <goals>
++                            <goal>enforce</goal>
++                        </goals>
++                        <configuration>
++                            <rules>
++                                <requirePluginVersions />
++                            </rules>
++                        </configuration>
++                    </execution>
++                </executions>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-deploy-plugin</artifactId>
++                <version>3.1.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-resources-plugin</artifactId>
++                <version>3.3.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-site-plugin</artifactId>
++                <version>4.0.0-M13</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-install-plugin</artifactId>
++                <version>3.1.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-clean-plugin</artifactId>
++                <version>3.3.2</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-jar-plugin</artifactId>
++                <version>3.3.0</version>
++            </plugin>
++
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pkgs/by-name/ce/certificate-ripper/package.nix
+++ b/pkgs/by-name/ce/certificate-ripper/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, maven
+, fetchFromGitHub
+, buildGraalvmNativeImage
+}:
+
+let
+  pname = "certificate-ripper";
+  version = "2.2.0";
+
+  jar = maven.buildMavenPackage {
+    pname = "${pname}-jar";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "Hakky54";
+      repo = "certificate-ripper";
+      rev = version;
+      hash = "sha256-snavZVLY8sHinLnG6k61eSQlR9sb8+k5tRHqu4kzQKM=";
+    };
+
+    patches = [
+      ./make-deterministic.patch
+      ./fix-test-temp-dir-path.patch
+    ];
+
+    mvnHash = "sha256-ahw9VVlvBPlWChcJzXFna55kxqVeJMmdaLtwWcJ+qSA=";
+
+    installPhase = ''
+      install -Dm644 target/crip.jar $out
+    '';
+  };
+in
+buildGraalvmNativeImage {
+  inherit pname version;
+
+  src = jar;
+
+  executable = "crip";
+
+  # Copied from pom.xml
+  extraNativeImageBuildArgs = [
+    "--no-fallback"
+    "-H:ReflectionConfigurationResources=graalvm_config.json"
+    "-H:EnableURLProtocols=https"
+    "-H:EnableURLProtocols=http"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Hakky54/certificate-ripper/releases/tag/${version}";
+    description = "A CLI tool to extract server certificates";
+    homepage = "https://github.com/Hakky54/certificate-ripper";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/274263

This PR adds 1 package: `certificate-ripper` with 1 executable: `crip`

I added a patch so that makes the final store hash is deterministic (the timestamp is fixed to the lowest accepted value now) and also locks the default maven plugin versions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
