### PR TITLE
[23.11] python3Packages.twisted: add patch for CVE-2023-46137

### DIFF
--- a/pkgs/development/python-modules/twisted/23.8.0-CVE-2023-46137.patch
+++ b/pkgs/development/python-modules/twisted/23.8.0-CVE-2023-46137.patch
@@ -1,0 +1,174 @@
+Based on upstream merge
+1e6e9d23cac59689760558dcb6634285e694b04c adjusted
+to apply to 23.8.0
+
+--- a/src/twisted/web/http.py
++++ b/src/twisted/web/http.py
+@@ -2443,14 +2443,38 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
+ 
+         self._handlingRequest = True
+ 
++        # We go into raw mode here even though we will be receiving lines next
++        # in the protocol; however, this data will be buffered and then passed
++        # back to line mode in the setLineMode call in requestDone.
++        self.setRawMode()
++
+         req = self.requests[-1]
+         req.requestReceived(command, path, version)
+ 
+-    def dataReceived(self, data):
++    def rawDataReceived(self, data: bytes) -> None:
+         """
+-        Data was received from the network.  Process it.
++        This is called when this HTTP/1.1 parser is in raw mode rather than
++        line mode.
++
++        It may be in raw mode for one of two reasons:
++
++            1. All the headers of a request have been received and this
++               L{HTTPChannel} is currently receiving its body.
++
++            2. The full content of a request has been received and is currently
++               being processed asynchronously, and this L{HTTPChannel} is
++               buffering the data of all subsequent requests to be parsed
++               later.
++
++        In the second state, the data will be played back later.
++
++        @note: This isn't really a public API, and should be invoked only by
++            L{LineReceiver}'s line parsing logic.  If you wish to drive an
++            L{HTTPChannel} from a custom data source, call C{dataReceived} on
++            it directly.
++
++        @see: L{LineReceive.rawDataReceived}
+         """
+-        # If we're currently handling a request, buffer this data.
+         if self._handlingRequest:
+             self._dataBuffer.append(data)
+             if (
+@@ -2462,9 +2486,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
+                 # ready.  See docstring for _optimisticEagerReadSize above.
+                 self._networkProducer.pauseProducing()
+             return
+-        return basic.LineReceiver.dataReceived(self, data)
+ 
+-    def rawDataReceived(self, data):
+         self.resetTimeout()
+ 
+         try:
+--- /dev/null
++++ b/src/twisted/web/newsfragments/11976.bugfix
+@@ -0,0 +1,7 @@
++In Twisted 16.3.0, we changed twisted.web to stop dispatching HTTP/1.1
++pipelined requests to application code.  There was a bug in this change which
++still allowed clients which could send multiple full HTTP requests in a single
++TCP segment to trigger asynchronous processing of later requests, which could
++lead to out-of-order responses.  This has now been corrected and twisted.web
++should never process a pipelined request over HTTP/1.1 until the previous
++request has fully completed.
+--- a/src/twisted/web/test/test_web.py
++++ b/src/twisted/web/test/test_web.py
+@@ -8,6 +8,7 @@ Tests for various parts of L{twisted.web}.
+ import os
+ import zlib
+ from io import BytesIO
++from typing import List
+ 
+ from zope.interface import implementer
+ from zope.interface.verify import verifyObject
+@@ -15,12 +16,15 @@ from zope.interface.verify import verifyObject
+ from twisted.internet import interfaces
+ from twisted.internet.address import IPv4Address, IPv6Address
+ from twisted.internet.task import Clock
+-from twisted.internet.testing import EventLoggingObserver
++from twisted.internet.testing import EventLoggingObserver, StringTransport
+ from twisted.logger import LogLevel, globalLogPublisher
+ from twisted.python import failure, reflect
++from twisted.python.compat import iterbytes
+ from twisted.python.filepath import FilePath
+ from twisted.trial import unittest
+ from twisted.web import error, http, iweb, resource, server
++from twisted.web.resource import Resource
++from twisted.web.server import NOT_DONE_YET, Request, Site
+ from twisted.web.static import Data
+ from twisted.web.test.requesthelper import DummyChannel, DummyRequest
+ from ._util import assertIsFilesystemTemporary
+@@ -1849,3 +1853,78 @@ class ExplicitHTTPFactoryReactor(unittest.TestCase):
+ 
+         factory = http.HTTPFactory()
+         self.assertIs(factory.reactor, reactor)
++
++
++class QueueResource(Resource):
++    """
++    Add all requests to an internal queue,
++    without responding to the requests.
++    You can access the requests from the queue and handle their response.
++    """
++
++    isLeaf = True
++
++    def __init__(self) -> None:
++        super().__init__()
++        self.dispatchedRequests: List[Request] = []
++
++    def render_GET(self, request: Request) -> int:
++        self.dispatchedRequests.append(request)
++        return NOT_DONE_YET
++
++
++class TestRFC9112Section932(unittest.TestCase):
++    """
++    Verify that HTTP/1.1 request ordering is preserved.
++    """
++
++    def test_multipleRequestsInOneSegment(self) -> None:
++        """
++        Twisted MUST NOT respond to a second HTTP/1.1 request while the first
++        is still pending.
++        """
++        qr = QueueResource()
++        site = Site(qr)
++        proto = site.buildProtocol(None)
++        serverTransport = StringTransport()
++        proto.makeConnection(serverTransport)
++        proto.dataReceived(
++            b"GET /first HTTP/1.1\r\nHost: a\r\n\r\n"
++            b"GET /second HTTP/1.1\r\nHost: a\r\n\r\n"
++        )
++        # The TCP data contains 2 requests,
++        # but only 1 request was dispatched,
++        # as the first request was not yet finalized.
++        self.assertEqual(len(qr.dispatchedRequests), 1)
++        # The first request is finalized and the
++        # second request is dispatched right away.
++        qr.dispatchedRequests[0].finish()
++        self.assertEqual(len(qr.dispatchedRequests), 2)
++
++    def test_multipleRequestsInDifferentSegments(self) -> None:
++        """
++        Twisted MUST NOT respond to a second HTTP/1.1 request while the first
++        is still pending, even if the second request is received in a separate
++        TCP package.
++        """
++        qr = QueueResource()
++        site = Site(qr)
++        proto = site.buildProtocol(None)
++        serverTransport = StringTransport()
++        proto.makeConnection(serverTransport)
++        raw_data = (
++            b"GET /first HTTP/1.1\r\nHost: a\r\n\r\n"
++            b"GET /second HTTP/1.1\r\nHost: a\r\n\r\n"
++        )
++        # Just go byte by byte for the extreme case in which each byte is
++        # received in a separate TCP package.
++        for chunk in iterbytes(raw_data):
++            proto.dataReceived(chunk)
++        # The TCP data contains 2 requests,
++        # but only 1 request was dispatched,
++        # as the first request was not yet finalized.
++        self.assertEqual(len(qr.dispatchedRequests), 1)
++        # The first request is finalized and the
++        # second request is dispatched right away.
++        qr.dispatchedRequests[0].finish()
++        self.assertEqual(len(qr.dispatchedRequests), 2)

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -77,6 +77,7 @@ buildPythonPackage rec {
       url = "https://github.com/mweinelt/twisted/commit/e69e652de671aac0abf5c7e6c662fc5172758c5a.patch";
       hash = "sha256-LmvKUTViZoY/TPBmSlx4S9FbJNZfB5cxzn/YcciDmoI=";
     })
+    ./23.8.0-CVE-2023-46137.patch
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-46137

Includes enabled test. Not bumping because the release with the fix removes python3.7 support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
