### PR TITLE
opensearch-cli: init at 1.2.0

### DIFF
--- a/pkgs/by-name/op/opensearch-cli/package.nix
+++ b/pkgs/by-name/op/opensearch-cli/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "opensearch-cli";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    repo = "opensearch-cli";
+    owner = "opensearch-project";
+    rev = version;
+    hash = "sha256-Ah64a9hpc2tnIXiwxg/slE6fUTAoHv9koNmlUHrVj/s=";
+  };
+
+  vendorHash = "sha256-r3Bnud8pd0Z9XmGkj9yxRW4U/Ry4U8gvVF4pAdN14lQ=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    export HOME="$(mktemp -d)"
+    installShellCompletion --cmd opensearch-cli \
+      --bash <($out/bin/opensearch-cli completion bash) \
+      --zsh <($out/bin/opensearch-cli completion zsh) \
+      --fish <($out/bin/opensearch-cli completion fish)
+  '';
+
+  meta = {
+    description = "A full-featured command line interface (CLI) for OpenSearch.";
+    homepage = "https://github.com/opensearch-project/opensearch-cli";
+    license = lib.licenses.asl20;
+    mainProgram = "opensearch-cli";
+    maintainers = with lib.maintainers; [ shyim ];
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}

--- a/pkgs/servers/search/opensearch/default.nix
+++ b/pkgs/servers/search/opensearch/default.nix
@@ -41,7 +41,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --set JAVA_HOME "${jre_headless}"
 
     wrapProgram $out/bin/opensearch-plugin --set JAVA_HOME "${jre_headless}"
-    wrapProgram $out/bin/opensearch-cli --set JAVA_HOME "${jre_headless}"
+
+    rm $out/bin/opensearch-cli
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

Added opensearch-cli package, see #237057

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
