### PR TITLE
postgresqlPackages.postgis: build minimal gdal version

### DIFF
--- a/nixos/tests/postgis.nix
+++ b/nixos/tests/postgis.nix
@@ -24,6 +24,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     master.wait_for_unit("postgresql")
     master.sleep(10)  # Hopefully this is long enough!!
     master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis;'")
+    master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis_raster;'")
     master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis_topology;'")
   '';
 })

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -5,7 +5,7 @@
 , postgresql
 , geos
 , proj
-, gdal
+, gdalMinimal
 , json_c
 , pkg-config
 , file
@@ -14,6 +14,10 @@
 , pcre2
 , nixosTests
 }:
+
+let
+  gdal = gdalMinimal;
+in
 stdenv.mkDerivation rec {
   pname = "postgis";
   version = "3.4.1";


### PR DESCRIPTION
## Description of changes

Build Postgis with minimal gdal version (`gdalMinimal`).

`gdalMinimal` variant is disabling support for following features :

* useTiledb - TileDB
* useLibHEIF - HEIF and AVIF (AV1 Image File Format) file format decoder and encoder
* useLibJXL - JPEG XL (encoder and decoder)
* useMysql - MySQL
* usePostgres - PostgreSQL
* usePoppler - PDF rendering library
* useArrow - in-memory data
* useHDF - The Hierarchical Data Format version (HDF)
* useNetCDF -  Unidata network Common Data Format (CDF)
* useArmadillo - Armadillo is a high quality linear algebra library 

Following is the difference in output of
```
SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';

SELECT short_name, long_name, can_write
FROM st_gdaldrivers()
ORDER BY short_name
```

between PostGIS built with `gdal` and `gdalMinimal`:

```diff
--- pg_drivers-full.txt	2024-01-03 11:27:45.906789288 +0100
+++ pg_drivers-minimal.txt	2024-01-03 11:10:26.521792334 +0100
@@ -6,7 +6,6 @@
  AIG             | Arc/Info Binary Grid
  AirSAR          | AirSAR Polarimetric Image
  ARG             | Azavea Raster Grid format
- BAG             | Bathymetry Attributed Grid
  BIGGIF          | Graphics Interchange Format (.gif)
  BLX             | Magellan topo (.blx)
  BMP             | MS Windows Device Independent Bitmap
@@ -54,11 +53,6 @@
  GTiff           | GeoTIFF
  GTX             | NOAA Vertical Datum .GTX
  GXF             | GeoSoft Grid Exchange Format
- HDF4            | Hierarchical Data Format Release 4
- HDF4Image       | HDF4 Dataset
- HDF5            | Hierarchical Data Format Release 5
- HDF5Image       | HDF5 Dataset
- HEIF            | ISO/IEC 23008-12:2017 High Efficiency Image File Format
  HF2             | HF2/HFZ heightfield raster
  HFA             | Erdas Imagine Images (.img)
  HTTP            | HTTP Fetching Wrapper
@@ -72,7 +66,6 @@
  JDEM            | Japanese DEM (.mem)
  JP2OpenJPEG     | JPEG-2000 driver based on OpenJPEG library
  JPEG            | JPEG JFIF
- JPEGXL          | JPEG-XL
  KMLSUPEROVERLAY | Kml Super Overlay
  KRO             | KOLOR Raw
  L1B             | NOAA Polar Orbiter Level 1b Data Set
@@ -88,7 +81,6 @@
  MRF             | Meta Raster Format
  MSGN            | EUMETSAT Archive native (.nat)
  NDF             | NLAPS Data Format
- netCDF          | Network Common Data Format
  NGSGEOID        | NOAA NGS Geoid Height Grids
  NGW             | NextGIS Web
  NITF            | National Imagery Transmission Format
@@ -110,7 +102,6 @@
  PLSCENES        | Planet Labs Scenes API
  PNG             | Portable Network Graphics
  PNM             | Portable Pixmap Format (netpbm)
- PostGISRaster   | PostGIS Raster driver
  PRF             | Racurs PHOTOMOD PRF
  R               | R Object Data Store
  Rasterlite      | Rasterlite
@@ -121,7 +112,6 @@
  RRASTER         | R Raster
  RS2             | RadarSat 2 XML Product
  RST             | Idrisi Raster A.1
- S102            | S-102 Bathymetric Surface Product
  SAFE            | Sentinel-1 SAR SAFE Product
  SAGA            | SAGA GIS Binary Grid (.sdat, .sg-grd-z)
  SAR_CEOS        | CEOS SAR Image
@@ -137,7 +127,6 @@
  Terragen        | Terragen heightfield
  TGA             | TGA/TARGA Image File Format
  TIL             | EarthWatch .TIL
- TileDB          | TileDB
  TSX             | TerraSAR-X Product
  USGSDEM         | USGS Optional ASCII DEM (and CDED)
  VICAR           | MIPL VICAR file
@@ -150,5 +139,5 @@
  XYZ             | ASCII Gridded XYZ
  Zarr            | Zarr
  ZMap            | ZMap Plus Grid
-(150 rows)
+(139 rows)
```


This change is reducing closure size from 1.5G to
544M.

* Closure size with full gdal
```
nix path-info -rsSh /nix/store/0l4kxyvzclrb0nvaf5aqw6q1rcmfbg6h-postgis-3.4.1

...

/nix/store/9bji3x8w4j2j679k9z8mm359nv5ivv84-gdal-3.8.2                     	  42.3M	   1.3G
/nix/store/0l4kxyvzclrb0nvaf5aqw6q1rcmfbg6h-postgis-3.4.1                  	  42.4M	   1.5G
```

* Closure size with gdalMinimal
```
nix path-info -rsSh /nix/store/dghk2lkjbqz0k2i54lfw0c5hspgj8j3m-postgis-3.4.1
...

/nix/store/j1ybly3xvcqac0yngq7r37rvqp3p1amk-gdal-3.8.2                     	  38.5M	 308.1M
/nix/store/dghk2lkjbqz0k2i54lfw0c5hspgj8j3m-postgis-3.4.1                  	  42.4M	 544.1M
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
