### PR TITLE
liboqs: Fix build error

### DIFF
--- a/pkgs/development/libraries/liboqs/default.nix
+++ b/pkgs/development/libraries/liboqs/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-h3mXoGRYgPg0wKQ1u6uFP7wlEUMQd5uIBt4Hr7vjNtA=";
   };
 
+  patches = [ ./fix-openssl-detection.patch ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl ];
 

--- a/pkgs/development/libraries/liboqs/fix-openssl-detection.patch
+++ b/pkgs/development/libraries/liboqs/fix-openssl-detection.patch
@@ -1,0 +1,36 @@
+From 6bdcf53de74ac2afba42deea63522939ca51f871 Mon Sep 17 00:00:00 2001
+From: Raphael Robatsch <raphael-git@tapesoftware.net>
+Date: Mon, 25 Dec 2023 16:15:29 +0000
+Subject: [PATCH] Do not forcibly set OPENSSL_ROOT_DIR.
+
+CMake can already find OpenSSL via pkg-config. Setting OPENSSL_ROOT_DIR
+forcibly to "/usr" breaks this.
+---
+ CMakeLists.txt | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 288bcbe8..9750fae6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,17 +119,6 @@ include(.CMake/compiler_opts.cmake)
+ include(.CMake/alg_support.cmake)
+ 
+ if(${OQS_USE_OPENSSL})
+-    if(NOT DEFINED OPENSSL_ROOT_DIR)
+-        if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
+-            if(EXISTS "/usr/local/opt/openssl@1.1")
+-                set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl@1.1")
+-            elseif(EXISTS "/opt/homebrew/opt/openssl@1.1")
+-                set(OPENSSL_ROOT_DIR "/opt/homebrew/opt/openssl@1.1")
+-            endif()
+-        elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
+-            set(OPENSSL_ROOT_DIR "/usr")
+-        endif()
+-    endif()
+     find_package(OpenSSL 1.1.1 REQUIRED)
+ endif()
+ 
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

Currently the build fails with

```
CMake Error at /nix/store/4vq5ggsg1vmfs09r4sqbidmgvqlxrv14-cmake-3.27.8/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
  OPENSSL_INCLUDE_DIR) (Required is at least version "1.1.1")
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
