### PR TITLE
verdict: init at 1.4.2

### DIFF
--- a/pkgs/by-name/ve/verdict/package.nix
+++ b/pkgs/by-name/ve/verdict/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "verdict";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "sandialabs";
+    repo = "verdict";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-VrjyAMou5BajOIb13RjEqVgOsDcllfzI/OJ81fyILjs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  nativeCheckInputs = [
+    gtest
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Compute functions of 2- and 3-dimensional regions";
+    homepage = "https://github.com/sandialabs/verdict";
+    license = licenses.bsd3;
+    changelog = "https://github.com/sandialabs/verdict/releases/tag/${finalAttrs.version}";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Init `verdict`, a small package for computations involving 2- and 3-d regions.

This package is used in `vtk` and I will shortly unvendor it from there.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

