### PR TITLE
[23.11] nwjs: 0.54.1 -> 0.83.0

### DIFF
--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -85,7 +85,7 @@ let
     extraOutputsToInstall = [ "lib" "out" ];
   };
 
-  version = "0.82.0";
+  version = "0.83.0";
 in
 stdenv.mkDerivation {
   pname = "nwjs";
@@ -96,10 +96,10 @@ stdenv.mkDerivation {
     in fetchurl {
       url = "https://dl.nwjs.io/v${version}/nwjs-${flavor}v${version}-linux-${bits}.tar.gz";
       hash = {
-        "sdk-ia32" = "sha256-aIRnZDslOhoD5F0coX43VNFWGEImPU5oq9Roc4jYfsY=";
-        "sdk-x64" = "sha256-rKbnNAq9AVjSUjTipYze2VHiVi0RnZZsdQj1725DPd0=";
-        "ia32" = "sha256-pA53+A+EtS7m6026jPlC3vFxb2iheS4peDJFNkQAf/s=";
-        "x64" = "sha256-hRih8o8hBbYBEes3Z62PSMIC720SLRa3t2rL/5LaJAE=";
+        "sdk-ia32" = "sha256-Sps0XFOnnJIkDRPI+PJSjseF8cyaYvXXs4ZeVI8mcm8=";
+        "sdk-x64" = "sha256-qsNPfmDQK/BZzMTlX9MDaV7KZsU32YQ1B/Qh/EHIZrQ=";
+        "ia32" = "sha256-99+EU4Kg8lH8facRmIl2SV3GyWUw46rGYpso5QSP//k=";
+        "x64" = "sha256-y0oBVvVguRDe391EsQs6qYqkTRPzUfm50m6NDOZh+7o=";
       }."${flavor + bits}";
     };
 

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -21,6 +21,7 @@
 , libuuid
 , libxcb
 , libxkbcommon
+, makeWrapper
 , mesa
 , nspr
 , nss
@@ -30,6 +31,7 @@
 , stdenv
 , systemd
 , udev
+, wrapGAppsHook
 , xorg
 }:
 
@@ -101,9 +103,19 @@ stdenv.mkDerivation {
       }."${flavor + bits}";
     };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    (wrapGAppsHook.override { inherit makeWrapper; })
+  ];
+
   buildInputs = [ nwEnv ];
   appendRunpaths = map (pkg: (lib.getLib pkg) + "/lib") [ nwEnv stdenv.cc.libc stdenv.cc.cc ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+    )
+  '';
 
   installPhase = ''
       runHook preInstall

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -129,6 +129,7 @@ stdenv.mkDerivation {
     platforms = [ "i686-linux" "x86_64-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = [ maintainers.mikaelfangel ];
+    mainProgram = "nw";
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildEnv, makeWrapper
+{ stdenv, lib, fetchurl, buildEnv, makeWrapper, autoPatchelfHook
 
 , xorg, alsa-lib, at-spi2-core, dbus, glib, gtk3, atk, pango, freetype
 , fontconfig , gdk-pixbuf, cairo, mesa, nss, nspr, expat, systemd
@@ -35,22 +35,22 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "nwjs";
-  version = "0.54.1";
+  version = "0.82.0";
 
   src = if sdk then fetchurl {
     url = "https://dl.nwjs.io/v${version}/nwjs-sdk-v${version}-linux-${bits}.tar.gz";
-    sha256 = if bits == "x64" then
-      "sha256-1qeU4+EIki0M7yJPkRuzFwMdswfDOni5gltdmM6A/ds=" else
-      "sha256-wDEGePE9lrKa6OAzeiDLhVj992c0TJgiMHb8lJ4PF80=";
+    hash = if bits == "x64" then
+      "sha256-rKbnNAq9AVjSUjTipYze2VHiVi0RnZZsdQj1725DPd0=" else
+      "sha256-aIRnZDslOhoD5F0coX43VNFWGEImPU5oq9Roc4jYfsY=";
   } else fetchurl {
     url = "https://dl.nwjs.io/v${version}/nwjs-v${version}-linux-${bits}.tar.gz";
-    sha256 = if bits == "x64" then
-      "sha256-TACEM06K2t6dDXRD44lSW7GRi77yzSW4BZJw8gT+fl4=" else
-      "sha256-yX9knqFV5VQTT3TJDmQoDgt17NqH8fLt+bLQAqKleTU=";
+    hash = if bits == "x64" then
+      "sha256-aIRnZDslOhoD5F0coX43VNFWGEImPU5oq9Roc4jYfsY=" else
+      "sha256-pA53+A+EtS7m6026jPlC3vFxb2iheS4peDJFNkQAf/s=";
   };
 
-  # we have runtime deps like sqlite3 that should remain
-  dontPatchELF = true;
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+  runtimeDependencies = [ sqlite libuuid udev ];
 
   installPhase =
     let ccPath = lib.makeLibraryPath [ stdenv.cc.cc ];
@@ -85,8 +85,6 @@ in stdenv.mkDerivation rec {
       mkdir $out/lib
       ln -s $out/share/nwjs/lib/libnw.so $out/lib/libnw.so
   '';
-
-  nativeBuildInputs = [ makeWrapper ];
 
   meta = with lib; {
     description = "An app runtime based on Chromium and node.js";

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation {
     homepage = "https://nwjs.io/";
     platforms = [ "i686-linux" "x86_64-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = [ maintainers.offline ];
+    maintainers = [ maintainers.mikaelfangel ];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -1,60 +1,113 @@
-{ stdenv, lib, fetchurl, buildEnv, makeWrapper, autoPatchelfHook
-
-, xorg, alsa-lib, at-spi2-core, dbus, glib, gtk3, atk, pango, freetype
-, fontconfig , gdk-pixbuf, cairo, mesa, nss, nspr, expat, systemd
-, libcap, libdrm, libxkbcommon
+{ alsa-lib
+, at-spi2-core
+, atk
+, autoPatchelfHook
+, buildEnv
+, cairo
+, cups
+, dbus
+, expat
+, fetchurl
+, ffmpeg
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, lib
+, libcap
+, libdrm
 , libnotify
-, ffmpeg, libxcb, cups
-, sqlite, udev
 , libuuid
+, libxcb
+, libxkbcommon
+, makeWrapper
+, mesa
+, nspr
+, nss
+, pango
 , sdk ? false
+, sqlite
+, stdenv
+, systemd
+, udev
+, xorg
 }:
+
 let
-  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
-         else "ia32";
+  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64" else "ia32";
 
   nwEnv = buildEnv {
     name = "nwjs-env";
     paths = [
-      xorg.libX11 xorg.libXrender glib gtk3 atk at-spi2-core pango cairo gdk-pixbuf
-      freetype fontconfig xorg.libXcomposite alsa-lib xorg.libXdamage
-      xorg.libXext xorg.libXfixes mesa nss nspr expat dbus
-      xorg.libXtst xorg.libXi xorg.libXcursor xorg.libXrandr
-      xorg.libXScrnSaver xorg.libxshmfence cups
-      libcap libdrm libnotify
+      alsa-lib
+      at-spi2-core
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      gtk3
+      libcap
+      libdrm
+      libnotify
       libxkbcommon
+      mesa
+      nspr
+      nss
+      pango
+      xorg.libX11
+      xorg.libXScrnSaver
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libxshmfence
       # libnw-specific (not chromium dependencies)
-      ffmpeg libxcb
+      ffmpeg
+      libxcb
       # chromium runtime deps (dlopen’d)
-      sqlite udev
       libuuid
+      sqlite
+      udev
     ];
 
     extraOutputsToInstall = [ "lib" "out" ];
   };
 
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "nwjs";
   version = "0.82.0";
 
-  src = if sdk then fetchurl {
-    url = "https://dl.nwjs.io/v${version}/nwjs-sdk-v${version}-linux-${bits}.tar.gz";
-    hash = if bits == "x64" then
-      "sha256-rKbnNAq9AVjSUjTipYze2VHiVi0RnZZsdQj1725DPd0=" else
-      "sha256-aIRnZDslOhoD5F0coX43VNFWGEImPU5oq9Roc4jYfsY=";
-  } else fetchurl {
-    url = "https://dl.nwjs.io/v${version}/nwjs-v${version}-linux-${bits}.tar.gz";
-    hash = if bits == "x64" then
-      "sha256-aIRnZDslOhoD5F0coX43VNFWGEImPU5oq9Roc4jYfsY=" else
-      "sha256-pA53+A+EtS7m6026jPlC3vFxb2iheS4peDJFNkQAf/s=";
-  };
+  src =
+    let flavor = if sdk then "sdk-" else "";
+    in fetchurl {
+      url = "https://dl.nwjs.io/v${version}/nwjs-${flavor}v${version}-linux-${bits}.tar.gz";
+      hash = {
+        "sdk-ia32" = "sha256-aIRnZDslOhoD5F0coX43VNFWGEImPU5oq9Roc4jYfsY=";
+        "sdk-x64" = "sha256-rKbnNAq9AVjSUjTipYze2VHiVi0RnZZsdQj1725DPd0=";
+        "ia32" = "sha256-pA53+A+EtS7m6026jPlC3vFxb2iheS4peDJFNkQAf/s=";
+        "x64" = "sha256-hRih8o8hBbYBEes3Z62PSMIC720SLRa3t2rL/5LaJAE=";
+      }."${flavor + bits}";
+    };
 
   nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
   runtimeDependencies = [ sqlite libuuid udev ];
 
   installPhase =
     let ccPath = lib.makeLibraryPath [ stdenv.cc.cc ];
-    in ''
+    in
+    ''
       mkdir -p $out/share/nwjs
       cp -R * $out/share/nwjs
       find $out/share/nwjs
@@ -84,12 +137,12 @@ in stdenv.mkDerivation rec {
 
       mkdir $out/lib
       ln -s $out/share/nwjs/lib/libnw.so $out/lib/libnw.so
-  '';
+    '';
 
   meta = with lib; {
     description = "An app runtime based on Chromium and node.js";
     homepage = "https://nwjs.io/";
-    platforms = ["i686-linux" "x86_64-linux"];
+    platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = [ maintainers.offline ];
     license = licenses.bsd3;
   };


### PR DESCRIPTION
## Description of changes

This introduced important security fixes to nwjs, which includes a chromium engine.

Backport of: #262424 and #276397

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
