### PR TITLE
passage: add additional deps to wrapper

### DIFF
--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";
     homepage    = "https://github.com/FiloSottile/passage";
     license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ kaction ];
+    maintainers = with maintainers; [ kaction ma27 ];
     platforms   = platforms.unix;
     mainProgram = "passage";
 

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -5,6 +5,12 @@
 , substituteAll
 , age
 , getopt
+, coreutils
+, findutils
+, gnugrep
+, gnused
+, qrencode ? null
+, wl-clipboard ? null
 , git ? null
 , xclip ? null
 # Used to pretty-print list of all stored passwords, but is not needed to fetch
@@ -32,7 +38,18 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  extraPath = lib.makeBinPath [ age git xclip tree ];
+  extraPath = lib.makeBinPath [
+    age
+    coreutils
+    findutils
+    git
+    gnugrep
+    gnused
+    qrencode
+    tree
+    wl-clipboard
+    xclip
+  ];
 
   # Using $0 is bad, it causes --help to mention ".passage-wrapped".
   postInstall = ''


### PR DESCRIPTION

## Description of changes

I realized that passage won't work properly in e.g. systemd units as these don't have `/run/current-system/sw/bin` inside their `PATH` and thus globally installed things like `coreutils` are not available there.

Added the following tools now:

* `coreutils` for `base64` & `shred` (most notably `passage show`).
* `wl-clipboard` for copying things to the clipboard on Wayland (most notable `passage show -c`).
* `gnused` for `sed` (most notably `passage show`).
* `gnugrep` for `grep` (for `passage grep`).
* `findutils` for `find` (most notably `mv`/`cp` - used in `reencrypt_path()`).

Decided against adding stuff like `feh`/`gm` for showing a QR code. These are optional and the script falls back to printing the QR code on CLI.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
