### PR TITLE
cwiid: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/cwiid/default.nix
+++ b/pkgs/development/libraries/cwiid/default.nix
@@ -1,13 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, bison, flex, bluez, pkg-config, gtk2 }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, bison
+, flex
+, bluez
+, pkg-config
+, gtk2
+}:
 
 stdenv.mkDerivation rec {
   pname = "cwiid";
   version = "unstable-2010-02-21";
 
   src = fetchFromGitHub {
-    owner  = "abstrakraft";
-    repo   = "cwiid";
-    rev    = "fadf11e89b579bcc0336a0692ac15c93785f3f82";
+    owner = "abstrakraft";
+    repo = "cwiid";
+    rev = "fadf11e89b579bcc0336a0692ac15c93785f3f82";
     sha256 = "0qdb0x757k76nfj32xc2nrrdqd9jlwgg63vfn02l2iznnzahxp0h";
   };
 
@@ -19,9 +28,21 @@ stdenv.mkDerivation rec {
     sed -i -e '/$(LDCONFIG)/d' common/include/lib.mak.in
   '';
 
-  buildInputs = [ bison flex bluez gtk2 ];
+  patches = [
+    ./fix-ar.diff
+  ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [
+    bluez
+    gtk2
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    bison
+    flex
+  ];
 
   NIX_LDFLAGS = "-lbluetooth";
 
@@ -32,9 +53,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Linux Nintendo Wiimote interface";
-    homepage    = "http://cwiid.org";
-    license     = licenses.gpl2Plus;
+    homepage = "http://cwiid.org";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ bennofs ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/cwiid/fix-ar.diff
+++ b/pkgs/development/libraries/cwiid/fix-ar.diff
@@ -1,0 +1,26 @@
+diff --git a/common/include/lib.mak.in b/common/include/lib.mak.in
+index 3afbb14..b8df9d9 100644
+--- a/common/include/lib.mak.in
++++ b/common/include/lib.mak.in
+@@ -22,7 +22,7 @@ static: $(STATIC_LIB)
+ shared: $(SHARED_LIB)
+ 
+ $(STATIC_LIB): $(OBJECTS)
+-	ar rcs $(STATIC_LIB) $(OBJECTS)
++	$(AR) rcs $(STATIC_LIB) $(OBJECTS)
+ 
+ $(SHARED_LIB): $(OBJECTS)
+ 	$(CC) -shared -Wl,-soname,$(SO_NAME) $(LDFLAGS) -o $(SHARED_LIB) \
+diff --git a/configure.ac b/configure.ac
+index 82ca3e1..0a78283 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -15,6 +15,8 @@ if test "$YACC" != "bison -y"; then
+ 	AC_MSG_ERROR([bison not found])
+ fi
+ 
++AC_CHECK_TOOL([AR], [ar], [:])
++
+ AC_ARG_WITH(
+ 	[python],
+ 	[AS_HELP_STRING([--without-python],[compile without python support])],


### PR DESCRIPTION
## Description of changes

Fix cross-compilation of `cwiid`.

* Remove hardcoded use of ar.
* Move flex and bison to nativeBuildInputs.
* Reformat for good measure.

Note: this package hasn't been updated in 14 years, is it still needed, and does it still work?

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux -> aarch64-multiplatform
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
