### PR TITLE
nixos/nat: Match iptables behavior with nftables, add externalIP check

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22347,6 +22347,12 @@
     githubId = 6118602;
     name = "Viktor";
   };
+  tne = {
+    email = "tne@garudalinux.org";
+    github = "JustTNE";
+    githubId = 38938720;
+    name = "TNE";
+  };
   tnias = {
     email = "phil@grmr.de";
     matrix = "@tnias:stratum0.org";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -39,6 +39,8 @@
 
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
 
+- The behavior of the `networking.nat.externalIP` and `networking.nat.externalIPv6` options has been changed. `networking.nat.forwardPorts` now only forwards packets destined for the specified IP addresses.
+
 - `kanata` was updated to v1.7.0, which introduces several breaking changes.
   See the release notes of
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)

--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -20,7 +20,10 @@ in
       type = types.bool;
       default = false;
       description = ''
-        Whether to enable Network Address Translation (NAT).
+        Whether to enable Network Address Translation (NAT). A
+        properly configured firewall or a trusted L2 on all network
+        interfaces is required to prevent unauthorized access to
+        the internal network.
       '';
     };
 

--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -82,7 +82,8 @@ in
         The public IP address to which packets from the local
         network are to be rewritten.  If this is left empty, the
         IP address associated with the external interface will be
-        used.
+        used.  Only connections made to this IP address will be
+        forwarded to the internal network when using forwardPorts.
       '';
     };
 
@@ -94,7 +95,8 @@ in
         The public IPv6 address to which packets from the local
         network are to be rewritten.  If this is left empty, the
         IP address associated with the external interface will be
-        used.
+        used.  Only connections made to this IP address will be
+        forwarded to the internal network when using forwardPorts.
       '';
     };
 

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -1,100 +1,278 @@
-# This is a simple distributed test involving a topology with two
-# separate virtual networks - the "inside" and the "outside" - with a
-# client on the inside network, a server on the outside network, and a
-# router connected to both that performs Network Address Translation
-# for the client.
-import ./make-test-python.nix ({ pkgs, lib, withFirewall, nftables ? false, ... }:
+# This is a distributed test of the Network Address Translation involving a topology
+# with a router inbetween three separate virtual networks:
+# - "external" -- i.e. the internet,
+# - "internal" -- i.e. an office LAN,
+#
+# This test puts one server on each of those networks and its primary goal is to ensure that:
+# - server (named client in the code) in internal network can reach server (named server in the code) on the external network,
+# - server in external network can not reach server in internal network (skipped in some cases),
+# - when using externalIP, only the specified IP is used for NAT,
+# - port forwarding functionality behaves correctly
+#
+# The client is behind the nat (read: protected by the nat) and the server is on the external network, attempting to access services behind the NAT.
+
+import ./make-test-python.nix ({ pkgs, lib, withFirewall ? false, nftables ? false, ... }:
   let
     unit = if nftables then "nftables" else (if withFirewall then "firewall" else "nat");
+
+    routerAlternativeExternalIp = "192.168.2.234";
+
+    makeNginxConfig = hostname: {
+        enable = true;
+        virtualHosts."${hostname}" = {
+            root = "/etc";
+            locations."/".index = "hostname";
+            listen = [
+                {
+                    addr = "0.0.0.0";
+                    port = 80;
+                }
+                {
+                    addr = "0.0.0.0";
+                    port = 8080;
+                }
+            ];
+        };
+    };
+
+    makeCommonConfig = hostname: {
+      services.nginx = makeNginxConfig hostname;
+      services.vsftpd = {
+        enable = true;
+        anonymousUser = true;
+        localRoot = "/etc/";
+        extraConfig = ''
+          pasv_min_port=51000
+          pasv_max_port=51999
+        '';
+      };
+
+      # Disable eth0 autoconfiguration
+      networking.useDHCP = false;
+
+      environment.systemPackages = [
+        (pkgs.writeScriptBin "check-connection"
+          ''
+            #!/usr/bin/env bash
+
+            set -e
+
+            if [[ "$2" == "" || "$3" == "" || "$1" == "--help" || "$1" == "-h" ]];
+            then
+                echo "check-connection <target-address> <target-hostname> <[expect-success|expect-failure]>"
+                exit 1
+            fi
+
+            ADDRESS="$1"
+            HOSTNAME="$2"
+
+            function test_icmp() { timeout 3 ping -c 1 $ADDRESS; }
+            function test_http() { [[ `timeout 3 curl $ADDRESS` == "$HOSTNAME" ]]; }
+            function test_ftp() { timeout 3 curl ftp://$ADDRESS; }
+
+            if [[ "$3" == "expect-success" ]];
+            then
+                test_icmp; test_http; test_ftp
+            else
+                ! test_icmp; ! test_http; ! test_ftp
+            fi
+          ''
+        )
+        (pkgs.writeScriptBin "check-last-clients-ip"
+          ''
+            #!/usr/bin/env bash
+            set -e
+
+            [[ `cat /var/log/nginx/access.log | tail -n1 | awk '{print $1}'` == "$1" ]]
+          ''
+        )
+      ];
+    };
+
+  # VLANS:
+  # 1 -- simulates the internal network
+  # 2 -- simulates the external network
   in
   {
     name = "nat" + (lib.optionalString nftables "Nftables")
                  + (if withFirewall then "WithFirewall" else "Standalone");
     meta = with pkgs.lib.maintainers; {
-      maintainers = [ rob ];
+      maintainers = [ tne rob ];
     };
 
     nodes =
-      {
-        client = { lib, nodes, ... }: {
-          virtualisation.vlans = [ 1 ];
-          networking.defaultGateway =
-            (lib.head nodes.router.networking.interfaces.eth2.ipv4.addresses).address;
-          networking.nftables.enable = nftables;
-        };
+      { client =
+          { pkgs, nodes, ... }:
+          lib.mkMerge [
+            ( makeCommonConfig "client" )
+            { virtualisation.vlans = [ 1 ];
+              networking.defaultGateway =
+                (pkgs.lib.head nodes.router.networking.interfaces.eth1.ipv4.addresses).address;
+              networking.nftables.enable = nftables;
+              networking.firewall.enable = false;
+            }
+          ];
 
-        router = { lib, ... }: {
-          virtualisation.vlans = [ 2 1 ];
-          networking.firewall.enable = withFirewall;
-          networking.firewall.filterForward = nftables;
-          networking.nftables.enable = nftables;
-          networking.nat.enable = true;
-          networking.nat.internalIPs = [ "192.168.1.0/24" ];
-          networking.nat.externalInterface = "eth1";
+        router =
+        { nodes, ... }: lib.mkMerge [
+          ( makeCommonConfig "router" )
+          { virtualisation.vlans = [ 1 2 ];
+            networking.firewall = {
+              enable = withFirewall;
+              filterForward = nftables;
+              allowedTCPPorts = [ 21 80 8080 ];
+              # For FTP passive mode
+              allowedTCPPortRanges = [ { from = 51000; to = 51999; } ];
+            };
+            networking.nftables.enable = nftables;
+            networking.nat =
+              let
+                clientIp = (pkgs.lib.head nodes.client.networking.interfaces.eth1.ipv4.addresses).address;
+                serverIp = (pkgs.lib.head nodes.router.networking.interfaces.eth2.ipv4.addresses).address;
+              in
+              {
+                enable = true;
+                internalIPs = [ "${clientIp}/24" ];
+                # internalInterfaces = [ "eth1" ];
+                externalInterface = "eth2";
+                externalIP = serverIp;
 
-          specialisation.no-nat.configuration = {
-            networking.nat.enable = lib.mkForce false;
-          };
-        };
+                forwardPorts = [
+                  {
+                    destination = "${clientIp}:8080";
+                    proto = "tcp";
+                    sourcePort = 8080;
+
+                    loopbackIPs = [ serverIp ];
+                  }
+                ];
+              };
+
+            networking.interfaces.eth2.ipv4.addresses =
+              lib.mkOrder 10000 [ { address = routerAlternativeExternalIp; prefixLength = 24; } ];
+
+            services.nginx.virtualHosts.router.listen = lib.mkOrder (-1) [ {
+              addr = routerAlternativeExternalIp;
+              port = 8080;
+            } ];
+
+            specialisation.no-nat.configuration = {
+              networking.nat.enable = lib.mkForce false;
+            };
+          }
+        ];
 
         server =
-          { ... }:
-          { virtualisation.vlans = [ 2 ];
-            networking.firewall.enable = false;
-            services.httpd.enable = true;
-            services.httpd.adminAddr = "foo@example.org";
-            services.vsftpd.enable = true;
-            services.vsftpd.anonymousUser = true;
-          };
+          { nodes, ... }: lib.mkMerge [
+            ( makeCommonConfig "server" )
+            { virtualisation.vlans = [ 2 ];
+              networking.firewall.enable = false;
+
+              networking.defaultGateway =
+                (pkgs.lib.head nodes.router.networking.interfaces.eth2.ipv4.addresses).address;
+            }
+          ];
       };
 
-    testScript = ''
+    testScript =
+      { nodes, ... }: let
+        clientIp = (pkgs.lib.head nodes.client.networking.interfaces.eth1.ipv4.addresses).address;
+        serverIp = (pkgs.lib.head nodes.server.networking.interfaces.eth1.ipv4.addresses).address;
+        routerIp = (pkgs.lib.head nodes.router.networking.interfaces.eth2.ipv4.addresses).address;
+      in ''
+        def wait_for_machine(m):
+          m.wait_for_unit("network.target")
+          m.wait_for_unit("nginx.service")
+
         client.start()
         router.start()
         server.start()
 
-        # The router should have access to the server.
-        server.wait_for_unit("network.target")
-        server.wait_for_unit("httpd")
-        router.wait_for_unit("network.target")
-        router.succeed("curl -4 --fail http://server/ >&2")
+        wait_for_machine(router)
+        wait_for_machine(client)
+        wait_for_machine(server)
 
-        # The client should be also able to connect via the NAT router.
-        router.wait_for_unit("${unit}")
-        client.wait_for_unit("network.target")
-        client.succeed("curl --fail http://server/ >&2")
-        client.succeed("ping -4 -c 1 server >&2")
+        # We assume we are isolated from layer 2 attacks or are securely configured (like disabling forwarding by default)
+        # Relevant moby issue describing the problem allowing bypassing of NAT: https://github.com/moby/moby/issues/14041
+        ${lib.optionalString (!nftables) ''
+          router.succeed("iptables -P FORWARD DROP")
+        ''}
 
-        # Test whether passive FTP works.
-        server.wait_for_unit("vsftpd")
-        server.succeed("echo Hello World > /home/ftp/foo.txt")
-        client.succeed("curl -v ftp://server/foo.txt >&2")
+        # Sanity checks.
+        ## The router should have direct access to the server
+        router.succeed("check-connection ${serverIp} server expect-success")
+        ## The server should have direct access to the router
+        server.succeed("check-connection ${routerIp} router expect-success")
 
-        # Test whether active FTP works.
-        client.fail("curl -v -P - ftp://server/foo.txt >&2")
+        # The client should be also able to connect via the NAT router...
+        client.succeed("check-connection ${serverIp} server expect-success")
+        # ... but its IP should be rewritten to be that of the router.
+        server.succeed("check-last-clients-ip ${routerIp}")
 
-        # Test ICMP.
-        client.succeed("ping -4 -c 1 router >&2")
-        router.succeed("ping -4 -c 1 client >&2")
+        # Active FTP (where the FTP server connects back to us via a random port) should work directly...
+        router.succeed("timeout 3 curl -P eth2:51000-51999 ftp://${serverIp}")
+        # ... but not from behind NAT.
+        client.fail("timeout 3 curl -P eth1:51000-51999 ftp://${serverIp};")
 
-        # If we turn off NAT, the client shouldn't be able to reach the server.
+        # If using nftables without firewall, filterForward can't be used and L2 security can't easily be simulated like with iptables, skipping.
+        # See moby github issue mentioned above.
+        ${lib.optionalString (nftables && withFirewall) ''
+          # The server should not be able to reach the client directly...
+          server.succeed("check-connection ${clientIp} client expect-failure")
+        ''}
+        # ... but the server should be able to reach a port forwarded address of the client
+        server.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "client" ]]')
+        # The IP address the client sees should not be rewritten to be that of the router (#277016)
+        client.succeed("check-last-clients-ip ${serverIp}")
+
+        # But this forwarded port shouldn't intercept communication with
+        # other IPs than externalIp.
+        server.succeed('[[ `timeout 3 curl http://${routerAlternativeExternalIp}:8080` == "router" ]]')
+
+        # The loopback should allow the router itself to access the forwarded port
+        # Note: The reason we use routerIp here is because only routerIp is listed for reflection in networking.nat.forwardPorts.loopbackIPs
+        # The purpose of loopbackIPs is to allow things inside of the NAT to for example access their own public domain when a service has to make a request
+        #   to itself/another service on the same NAT through a public address
+        router.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "client" ]]')
+        # The loopback should also allow the client to access its own forwarded port
+        client.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "client" ]]')
+
+        # If we turn off NAT, nothing should work
+        router.succeed(
+            "systemctl stop ${unit}.service"
+        )
+
+        # If using nftables and firewall, this makes no sense. We deactivated the firewall after all,
+        # so we are once again affected by the same issue as the moby github issue mentioned above.
+        # If using nftables without firewall, filterForward can't be used and L2 security can't easily be simulated like with iptables, skipping.
+        # See moby github issue mentioned above.
+        ${lib.optionalString (!nftables) ''
+          client.succeed("check-connection ${serverIp} server expect-failure")
+          server.succeed("check-connection ${clientIp} client expect-failure")
+        ''}
+        # These should revert to their pre-NATed versions
+        server.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "router" ]]')
+        router.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "router" ]]')
+
+        # Reverse the effect of nat stop
+        router.succeed(
+            "systemctl start ${unit}.service"
+          )
+
+        # Switch to a config without NAT at all, again nothing should work
         router.succeed(
             "/run/booted-system/specialisation/no-nat/bin/switch-to-configuration test 2>&1"
         )
-        client.fail("curl -4 --fail --connect-timeout 5 http://server/ >&2")
-        client.fail("ping -4 -c 1 server >&2")
 
-        # And make sure that reloading the NAT job works.
-        router.succeed(
-            "/run/booted-system/bin/switch-to-configuration test 2>&1"
-        )
-        # FIXME: this should not be necessary, but nat.service is not started because
-        #        network.target is not triggered
-        #        (https://github.com/NixOS/nixpkgs/issues/16230#issuecomment-226408359)
-        ${lib.optionalString (!withFirewall && !nftables) ''
-          router.succeed("systemctl start nat.service")
+        # If using nftables without firewall, filterForward can't be used and L2 security can't easily be simulated like with iptables, skipping.
+        # See moby github issue mentioned above.
+        ${lib.optionalString (nftables && withFirewall) ''
+          client.succeed("check-connection ${serverIp} server expect-failure")
+          server.succeed("check-connection ${clientIp} client expect-failure")
         ''}
-        client.succeed("curl -4 --fail http://server/ >&2")
-        client.succeed("ping -4 -c 1 server >&2")
+
+        # These should revert to their pre-NATed versions
+        server.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "router" ]]')
+        router.succeed('[[ `timeout 3 curl http://${routerIp}:8080` == "router" ]]')
       '';
 })


### PR DESCRIPTION
## Description of changes

Previously, the behavior of the iptables and nftables NAT implementations had some differences. This PR addresses these differences by matching iptable nat's functionality with that of nftables. Additionally, this PR implements updated tests based on https://github.com/NixOS/nixpkgs/pull/279629. Finally, a relatively minor change mentioned in #279629 section 3 was implemented as well.

## 1. Previously, all requests arriving from outside NAT would still have their "source address" adjusted on iptables.

The following diagram describes the setup I've experienced the issue in:

1.2.3.4 - Example client
101.101.101.101 - Server's public address
10.0.0.5 - nixos nspawn container (via containers.*) address behind NAT

```
+--------------+   +----------------+   +-----+   +------------+
|    Client    |   |     Server     |   |     |   | Container  |
|   1.2.3.4    +---> 101.101.101.101+---> NAT +--->  10.0.0.5  |
|              |   |                |   |     |   |            |
+--------------+   +----------------+   +-----+   +------------+
``` 

If we introduce this example configuration:
```nix
networking.nat.forwardPorts = [
  {
    destination = "10.0.0.5:443";
    loopbackIPs = [ "101.101.101.101" ];
    proto = "tcp";
    sourcePort = 443;
  }
];
``` 
Any request previously targeted at 10.0.0.5, even from outside the NAT (outside of where NAT reflection is supposed to act), would have its source address rewritten to 101.101.101.101.

An application, like nginx, behind this NAT would then see the following:

```
101.101.101.101 - - [27/Dec/2023:02:00:04 +0100] "GET / HTTP/2.0" 200 11 "-" "curl/7.58.0"
```

The changes in this PR prevent the outside client's IP address from being overwritten by limiting the source address change to behind the NAT, matching the behavior with nftables. [Test](https://github.com/NixOS/nixpkgs/pull/277016/commits/4955a9a1494d7feaadc1a0f421d46e4e990d11e8#diff-9f245a457b1755691c48c67b435cc52991e7bec8c06ebbcac6f7f5562951ae99R235)

## 2. NAT now supports default forward drop iptables rules.

Behaviors allowed by the NAT are now explicitly whitelisted in the forward ruleset on iptables, which allows behavior similar to nftables with the firewall filterForward setting enabled. [Test](https://github.com/NixOS/nixpkgs/commit/4955a9a1494d7feaadc1a0f421d46e4e990d11e8#diff-9f245a457b1755691c48c67b435cc52991e7bec8c06ebbcac6f7f5562951ae99R206-R208)

## 3. Only connections made to the nat.externalIP will be port forwarded

This is the one new addition to both nftables and iptables. This means that an interface that has multiple IP addresses can now correctly use only one of those IP addresses as the IP address used for NAT port forwarding, allowing the rest of the IP addresses on the interface to be used however else desired without interference. [Test](https://github.com/NixOS/nixpkgs/commit/4955a9a1494d7feaadc1a0f421d46e4e990d11e8#diff-9f245a457b1755691c48c67b435cc52991e7bec8c06ebbcac6f7f5562951ae99R237-R239)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@ofborg test nat

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
