### PR TITLE
cudaPackages: apply runpath setup hooks to non-executable ELF files

### DIFF
--- a/pkgs/development/cuda-modules/setup-hooks/auto-add-cuda-compat-runpath.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/auto-add-cuda-compat-runpath.sh
@@ -10,7 +10,7 @@ elfHasDynamicSection() {
 autoAddCudaCompatRunpathPhase() (
   local outputPaths
   mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "${!o}"; done)
-  find "${outputPaths[@]}" -type f -executable -print0  | while IFS= read -rd "" f; do
+  find "${outputPaths[@]}" -type f -print0  | while IFS= read -rd "" f; do
     if isELF "$f"; then
       # patchelf returns an error on statically linked ELF files
       if elfHasDynamicSection "$f" ; then

--- a/pkgs/development/cuda-modules/setup-hooks/auto-add-opengl-runpath-hook.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/auto-add-opengl-runpath-hook.sh
@@ -9,7 +9,7 @@ elfHasDynamicSection() {
 autoAddOpenGLRunpathPhase() (
   local outputPaths
   mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "${!o}"; done)
-  find "${outputPaths[@]}" -type f -executable -print0  | while IFS= read -rd "" f; do
+  find "${outputPaths[@]}" -type f -print0  | while IFS= read -rd "" f; do
     if isELF "$f"; then
       # patchelf returns an error on statically linked ELF files
       if elfHasDynamicSection "$f" ; then


### PR DESCRIPTION
## Description of changes

This [prior PR](https://github.com/NixOS/nixpkgs/pull/250639) restored the ability for `autoAddOpenGLRunpathHook` to be run against shared libraries (which was originally changed by https://github.com/NixOS/nixpkgs/pull/250639). However, due to the `-executable` flag in the `find` command, this only works on shared libraries that also happen to have the executable bit set.

I ran into this issue when attempting to update `jetpack-nixos` for 23.11, which also uses `autoAddOpenGLRunpathHook`. At least for the package I have been working on (cudnn), this does not appear to be a problem with the cudnn redist package in nixpkgs, since the `.so` files have the executable bit set.  However, the deb package for cudnn used in `jetpack-nixos` do not.

CC @SomeoneSerge @ConnorBaker 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
