### PR TITLE
himitsu-ssh: init at unstable-2023-12-05

### DIFF
--- a/pkgs/tools/security/himitsu-ssh/default.nix
+++ b/pkgs/tools/security/himitsu-ssh/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, hare
+, hareThirdParty
+, himitsu
+, scdoc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "himitsu-ssh";
+  version = "unstable-2023-12-05";
+
+  src = fetchFromSourcehut {
+    name = pname + "-src";
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = "09b33fef81617fae200d8853cc18adb9ebc62119";
+    hash = "sha256-2bv3MPl4m7oVDdrL0ZuFq5mmPRGWlb0uzby1sE/XDEA=";
+  };
+
+  nativeBuildInputs = [
+    hare
+    hareThirdParty.hare-ssh
+    scdoc
+  ];
+
+  buildInputs = [
+    himitsu
+  ];
+
+  preConfigure = ''
+    export HARECACHE=$(mktemp -d)
+  '';
+
+  installFlags = [ "PREFIX=" "DESTDIR=$(out)" ];
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~sircmpwn/himitsu-ssh";
+    description = "Himitsu integration for SSH";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ patwid ];
+    inherit (hare.meta) platforms badPlatforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3975,6 +3975,8 @@ with pkgs;
 
   himitsu-firefox = callPackage ../tools/security/himitsu-firefox { };
 
+  himitsu-ssh = callPackage ../tools/security/himitsu-ssh { };
+
   hinit = haskell.lib.compose.justStaticExecutables haskellPackages.hinit;
 
   hostctl = callPackage ../tools/system/hostctl { };


### PR DESCRIPTION
## Description of changes

[himitsu-ssh](https://git.sr.ht/~sircmpwn/himitsu-ssh) package provides integration between Himitsu and SSH. Depends on #276437.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
