### PR TITLE
xfce.xfce4-docklike-plugin: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-docklike-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-docklike-plugin/default.nix
@@ -1,30 +1,30 @@
 { lib
 , mkXfceDerivation
+, cairo
 , glib
 , gtk3
+, libX11
 , libxfce4ui
 , libxfce4util
 , xfce4-panel
-, xfconf
 , libwnck
-, exo
 }:
 
 mkXfceDerivation {
   category = "panel-plugins";
   pname = "xfce4-docklike-plugin";
-  version = "0.4.1";
-  sha256 = "sha256-BKxd2TFEbRHeFy/dC2Wx5ppErsi7d2m7JicFCcZbjTo=";
+  version = "0.4.2";
+  sha256 = "sha256-M/V8cnEU/nSEDjQ3k8fWiklF5OuNg3uzzJMHBSZBiLU=";
 
   buildInputs = [
+    cairo
     glib
     gtk3
+    libX11
     libxfce4ui
     libxfce4util
     xfce4-panel
-    xfconf
     libwnck
-    exo
   ];
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";


### PR DESCRIPTION
https://gitlab.xfce.org/panel-plugins/xfce4-docklike-plugin/-/compare/xfce4-docklike-plugin-0.4.1...xfce4-docklike-plugin-0.4.2


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
