### PR TITLE
nixos/jellyfin: add directory options

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13559,6 +13559,12 @@
     github = "numkem";
     githubId = 332423;
   };
+  nu-nu-ko = {
+    email = "host@nuko.city";
+    github = "nu-nu-ko";
+    githubId = 153512689;
+    name = "nuko";
+  };
   nviets = {
     email = "nathan.g.viets@gmail.com";
     github = "nviets";

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -120,5 +120,5 @@ in
 
   };
 
-  meta.maintainers = with lib.maintainers; [ minijackson ];
+  meta.maintainers = with lib.maintainers; [ minijackson nu-nu-ko ];
 }

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -1,109 +1,149 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkIf getExe maintainers mkEnableOption mkOption mkPackageOption;
+  inherit (lib.types) str path bool;
   cfg = config.services.jellyfin;
 in
 {
   options = {
     services.jellyfin = {
-      enable = mkEnableOption (lib.mdDoc "Jellyfin Media Server");
-
-      user = mkOption {
-        type = types.str;
-        default = "jellyfin";
-        description = lib.mdDoc "User account under which Jellyfin runs.";
-      };
+      enable = mkEnableOption "Jellyfin Media Server";
 
       package = mkPackageOption pkgs "jellyfin" { };
 
-      group = mkOption {
-        type = types.str;
+      user = mkOption {
+        type = str;
         default = "jellyfin";
-        description = lib.mdDoc "Group under which jellyfin runs.";
+        description = "User account under which Jellyfin runs.";
+      };
+
+      group = mkOption {
+        type = str;
+        default = "jellyfin";
+        description = "Group under which jellyfin runs.";
+      };
+
+      dataDir = mkOption {
+        type = path;
+        default = "/var/lib/jellyfin";
+        description = ''
+          Base data directory,
+          passed with `--datadir` see [#data-directory](https://jellyfin.org/docs/general/administration/configuration/#data-directory)
+        '';
+      };
+
+      configDir = mkOption {
+        type = path;
+        default = "${cfg.dataDir}/config";
+        defaultText = "\${cfg.dataDir}/config";
+        description = ''
+          Directory containing the server configuration files,
+          passed with `--configdir` see [configuration-directory](https://jellyfin.org/docs/general/administration/configuration/#configuration-directory)
+        '';
+      };
+
+      cacheDir = mkOption {
+        type = path;
+        default = "/var/cache/jellyfin";
+        description = ''
+          Directory containing the jellyfin server cache,
+          passed with `--cachedir` see [#cache-directory](https://jellyfin.org/docs/general/administration/configuration/#cache-directory)
+        '';
+      };
+
+      logDir = mkOption {
+        type = path;
+        default = "${cfg.dataDir}/log";
+        defaultText = "\${cfg.dataDir}/log";
+        description = ''
+          Directory where the Jellyfin logs will be stored,
+          passed with `--logdir` see [#log-directory](https://jellyfin.org/docs/general/administration/configuration/#log-directory)
+        '';
       };
 
       openFirewall = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           Open the default ports in the firewall for the media server. The
           HTTP/HTTPS ports can be changed in the Web UI, so this option should
-          only be used if they are unchanged.
+          only be used if they are unchanged, see [Port Bindings](https://jellyfin.org/docs/general/networking/#port-bindings).
         '';
       };
     };
   };
 
   config = mkIf cfg.enable {
-    systemd.services.jellyfin = {
-      description = "Jellyfin Media Server";
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
+    systemd = {
+      tmpfiles.settings.jellyfinDirs = {
+        "${cfg.dataDir}"."d" = {
+          mode = "700";
+          inherit (cfg) user group;
+        };
+        "${cfg.configDir}"."d" = {
+          mode = "700";
+          inherit (cfg) user group;
+        };
+        "${cfg.logDir}"."d" = {
+          mode = "700";
+          inherit (cfg) user group;
+        };
+        "${cfg.cacheDir}"."d" = {
+          mode = "700";
+          inherit (cfg) user group;
+        };
+      };
+      services.jellyfin = {
+        description = "Jellyfin Media Server";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
 
-      # This is mostly follows: https://github.com/jellyfin/jellyfin/blob/master/fedora/jellyfin.service
-      # Upstream also disable some hardenings when running in LXC, we do the same with the isContainer option
-      serviceConfig = rec {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
-        StateDirectory = "jellyfin";
-        StateDirectoryMode = "0700";
-        CacheDirectory = "jellyfin";
-        CacheDirectoryMode = "0700";
-        UMask = "0077";
-        WorkingDirectory = "/var/lib/jellyfin";
-        ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
-        Restart = "on-failure";
-        TimeoutSec = 15;
-        SuccessExitStatus = ["0" "143"];
+        # This is mostly follows: https://github.com/jellyfin/jellyfin/blob/master/fedora/jellyfin.service
+        # Upstream also disable some hardenings when running in LXC, we do the same with the isContainer option
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          UMask = "0077";
+          WorkingDirectory = cfg.dataDir;
+          ExecStart = "${getExe cfg.package} --datadir '${cfg.dataDir}' --configdir '${cfg.configDir}' --cachedir '${cfg.cacheDir}' --logdir '${cfg.logDir}'";
+          Restart = "on-failure";
+          TimeoutSec = 15;
+          SuccessExitStatus = ["0" "143"];
 
-        # Security options:
-        NoNewPrivileges = true;
-        SystemCallArchitectures = "native";
-        # AF_NETLINK needed because Jellyfin monitors the network connection
-        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
-        RestrictNamespaces = !config.boot.isContainer;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        ProtectControlGroups = !config.boot.isContainer;
-        ProtectHostname = true;
-        ProtectKernelLogs = !config.boot.isContainer;
-        ProtectKernelModules = !config.boot.isContainer;
-        ProtectKernelTunables = !config.boot.isContainer;
-        LockPersonality = true;
-        PrivateTmp = !config.boot.isContainer;
-        # needed for hardware acceleration
-        PrivateDevices = false;
-        PrivateUsers = true;
-        RemoveIPC = true;
+          # Security options:
+          NoNewPrivileges = true;
+          SystemCallArchitectures = "native";
+          # AF_NETLINK needed because Jellyfin monitors the network connection
+          RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+          RestrictNamespaces = !config.boot.isContainer;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          ProtectControlGroups = !config.boot.isContainer;
+          ProtectHostname = true;
+          ProtectKernelLogs = !config.boot.isContainer;
+          ProtectKernelModules = !config.boot.isContainer;
+          ProtectKernelTunables = !config.boot.isContainer;
+          LockPersonality = true;
+          PrivateTmp = !config.boot.isContainer;
+          # needed for hardware acceleration
+          PrivateDevices = false;
+          PrivateUsers = true;
+          RemoveIPC = true;
 
-        SystemCallFilter = [
-          "~@clock"
-          "~@aio"
-          "~@chown"
-          "~@cpu-emulation"
-          "~@debug"
-          "~@keyring"
-          "~@memlock"
-          "~@module"
-          "~@mount"
-          "~@obsolete"
-          "~@privileged"
-          "~@raw-io"
-          "~@reboot"
-          "~@setuid"
-          "~@swap"
-        ];
-        SystemCallErrorNumber = "EPERM";
+          SystemCallFilter = [
+            "~@clock" "~@aio" "~@chown" "~@cpu-emulation" "~@debug" "~@keyring" "~@memlock" "~@module" "~@mount" "~@obsolete" "~@privileged" "~@raw-io" "~@reboot" "~@setuid" "~@swap"
+          ];
+          SystemCallErrorNumber = "EPERM";
+        };
       };
     };
 
     users.users = mkIf (cfg.user == "jellyfin") {
       jellyfin = {
-        group = cfg.group;
+        inherit (cfg) group;
         isSystemUser = true;
       };
     };
@@ -120,5 +160,5 @@ in
 
   };
 
-  meta.maintainers = with lib.maintainers; [ minijackson nu-nu-ko ];
+  meta.maintainers = with maintainers; [ minijackson nu-nu-ko ];
 }

--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -63,6 +63,7 @@ buildDotnetModule rec {
     # https://github.com/jellyfin/jellyfin/issues/610#issuecomment-537625510
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ nyanloutre minijackson purcell jojosch ];
+    mainProgram = "jellyfin";
     platforms = dotnet-runtime.meta.platforms;
   };
 }


### PR DESCRIPTION
## Description of changes
add `dataDir` `configDir` `cacheDir` and `logDir` options

ideally a lot of config and data dirs would be declared in some way, but the ability to easily define their locations is nicer than nothing.
the `webdir` option explained [here](https://jellyfin.org/docs/general/administration/configuration/#web-directory) is as far as i know not relevant given its in the store.
 
 this should replace PR #233617 ( I've tried to address the unresolved comments here )
 it should also close #141367 as a result.
 
 removed `with lib;` to address #208242 for this module.
 
 add `meta.mainProgram` to the jellyfin server package so that `getExe` can be used appropriately.

remove use of the now pointless `lib.mdDoc`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
