### PR TITLE
hdf5: refactor to reduce downstream closure size

### DIFF
--- a/pkgs/development/interpreters/gnudatalanguage/default.nix
+++ b/pkgs/development/interpreters/gnudatalanguage/default.nix
@@ -78,13 +78,15 @@ let
     if hdf5-forced != null
     then hdf5-forced
     else
-      hdf5.override {
+      hdf5.override ({
         usev110Api = useHdf5v110Api;
         mpiSupport = enableMPI;
         inherit mpi;
         szipSupport = enableSzip;
         inherit szip;
-      };
+      } // lib.optionalAttrs enableMPI {
+        cppSupport = false;
+      });
   netcdf-custom =
     if netcdf-forced != null
     then netcdf-forced

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , cmake
 , removeReferencesTo
-, cppSupport ? false
+, cppSupport ? true
 , fortranSupport ? false
 , fortran
 , zlibSupport ? true
@@ -13,6 +13,7 @@
 , mpiSupport ? false
 , mpi
 , enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.hostPlatform.isStatic
 , javaSupport ? false
 , jdk
 , usev110Api ? false
@@ -58,7 +59,7 @@ stdenv.mkDerivation rec {
       ;
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "bin" ];
 
   nativeBuildInputs = [ removeReferencesTo cmake ]
     ++ optional fortranSupport fortran;
@@ -72,6 +73,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DHDF5_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake"
+    "-DBUILD_STATIC_LIBS=${lib.boolToString enableStatic}"
   ] ++ lib.optional stdenv.isDarwin "-DHDF5_BUILD_WITH_INSTALL_NAME=ON"
     ++ lib.optional cppSupport "-DHDF5_BUILD_CPP_LIB=ON"
     ++ lib.optional fortranSupport "-DHDF5_BUILD_FORTRAN=ON"
@@ -85,10 +87,33 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
+    moveToOutput 'bin/' "''${!outputBin}"
     moveToOutput 'bin/h5cc' "''${!outputDev}"
     moveToOutput 'bin/h5c++' "''${!outputDev}"
     moveToOutput 'bin/h5fc' "''${!outputDev}"
     moveToOutput 'bin/h5pcc' "''${!outputDev}"
+    moveToOutput 'bin/h5hlcc' "''${!outputDev}"
+    moveToOutput 'bin/h5hlc++' "''${!outputDev}"
+  '' + lib.optionalString enableShared
+  # The shared build creates binaries with -shared suffixes,
+  # so we remove these suffixes.
+  ''
+    mv ''${!outputBin}/bin/h5clear{-shared,}
+    mv ''${!outputBin}/bin/h5copy{-shared,}
+    mv ''${!outputBin}/bin/h5debug{-shared,}
+    mv ''${!outputBin}/bin/h5delete{-shared,}
+    mv ''${!outputBin}/bin/h5diff{-shared,}
+    mv ''${!outputBin}/bin/h5dump{-shared,}
+    mv ''${!outputBin}/bin/h5format_convert{-shared,}
+    mv ''${!outputBin}/bin/h5import{-shared,}
+    mv ''${!outputBin}/bin/h5jam{-shared,}
+    mv ''${!outputBin}/bin/h5ls{-shared,}
+    mv ''${!outputBin}/bin/h5mkgrp{-shared,}
+    mv ''${!outputBin}/bin/h5repack{-shared,}
+    mv ''${!outputBin}/bin/h5repart{-shared,}
+    mv ''${!outputBin}/bin/h5stat{-shared,}
+    mv ''${!outputBin}/bin/h5unjam{-shared,}
+    mv ''${!outputBin}/bin/h5watch{-shared,}
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9195,7 +9195,10 @@ with pkgs;
 
   hdf5_1_10 = callPackage ../tools/misc/hdf5/1.10.nix { };
 
-  hdf5-mpi = hdf5.override { mpiSupport = true; };
+  hdf5-mpi = hdf5.override {
+    mpiSupport = true;
+    cppSupport = false;
+  };
 
   hdf5-cpp = hdf5.override { cppSupport = true; };
 


### PR DESCRIPTION
* Only build static libs by default when stdenv.hostPlatform.isStatic
* Add separate -bin output
* Move h5hlcc/c++ dev binaries to -dev output
* Default to building with C++ support to cut down on duplicated hdf5/hdf5-cpp in downstream closures

cc @NixOS/geospatial - this is motivated by geospatial packages, e.g. gdal

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
