### PR TITLE
[23.11] legba: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/by-name/le/legba/package.nix
+++ b/pkgs/by-name/le/legba/package.nix
@@ -4,23 +4,24 @@
 , cmake
 , pkg-config
 , openssl
+, samba
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "legba";
-  version = "0.6.1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "legba";
     rev = "v${version}";
-    hash = "sha256-/ASjvlsPQAPNZpzdTTyZYrcYImV2GS+SSfhSQP0K2n0=";
+    hash = "sha256-7HDW5M0lsKbcQw3p/CYmUeX2xE4BZXUSNqa9Ab/ZP0I=";
   };
 
-  cargoHash = "sha256-QgnJ/oUpW4o2Hi2+xKfprxjCw4sho8kIyW+AUJ9pwuU=";
+  cargoHash = "sha256-rkqwc8BILW/OIHa95skkG4IDlBfH3qX1ROJgcn8f2W0=";
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ openssl.dev ];
+  buildInputs = [ openssl.dev samba ];
 
   # Paho C test fails due to permission issue
   doCheck = false;

--- a/pkgs/by-name/le/legba/package.nix
+++ b/pkgs/by-name/le/legba/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "legba";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "legba";
     rev = "v${version}";
-    hash = "sha256-zZQZuMjyQEuXNor3g4P0YLvvj2DaU3A3/FUzCRJxnZQ=";
+    hash = "sha256-/ASjvlsPQAPNZpzdTTyZYrcYImV2GS+SSfhSQP0K2n0=";
   };
 
-  cargoHash = "sha256-qFdV4s//CsLi8tjQ36z3+ECMQR8evtCUKbauf6XpJ04=";
+  cargoHash = "sha256-QgnJ/oUpW4o2Hi2+xKfprxjCw4sho8kIyW+AUJ9pwuU=";
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ openssl.dev ];


### PR DESCRIPTION
## Description of changes

Backports: #270772 and #275274

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
