### PR TITLE
beets: fix broken aarch64 build due to missing plugin test

### DIFF
--- a/pkgs/tools/audio/beets/builtin-plugins.nix
+++ b/pkgs/tools/audio/beets/builtin-plugins.nix
@@ -14,6 +14,7 @@
   absubmit = {
     enable = lib.elem stdenv.hostPlatform.system essentia-extractor.meta.platforms;
     wrapperBins = [ essentia-extractor ];
+    testPaths = [ ];
   };
   acousticbrainz.propagatedBuildInputs = [ python3Packages.requests ];
   albumtypes = { };


### PR DESCRIPTION
The `absubmit` plugin for beets has no respective plugin test that is named after the default plugin test schema defined in `common.nix` [^1], so not explicitly declaring that the plugin has *no tests* (i.e. the respective test list is empty), `mkPlugin` will try to disable the non-existant test `test/test_absubmit.py`), breaking beet's build.

[^1]: https://github.com/NixOS/nixpkgs/blob/c7916a507b6657f82a42741790a86e66f7783480/pkgs/tools/audio/beets/common.nix#L39

## Description of changes

Explicitly flag `absubmit` plugin as having no tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>18 packages built:</summary>
  <ul>
    <li>beets</li>
    <li>beets-unstable</li>
    <li>beets-unstable.dist</li>
    <li>beets-unstable.doc</li>
    <li>beets-unstable.man</li>
    <li>beets.dist</li>
    <li>beets.doc</li>
    <li>beets.man</li>
    <li>beetsPackages.alternatives</li>
    <li>beetsPackages.alternatives.dist</li>
    <li>beetsPackages.beets-minimal</li>
    <li>beetsPackages.beets-minimal.dist</li>
    <li>beetsPackages.beets-minimal.doc</li>
    <li>beetsPackages.beets-minimal.man</li>
    <li>beetsPackages.copyartifacts</li>
    <li>beetsPackages.copyartifacts.dist</li>
    <li>beetsPackages.extrafiles</li>
    <li>beetsPackages.extrafiles.dist</li>
  </ul>
</details>