### PR TITLE
python3.pkgs.django-modeltranslation: init at 0.18.11

### DIFF
--- a/pkgs/development/python-modules/django-modeltranslation/default.nix
+++ b/pkgs/development/python-modules/django-modeltranslation/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, django
+, pytestCheckHook
+, pytest-django
+, parameterized
+}:
+let
+  # 0.18.12 was yanked from PyPI, it refers to this issue:
+  # https://github.com/deschler/django-modeltranslation/issues/701
+  version = "0.18.11";
+in
+buildPythonPackage {
+  pname = "django-modeltranslation";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "deschler";
+    repo = "django-modeltranslation";
+    rev = "v${version}";
+    hash = "sha256-WEtTy449z7Fo9+UmiM+QAuUJ5eQ1RFe1HrIqFrY3L9k=";
+  };
+
+  # Remove all references to pytest-cov
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--no-cov-on-fail" "" \
+      --replace "--cov-report=\"\"" "" \
+      --replace "--cov modeltranslation" ""
+  '';
+
+  disabled = pythonOlder "3.6";
+
+  propagatedBuildInputs = [ django ];
+
+  nativeCheckInputs = [ pytestCheckHook pytest-django parameterized ];
+
+  meta = with lib; {
+    description = "Translates Django models using a registration approach";
+    homepage = "https://github.com/deschler/django-modeltranslation";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ augustebaum ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3085,6 +3085,8 @@ self: super: with self; {
 
   django-modelcluster = callPackage ../development/python-modules/django-modelcluster { };
 
+  django-modeltranslation = callPackage ../development/python-modules/django-modeltranslation { };
+
   django-multiselectfield = callPackage ../development/python-modules/django-multiselectfield { };
 
   django-maintenance-mode = callPackage ../development/python-modules/django-maintenance-mode { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
