### PR TITLE
alsa-lib: provide wrapper for run-time access to plugins

### DIFF
--- a/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, pkgs
+, alsa-lib
+, plugins ? [ pkgs.alsa-plugins ]
+, lndir
+, symlinkJoin
+, runCommand
+}:
+let
+  merged = symlinkJoin { name = "alsa-plugins-merged"; paths = plugins; };
+in
+runCommand "${alsa-lib.pname}-${alsa-lib.version}" {
+  meta = with lib; {
+    description = "wrapper to ease access to ALSA plugins";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ gm6k ];
+  };
+  outputs = alsa-lib.outputs;
+} (
+    (
+      lib.concatMapStringsSep "\n" (
+        output: ''
+          mkdir ${builtins.placeholder output}
+          ${lndir}/bin/lndir ${lib.attrByPath [output] null alsa-lib} \
+            ${builtins.placeholder output}
+        ''
+      ) alsa-lib.outputs
+    ) + ''
+    cp -r ${merged}/lib/alsa-lib $out/lib
+    (
+      echo $out | wc -c
+      echo ${alsa-lib} | wc -c
+    ) | xargs echo | grep -q "^\(.*\) \1$" || (
+      echo cannot binary patch
+      exit 1
+    )
+    rm $out/lib/libasound.la
+    rm $out/lib/libasound.so.?.?.?
+    rm $dev/lib/pkgconfig/alsa.pc
+    rm $dev/nix-support/propagated-build-inputs
+    cp ${alsa-lib}/lib/libasound.la $out/lib
+    cp ${alsa-lib}/lib/libasound.so.?.?.? $out/lib
+    cp ${alsa-lib.dev}/lib/pkgconfig/alsa.pc $dev/lib/pkgconfig
+    cp ${alsa-lib.dev}/nix-support/propagated-build-inputs $dev/nix-support
+    sed -i \
+        $out/lib/libasound.la \
+        $out/lib/libasound.so.?.?.? \
+        $dev/lib/pkgconfig/alsa.pc \
+        $dev/nix-support/propagated-build-inputs \
+      -e "s@${alsa-lib}@$out@g"
+  ''
+)


### PR DESCRIPTION
## Description of changes

This PR provides a wrapper `alsa-lib-with-plugins` which can be transparently used instead of `alsa-lib` in order have it find its plugins on load time. This works by merging together symlinks from `alsa-lib` and the plugin packages into one store path, and binary patching the library to point to the wrapper store path.

Currently, `alsa-lib` doesn't load its plugins out of the box because the load path points to its own store path, while the plugins get written into other store paths (mostly `alsa-plugins`). This leads to errors like this one:
```
ALSA lib conf.c:4005:(snd_config_hooks_call) Cannot open shared library libasound_module_conf_pulse.so (/nix/store/lxvizzp9h9fxrgr4pxclf7ydaz53rrcp-alsa-lib-1.2.9/lib/alsa-lib/libasound_module_conf_pulse.so: cannot open shared object file: No such file or directory)
ALSA lib seq.c:935:(snd_seq_open_noupdate) Unknown SEQ hw
error in snd_seq_open
```

This can currently be solved by additionally setting environment variables or configuration directives (see https://github.com/NixOS/nixpkgs/issues/6860). Packages can be adapted to do this by wrapping (e.g. https://github.com/NixOS/nixpkgs/pull/137816). However, this is not transparent and requires to manually adapt packages that use `alsa-lib`.

This PR simplifies the situation because it suffices to use `alsa-lib-with-plugins` instead of `alsa-lib` in the derivations. It provides access to ALSA's own plugins (`alsa-plugins`), but can be overridden to include more plugins. Example override to include `pipewire`:
```
    alsa-lib-with-plugins = alsa-lib-with-plugins.override {
      plugins = [ alsa-plugins pipewire.lib ];
    };
```
Fixes https://github.com/NixOS/nixpkgs/issues/6860 when using `alsa-lib-with-plugins` instead of `alsa-lib`.

For now, this requires pointing to a different package in the derivations. Once we're fine with the rebuild, we might rename `alsa-lib` to something like `alsa-lib-wrapped` and rename `alsa-lib-with-plugins` to `alsa-lib` in order to enable plugin loading for all packages fully transparently.

## Things done



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
