### PR TITLE
hfst-ospell: pull upstream fix for gcc-13 compatibility

### DIFF
--- a/pkgs/development/libraries/hfst-ospell/default.nix
+++ b/pkgs/development/libraries/hfst-ospell/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , autoreconfHook
 , fetchFromGitHub
+, fetchpatch
 , icu
 , libarchive
 , pkg-config
@@ -17,6 +18,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-16H1nbAIe+G71+TnlLG0WnH9LktZwmc0d0O+oYduH1k=";
   };
+
+  patches = [
+    # Pull upstream fix for gcc-13
+    (fetchpatch {
+      name = "cstdint.patch";
+      url = "https://github.com/hfst/hfst-ospell/commit/7481bffbf622bc9aee3547183fbe8db9cf8b22ce.patch";
+      hash = "sha256-q/B5mLx8Oc0nIRe3n3gl0OTyjIaEMCBsPc1GvpE226c=";
+    })
+  ];
 
   buildInputs = [
     icu


### PR DESCRIPTION
Without the change `hfst-ospell` fails build on `staging-next` as:

    hfst-ol.h:39:9: error: 'uint16_t' does not name a type
       39 | typedef uint16_t SymbolNumber;
          |         ^~~~~~~~
    hfst-ol.h:35:1: note: 'uint16_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       34 | #include <utility>
      +++ |+#include <cstdint>
       35 | #include "ol-exceptions.h"
    hfst-ol.h:40:9: error: 'uint32_t' does not name a type
       40 | typedef uint32_t TransitionTableIndex;
          |         ^~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
