### PR TITLE
nixos/pyload: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -24,6 +24,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Guix](https://guix.gnu.org), a functional package manager inspired by Nix. Available as [services.guix](#opt-services.guix.enable).
 
+- [pyLoad](https://pyload.net/), a FOSS download manager written in Python. Available as [services.pyload](#opt-services.pyload.enable)
+
 - [maubot](https://github.com/maubot/maubot), a plugin-based Matrix bot framework. Available as [services.maubot](#opt-services.maubot.enable).
 
 - systemd's gateway, upload, and remote services, which provides ways of sending journals across the network. Enable using [services.journald.gateway](#opt-services.journald.gateway.enable), [services.journald.upload](#opt-services.journald.upload.enable), and [services.journald.remote](#opt-services.journald.remote.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1056,6 +1056,7 @@
   ./services/networking/openvpn.nix
   ./services/networking/ostinato.nix
   ./services/networking/owamp.nix
+  ./services/networking/pyload.nix
   ./services/networking/pdns-recursor.nix
   ./services/networking/pdnsd.nix
   ./services/networking/peroxide.nix

--- a/nixos/modules/services/networking/pyload.nix
+++ b/nixos/modules/services/networking/pyload.nix
@@ -1,0 +1,147 @@
+{ config, lib, pkgs, utils, ... }:
+let
+  cfg = config.services.pyload;
+
+  stateDir = "/var/lib/pyload";
+in
+{
+  meta.maintainers = with lib.maintainers; [ ambroisie ];
+
+  options = with lib; {
+    services.pyload = {
+      enable = mkEnableOption "pyLoad download manager";
+
+      package = mkPackageOption pkgs "pyLoad" { default = [ "pyload-ng" ]; };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "localhost";
+        example = "0.0.0.0";
+        description = "Address to listen on for the web UI.";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 8000;
+        example = 9876;
+        description = "Port to listen on for the web UI.";
+      };
+
+      downloadDirectory = mkOption {
+        type = types.path;
+        default = "${stateDir}/downloads";
+        example = "/mnt/downloads";
+        description = "Directory to store downloads.";
+      };
+
+      credentialsFile = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        example = "/run/secrets/pyload-credentials.env";
+        description = ''
+          File containing {env}`PYLOAD_DEFAULT_USERNAME` and
+          {env}`PYLOAD_DEFAULT_PASSWORD` in the format of an `EnvironmentFile=`,
+          as described by {manpage}`systemd.exec(5)`.
+
+          If not given, they default to the username/password combo of
+          pyload/pyload.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.settings.pyload = {
+      ${cfg.downloadDirectory}.d = { };
+    };
+
+    systemd.services.pyload = {
+      description = "pyLoad download manager";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      # NOTE: unlike what the documentation says, it looks like `HOME` is not
+      # defined with this service definition...
+      # Since pyload tries to do the equivalent of `cd ~`, it needs to be able
+      # to resolve $HOME, which fails when `RootDirectory` is set.
+      # FIXME: check if `SetLoginEnvironment` fixes this issue in version 255
+      environment = {
+        HOME = stateDir;
+        PYLOAD__WEBUI__HOST = cfg.listenAddress;
+        PYLOAD__WEBUI__PORT = builtins.toString cfg.port;
+      };
+
+      serviceConfig = {
+        ExecStart = utils.escapeSystemdExecArgs [
+          (lib.getExe cfg.package)
+          "--userdir"
+          "${stateDir}/config"
+          "--storagedir"
+          cfg.downloadDirectory
+        ];
+
+        User = "pyload";
+        Group = "pyload";
+        DynamicUser = true;
+
+        EnvironmentFile = lib.optional (cfg.credentialsFile != null) cfg.credentialsFile;
+
+        StateDirectory = "pyload";
+        WorkingDirectory = stateDir;
+        RuntimeDirectory = "pyload";
+        RuntimeDirectoryMode = "0700";
+        RootDirectory = "/run/pyload";
+        BindReadOnlyPaths = [
+          builtins.storeDir # Needed to run the python interpreter
+        ];
+        BindPaths = [
+          cfg.downloadDirectory
+        ];
+
+        # Hardening options
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@resources" "~@privileged" ];
+        UMask = "0002";
+        CapabilityBoundingSet = [
+          "~CAP_BLOCK_SUSPEND"
+          "~CAP_BPF"
+          "~CAP_CHOWN"
+          "~CAP_IPC_LOCK"
+          "~CAP_KILL"
+          "~CAP_LEASE"
+          "~CAP_LINUX_IMMUTABLE"
+          "~CAP_NET_ADMIN"
+          "~CAP_SYS_ADMIN"
+          "~CAP_SYS_BOOT"
+          "~CAP_SYS_CHROOT"
+          "~CAP_SYS_NICE"
+          "~CAP_SYS_PACCT"
+          "~CAP_SYS_PTRACE"
+          "~CAP_SYS_RESOURCE"
+          "~CAP_SYS_TTY_CONFIG"
+        ];
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -387,6 +387,7 @@ in {
   installed-tests = pkgs.recurseIntoAttrs (handleTest ./installed-tests {});
   invidious = handleTest ./invidious.nix {};
   livebook-service = handleTest ./livebook-service.nix {};
+  pyload = handleTest ./pyload.nix {};
   oci-containers = handleTestOn ["aarch64-linux" "x86_64-linux"] ./oci-containers.nix {};
   odoo = handleTest ./odoo.nix {};
   odoo15 = handleTest ./odoo.nix { package = pkgs.odoo15; };

--- a/nixos/tests/pyload.nix
+++ b/nixos/tests/pyload.nix
@@ -1,0 +1,33 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "pyload";
+  meta.maintainers = with lib.maintainers; [ ambroisie ];
+
+  nodes = {
+    machine = { ... }: {
+      services.pyload = {
+        enable = true;
+
+        listenAddress = "0.0.0.0";
+        port = 9876;
+      };
+
+      networking.firewall.allowedTCPPorts = [ 9876 ];
+    };
+
+    client = { };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("pyload.service")
+
+    with subtest("Web interface accessible locally"):
+        machine.wait_until_succeeds("curl -fs localhost:9876")
+
+    client.wait_for_unit("network.target")
+
+    with subtest("Web interface accessible from a different machine"):
+        client.wait_until_succeeds("curl -fs machine:9876")
+  '';
+})

--- a/pkgs/applications/networking/pyload-ng/declarative-default-user.patch
+++ b/pkgs/applications/networking/pyload-ng/declarative-default-user.patch
@@ -1,0 +1,15 @@
+diff --git a/src/pyload/core/__init__.py b/src/pyload/core/__init__.py
+index 4324fc700..f7fcd66ec 100644
+--- a/src/pyload/core/__init__.py
++++ b/src/pyload/core/__init__.py
+@@ -46,8 +46,8 @@ class Exit(Exception):
+ #  improve external scripts
+ class Core:
+     LOCALE_DOMAIN = APPID
+-    DEFAULT_USERNAME = APPID
+-    DEFAULT_PASSWORD = APPID
++    DEFAULT_USERNAME = os.getenv("PYLOAD_DEFAULT_USERNAME", APPID)
++    DEFAULT_PASSWORD = os.getenv("PYLOAD_DEFAULT_PASSWORD", APPID)
+     DEFAULT_DATADIR = os.path.join(
+         os.getenv("APPDATA") or USERHOMEDIR, "pyLoad" if os.name == "nt" else ".pyload"
+     )

--- a/pkgs/applications/networking/pyload-ng/declarative-env-config.patch
+++ b/pkgs/applications/networking/pyload-ng/declarative-env-config.patch
@@ -1,0 +1,18 @@
+diff --git a/src/pyload/core/__init__.py b/src/pyload/core/__init__.py
+index 4324fc700..5d915a85e 100644
+--- a/src/pyload/core/__init__.py
++++ b/src/pyload/core/__init__.py
+@@ -128,6 +128,13 @@ class Core:
+         else:
+             self._debug = max(0, int(debug))
+
++        # Allow setting any option declaratively, for the NixOS module
++        for env, value in os.environ.items():
++            if not env.startswith("PYLOAD__"):
++                continue
++            section, opt = env.removeprefix("PYLOAD__").lower().split("__")
++            self.config.set(section, opt, value)
++
+         # If no argument set, read storage dir from config file,
+         # otherwise save setting to config dir
+         if storagedir is None:

--- a/pkgs/applications/networking/pyload-ng/default.nix
+++ b/pkgs/applications/networking/pyload-ng/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, python3 }:
+{ lib, fetchPypi, nixosTests, python3 }:
 
 python3.pkgs.buildPythonApplication rec {
   version = "0.5.0b3.dev75";
@@ -43,14 +43,20 @@ python3.pkgs.buildPythonApplication rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
-    plugins = with python3.pkgs; [
-      beautifulsoup4 # for some plugins
-      colorlog # colorful console logging
-      pillow # for some CAPTCHA plugin
-      send2trash # send some files to trash instead of deleting them
-      slixmpp # XMPP plugin
-    ];
+  passthru = {
+    optional-dependencies = {
+      plugins = with python3.pkgs; [
+        beautifulsoup4 # for some plugins
+        colorlog # colorful console logging
+        pillow # for some CAPTCHA plugin
+        send2trash # send some files to trash instead of deleting them
+        slixmpp # XMPP plugin
+      ];
+    };
+
+    tests = {
+      inherit (nixosTests) pyload;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/networking/pyload-ng/default.nix
+++ b/pkgs/applications/networking/pyload-ng/default.nix
@@ -10,6 +10,11 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-1lPIKkZESonDaVCnac0iUu/gCqXVDBhNZrk5S0eC6F0=";
   };
 
+  patches = [
+    # Makes it possible to change the default username/password in the module
+    ./declarative-default-user.patch
+  ];
+
   postPatch = ''
     # relax version bounds
     sed -i 's/\([A-z0-9]*\)~=.*$/\1/' setup.cfg

--- a/pkgs/applications/networking/pyload-ng/default.nix
+++ b/pkgs/applications/networking/pyload-ng/default.nix
@@ -13,6 +13,9 @@ python3.pkgs.buildPythonApplication rec {
   patches = [
     # Makes it possible to change the default username/password in the module
     ./declarative-default-user.patch
+    # Makes it possible to change the configuration through environment variables
+    # in the NixOS module (aimed mostly at listen address/port)
+    ./declarative-env-config.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

A few patches were made to the package, as configuring it declaratively is exceedingly difficult otherwise...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
