### PR TITLE
buttermanager: init at 2.5.1

### DIFF
--- a/pkgs/by-name/bu/buttermanager/package.nix
+++ b/pkgs/by-name/bu/buttermanager/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, wrapGAppsHook
+, qt5
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "buttermanager";
+  version = "2.5.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "egara";
+    repo = "buttermanager";
+    rev = version;
+    hash = "sha256-MLYJt7OMYlTFk8FCAlZJ1RGlFFXKfeAthWGp4JN+PfY=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyqt5
+    pyyaml
+    sip
+    tkinter
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    qt5.wrapQtAppsHook
+  ];
+
+  dontWrapQtApps = true;
+  dontWrapGApps = true;
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" "\${gappsWrapperArgs[@]}"];
+
+  postInstall = ''
+    substituteInPlace packaging/buttermanager.desktop \
+      --replace-fail /opt/buttermanager/gui/buttermanager.svg buttermanager
+
+    install -Dm444 packaging/buttermanager.desktop -t $out/share/applications
+    install -Dm444 packaging/buttermanager.svg -t $out/share/icons/hicolor/scalable/apps
+  '';
+
+  meta = with lib; {
+    description = "Btrfs tool for managing snapshots, balancing filesystems and upgrading the system safetly";
+    homepage = "https://github.com/egara/buttermanager";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ t4ccer ];
+    mainProgram = "buttermanager";
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes #196780

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
