### PR TITLE
verible: 0.0.3428 -> 0.0.3471

### DIFF
--- a/pkgs/development/tools/language-servers/verible/default.nix
+++ b/pkgs/development/tools/language-servers/verible/default.nix
@@ -2,7 +2,8 @@
 , stdenv
 , buildBazelPackage
 , fetchFromGitHub
-, bazel_4
+, bazel_5
+, jdk
 , bison
 , flex
 , python3
@@ -17,8 +18,8 @@ buildBazelPackage rec {
   # These environment variables are read in bazel/build-version.py to create
   # a build string shown in the tools --version output.
   # If env variables not set, it would attempt to extract it from .git/.
-  GIT_DATE = "2023-10-26";
-  GIT_VERSION = "v0.0-3428-gcfcbb82b";
+  GIT_DATE = "2023-12-23";
+  GIT_VERSION = "v0.0-3471-g9cb45092";
 
   # Derive nix package version from GIT_VERSION: "v1.2-345-abcde" -> "1.2.345"
   version = builtins.concatStringsSep "." (lib.take 3 (lib.drop 1 (builtins.splitVersion GIT_VERSION)));
@@ -27,7 +28,7 @@ buildBazelPackage rec {
     owner = "chipsalliance";
     repo  = "verible";
     rev   = "${GIT_VERSION}";
-    hash  = "sha256-snWhOuGyAdtdJDMttcbEjlkwPUO1mdR9vuro0tZt+Z8=";
+    hash  = "sha256-nFt5TeFv63Igx8Zer2s/ZLj5DsHeZj5V/+3burnEm9g=";
   };
 
   patches = [
@@ -37,25 +38,19 @@ buildBazelPackage rec {
     ./remove-unused-deps.patch
   ];
 
-  bazel = bazel_4;
+  bazel = bazel_5;
   bazelFlags = [
     "--//bazel:use_local_flex_bison"
-    "--javabase=@bazel_tools//tools/jdk:remote_jdk11"
-    "--host_javabase=@bazel_tools//tools/jdk:remote_jdk11"
+    "--java_runtime_version=local_jdk"
+    "--tool_java_runtime_version=local_jdk"
   ];
 
   fetchAttrs = {
-    # Fixed output derivation hash after bazel fetch.
-    # This varies per platform, probably from the JDK pulled in being part
-    # of the output derivation ? Is there a more robust way to do this ?
-    # (Hashes extracted from the ofborg build logs)
-    sha256 = {
-      aarch64-linux = "sha256-Hf/jF5Y7QS2ZNFmSx2LIb0b6gdjditE97HwWGqQJac8=";
-      x86_64-linux = "sha256-WBp5Fi5vvKLVgRWvQ3VB7sY6ySpbwCdhU5KqZH9sLy4=";
-    }.${system} or (throw "No hash for system: ${system}");
+    sha256 = "sha256-gZzrgZsHQ9zMoIDooVo9nRQbkJ41igme8wcNFj5EzWc=";
   };
 
   nativeBuildInputs = [
+    jdk        # bazel uses that.
     bison      # We use local flex and bison as WORKSPACE sources fail
     flex       # .. to compile with newer glibc
     python3


### PR DESCRIPTION
## Description of changes

Update to latest Version. It needs bazel5 now.
Fixing one ASAN issue.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
