### PR TITLE
nixos/shairport-sync: fix dbus support

### DIFF
--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -6,6 +6,37 @@ let
 
   cfg = config.services.shairport-sync;
 
+  # This is based off the upstream versions, but they can't be used directly because
+  # we allow customising the user.
+  dbusPolicy = pkgs.writeTextDir "etc/dbus-1/system.d/shairport-sync-dbus-policy.conf" ''
+    <!-- initial version, based on /etc/dbus-1/system.d/avahi-dbus.conf, with thanks -->
+    <!DOCTYPE busconfig PUBLIC
+              "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+              "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+    <busconfig>
+
+      <!-- Allow users "root" and "${cfg.user}" to own the Shairport Sync services -->
+      <policy user="root">
+        <allow own="org.gnome.ShairportSync"/>
+        <allow own="org.mpris.MediaPlayer2.ShairportSync"/>
+      </policy>
+      <policy user="${cfg.user}">
+        <allow own="org.gnome.ShairportSync"/>
+        <allow own="org.mpris.MediaPlayer2.ShairportSync"/>
+      </policy>
+
+
+      <!-- Allow anyone to invoke methods on Shairport Sync servers -->
+      <policy context="default">
+        <allow send_destination="org.gnome.ShairportSync"/>
+        <allow receive_sender="org.gnome.ShairportSync"/>
+        <allow send_destination="org.mpris.MediaPlayer2.ShairportSync"/>
+        <allow receive_sender="org.mpris.MediaPlayer2.ShairportSync"/>
+      </policy>
+
+    </busconfig>
+  '';
+
 in
 
 {
@@ -103,9 +134,18 @@ in
           ExecStart = "${pkgs.shairport-sync}/bin/shairport-sync ${cfg.arguments}";
           RuntimeDirectory = "shairport-sync";
         };
+
+        environment = {
+          # Force to use system dbus.
+          DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/dbus/system_bus_socket";
+        };
       };
 
     environment.systemPackages = [ pkgs.shairport-sync ];
+
+    services.dbus.packages = [
+      dbusPolicy
+    ];
 
   };
 


### PR DESCRIPTION
## Description of changes

Adds a policy (based off upstream's) that allows root and the configured user to own/use the main service and MPRIS interface.

Note that the upstream policies cannot be directly used because we allow configuring the user.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
