### PR TITLE
boinctui: init at 2.7.1

### DIFF
--- a/pkgs/by-name/bo/boinctui/package.nix
+++ b/pkgs/by-name/bo/boinctui/package.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, expat, ncurses, openssl }:
+
+stdenv.mkDerivation {
+  pname = "boinctui";
+  version = "2.7.1-unstable-2023-12-14";
+
+  src = fetchFromGitHub {
+    owner = "suleman1971";
+    repo = "boinctui";
+    rev = "6656f288580170121f53d0e68c35077f5daa700b"; # no proper release tags unfortunaly
+    hash = "sha256-MsSTvlTt54ukQXyVi8LiMFIkv8FQJOt0q30iDxf4TsE=";
+  };
+
+  # Fix wrong path; @docdir@ already gets replaced with the correct store path
+  postPatch = ''
+    substituteInPlace Makefile.in \
+      --replace 'DOCDIR = $(DATAROOTDIR)@docdir@' 'DOCDIR = @docdir@'
+  '';
+
+  outputs = [ "out" "man" ];
+  separateDebugInfo = stdenv.isLinux;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [ "--without-gnutls" ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ expat ncurses openssl ];
+
+  meta = with lib; {
+    description = "Curses based fullscreen BOINC manager";
+    homepage = "https://github.com/suleman1971/boinctui";
+    changelog = "https://github.com/suleman1971/boinctui/blob/master/changelog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ christoph-heiss ];
+    platforms = platforms.linux;
+    mainProgram = "boinctui";
+  };
+}


### PR DESCRIPTION
## Description of changes

[boinctui](https://github.com/suleman1971/boinctui) is a curses-based TUI for (remotely) managing BOINC instances.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
