### PR TITLE
outfox: init at 0.5.0-pre042

### DIFF
--- a/pkgs/by-name/ou/outfox/package.nix
+++ b/pkgs/by-name/ou/outfox/package.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, alsa-lib
+, freetype
+, libjack2
+, libglvnd
+, libpulseaudio
+, makeDesktopItem
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "outfox";
+  version = "0.5.0-pre042";
+
+  src = {
+    i686-linux = fetchurl {
+      url =  "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Linux-14.04-32bit-i386-i386-legacy-date-20231227.tar.gz";
+      sha256 = "sha256-NFjNoqJ7Fq4A7Y0k6oQcWjykV+/b/MiRtJ1p6qlZdjs=";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Linux-22.04-amd64-current-date-20231224.tar.gz";
+      hash = "sha256-dW+g/JYav3rUuI+nHDi6rXu/O5KYiEdk/HH82jgOUnI=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Raspberry-Pi-Linux-18.04-arm64-arm64v8-modern-date-20231225.tar.gz";
+      hash = "sha256-7Qrq6t8KmUSIK4Rskkxw5l4UZ2vsb9/orzPegHySaJ4=";
+    };
+    armv7l-linux = fetchurl {
+      url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Raspberry-Pi-Linux-14.04-arm32-arm32v7-legacy-date-20231227.tar.gz";
+      hash = "sha256-PRp7kuqFBRy7nextTCB+/poc+A9AX2EiQphx6aUfT8E=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    libjack2
+    libglvnd
+    libpulseaudio
+  ];
+
+  desktop = makeDesktopItem {
+    name = "project-outfox";
+    desktopName = "Project OutFox";
+    genericName = "Rhythm game engine";
+    exec = "OutFox";
+    tryExec = "OutFox";
+    categories = [ "Game" ];
+  };
+
+  patchPhase = ''
+    find ./Appearance -type f -executable -exec chmod -x {} \;
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/OutFox $out/share/applications
+    cp -r ./. $out/share/OutFox
+    ln -s ${desktop}/share/applications/project-outfox.desktop $out/share/applications/project-outfox.desktop
+    makeWrapper $out/share/OutFox/OutFox $out/bin/OutFox --argv0
+  '';
+
+  meta = with lib; {
+    description = "A rhythm game engine forked from StepMania";
+    homepage = "https://projectoutfox.com";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" "armv7l-linux" ];
+    maintainers = with maintainers; [ maxwell-lt ];
+    mainProgram = "OutFox";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Project OutFox](https://projectoutfox.com/) is a rhythm game engine forked from StepMania that is performing major refactors of the original code, with a goal of supporting many platforms, input devices, and charts from other rhythm games.

The project is currently closed-source, with plans to release the source under GPL3 at some date in the future when development has stabilized. For now, I've marked the license as unfreeRedistributable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Built and tested on x86_64-linux.
Successfully built for i686-linux, armv7l-linux, aarch64-linux with pkgsCross, but was not able to test on those platforms.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] armv7l-linux
  - [x] i686-linux 
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
