### PR TITLE
melpa2nix: update to work with Emacs HEAD

### DIFF
--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -40,8 +40,8 @@ import ./generic.nix { inherit lib stdenv emacs texinfo writeText gcc; } ({
     src = fetchFromGitHub {
       owner = "melpa";
       repo = "package-build";
-      rev = "c3c535e93d9dc92acd21ebc4b15016b5c3b90e7d";
-      sha256 = "17z0wbqdd6fspbj43yq8biff6wfggk74xgnaf1xx6ynsp1i74is5";
+      rev = "c48aa078c01b4f07b804270c4583a0a58ffea1c0";
+      sha256 = "sha256-MzPj375upIiYXdQR+wWXv3A1zMqbSrZlH0taLuxx/1M=";
     };
 
     patches = [ ./package-build-dont-use-mtime.patch ];

--- a/pkgs/build-support/emacs/melpa2nix.el
+++ b/pkgs/build-support/emacs/melpa2nix.el
@@ -11,22 +11,22 @@
 ;; Allow installing package tarfiles larger than 10MB
 (setq large-file-warning-threshold nil)
 
-(defun melpa2nix-build-package-1 (rcp version commit)
-  (let ((source-dir (package-recipe--working-tree rcp)))
+(defun melpa2nix-build-package-1 (rcp)
+  (let* ((default-directory (package-recipe--working-tree rcp)))
     (unwind-protect
         (let ((files (package-build-expand-files-spec rcp t)))
-          (cond
-           ((= (length files) 1)
-            (package-build--build-single-file-package
-             rcp version commit files source-dir))
-           ((> (length files) 1)
-            (package-build--build-multi-file-package
-             rcp version commit files source-dir))
-           (t (error "Unable to find files matching recipe patterns")))))))
+          (unless files
+            (error "Unable to find files matching recipe patterns"))
+          (if (> (length files) 1)
+              (package-build--build-multi-file-package rcp files)
+            (package-build--build-single-file-package rcp files))))))
 
 (defun melpa2nix-build-package ()
-  (if (not noninteractive)
-      (error "`melpa2nix-build-package' is to be used only with -batch"))
+  (unless noninteractive
+    (error "`melpa2nix-build-package' is to be used only with -batch"))
   (pcase command-line-args-left
     (`(,package ,version ,commit)
-     (melpa2nix-build-package-1 (package-recipe-lookup package) version commit))))
+     (let ((recipe (package-recipe-lookup package)))
+       (setf (oref recipe commit) commit)
+       (setf (oref recipe version) version)
+       (melpa2nix-build-package-1 recipe)))))

--- a/pkgs/build-support/emacs/package-build-dont-use-mtime.patch
+++ b/pkgs/build-support/emacs/package-build-dont-use-mtime.patch
@@ -1,40 +1,21 @@
 diff --git a/package-build.el b/package-build.el
-index e572045..9eb0f82 100644
+index 29cdb61..c19be1b 100644
 --- a/package-build.el
 +++ b/package-build.el
-@@ -415,7 +415,7 @@ (defun package-build--write-pkg-file (desc dir)
-       (princ ";; Local Variables:\n;; no-byte-compile: t\n;; End:\n"
-              (current-buffer)))))
- 
--(defun package-build--create-tar (name version directory mtime)
-+(defun package-build--create-tar (name version directory)
-   "Create a tar file containing the contents of VERSION of package NAME.
- DIRECTORY is a temporary directory that contains the directory
- that is put in the tarball.  MTIME is used as the modification
-@@ -434,7 +434,7 @@ (defun package-build--create-tar (name version directory mtime)
-        ;; prevent a reproducable tarball as described at
+@@ -923,7 +923,6 @@ DIRECTORY is a temporary directory that contains the directory
+ that is put in the tarball."
+   (let* ((name (oref rcp name))
+          (version (oref rcp version))
+-         (time (oref rcp time))
+          (tar (expand-file-name (concat name "-" version ".tar")
+                                 package-build-archive-dir))
+          (dir (concat name "-" version)))
+@@ -939,7 +938,7 @@ that is put in the tarball."
+        ;; prevent a reproducible tarball as described at
         ;; https://reproducible-builds.org/docs/archives.
         "--sort=name"
--       (format "--mtime=@%d" mtime)
+-       (format "--mtime=@%d" time)
 +       "--mtime=@0"
         "--owner=0" "--group=0" "--numeric-owner"
         "--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"))
      (when (and package-build-verbose noninteractive)
-@@ -848,12 +848,11 @@ (defun package-build--build-multi-file-package (rcp version commit files source-
-                            (package-build--desc-from-library
-                             name version commit files 'tar)
-                            (error "%s[-pkg].el matching package name is missing"
--                                  name))))
--               (mtime (package-build--get-commit-time rcp commit)))
-+                                  name)))))
-           (package-build--copy-package-files files source-dir target)
-           (package-build--write-pkg-file desc target)
-           (package-build--generate-info-files files source-dir target)
--          (package-build--create-tar name version tmp-dir mtime)
-+          (package-build--create-tar name version tmp-dir)
-           (package-build--write-pkg-readme name files source-dir)
-           (package-build--write-archive-entry desc))
-       (delete-directory tmp-dir t nil))))
--- 
-2.37.2
-


### PR DESCRIPTION
## Description of changes

When building recent Emacs HEAD with Nix, `melpaPackages` do not build, since the `package-build.el` version used here relies on a function in `package.el` that has been removed.

To resolve this, this PR makes `melpa2nix` use a newer version of `package-build` that has been fixed to work with Emacs HEAD. See https://github.com/melpa/package-build/pull/87

Some changes have also been necessary to the corresponding patch and to the elisp in `melpa2nix.el`.

_Edited for clarity_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
