### PR TITLE
wlroots: 0.17.0 -> 0.17.1

### DIFF
--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -128,19 +128,12 @@ rec {
   };
 
   wlroots_0_17 = generic {
-    version = "0.17.0";
-    hash = "sha256-VUrnSG4UAAH0cBy15lG0w8RernwegD6lkOdLvWU3a4c=";
+    version = "0.17.1";
+    hash = "sha256-Z0gWM7AQqJOSr2maUtjdgk/MF6pyeyFMMTaivgt+RMI=";
     extraBuildInputs = [
       hwdata
       libliftoff
       libdisplay-info
-    ];
-    patches = [
-      (fetchpatch {
-        name = "tinywl-fix-wlroots-dependency-constraint-in-Makefile.patch";
-        url = "https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/fe53ec693789afb44c899cad8c2df70c8f9f9023.patch";
-        hash = "sha256-wU62hXgmsAyT5j/bWeCFBkvM9cYjUntdCycQt5HAhb8=";
-      })
     ];
   };
 

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -17,6 +17,7 @@
 , xorg
 , libpng
 , ffmpeg_4
+, ffmpeg
 , hwdata
 , seatd
 , vulkan-loader
@@ -57,7 +58,6 @@ let
         ++ extraNativeBuildInputs;
 
       buildInputs = [
-        ffmpeg_4
         libGL
         libcap
         libinput
@@ -116,6 +116,9 @@ rec {
   wlroots_0_15 = generic {
     version = "0.15.1";
     hash = "sha256-MFR38UuB/wW7J9ODDUOfgTzKLse0SSMIRYTpEaEdRwM=";
+    extraBuildInputs = [
+      ffmpeg_4
+    ];
   };
 
   wlroots_0_16 = generic {
@@ -125,12 +128,16 @@ rec {
       substituteInPlace backend/drm/meson.build \
         --replace /usr/share/hwdata/ ${hwdata}/share/hwdata/
     '';
+    extraBuildInputs = [
+      ffmpeg_4
+    ];
   };
 
   wlroots_0_17 = generic {
     version = "0.17.1";
     hash = "sha256-Z0gWM7AQqJOSr2maUtjdgk/MF6pyeyFMMTaivgt+RMI=";
     extraBuildInputs = [
+      ffmpeg
       hwdata
       libliftoff
       libdisplay-info


### PR DESCRIPTION
## Description of changes

Use the default version (6.0)  ffmpeg for wlroots_0_17

https://gitlab.freedesktop.org/wlroots/wlroots/-/tags
wlroots 0.17.1
```
Kirill Primak (2):
      backend/x11: don't send ConfigureRequest with the same size
      backend/x11: check buffer format in output_test()

Simon Ser (12):
      tinywl: fix wlroots dependency constraint in Makefile
      viewporter: rename state var in viewport_handle_surface_commit()
      viewporter: listen to client_commit
      viewporter: fix src buffer bounds check
      render/egl: fallback to GBM FD if EGLDevice is not available
      render: disable linux-dmabuf without DRM FD
      cursor: send surface scale events
      cursor: fix initial cursor position for new outputs
      xcursor: fix duplicate cursor check check in load_callback()
      input-method-v2: drop unnecessary variable and cast
      output-layout: fix missing global for outputs with a custom mode
      build: bump vesion to 0.17.1

Simon Zeni (1):
      types/output: emit destroy event before destroying global

pastel raschke (2):
      input-method-v2: free current strings on commit
      input-method-v2: validate commit serial
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
