### PR TITLE
kanagawa-gtk-theme: init at 0-unstable-2023-07-03, kanagawa-icon-theme: init at 0-unstable-2023-07-03

### DIFF
--- a/pkgs/by-name/ka/kanagawa-gtk-theme/package.nix
+++ b/pkgs/by-name/ka/kanagawa-gtk-theme/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, gtk-engine-murrine
+}:
+stdenvNoCC.mkDerivation {
+  pname = "kanagawa-gtk-theme";
+  version = "unstable-2023-07-03";
+
+  src = fetchFromGitHub {
+    owner = "Fausto-Korpsvart";
+    repo = "Kanagawa-GKT-Theme";
+    rev = "35936a1e3bbd329339991b29725fc1f67f192c1e";
+    hash = "sha256-BZRmjVas8q6zsYbXFk4bCk5Ec/3liy9PQ8fqFGHAXe0=";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/themes
+    cp -a themes/* $out/share/themes
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A GTK theme with the Kanagawa colour palette";
+    homepage = "https://github.com/Fausto-Korpsvart/Kanagawa-GKT-Theme";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ iynaix ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/ka/kanagawa-icon-theme/package.nix
+++ b/pkgs/by-name/ka/kanagawa-icon-theme/package.nix
@@ -2,10 +2,10 @@
 , stdenvNoCC
 , fetchFromGitHub
 , gtk3
-, gtk-engine-murrine
+, hicolor-icon-theme
 }:
 stdenvNoCC.mkDerivation {
-  pname = "kanagawa-gtk-theme";
+  pname = "kanagawa-icon-theme";
   version = "0-unstable-2023-07-03";
 
   src = fetchFromGitHub {
@@ -19,21 +19,26 @@ stdenvNoCC.mkDerivation {
     gtk3
   ];
 
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine
+  propagatedBuildInputs = [
+    hicolor-icon-theme
   ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/themes
-    cp -a themes/* $out/share/themes
+    mkdir -p $out/share/icons
+    cp -a icons/* $out/share/icons
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache -f $theme
+    done
 
     runHook postInstall
   '';
 
   meta = with lib; {
-    description = "A GTK theme with the Kanagawa colour palette";
+    description = "An icon theme for the Kanagawa colour palette";
     homepage = "https://github.com/Fausto-Korpsvart/Kanagawa-GKT-Theme";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ iynaix ];


### PR DESCRIPTION
## Description of changes

Adds the [Kanagwa GTK Theme](https://github.com/Fausto-Korpsvart/Kanagawa-GKT-Theme), along with its corresponding icon theme.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
