### PR TITLE
cudaPackages: eliminate exceptions

### DIFF
--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -77,7 +77,7 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
   cuda_nvcc = prev.cuda_nvcc.overrideAttrs (
     oldAttrs: {
 
-      outputs = oldAttrs.outputs ++ [ "lib" ];
+      outputs = oldAttrs.outputs ++ lists.optionals (!(builtins.elem "lib" oldAttrs.outputs)) [ "lib" ];
 
       # Patch the nvcc.profile.
       # Syntax:

--- a/pkgs/development/cuda-modules/flags.nix
+++ b/pkgs/development/cuda-modules/flags.nix
@@ -143,7 +143,7 @@ let
     else if nixSystem == "x86_64-windows" then
       "windows-x86_64"
     else
-      builtins.throw "Unsupported Nix system: ${nixSystem}";
+      "unsupported";
 
   # Maps NVIDIA redist arch to Nix system.
   # It is imperative that we include the boolean condition based on jetsonTargets to ensure
@@ -163,7 +163,7 @@ let
     else if redistArch == "windows-x86_64" then
       "x86_64-windows"
     else
-      builtins.throw "Unsupported NVIDIA redist arch: ${redistArch}";
+      "unsupported-${redistArch}";
 
   formatCapabilities =
     {
@@ -175,9 +175,10 @@ let
 
       # archNames :: List String
       # E.g. [ "Turing" "Ampere" ]
+      #
+      # Unknown architectures are rendered as sm_XX gencode flags.
       archNames = lists.unique (
-        lists.map (cap: cudaComputeCapabilityToName.${cap} or (throw "missing cuda compute capability"))
-          cudaCapabilities
+        lists.map (cap: cudaComputeCapabilityToName.${cap} or "sm_${dropDot cap}") cudaCapabilities
       );
 
       # realArches :: List String

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -117,10 +117,14 @@ backendStdenv.mkDerivation (
     brokenConditions = {};
 
     src = fetchurl {
-      url = "https://developer.download.nvidia.com/compute/${redistName}/redist/${
-        redistribRelease.${redistArch}.relative_path
-      }";
-      inherit (redistribRelease.${redistArch}) sha256;
+      url =
+        if (builtins.hasAttr redistArch redistribRelease) then
+          "https://developer.download.nvidia.com/compute/${redistName}/redist/${
+            redistribRelease.${redistArch}.relative_path
+          }"
+        else
+          "cannot-construct-an-url-for-the-${redistArch}-platform";
+      sha256 = redistribRelease.${redistArch}.sha256 or lib.fakeHash;
     };
 
     postPatch = ''

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -77,7 +77,7 @@ backendStdenv.mkDerivation (
             false
             featureRelease;
         # Order is important here so we use a list.
-        additionalOutputs = builtins.filter hasOutput [
+        possibleOutputs = [
           "bin"
           "lib"
           "static"
@@ -86,8 +86,10 @@ backendStdenv.mkDerivation (
           "sample"
           "python"
         ];
+        additionalOutputs =
+          if redistArch == "unsupported" then possibleOutputs else builtins.filter hasOutput possibleOutputs;
         # The out output is special -- it's the default output and we always include it.
-        outputs = ["out"] ++ additionalOutputs;
+        outputs = [ "out" ] ++ additionalOutputs;
       in
       outputs;
 
@@ -283,9 +285,9 @@ backendStdenv.mkDerivation (
           (
             redistArch:
             let
-              nixSystem = builtins.tryEval (flags.getNixSystem redistArch);
+              nixSystem = flags.getNixSystem redistArch;
             in
-            if nixSystem.success then [nixSystem.value] else []
+            lists.optionals (!(strings.hasPrefix "unsupported-" nixSystem)) [ nixSystem ]
           )
           supportedRedistArchs;
       broken = lists.any trivial.id (attrsets.attrValues finalAttrs.brokenConditions);

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -480,6 +480,7 @@ let
     };
 
     meta = with lib; {
+      badPlatforms = lib.optionals cudaSupport lib.platforms.darwin;
       changelog = "https://github.com/tensorflow/tensorflow/releases/tag/v${version}";
       description = "Computation using data flow graphs for scalable machine learning";
       homepage = "http://tensorflow.org";


### PR DESCRIPTION
as they break common nixpkgs tools like lib.meta,
cf. https://github.com/NixOS/nixpkgs/issues/276795

@NixOS/cuda-maintainers 

## Description of changes

Before:

```
Before:
❯ nix repl --show-trace
Welcome to Nix 2.19.2. Type :? for help.
nix-repl> :lf nixpkgs
nix-repl> with legacyPackages.aarch64-darwin; lib.meta.availableOn "aarch64-darwin" cudaPackages.cuda_nvcc
...
       … while calling 'getRedistArch'
...
       error: Unsupported Nix system: aarch64-darwin
```


After:

```
nix-repl> with legacyPackages.aarch64-darwin; lib.meta.availableOn "aarch64-darwin" cudaPackages.cuda_nvcc
false
nix-repl> with legacyPackages.x86_64-darwin; cudaPackages.cuda_nvcc.meta.unsupported  
true
nix-repl> with legacyPackages.x86_64-linux; cudaPackages.cuda_nvcc.meta.unsupported  
false
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
