### PR TITLE
services.gitea: add extraRootConfig

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -16,6 +16,7 @@ let
     RUN_USER = ${cfg.user}
     RUN_MODE = prod
     WORK_PATH = ${cfg.stateDir}
+    ${optionalString (cfg.extraRootConfig != null) cfg.extraRootConfig}
 
     ${generators.toINI {} cfg.settings}
 
@@ -383,10 +384,16 @@ in
         };
       };
 
+      extraRootConfig = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = lib.mdDoc "Configuration lines appended to the top of the gitea configuration file.";
+      };
+
       extraConfig = mkOption {
         type = with types; nullOr str;
         default = null;
-        description = lib.mdDoc "Configuration lines appended to the generated gitea configuration file.";
+        description = lib.mdDoc "Configuration lines appended to the end of the generated gitea configuration file.";
       };
     };
   };


### PR DESCRIPTION
## Description of changes

extraConfig is amended to the bottom of the configuration file, meaning that there previously existed no mechanism to emit top-level options (which is required in some cases). Add extraRootConfig to expose this functionality.

closes https://github.com/NixOS/nixpkgs/issues/276577