### PR TITLE
python3Packages.facenet-pytorch: init at 2.5.3

### DIFF
--- a/pkgs/development/python-modules/facenet-pytorch/default.nix
+++ b/pkgs/development/python-modules/facenet-pytorch/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchPypi
+, pillow
+, torchvision
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "facenet-pytorch";
+  version = "2.5.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mMxbQqSPg3wCPrkvKlcc1KxqRmh8XnG56ZtJEIcnPis=";
+  };
+
+  doCheck = false; # pypi version doesn't ship with tests
+
+  pythonImportsCheck = ["facenet_pytorch"];
+
+  propagatedBuildInputs = [ pillow torchvision ];
+
+  meta = {
+    description = "Pretrained Pytorch face detection (MTCNN) and facial recognition (InceptionResnet) models";
+    homepage = "https://github.com/timesler/facenet-pytorch";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.lucasew ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3833,6 +3833,8 @@ self: super: with self; {
 
   face-recognition = callPackage ../development/python-modules/face-recognition { };
 
+  facenet-pytorch = callPackage ../development/python-modules/facenet-pytorch { };
+
   face-recognition-models = callPackage ../development/python-modules/face-recognition/models.nix { };
 
   factory-boy = callPackage ../development/python-modules/factory-boy { };


### PR DESCRIPTION
## Description of changes
Low hanging fruit package of a library that I am using to generate embeddings from faces.

Also, libraries based on Pytorch are far easier to maintain.

I found this while looking for an alternative to `face_recognition` that doesn't use [dlib](https://github.com/NixOS/nixpkgs/issues/277004).

Example usage: https://github.com/lucasew/nixcfg/blob/f66f43ab481e2a673bc65dd24538d2590e13eba4/bin/ai/face_recognition



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
