### PR TITLE
phantomsocks: unstable-2023-04-05 -> unstable-2023-11-30

### DIFF
--- a/pkgs/tools/networking/phantomsocks/default.nix
+++ b/pkgs/tools/networking/phantomsocks/default.nix
@@ -3,26 +3,27 @@
 , fetchFromGitHub
 , stdenv
 , libpcap
-# Cann't be build with both pcap and rawsocket tags
+  # Cann't be build with both pcap and rawsocket tags
 , withPcap ? (!stdenv.isLinux && !withRawsocket)
 , withRawsocket ? (stdenv.isLinux && !withPcap)
 }:
 
 buildGoModule rec {
   pname = "phantomsocks";
-  version = "unstable-2023-04-05";
+  version = "unstable-2023-11-30";
 
   src = fetchFromGitHub {
     owner = "macronut";
     repo = pname;
-    rev = "a54ae9f3611e8623f89e69273f2ded7f7c0a7abf";
-    hash = "sha256-ytTLwKlwbaiSWDRZBkOV7Hrl5ywWzLbv/fJ7nVlD++E=";
+    rev = "b1b13c5b88cf3bac54f39c37c0ffcb0b46e31049";
+    hash = "sha256-ptCzd2/8dNHjAkhwA2xpZH8Ki/9DnblHI2gAIpgM+8E=";
   };
 
-  vendorHash = "sha256-c0NQfZuMMWz1ASwFBcpMNjxZwXLo++gMYBiNgvT8ZLQ=";
+  vendorHash = "sha256-0MJlz7HAhRThn8O42yhvU3p5HgTG8AkPM0ksSjWYAC4=";
 
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
   ];
   buildInputs = lib.optional withPcap libpcap;
   tags = lib.optional withPcap "pcap"


### PR DESCRIPTION
Diff: https://github.com/macronut/phantomsocks/compare/a54ae9f3611e8623f89e69273f2ded7f7c0a7abf...b1b13c5b88cf3bac54f39c37c0ffcb0b46e31049

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
