### PR TITLE
nixos/systemtap: fix and test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -856,6 +856,7 @@ in {
   systemd-misc = handleTest ./systemd-misc.nix {};
   systemd-userdbd = handleTest ./systemd-userdbd.nix {};
   systemd-homed = handleTest ./systemd-homed.nix {};
+  systemtap = handleTest ./systemtap.nix {};
   tandoor-recipes = handleTest ./tandoor-recipes.nix {};
   tang = handleTest ./tang.nix {};
   taskserver = handleTest ./taskserver.nix {};

--- a/nixos/tests/systemtap.nix
+++ b/nixos/tests/systemtap.nix
@@ -35,27 +35,17 @@ let
             assert "println works\n" == output, "println works\n != " + output
       '';
   }) args);
+
+  ## TODO shared infra with ../kernel-generic.nix
   kernels = {
     inherit (pkgs.linuxKernel.vanillaPackages)
-      linux_6_1;
+      linux_6_1 linux_6_6
+    ;
+    inherit (pkgs.linuxKernel.packages)
+      linux_rt_6_1 linux_6_1_hardened
+      linux_libre linux_testing
+    ;
   };
-  # kernels = pkgs.linuxKernel.vanillaPackages // {
-  #   inherit (pkgs.linuxKernel.packages)
-  #     linux_4_19_hardened
-  #     linux_5_4_hardened
-  #     linux_5_10_hardened
-  #     linux_5_15_hardened
-  #     linux_6_1_hardened
-  #     linux_6_5_hardened
-  #     linux_6_6_hardened
-  #     linux_rt_5_4
-  #     linux_rt_5_10
-  #     linux_rt_5_15
-  #     linux_rt_6_1
-  #     linux_libre
-
-  #     linux_testing;
-  # };
 
 in mapAttrs (_: lP: testsForLinuxPackages lP) kernels // {
   passthru = {

--- a/nixos/tests/systemtap.nix
+++ b/nixos/tests/systemtap.nix
@@ -1,0 +1,60 @@
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../.. { inherit system config; }
+}@args:
+
+with pkgs.lib;
+
+let
+  testsForLinuxPackages = linuxPackages: (import ./make-test-python.nix ({ pkgs, ... }: {
+    name = "kernel-${linuxPackages.kernel.version}";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ bendlas ];
+    };
+
+    nodes.machine = { ... }:
+      {
+        boot.kernelPackages = linuxPackages;
+        programs.systemtap.enable = true;
+      };
+
+    testScript =
+      ''
+        print("SYSTEMTAP TESTS for ${linuxPackages.kernel.modDirVersion}")
+        machine.succeed("stap ${pkgs.writeText "test.stp" ''
+          probe begin {
+            println("hello world\n")
+            exit()
+          }
+        ''}")
+      '';
+  }) args);
+  kernels = {
+    inherit (pkgs.linuxKernel.vanillaPackages)
+      linux_6_1;
+  };
+  # kernels = pkgs.linuxKernel.vanillaPackages // {
+  #   inherit (pkgs.linuxKernel.packages)
+  #     linux_4_19_hardened
+  #     linux_5_4_hardened
+  #     linux_5_10_hardened
+  #     linux_5_15_hardened
+  #     linux_6_1_hardened
+  #     linux_6_5_hardened
+  #     linux_6_6_hardened
+  #     linux_rt_5_4
+  #     linux_rt_5_10
+  #     linux_rt_5_15
+  #     linux_rt_6_1
+  #     linux_libre
+
+  #     linux_testing;
+  # };
+
+in mapAttrs (_: lP: testsForLinuxPackages lP) kernels // {
+  passthru = {
+    inherit testsForLinuxPackages;
+
+    testsForKernel = kernel: testsForLinuxPackages (pkgs.linuxPackagesFor kernel);
+  };
+}

--- a/nixos/tests/systemtap.nix
+++ b/nixos/tests/systemtap.nix
@@ -7,8 +7,8 @@ with pkgs.lib;
 
 let
   stapScript = pkgs.writeText "test.stp" ''
-    probe begin {
-      println("println works")
+    probe kernel.function("do_sys_poll") {
+      println("kernel function probe & println work")
       exit()
     }
   '';
@@ -32,19 +32,13 @@ let
             output = machine.succeed("stap ${stapScript} 2>&1")
 
         with subtest("Ensure that expected output from stap script is there"):
-            assert "println works\n" == output, "println works\n != " + output
+            assert "kernel function probe & println work\n" == output, "kernel function probe & println work\n != " + output
       '';
   }) args);
 
   ## TODO shared infra with ../kernel-generic.nix
   kernels = {
-    inherit (pkgs.linuxKernel.vanillaPackages)
-      linux_6_1 linux_6_6
-    ;
-    inherit (pkgs.linuxKernel.packages)
-      linux_rt_6_1 linux_6_1_hardened
-      linux_libre linux_testing
-    ;
+    inherit (pkgs.linuxKernel.packageAliases) linux_default linux_latest;
   };
 
 in mapAttrs (_: lP: testsForLinuxPackages lP) kernels // {

--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -23,13 +23,10 @@ let
   };
 
   ## symlink farm for --sysroot flag
-  sysroot = runCommand "systemtap-sysroot-${kernel.version}" {
-    modulePath = "lib/modules/${kernel.version}";
-  } ''
-    mkdir -p $out/$modulePath $out/boot
-    cp -s ${kernel.dev}/vmlinux $out
-    cp -s ${kernel}/System.map $out/boot/System.map-${kernel.version}
-    cp -Rs ${kernel.dev}/$modulePath/* ${kernel}/$modulePath/* $out/$modulePath
+  sysroot = runCommand "systemtap-sysroot-${kernel.version}" { } ''
+    mkdir -p $out/boot
+    ln -s ${kernel.dev}/vmlinux ${kernel.dev}/lib $out
+    ln -s ${kernel}/System.map $out/boot/System.map-${kernel.version}
   '';
 
   pypkgs = with python3.pkgs; makePythonPath [ pyparsing ];

--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -6,8 +6,8 @@ let
   ## fetchgit info
   url = "git://sourceware.org/git/systemtap.git";
   rev = "release-${version}";
-  sha256 = "sha256-UiUMoqdfkk6mzaPGctpQW3dvOWKhNBNuScJ5BpCykVg=";
-  version = "4.8";
+  sha256 = "sha256-2L7+k/tgI6trkstDTY4xxfFzmNDlxbCHDRKAFaERQeM=";
+  version = "5.0a";
 
   inherit (kernel) stdenv;
 

--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -24,8 +24,9 @@ let
 
   ## symlink farm for --sysroot flag
   sysroot = runCommand "systemtap-sysroot-${kernel.version}" { } ''
-    mkdir -p $out/boot
+    mkdir -p $out/boot $out/usr/lib/debug
     ln -s ${kernel.dev}/vmlinux ${kernel.dev}/lib $out
+    ln -s ${kernel.dev}/vmlinux $out/usr/lib/debug
     ln -s ${kernel}/System.map $out/boot/System.map-${kernel.version}
   '';
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`stap` can run with a `--sysroot` flag, which allows it to find paths like `/boot` or `/lib/modules` within a directory. This allows us to pass a custom sysroot directory, tailored for what systemtap looks for.

## Things done

- use `--sysroot` instead of `-r`
- add vm tests

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
