### PR TITLE
fast-ssh: fix build issue due to ambiguous trait impls

### DIFF
--- a/pkgs/tools/networking/fast-ssh/default.nix
+++ b/pkgs/tools/networking/fast-ssh/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , rustPlatform
 , Security
 }:
@@ -17,6 +18,15 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-sIQNoH3UWX3SwCFCPZEREIFR7C28ml4oGsrq6wuOAT0=";
+
+  patches = [
+    # Can be removed as soon as this is is merged: https://github.com/Julien-R44/fast-ssh/pull/22
+    (fetchpatch {
+      name = "fix-ambiguous-as_ref.patch";
+      url = "https://github.com/Julien-R44/fast-ssh/commit/c082a64a4b412380b2ab145c24161fdaa26175db.patch";
+      hash = "sha256-egkoJF+rQiuClNL8ltzmB7oHngbpOxO29rlwZ3nELOE=";
+    })
+  ];
 
   buildInputs = lib.optional stdenv.isDarwin Security;
 


### PR DESCRIPTION
See this upstream PR: https://github.com/Julien-R44/fast-ssh/pull/22

Failing Hydra build: https://hydra.nixos.org/build/243071074
Hydra log: https://hydra.nixos.org/build/243071074/nixlog/4

Relevant log excerpt:

```
Compiling fast-ssh v0.3.1 (/build/source)
error[E0283]: type annotations needed
  --> src/layout.rs:60:10
   |
60 |         .constraints(constraints.as_ref())
   |          ^^^^^^^^^^^             ------ type must be known at this point
   |          |
   |          cannot infer type of the type parameter `C` declared on the method `constraints`
   |
   = note: multiple `impl`s satisfying `Vec<Constraint>: AsRef<_>` found in the `alloc` crate:
           - impl<T, A> AsRef<Vec<T, A>> for Vec<T, A>
             where A: Allocator;
           - impl<T, A> AsRef<[T]> for Vec<T, A>
             where A: Allocator;
help: consider specifying the generic argument
   |
60 |         .constraints::<&T>(constraints.as_ref())
   |                     ++++++

For more information about this error, try `rustc --explain E0283`.
error: could not compile `fast-ssh` (bin "fast-ssh") due to previous error
```

## Description of changes

Add a patch that fixes a type ambiguity.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
