### PR TITLE
mcfly-fzf: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16965,6 +16965,11 @@
     githubId = 50401154;
     name = "Simone Ruffini";
   };
+  simonhammes = {
+    github = "simonhammes";
+    githubId = 10352679;
+    name = "Simon Hammes";
+  };
   simonkampe = {
     email = "simon.kampe+nix@gmail.com";
     github = "simonkampe";

--- a/pkgs/by-name/mc/mcfly-fzf/package.nix
+++ b/pkgs/by-name/mc/mcfly-fzf/package.nix
@@ -1,0 +1,29 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mcfly-fzf";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "bnprks";
+    repo = "mcfly-fzf";
+    rev = version;
+    hash = "sha256-3QxiG9MR0BCKRjA8ue/Yb/AZ5SwiSdjn6qaOxSAK0SI=";
+  };
+
+  postPatch = ''
+    substituteInPlace shell/mcfly-fzf.bash --replace '$(command -v mcfly-fzf)' '${placeholder "out"}/bin/mcfly-fzf'
+    substituteInPlace shell/mcfly-fzf.zsh --replace '$(command -v mcfly-fzf)' '${placeholder "out"}/bin/mcfly-fzf'
+    substituteInPlace shell/mcfly-fzf.fish --replace '(command -v mcfly-fzf)' '${placeholder "out"}/bin/mcfly-fzf'
+  '';
+
+  cargoHash = "sha256-pR5Fni/8iJuaDyWKrOnSanO50hvFXh73Qlgmd4a3Ucs=";
+
+  meta = with lib; {
+    homepage = "https://github.com/bnprks/mcfly-fzf";
+    description = "Integrate Mcfly with fzf to combine a solid command history database with a widely-loved fuzzy search UI";
+    license = licenses.mit;
+    maintainers = [ maintainers.simonhammes ];
+    mainProgram = "mcfly-fzf";
+  };
+}


### PR DESCRIPTION
## Description of changes

[mcfly-fzf](https://github.com/bnprks/mcfly-fzf)

> Integrate Mcfly with fzf to combine a solid command history database with a widely-loved fuzzy search UI 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
