### PR TITLE
serioussam: init at 1.10.6b

### DIFF
--- a/pkgs/games/serioussam/generic.nix
+++ b/pkgs/games/serioussam/generic.nix
@@ -1,0 +1,84 @@
+{ pname
+, version
+, src
+, extraNativeBuildInputs ? [ ]
+, extraBuildInputs ? [ ]
+
+, lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, cmake
+, imagemagick
+, bison
+, flex
+, nasm
+, SDL2
+, zlib
+, libogg
+, libvorbis
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version src;
+
+  patches = [
+    ./tfe-fix-cmake-libdir-override.patch
+    ./tse-fix-cmake-libdir-override.patch
+    ./tfe-force-using-system-path.patch
+    ./tse-force-using-system-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace SamTFE/Sources/CMakeLists.txt --replace "-march=native" "-mtune=generic"
+    substituteInPlace SamTSE/Sources/CMakeLists.txt --replace "-march=native" "-mtune=generic"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    cmake
+    imagemagick
+    bison
+    flex
+    nasm
+  ] ++ extraNativeBuildInputs;
+
+  buildInputs = [
+    SDL2
+    zlib
+    libogg
+    libvorbis
+  ] ++ extraBuildInputs;
+
+  # I've tried to use patchelf --add-needed and --add-rpath with libvorbis, didn't work
+  postInstall = ''
+    wrapProgram $out/bin/serioussam --suffix LD_LIBRARY_PATH : ${libvorbis}/lib
+    wrapProgram $out/bin/serioussamse --suffix LD_LIBRARY_PATH : ${libvorbis}/lib
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tx00100xt/${finalAttrs.src.repo}";
+    description = "Open source game engine version developed by Croteam for Serious Sam Classic";
+    longDescription = ''
+      Note: This package allows to run both Serious Sam: The First Encounter (serioussam)
+      and The Second Encounter (serioussamse).
+
+      For serioussam you must copy all the assets of the original games into
+      ~/.local/share/Serious-Engine/serioussam for serioussam and
+      ~/.local/share/Serious-Engine/serioussamse for serioussamse.
+      Look at
+      https://github.com/tx00100xt/${finalAttrs.src.repo}/wiki/How-to-building-a-package-for-Debian-or-Ubuntu.md#game-resources
+      for instructions on how to do that.
+      For both games you must also copy the files SE1_10b.gro and ModEXT.txt into the assets.
+      For serioussam:
+      - https://raw.githubusercontent.com/tx00100xt/${finalAttrs.src.repo}/${finalAttrs.src.rev}/SamTFE/ModEXT.txt
+      - https://raw.githubusercontent.com/tx00100xt/${finalAttrs.src.repo}/${finalAttrs.src.rev}/SamTFE/SE1_10b.gro
+      For serioussamse:
+      - https://raw.githubusercontent.com/tx00100xt/${finalAttrs.src.repo}/${finalAttrs.src.rev}/SamTSE/ModEXT.txt
+      - https://raw.githubusercontent.com/tx00100xt/${finalAttrs.src.repo}/${finalAttrs.src.rev}/SamTSE/SE1_10b.gro
+    '';
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+  };
+})

--- a/pkgs/games/serioussam/serioussam-vk.nix
+++ b/pkgs/games/serioussam/serioussam-vk.nix
@@ -1,0 +1,21 @@
+{ callPackage
+, fetchFromGitHub
+, vulkan-headers
+, vulkan-loader
+}:
+
+callPackage ./generic.nix rec {
+  pname = "serioussam-vk";
+
+  version = "1.10.6b";
+
+  src = fetchFromGitHub {
+    owner = "tx00100xt";
+    repo = "SeriousSamClassic-VK";
+    rev = version;
+    hash = "sha256-nPmxGnMjaYPTnQYxbGEMGaW/6eRr1Smr5SmFRWsrdQs=";
+  };
+
+  extraNativeBuildInputs = [ vulkan-headers ];
+  extraBuildInputs = [ vulkan-loader ];
+}

--- a/pkgs/games/serioussam/serioussam.nix
+++ b/pkgs/games/serioussam/serioussam.nix
@@ -1,0 +1,16 @@
+{ callPackage
+, fetchFromGitHub
+}:
+
+callPackage ./generic.nix rec {
+  pname = "serioussam";
+
+  version = "1.10.6b";
+
+  src = fetchFromGitHub {
+    owner = "tx00100xt";
+    repo = "SeriousSamClassic";
+    rev = version;
+    hash = "sha256-GjV42HQuodWIHc5CFMaE6muc6lJm1eetKrUDWVXTK5I=";
+  };
+}

--- a/pkgs/games/serioussam/tfe-fix-cmake-libdir-override.patch
+++ b/pkgs/games/serioussam/tfe-fix-cmake-libdir-override.patch
@@ -1,0 +1,17 @@
+diff --git a/SamTFE/Sources/CMakeLists.txt b/SamTFE/Sources/CMakeLists.txt
+index 956518b..76308f2 100644
+--- a/SamTFE/Sources/CMakeLists.txt
++++ b/SamTFE/Sources/CMakeLists.txt
+@@ -221,10 +221,10 @@ endif (LINUX)
+ message(STATUS "Operating system name: ${CMAKE_OS_NAME}")
+ 
+ set(CMAKE_ARCH_BITS 32)
+-set(CMAKE_INSTALL_LIBDIR "/usr/lib")
++#set(CMAKE_INSTALL_LIBDIR "/usr/lib")
+ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+     set(CMAKE_ARCH_BITS 64)
+-    set(CMAKE_INSTALL_LIBDIR "/usr/lib64")
++    #set(CMAKE_INSTALL_LIBDIR "/usr/lib64")
+ endif()
+ 
+ message(STATUS "Arch bits: ${CMAKE_ARCH_BITS}")

--- a/pkgs/games/serioussam/tfe-force-using-system-path.patch
+++ b/pkgs/games/serioussam/tfe-force-using-system-path.patch
@@ -1,0 +1,60 @@
+diff --git a/SamTFE/Sources/Engine/Engine.cpp b/SamTFE/Sources/Engine/Engine.cpp
+index 6febab8..5963e34 100644
+--- a/SamTFE/Sources/Engine/Engine.cpp
++++ b/SamTFE/Sources/Engine/Engine.cpp
+@@ -742,53 +742,8 @@
+   CPrintF(TRANSV("Running %d-bit version\n"), sys_iGameBits);
+ 
+ #ifdef PLATFORM_UNIX
+-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/local/bin/", (size_t) 15 );
+-#elif defined(__NetBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/pkg/bin/", (size_t) 13 );
+-#else
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/bin/", (size_t) 9 );
+-#endif
+-  if( _isystempath == 0 ) {
+-       sys_iSysPath = 1; // using system path
+-  } else {
+-       sys_iSysPath = 0; // using standarted path
+-  }
+-
+-  // get library path for mods
+-  _fnmModLibPath = "";
+-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+-  if( sys_iSysPath == 1 ) {
+-    _fnmModLibPath = "/usr/local/lib/" + strGameID + "/";
+-#elif defined(__NetBSD__)
+-  if( sys_iSysPath == 1 ) {
+-    _fnmModLibPath = "/usr/pkg/lib/" + strGameID + "/";
+-#else
+-  if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/aarch64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/aarch64-linux-gnu/" + strGameID + "/"; 
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 32 && _pFileSystem->IsDirectory((const char *) "/usr/lib/arm-linux-gnueabihf/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/arm-linux-gnueabihf/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/riscv64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/riscv64-linux-gnu/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/s390x-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/s390x-linux-gnu/" + strGameID + "/"; 
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/powerpc64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/powerpc64-linux-gnu/" + strGameID + "/"; 
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/x86_64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/x86_64-linux-gnu/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 32 && _pFileSystem->IsDirectory((const char *) "/usr/lib/i386-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/i386-linux-gnu/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib64/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib64/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 32 && _pFileSystem->IsDirectory((const char *) "/usr/lib//" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/" + strGameID + "/";
+-#endif
+-  } else if( sys_iSysPath == 0 ) {
+-    _fnmModLibPath = _fnmApplicationPath;
+-  } else {
+-    CPrintF(TRANSV("ERROR: Game libraries not ound!\n"));
+-    FatalError(TRANSV("Failed to search game libraries installed!\nPlease reinstall the game.\nSee the log for more details.\nGame log is here: ~/.local/share/Serious-Engine/%s/SeriousSam.log"),(const char *) strGameID);
+-  }
++  sys_iSysPath = 1; // using system path
++  _fnmModLibPath = _fnmApplicationPath + "lib/" + strGameID + "/";
+ 
+   if( sys_iSysPath == 1 ) { // search game data
+     CTFileName _fnm_usr_TestFile, _fnm_local_TestFile, _fnm_home_TestFile;

--- a/pkgs/games/serioussam/tse-fix-cmake-libdir-override.patch
+++ b/pkgs/games/serioussam/tse-fix-cmake-libdir-override.patch
@@ -1,0 +1,17 @@
+diff --git a/SamTSE/Sources/CMakeLists.txt b/SamTSE/Sources/CMakeLists.txt
+index 956518b..76308f2 100644
+--- a/SamTSE/Sources/CMakeLists.txt
++++ b/SamTSE/Sources/CMakeLists.txt
+@@ -221,10 +221,10 @@ endif (LINUX)
+ message(STATUS "Operating system name: ${CMAKE_OS_NAME}")
+ 
+ set(CMAKE_ARCH_BITS 32)
+-set(CMAKE_INSTALL_LIBDIR "/usr/lib")
++#set(CMAKE_INSTALL_LIBDIR "/usr/lib")
+ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+     set(CMAKE_ARCH_BITS 64)
+-    set(CMAKE_INSTALL_LIBDIR "/usr/lib64")
++    #set(CMAKE_INSTALL_LIBDIR "/usr/lib64")
+ endif()
+ 
+ message(STATUS "Arch bits: ${CMAKE_ARCH_BITS}")

--- a/pkgs/games/serioussam/tse-force-using-system-path.patch
+++ b/pkgs/games/serioussam/tse-force-using-system-path.patch
@@ -1,0 +1,60 @@
+diff --git a/SamTSE/Sources/Engine/Engine.cpp b/SamTSE/Sources/Engine/Engine.cpp
+index 6febab8..5963e34 100644
+--- a/SamTSE/Sources/Engine/Engine.cpp
++++ b/SamTSE/Sources/Engine/Engine.cpp
+@@ -742,53 +742,8 @@
+   CPrintF(TRANSV("Running %d-bit version\n"), sys_iGameBits);
+ 
+ #ifdef PLATFORM_UNIX
+-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/local/bin/", (size_t) 15 );
+-#elif defined(__NetBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/pkg/bin/", (size_t) 13 );
+-#else
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/bin/", (size_t) 9 );
+-#endif
+-  if( _isystempath == 0 ) {
+-       sys_iSysPath = 1; // using system path
+-  } else {
+-       sys_iSysPath = 0; // using standarted path
+-  }
+-
+-  // get library path for mods
+-  _fnmModLibPath = "";
+-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+-  if( sys_iSysPath == 1 ) {
+-    _fnmModLibPath = "/usr/local/lib/" + strGameID + "/";
+-#elif defined(__NetBSD__)
+-  if( sys_iSysPath == 1 ) {
+-    _fnmModLibPath = "/usr/pkg/lib/" + strGameID + "/";
+-#else
+-  if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/aarch64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/aarch64-linux-gnu/" + strGameID + "/"; 
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 32 && _pFileSystem->IsDirectory((const char *) "/usr/lib/arm-linux-gnueabihf/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/arm-linux-gnueabihf/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/riscv64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/riscv64-linux-gnu/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/s390x-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/s390x-linux-gnu/" + strGameID + "/"; 
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/powerpc64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/powerpc64-linux-gnu/" + strGameID + "/"; 
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib/x86_64-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/x86_64-linux-gnu/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 32 && _pFileSystem->IsDirectory((const char *) "/usr/lib/i386-linux-gnu/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/i386-linux-gnu/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 64 && _pFileSystem->IsDirectory((const char *) "/usr/lib64/" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib64/" + strGameID + "/";
+-  } else if( sys_iSysPath == 1 && sys_iGameBits == 32 && _pFileSystem->IsDirectory((const char *) "/usr/lib//" + strGameID)) {
+-    _fnmModLibPath = "/usr/lib/" + strGameID + "/";
+-#endif
+-  } else if( sys_iSysPath == 0 ) {
+-    _fnmModLibPath = _fnmApplicationPath;
+-  } else {
+-    CPrintF(TRANSV("ERROR: Game libraries not ound!\n"));
+-    FatalError(TRANSV("Failed to search game libraries installed!\nPlease reinstall the game.\nSee the log for more details.\nGame log is here: ~/.local/share/Serious-Engine/%s/SeriousSam.log"),(const char *) strGameID);
+-  }
++  sys_iSysPath = 1; // using system path
++  _fnmModLibPath = _fnmApplicationPath + "lib/" + strGameID + "/";
+ 
+   if( sys_iSysPath == 1 ) { // search game data
+     CTFileName _fnm_usr_TestFile, _fnm_local_TestFile, _fnm_home_TestFile;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37373,6 +37373,10 @@ with pkgs;
 
   keeperrl = callPackage ../games/keeperrl { };
 
+  serioussam = callPackage ../games/serioussam/serioussam.nix { };
+
+  serioussam-vk = callPackage ../games/serioussam/serioussam-vk.nix { };
+
   shipwright = callPackage ../games/shipwright { };
 
   wipeout-rewrite = callPackage ../games/wipeout-rewrite {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Open source game engine version developed by Croteam for Serious Sam Classic.
(This runs Serious Sam: The First Encounter and Serious San: The Second Encounter. Those are proprietary FPS games. The engine is libre but the assets are not)

Old PR at https://github.com/NixOS/nixpkgs/pull/249156. I messed it up

Fixes https://github.com/NixOS/nixpkgs/issues/189623

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
