### PR TITLE
wayfirePlugins.windecor: init at 0.8.0

### DIFF
--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -7,5 +7,6 @@ lib.makeScope pkgs.newScope (self:
     wayfire-plugins-extra = callPackage ./wayfire-plugins-extra.nix { };
     wcm = callPackage ./wcm.nix { };
     wf-shell = callPackage ./wf-shell.nix { };
+    windecor = callPackage ./windecor.nix { };
   }
 )

--- a/pkgs/applications/window-managers/wayfire/windecor.nix
+++ b/pkgs/applications/window-managers/wayfire/windecor.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, wayfire
+, wf-config
+, wayland
+, pango
+, eudev
+, libinput
+, libxkbcommon
+, librsvg
+, libGL
+, xcbutilwm
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "windecor";
+  version = "0.8.0";
+
+  src = fetchFromGitLab {
+    owner = "wayfireplugins";
+    repo = "windecor";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-v0kGT+KrtfFJ/hp1Dr8izKVj6UHhuW6udHFjWt1y9TY=";
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "wayfire.get_variable( pkgconfig: 'metadatadir' )" "join_paths(get_option('prefix'), 'share/wayfire/metadata')"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayfire
+    wf-config
+    wayland
+    pango
+    eudev
+    libinput
+    libxkbcommon
+    librsvg
+    libGL
+    xcbutilwm
+  ];
+
+  mesonFlags = [ "--sysconfdir=/etc" ];
+
+  meta = {
+    homepage = "https://gitlab.com/wayfireplugins/windecor";
+    description = "A window decoration plugin for wayfire";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rewine ];
+    inherit (wayfire.meta) platforms;
+  };
+})


### PR DESCRIPTION
## Description of changes

A window decoration plugin for wayfire - a more sophisticated alternative to the inbuilt decoration plugin.

![image](https://github.com/NixOS/nixpkgs/assets/22803888/9e8378cb-cbbc-4c9d-a490-6753603eaccf)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
