### PR TITLE
hareThirdParty.hare-ssh: init at unstable-2023-11-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14188,6 +14188,12 @@
     githubId = 15645854;
     name = "Brad Christensen";
   };
+  patwid = {
+    email = "patrick.widmer@tbwnet.ch";
+    github = "patwid";
+    githubId = 25278658;
+    name = "Patrick Widmer";
+  };
   paulsmith = {
     email = "paulsmith@pobox.com";
     github = "paulsmith";

--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, hare, hareThirdParty, fetchFromSourcehut }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-ssh";
+  version = "unstable-2023-11-16";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-ssh";
+    rev = "c6a39e37ba4a42721594e0a907fe016f8e2198a8";
+    hash = "sha256-I43TLPoImBsvkgV3hDy9dw0pXVt4ezINnxFtEV9P2/M=";
+  };
+
+  nativeBuildInputs = [ hare ];
+
+  makeFlags = [
+    "PREFIX=${builtins.placeholder "out"}"
+    "HARECACHE=.harecache"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~sircmpwn/hare-ssh/";
+    description = "SSH client & server protocol implementation for Hare";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ patwid ];
+
+    inherit (hare.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -8,5 +8,6 @@ in
   hare-compress = callPackage ../development/hare-third-party/hare-compress { };
   hare-ev = callPackage ../development/hare-third-party/hare-ev { };
   hare-json = callPackage ../development/hare-third-party/hare-json { };
+  hare-ssh = callPackage ../development/hare-third-party/hare-ssh { };
   hare-toml = callPackage ../development/hare-third-party/hare-toml { };
 })


### PR DESCRIPTION
## Description of changes

[hare-ssh](https://git.sr.ht/~sircmpwn/hare-ssh) package provides an implementation of the SSH client & server protocol for Hare.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
