### PR TITLE
python311Packages.lxml: 4.9.3-3 -> 4.9.4, backport libxml 2.12 build fix

### DIFF
--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -8,15 +8,21 @@
 
 buildPythonPackage rec {
   pname = "lxml";
-  version = "4.9.3-3";
+  version = "4.9.4";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/lxml-${version}";
-    hash = "sha256-Vrizi+6jUUEx7qODU4PAH5ZmvBIyT9H18+QpYB0m1f4=";
+    hash = "sha256-qS20wb83eFapiPZe25BViHpYkjgvnCIZpiYkPNIPHZg=";
   };
+
+  patches = [
+    # fix compile error with libxml 2.12
+    # backport of: https://github.com/lxml/lxml/commit/b0861bea17769584a85f57eb00235ce0ca9811af
+    ./libxml-2.12.patch
+  ];
 
   # setuptoolsBuildPhase needs dependencies to be passed through nativeBuildInputs
   nativeBuildInputs = [ libxml2.dev libxslt.dev cython ] ++ lib.optionals stdenv.isDarwin [ xcodebuild ];

--- a/pkgs/development/python-modules/lxml/libxml-2.12.patch
+++ b/pkgs/development/python-modules/lxml/libxml-2.12.patch
@@ -1,0 +1,94 @@
+From 3b8807306d79d2ae2e9fa28c5ecd3b40b32ee65b Mon Sep 17 00:00:00 2001
+From: Stefan Behnel <stefan_ml@behnel.de>
+Date: Wed, 29 Nov 2023 10:28:47 +0100
+Subject: [PATCH] Follow changes in libxml2 2.12 and make xmlError usages
+ 'const'. This mostly impacts the error callback functions.
+
+---
+ src/lxml/extensions.pxi | 4 ++--
+ src/lxml/parser.pxi     | 4 ++--
+ src/lxml/xmlerror.pxi   | 8 ++++----
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/lxml/extensions.pxi b/src/lxml/extensions.pxi
+index 35a321b7..42b4c4f6 100644
+--- a/src/lxml/extensions.pxi
++++ b/src/lxml/extensions.pxi
+@@ -393,7 +393,7 @@ cdef tuple LIBXML2_XPATH_ERROR_MESSAGES = (
+     b"?? Unknown error ??\n",
+ )
+ 
+-cdef void _forwardXPathError(void* c_ctxt, xmlerror.xmlError* c_error) with gil:
++cdef void _forwardXPathError(void* c_ctxt, const xmlerror.xmlError* c_error) with gil:
+     cdef xmlerror.xmlError error
+     cdef int xpath_code
+     if c_error.message is not NULL:
+@@ -414,7 +414,7 @@ cdef void _forwardXPathError(void* c_ctxt, xmlerror.xmlError* c_error) with gil:
+ 
+     (<_BaseContext>c_ctxt)._error_log._receive(&error)
+ 
+-cdef void _receiveXPathError(void* c_context, xmlerror.xmlError* error) nogil:
++cdef void _receiveXPathError(void* c_context, const xmlerror.xmlError* error) nogil:
+     if not __DEBUG:
+         return
+     if c_context is NULL:
+diff --git a/src/lxml/parser.pxi b/src/lxml/parser.pxi
+index 22463c7d..1566b6df 100644
+--- a/src/lxml/parser.pxi
++++ b/src/lxml/parser.pxi
+@@ -626,10 +626,10 @@ cdef _initParserContext(_ParserContext context,
+     if c_ctxt is not NULL:
+         context._initParserContext(c_ctxt)
+ 
+-cdef void _forwardParserError(xmlparser.xmlParserCtxt* _parser_context, xmlerror.xmlError* error) with gil:
++cdef void _forwardParserError(xmlparser.xmlParserCtxt* _parser_context, const xmlerror.xmlError* error) with gil:
+     (<_ParserContext>_parser_context._private)._error_log._receive(error)
+ 
+-cdef void _receiveParserError(void* c_context, xmlerror.xmlError* error) nogil:
++cdef void _receiveParserError(void* c_context, const xmlerror.xmlError* error) nogil:
+     if __DEBUG:
+         if c_context is NULL or (<xmlparser.xmlParserCtxt*>c_context)._private is NULL:
+             _forwardError(NULL, error)
+diff --git a/src/lxml/xmlerror.pxi b/src/lxml/xmlerror.pxi
+index 1b50444f..4cd745f9 100644
+--- a/src/lxml/xmlerror.pxi
++++ b/src/lxml/xmlerror.pxi
+@@ -66,7 +66,7 @@ cdef class _LogEntry:
+         tree.xmlFree(self._c_path)
+ 
+     @cython.final
+-    cdef _setError(self, xmlerror.xmlError* error):
++    cdef _setError(self, const xmlerror.xmlError* error):
+         self.domain   = error.domain
+         self.type     = error.code
+         self.level    = <int>error.level
+@@ -198,7 +198,7 @@ cdef class _BaseErrorLog:
+         pass
+ 
+     @cython.final
+-    cdef void _receive(self, xmlerror.xmlError* error):
++    cdef void _receive(self, const xmlerror.xmlError* error):
+         cdef bint is_error
+         cdef _LogEntry entry
+         cdef _BaseErrorLog global_log
+@@ -634,7 +634,7 @@ def use_global_python_log(PyErrorLog log not None):
+ 
+ 
+ # local log functions: forward error to logger object
+-cdef void _forwardError(void* c_log_handler, xmlerror.xmlError* error) with gil:
++cdef void _forwardError(void* c_log_handler, const xmlerror.xmlError* error) with gil:
+     cdef _BaseErrorLog log_handler
+     if c_log_handler is not NULL:
+         log_handler = <_BaseErrorLog>c_log_handler
+@@ -645,7 +645,7 @@ cdef void _forwardError(void* c_log_handler, xmlerror.xmlError* error) with gil:
+     log_handler._receive(error)
+ 
+ 
+-cdef void _receiveError(void* c_log_handler, xmlerror.xmlError* error) nogil:
++cdef void _receiveError(void* c_log_handler, const xmlerror.xmlError* error) nogil:
+     # no Python objects here, may be called without thread context !
+     if __DEBUG:
+         _forwardError(c_log_handler, error)
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

Bump mostly added since we're rebuilding it anyway, the interesting change is the patch.

Fixes https://hydra.nixos.org/build/244442380/nixlog/2

aarch64-darwin tested on the community builder.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
