### PR TITLE
criu: 3.17.1 -> 3.19

### DIFF
--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, protobuf, protobufc, asciidoc, iptables
+{ stdenv, lib, fetchFromGitHub, protobuf, protobufc, asciidoc, iptables
 , xmlto, docbook_xsl, libpaper, libnl, libcap, libnet, pkg-config, iproute2, gzip
 , which, python3, makeWrapper, docbook_xml_dtd_45, perl, nftables, libbsd, gnutar
 , buildPackages
@@ -6,32 +6,14 @@
 
 stdenv.mkDerivation rec {
   pname = "criu";
-  version = "3.17.1";
+  version = "3.19";
 
   src = fetchFromGitHub {
     owner = "checkpoint-restore";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-0B0cdX5bemy4glF9iWjrQIXIqilyYcCcAN9x4Jjrwzk=";
+    hash = "sha256-S0nxBHfm7tWmW5PhSDhSAgy1uDa0RD5GTNpMDUHKqwY=";
   };
-
-  patches = [
-    # Fixes redefinition of rseq headers
-    (fetchpatch {
-      url = "https://github.com/checkpoint-restore/criu/commit/1e6e826ffb7ac05f33fa123051c2fc2ddf0f68ea.patch";
-      hash = "sha256-LJjk0jQ5v5wqeprvBMpxhjLXn7v+lSPldEGgazGUM44=";
-    })
-
-    # compat fixes for glibc-2.36
-    (fetchpatch {
-      url = "https://github.com/checkpoint-restore/criu/commit/8cd5fccd6cf3d03afb5abe463134d31f54d42258.patch";
-      sha256 = "sha256-b65DdLmyIuZik0dNRuWJKUPcDFA6CKq0bi4Vd26zgS4=";
-    })
-    (fetchpatch {
-      url = "https://github.com/checkpoint-restore/criu/commit/517c0947050e63aac72f63a3bf373d76264723b9.patch";
-      sha256 = "sha256-MPZ6oILVoZ7BQEZFjUlp3RuMC7iKTKXAtrUDFqbN4T8=";
-    })
-  ];
 
   enableParallelBuilding = true;
   depsBuildBuild = [ protobufc buildPackages.stdenv.cc ];


### PR DESCRIPTION
The main change is the build fix against `gcc-13`. Otherwise build fails as:

    include/common/list.h:35:19: error: storing the address of local variable 'postpone' in '((struct list_head *)((char *)start + 8))[24].prev' [-Werror=dangling-pointer=]
       35 |         new->prev = prev;
          |         ~~~~~~~~~~^~~~~~

Changes:
- https://github.com/checkpoint-restore/criu/releases/tag/v3.18
- https://github.com/checkpoint-restore/criu/releases/tag/v3.19

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
