### PR TITLE
nixos: opengl -> impure-drivers.opengl

### DIFF
--- a/nixos/doc/manual/configuration/gpu-accel.chapter.md
+++ b/nixos/doc/manual/configuration/gpu-accel.chapter.md
@@ -30,7 +30,7 @@ $ export \
 ```
 
 The second mechanism is to add the OpenCL driver package to
-[](#opt-hardware.opengl.extraPackages).
+[](#opt-hardware.impure-drivers.packages).
 This links the ICD file under `/run/opengl-driver`, where it will be visible
 to the ICD loader.
 
@@ -51,11 +51,11 @@ Platform Vendor      Advanced Micro Devices, Inc.
 Modern AMD [Graphics Core
 Next](https://en.wikipedia.org/wiki/Graphics_Core_Next) (GCN) GPUs are
 supported through the rocmPackages.clr.icd package. Adding this package to
-[](#opt-hardware.opengl.extraPackages)
+[](#opt-hardware.impure-drivers.packages)
 enables OpenCL support:
 
 ```nix
-hardware.opengl.extraPackages = [
+hardware.impure-drivers.packages = [
   rocmPackages.clr.icd
 ];
 ```
@@ -71,12 +71,12 @@ proprietary Intel OpenCL runtime, in the intel-ocl package, is an
 alternative for Gen7 GPUs.
 
 The intel-compute-runtime, beignet, or intel-ocl package can be added to
-[](#opt-hardware.opengl.extraPackages)
+[](#opt-hardware.impure-drivers.packages)
 to enable OpenCL support. For example, for Gen8 and later GPUs, the following
 configuration can be used:
 
 ```nix
-hardware.opengl.extraPackages = [
+hardware.impure-drivers.packages = [
   intel-compute-runtime
 ];
 ```
@@ -88,7 +88,7 @@ compute API for GPUs. It is used directly by games or indirectly though
 compatibility layers like
 [DXVK](https://github.com/doitsujin/dxvk/wiki).
 
-By default, if [](#opt-hardware.opengl.driSupport)
+By default, if [](#opt-hardware.impure-drivers.opengl.driSupport)
 is enabled, mesa is installed and provides Vulkan for supported hardware.
 
 Similar to OpenCL, Vulkan drivers are loaded through the *Installable
@@ -108,7 +108,7 @@ $ export \
 ```
 
 The second mechanism is to add the Vulkan driver package to
-[](#opt-hardware.opengl.extraPackages).
+[](#opt-hardware.impure-drivers.packages).
 This links the ICD file under `/run/opengl-driver`, where it will be
 visible to the ICD loader.
 
@@ -138,7 +138,7 @@ Modern AMD [Graphics Core
 Next](https://en.wikipedia.org/wiki/Graphics_Core_Next) (GCN) GPUs are
 supported through either radv, which is part of mesa, or the amdvlk
 package. Adding the amdvlk package to
-[](#opt-hardware.opengl.extraPackages)
+[](#opt-hardware.impure-drivers.packages)
 makes amdvlk the default driver and hides radv and lavapipe from the device list.
 A specific driver can be forced as follows:
 
@@ -167,7 +167,7 @@ graphics hardware acceleration capabilities for video processing.
 
 VA-API drivers are loaded by `libva`. The version in nixpkgs is built to search
 the opengl driver path, so drivers can be installed in
-[](#opt-hardware.opengl.extraPackages).
+[](#opt-hardware.impure-drivers.packages).
 
 VA-API can be tested using:
 

--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -66,7 +66,7 @@ On 64-bit systems, if you want OpenGL for 32-bit programs such as in
 Wine, you should also set the following:
 
 ```nix
-hardware.opengl.driSupport32Bit = true;
+hardware.impure-drivers.opengl.driSupport32Bit = true;
 ```
 
 ## Auto-login {#sec-x11-auto-login}

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -6,6 +6,9 @@ let
 
   cfg = config.hardware.impure-drivers;
 
+  impurePath = pkgs.addDriverRunpath.driverLink;
+  impurePath32 = pkgs.pkgsi686Linux.addDriverRunpath.driverLink;
+
   kernelPackages = config.boot.kernelPackages;
 
   videoDrivers = config.services.xserver.videoDrivers;
@@ -163,19 +166,19 @@ in
     ];
 
     systemd.tmpfiles.rules = [
-      "L+ /run/opengl-driver - - - - ${package}"
+      "L+ ${impurePath} - - - - ${package}"
       (
         if pkgs.stdenv.isi686 then
-          "L+ /run/opengl-driver-32 - - - - opengl-driver"
+          "L+ ${impurePath32} - - - - ${impurePath}"
         else if cfg.opengl.driSupport32Bit then
-          "L+ /run/opengl-driver-32 - - - - ${package32}"
+          "L+ ${impurePath32} - - - - ${package32}"
         else
-          "r /run/opengl-driver-32"
+          "r ${impurePath32}"
       )
     ];
 
     environment.sessionVariables.LD_LIBRARY_PATH = mkIf cfg.setLdLibraryPath
-      ([ "/run/opengl-driver/lib" ] ++ optional cfg.driSupport32Bit "/run/opengl-driver-32/lib");
+      ([ "${impurePath}/lib" ] ++ optionals cfg.driSupport32Bit ["${impurePath32}/lib"]);
 
     hardware.impure-drivers.opengl.package = mkDefault pkgs.mesa.drivers;
     hardware.impure-drivers.opengl.package32 = mkDefault pkgs.pkgsi686Linux.mesa.drivers;

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -286,11 +286,11 @@ in {
           KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 0'"
           KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm-tools c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
         '';
-        hardware.opengl = {
-          extraPackages = [
+        hardware.impure-drivers = {
+          packages = [
             nvidia_x11.out
           ];
-          extraPackages32 = [
+          packages32 = [
             nvidia_x11.lib32
           ];
         };
@@ -453,11 +453,11 @@ in {
           "egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
         };
 
-        hardware.opengl = {
-          extraPackages = [
+        hardware.impure-drivers = {
+          packages = [
             pkgs.nvidia-vaapi-driver
           ];
-          extraPackages32 = [
+          packages32 = [
             pkgs.pkgsi686Linux.nvidia-vaapi-driver
           ];
         };

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -661,7 +661,7 @@ in
                     || dmConf.lightdm.enable);
       in mkIf (noDmUsed) (mkDefault false);
 
-    hardware.opengl.enable = mkDefault true;
+    hardware.impure-drivers.enable = mkDefault true;
 
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];
 
@@ -759,8 +759,8 @@ in
         restartIfChanged = false;
 
         environment =
-          optionalAttrs config.hardware.opengl.setLdLibraryPath
-            { LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.addOpenGLRunpath.driverLink ]; }
+          optionalAttrs config.impure-drivers.setLdLibraryPath
+            { LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.addDriverRunpath.driverLink ]; }
           // cfg.displayManager.job.environment;
 
         preStart =


### PR DESCRIPTION
## Description of changes

WIP. Following https://github.com/NixOS/nixpkgs/pull/275241 and https://github.com/NixOS/nixpkgs/pull/269475

The motivation is that it's extremely confusing for the new users when instructions for enabling something like CUDA involve setting `hardware.opengl.enable` and `services.xserver.videoDrivers`. The module's new name is meant to suggest that it's there to ensure integration with the `addDriverRunpath`, and it hopefully explains why/when the module has to be enabled (when we're forced to link drivers "impurely").

I think it'd also make sense to introduce an option like `hardware.impure-drivers.cuda.enable`, which would guide the user through the process of setting up the x11 or datacenter drivers (e.g. through assertions). I'd keep that for a separate PR

Thoughts? @jonringer @Kiskae @NixOS/cuda-maintainers @NixOS/rocm-maintainers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
  - [x] `nixosTests.quake3`
  - [x] `nixosTests.tinywl`
  - [ ] `nixosTests.openarena`
  - [ ] `nixosTests.seatd`
  - [ ] `nixosTests.cagebreak`
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
