### PR TITLE
satysfi: 0.0.8 → 0.0.10

### DIFF
--- a/pkgs/development/ocaml-modules/otfed/default.nix
+++ b/pkgs/development/ocaml-modules/otfed/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+, base
+, ppx_deriving
+, ppx_inline_test
+, uutf
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "otfed";
+  version = "0.3.1";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "gfngfn";
+    repo = pname;
+    rev = version;
+    hash = "sha256-6QCom9nrz0B5vCmuBzqsM0zCs8tBLJC6peig+vCgMVA=";
+  };
+
+  buildInputs = [
+    uutf
+  ];
+
+  propagatedBuildInputs = [
+    base
+    ppx_deriving
+    ppx_inline_test
+  ];
+
+  checkInputs = [
+    alcotest
+  ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/gfngfn/otfed";
+    description = "OpenType Font Format Encoder & Decoder";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -10,15 +10,6 @@ let
       sha256 = "1s8wcqdkl1alvfcj67lhn3qdz8ikvd1v64f4q6bi4c0qj9lmp30k";
     };
   };
-  otfm = ocamlPackages.otfm.overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "gfngfn";
-      repo = "otfm";
-      rev = "v0.3.7+satysfi";
-      sha256 = "0y8s0ij1vp1s4h5y1hn3ns76fzki2ba5ysqdib33akdav9krbj8p";
-    };
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ ocamlPackages.result ];
-  });
   yojson-with-position = ocamlPackages.buildDunePackage {
     pname = "yojson-with-position";
     version = "1.4.2";
@@ -28,7 +19,6 @@ let
       rev = "v1.4.2+satysfi";
       sha256 = "17s5xrnpim54d1apy972b5l08bph4c0m5kzbndk600fl0vnlirnl";
     };
-    duneVersion = "3";
     nativeBuildInputs = [ ocamlPackages.cppo ];
     propagatedBuildInputs = [ ocamlPackages.biniou ];
     inherit (ocamlPackages.yojson) meta;
@@ -36,12 +26,12 @@ let
 in
   ocamlPackages.buildDunePackage rec {
     pname = "satysfi";
-    version = "0.0.8";
+    version = "0.0.10";
     src = fetchFromGitHub {
       owner = "gfngfn";
       repo = "SATySFi";
       rev = "v${version}";
-      sha256 = "sha256-cVGe1N3qMlEGAE/jPUji/X3zlijadayka1OL6iFioY4=";
+      hash = "sha256-qgVM7ExsKtzNQkZO+I+rcWLj4LSvKL5uyitH7Jg+ns0=";
       fetchSubmodules = true;
     };
 
@@ -51,13 +41,12 @@ in
       $out/share/satysfi
     '';
 
-    duneVersion = "3";
-
     nativeBuildInputs = with ocamlPackages; [ menhir cppo ];
 
-    buildInputs = [ camlpdf otfm yojson-with-position ] ++ (with ocamlPackages; [
+    buildInputs = [ camlpdf yojson-with-position ] ++ (with ocamlPackages; [
       menhirLib
       batteries camlimages core_kernel ppx_deriving uutf omd re
+      otfed
     ]);
 
     postInstall = ''

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1387,6 +1387,8 @@ let
 
     oseq = callPackage ../development/ocaml-modules/oseq { };
 
+    otfed = callPackage ../development/ocaml-modules/otfed { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otoml = callPackage ../development/ocaml-modules/otoml { };


### PR DESCRIPTION
## Description of changes

https://github.com/gfngfn/SATySFi/blob/v0.0.10/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
