### PR TITLE
scaleway-cli: 2.25.0 -> 2.26.0; re-enabled tests, configured `installCheckPhase`

### DIFF
--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -23,8 +23,24 @@ buildGoModule rec {
     "-X main.BuildDate=unknown"
   ];
 
-  # some tests require network access to scaleway's API, failing when sandboxed
-  doCheck = false;
+  doCheck = true;
+
+  # Some tests require access to scaleway's API, failing when sandboxed
+  preCheck = ''
+    substituteInPlace internal/core/bootstrap_test.go \
+      --replace "TestInterruptError" "SkipInterruptError"
+    substituteInPlace internal/e2e/errors_test.go \
+      --replace "TestStandardErrors" "SkipStandardErrors"
+    substituteInPlace internal/e2e/human_test.go \
+      --replace "TestTestCommand" "SkipTestCommand" \
+      --replace "TestHumanCreate" "SkipHumanCreate" \
+      --replace "TestHumanList" "SkipHumanList" \
+      --replace "TestHumanUpdate" "SkipHumanUpdate" \
+      --replace "TestHumanGet" "SkipHumanGet" \
+      --replace "TestHumanDelete" "SkipHumanDelete"
+    substituteInPlace internal/e2e/sdk_errors_test.go \
+      --replace "TestSdkStandardErrors" "SkipSdkStandardErrors"
+  '';
 
   meta = with lib; {
     description = "Interact with Scaleway API from the command line";

--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -42,6 +42,16 @@ buildGoModule rec {
       --replace "TestSdkStandardErrors" "SkipSdkStandardErrors"
   '';
 
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/scw --help
+
+    runHook postInstallCheck
+  '';
+
   meta = with lib; {
     description = "Interact with Scaleway API from the command line";
     homepage = "https://github.com/scaleway/scaleway-cli";

--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -56,6 +56,6 @@ buildGoModule rec {
     description = "Interact with Scaleway API from the command line";
     homepage = "https://github.com/scaleway/scaleway-cli";
     license = licenses.mit;
-    maintainers = with maintainers; [ nickhu techknowlogick ];
+    maintainers = with maintainers; [ nickhu techknowlogick kashw2 ];
   };
 }

--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "scaleway-cli";
-  version = "2.25.0";
+  version = "2.26.0";
 
   src = fetchFromGitHub {
     owner = "scaleway";
     repo = "scaleway-cli";
     rev = "v${version}";
-    sha256 = "sha256-wx/247ZNbdNdRiGLTfCig1JAjmXZX0aCHbOgelzMcyw=";
+    sha256 = "sha256-RfXNwuynlELT7gVWjlhjaX5nKuBJM+v6eAD/JCuRyck=";
   };
 
-  vendorHash = "sha256-FftJsXM9sexRqBKrIeTdWh5Z0eYIK3acDNtptqqILD8=";
+  vendorHash = "sha256-hBfEQtuBkU2fKoCd78dpp+I19lTOycItqjlcA6KByLY=";
 
   ldflags = [
     "-w"


### PR DESCRIPTION
## Description of changes

https://github.com/scaleway/scaleway-cli/releases/tag/v2.26.0

updated scaleway-cli to 2.26.0
enabled `doCheck` and skipped all failing tests that require access to the scaleway API allowing other tests to run
configured `installCheckPhase`
added myself as a maintainer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
