### PR TITLE
lxc: 4.0.12 -> 5.0.3

### DIFF
--- a/pkgs/os-specific/linux/lxc/add-meson-options.patch
+++ b/pkgs/os-specific/linux/lxc/add-meson-options.patch
@@ -1,0 +1,153 @@
+diff --git a/meson.build b/meson.build
+index 21a8705d0..f12b81442 100644
+--- a/meson.build
++++ b/meson.build
+@@ -50,7 +50,7 @@ rootfsmount = get_option('rootfs-mount-path')
+ user_network_db_opt = get_option('usernet-db-path')
+ user_network_conf_opt = get_option('usernet-config-path')
+ 
+-bashcompletiondir = join_paths('/', 'usr', 'share', 'bash-completion', 'completions')
++bashcompletiondir = join_paths(prefixdir, get_option('datadir'), 'bash-completion', 'completions')
+ bindir = join_paths(prefixdir, get_option('bindir'))
+ datadir = join_paths(prefixdir, get_option('datadir'))
+ mandir = join_paths(prefixdir, get_option('mandir'))
+@@ -123,22 +123,6 @@ conf.set('PACKAGE_VERSION', meson.project_version())
+ conf.set('RUNTIME_PATH', runtimepath)
+ conf.set('SYSCONFDIR', sysconfdir)
+ 
+-# Set sysconfdir
+-fs = import('fs')
+-distrosysconfdir = get_option('distrosysconfdir')
+-if distrosysconfdir != ''
+-    distrosysconfdir = join_paths(sysconfdir, distrosysconfdir)
+-    conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
+-elif fs.is_dir('/etc/sysconfig')
+-    distrosysconfdir = join_paths(sysconfdir, 'sysconfig')
+-    conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
+-elif fs.is_dir('/etc/default')
+-    distrosysconfdir = join_paths(sysconfdir, 'default')
+-    conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
+-else
+-    error('"distrosysconfdir" is not set')
+-endif
+-
+ # Cross-compile on Android.
+ srcconf.set10('IS_BIONIC', host_machine.system() == 'android')
+ 
+@@ -148,6 +132,7 @@ coverity = get_option('coverity-build')
+ init_script = get_option('init-script')
+ sanitize = get_option('b_sanitize')
+ want_examples = get_option('examples')
++want_install_init = get_option('install-init-files')
+ want_io_uring = get_option('io-uring-event-loop')
+ want_pam_cgroup = get_option('pam-cgroup')
+ want_mans = get_option('man')
+@@ -160,10 +145,30 @@ want_openssl = get_option('openssl')
+ want_selinux = get_option('selinux')
+ want_oss_fuzz = get_option('oss-fuzz')
+ want_seccomp = get_option('seccomp')
++want_spec = get_option('specfile')
++want_state_dirs = get_option('install-state-dirs')
+ want_thread_safety = get_option('thread-safety')
+ want_memfd_rexec = get_option('memfd-rexec')
+ want_sd_bus = get_option('sd-bus')
+ 
++# Set sysconfdir
++fs = import('fs')
++if want_install_init
++    distrosysconfdir = get_option('distrosysconfdir')
++    if distrosysconfdir != ''
++        distrosysconfdir = join_paths(sysconfdir, distrosysconfdir)
++        conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
++    elif fs.is_dir('/etc/sysconfig')
++        distrosysconfdir = join_paths(sysconfdir, 'sysconfig')
++        conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
++    elif fs.is_dir('/etc/default')
++        distrosysconfdir = join_paths(sysconfdir, 'default')
++        conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
++    else
++        error('"distrosysconfdir" is not set')
++    endif
++endif
++
+ srcconf.set_quoted('DEFAULT_CGROUP_PATTERN', cgrouppattern)
+ if coverity
+     srcconf.set('ENABLE_COVERITY_BUILD', 1)
+@@ -926,14 +931,16 @@ if want_apparmor
+ endif
+ subdir('config/bash')
+ subdir('config/etc')
+-subdir('config/init/common')
+-subdir('config/init/systemd')
+-subdir('config/init/sysvinit')
+-subdir('config/init/upstart')
++if want_install_init
++    subdir('config/init/common')
++    subdir('config/init/systemd')
++    subdir('config/init/sysvinit')
++    subdir('config/init/upstart')
++    subdir('config/sysconfig')
++endif
+ if want_selinux
+     subdir('config/selinux')
+ endif
+-subdir('config/sysconfig')
+ subdir('config/templates')
+ subdir('config/templates/common.conf.d')
+ subdir('config/yum')
+@@ -963,21 +970,25 @@ pkg_config_file = pkgconfig.generate(liblxc,
+ )
+ 
+ # Empty dirs.
+-install_emptydir(join_paths(localstatedir, 'cache', 'lxc'))
+-install_emptydir(join_paths(localstatedir, 'lib', 'lxc'))
++if want_state_dirs
++    install_emptydir(join_paths(localstatedir, 'cache', 'lxc'))
++    install_emptydir(join_paths(localstatedir, 'lib', 'lxc'))
++endif
+ 
+ # RPM spec file.
+-specconf = configuration_data()
+-specconf.set('LXC_VERSION_BASE', meson.project_version())
+-specconf.set('LXC_VERSION_BETA', version_data.get('LXC_VERSION_BETA'))
+-specconf.set('PACKAGE', meson.project_name())
+-specconf.set('LXC_DISTRO_SYSCONF', conf.get('LXC_DISTRO_SYSCONF'))
+-
+-configure_file(
+-    configuration: specconf,
+-    input: 'lxc.spec.in',
+-    output: 'lxc.spec',
+-    install: false)
++if want_spec
++    specconf = configuration_data()
++    specconf.set('LXC_VERSION_BASE', meson.project_version())
++    specconf.set('LXC_VERSION_BETA', version_data.get('LXC_VERSION_BETA'))
++    specconf.set('PACKAGE', meson.project_name())
++    specconf.set('LXC_DISTRO_SYSCONF', conf.get('LXC_DISTRO_SYSCONF'))
++
++    configure_file(
++        configuration: specconf,
++        input: 'lxc.spec.in',
++        output: 'lxc.spec',
++        install: false)
++endif
+ 
+ # Build overview.
+ status = [
+diff --git a/meson_options.txt b/meson_options.txt
+index 9803473d2..84a6d45b5 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -120,3 +120,12 @@ option('memfd-rexec', type : 'boolean', value : 'true',
+ 
+ option('distrosysconfdir', type : 'string', value: '',
+        description: 'relative path to sysconfdir for distro default configuration')
++
++option('specfile', type : 'boolean', value: true,
++       description: 'whether to prepare RPM spec')
++
++option('install-init-files', type : 'boolean', value: true,
++       description: 'whether to install init files for local init (e.g. systemd, sysvinit)')
++
++option('install-state-dirs', type : 'boolean', value: true,
++       description: 'whether to create state directories on install')

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -1,90 +1,71 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, perl, docbook2x
-, docbook_xml_dtd_45, python3Packages, pam, fetchpatch
-
-# Optional Dependencies
-, libapparmor ? null, gnutls ? null, libselinux ? null, libseccomp ? null
-, libcap ? null, systemd ? null
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  docbook2x,
+  libapparmor,
+  libcap,
+  libseccomp,
+  libselinux,
+  meson,
+  ninja,
+  nix-update-script,
+  nixosTests,
+  openssl,
+  pam,
+  pkg-config,
+  systemd,
 }:
 
 stdenv.mkDerivation rec {
   pname = "lxc";
-  version = "4.0.12";
+  version = "5.0.3";
 
-  src = fetchurl {
-    url = "https://linuxcontainers.org/downloads/lxc/lxc-${version}.tar.gz";
-    sha256 = "1vyk2j5w9gfyh23w3ar09cycyws16mxh3clbb33yhqzwcs1jy96v";
+  src = fetchFromGitHub {
+    owner = "lxc";
+    repo = "lxc";
+    rev = "refs/tags/lxc-${version}";
+    hash = "sha256-lnLmLgWXt3pI2S+4OeHRlPP5gui7S7ZXXClFt+n/8sY=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook pkg-config perl docbook2x python3Packages.wrapPython
+    docbook2x
+    meson
+    ninja
+    pkg-config
   ];
+
   buildInputs = [
-    pam libapparmor gnutls libselinux libseccomp libcap
-    python3Packages.python python3Packages.setuptools systemd
+    libapparmor
+    libcap
+    libseccomp
+    libselinux
+    openssl
+    pam
+    systemd
   ];
 
-  patches = [
-    ./support-db2x.patch
+  patches = [ ./add-meson-options.patch ];
 
-    # Backport of https://github.com/lxc/lxc/pull/4179 for glibc-2.36 build
-    (fetchpatch {
-      url = "https://github.com/lxc/lxc/commit/c1115e1503bf955c97f4cf3b925a6a9f619764c3.patch";
-      sha256 = "sha256-aC1XQesRJfkyQnloB3NvR4p/1WITrqkGYzw50PDxDrs=";
-      excludes = [ "meson.build" ];
-    })
+  mesonFlags = [
+    "-Dinstall-init-files=false"
+    "-Dinstall-state-dirs=false"
+    "-Dspecfile=false"
   ];
 
-  postPatch = ''
-    sed -i '/chmod u+s/d' src/lxc/Makefile.am
-  '';
+  enableParallelBuilding = true;
 
-  XML_CATALOG_FILES = "${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml";
+  doCheck = true;
 
-  configureFlags = [
-    "--enable-pam"
-    "--localstatedir=/var"
-    "--sysconfdir=/etc"
-    "--disable-api-docs"
-    "--with-init-script=none"
-    "--with-distro=nixos" # just to be sure it is "unknown"
-  ] ++ lib.optional (libapparmor != null) "--enable-apparmor"
-    ++ lib.optional (libselinux != null) "--enable-selinux"
-    ++ lib.optional (libseccomp != null) "--enable-seccomp"
-    ++ lib.optional (libcap != null) "--enable-capabilities"
-    ++ [
-    "--disable-examples"
-    "--enable-python"
-    "--disable-lua"
-    "--enable-bash"
-    (if doCheck then "--enable-tests" else "--disable-tests")
-    "--with-rootfs-path=/var/lib/lxc/rootfs"
-  ];
-
-  doCheck = false;
-
-  installFlags = [
-    "localstatedir=\${TMPDIR}"
-    "sysconfdir=\${out}/etc"
-    "sysconfigdir=\${out}/etc/default"
-    "bashcompdir=\${out}/share/bash-completion/completions"
-    "READMEdir=\${TMPDIR}/var/lib/lxc/rootfs"
-    "LXCPATH=\${TMPDIR}/var/lib/lxc"
-  ];
-
-  postInstall = ''
-    wrapPythonPrograms
-
-    completions=(
-      lxc-attach lxc-cgroup lxc-console lxc-destroy lxc-device lxc-execute
-      lxc-freeze lxc-info lxc-monitor lxc-snapshot lxc-stop lxc-unfreeze
-    )
-    pushd $out/share/bash-completion/completions/
-      mv lxc lxc-start
-      for completion in ''${completions[@]}; do
-        ln -sfn lxc-start $completion
-      done
-    popd
-  '';
+  passthru = {
+    tests.incus = nixosTests.incus.container;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "-vr"
+        "lxc-(.*)"
+      ];
+    };
+  };
 
   meta = {
     homepage = "https://linuxcontainers.org/";

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -89,14 +89,12 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://linuxcontainers.org/";
     description = "Userspace tools for Linux Containers, a lightweight virtualization system";
-    license = lib.licenses.lgpl21Plus;
+    license = lib.licenses.gpl2;
 
     longDescription = ''
-      LXC is the userspace control package for Linux Containers, a
-      lightweight virtual system mechanism sometimes described as
-      "chroot on steroids". LXC builds up from chroot to implement
-      complete virtual systems, adding resource management and isolation
-      mechanisms to Linux’s existing process management infrastructure.
+      LXC containers are often considered as something in the middle between a chroot and a
+      full fledged virtual machine. The goal of LXC is to create an environment as close as
+      possible to a standard Linux installation but without the need for a separate kernel.
     '';
 
     platforms = lib.platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10731,9 +10731,7 @@ with pkgs;
 
   lwc = callPackage ../tools/misc/lwc { };
 
-  lxc = callPackage ../os-specific/linux/lxc {
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  lxc = callPackage ../os-specific/linux/lxc {  };
   lxcfs = callPackage ../os-specific/linux/lxcfs { };
 
   lxd = callPackage ../tools/admin/lxd/wrapper.nix { };


### PR DESCRIPTION
## Description of changes

This is a major LTS version upgrade, but it has been outdated for some time now. 

https://linuxcontainers.org/lxc/news/

- lxc: fix license and update long description
- lxc: 4.0.12 -> 5.0.3

Patch submitted upstream for meson options: https://github.com/lxc/lxc/pull/4377

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
