### PR TITLE
nixVersions.nix_2_3: fix build against current gcc

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -8,7 +8,6 @@
 , fetchpatch2
 , runCommand
 , Security
-, pin-to-gcc12-if-gcc13
 
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
@@ -152,16 +151,14 @@ let
     pkg;
 
 in lib.makeExtensible (self: ({
-  nix_2_3 = pin-to-gcc12-if-gcc13 ((common {
+  nix_2_3 = (common {
     version = "2.3.17";
     hash = "sha256-EK0pgHDekJFqr0oMj+8ANIjq96WPjICe2s0m4xkUdH4=";
     patches = [
       patch-monitorfdhup
     ];
     maintainers = with lib.maintainers; [ flokli raitobezarius ];
-  }).override {
-    boehmgc = boehmgc-nix_2_3;
-  });
+  }).override { boehmgc = boehmgc-nix_2_3; };
 
   nix_2_10 = common {
     version = "2.10.3";


### PR DESCRIPTION
Without the change `nix_2_3` fails the build due to it's dependency pulling in newer `libstdc++`:

    $ nix build --no-link -f. nix_2_3
    error: builder for '/nix/store/d3vqya9ka7sh4m7q53xkjrv1rzbc0qa1-nix-2.3.17.drv' failed with exit code 2;
           last 10 log lines:
           > Note: Writing nix-instantiate.1
           > Note: Writing nix-prefetch-url.1
           > Note: Writing nix.conf.5
           >   LD     src/libstore/libnixstore.so
           >   LD     src/libmain/libnixmain.so
           >   LD     src/libexpr/libnixexpr.so
           >   LD     src/nix/nix
           > /nix/store/xdqs45iclhp9dz8zz9pvn5zivjbhid1a-binutils-2.40/bin/ld: /nix/store/i3qy2bskybxz53kbi9bbz5a3ysbm8asi-aws-sdk-cpp-1.9.294/lib/libaws-cpp-sdk-transfer.so: undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32'
           > collect2: error: ld returned 1 exit status
           > make: *** [mk/lib.mk:122: src/nix/nix] Error 1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
