### PR TITLE
swig4: 4.0.2 -> 4.2.1

### DIFF
--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -63,6 +63,15 @@ stdenv.mkDerivation {
     })
   ];
 
+  postPatch = ''
+    # Remove the following substituteInPlace when updating
+    # to a release that contains change from PR
+    # https://github.com/facebookresearch/faiss/issues/3239
+    # that fixes building faiss with swig 4.2.x
+    substituteInPlace faiss/python/swigfaiss.swig \
+      --replace-fail '#ifdef SWIGWORDSIZE64' '#if (__SIZEOF_LONG__ == 8)'
+  '';
+
   buildInputs = [
     blas
     swig

--- a/pkgs/development/tools/misc/swig/4.nix
+++ b/pkgs/development/tools/misc/swig/4.nix
@@ -1,19 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre }:
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre2 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "swig";
-  version = "4.0.2";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "swig";
     repo = "swig";
-    rev = "rel-${version}";
-    sha256 = "12vlps766xvwck8q0i280s8yx21qm2dxl34710ybpmz3c1cfdjsc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-VlUsiRZLScmbC7hZDzKqUr9481YXVwo0eXT/jy6Fda8=";
   };
 
-  PCRE_CONFIG = "${pcre.dev}/bin/pcre-config";
+  PCRE_CONFIG = "${pcre2.dev}/bin/pcre-config";
   nativeBuildInputs = [ autoconf automake libtool bison ];
-  buildInputs = [ pcre ];
+  buildInputs = [ pcre2 ];
 
   configureFlags = [ "--without-tcl" ];
 
@@ -26,12 +26,14 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = with lib; {
-    description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
+  meta = {
+    changelog = "https://github.com/swig/swig/blob/${finalAttrs.src.rev}/CHANGES.current";
+    description = "Interface compiler that connects C/C++ code to higher-level languages";
     homepage = "https://swig.org/";
-    # Different types of licenses available: http://www.swig.org/Release/LICENSE .
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ orivej ];
-    platforms = with platforms; linux ++ darwin;
+    # Different types of licenses available: https://www.swig.org/Release/LICENSE .
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ orivej ];
+    mainProgram = "swig";
+    platforms = with lib.platforms; linux ++ darwin;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

👉 **NOTA BENE:** This PR depends on the [relaxed gpytorch version requirement for botorch](https://github.com/NixOS/nixpkgs/pull/328732/commits/6f37cbe18454ba58351054c9136c7d50c223e323) changes from #328732 in order to successfully run ``nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` on `aarch64-darwin`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
