### PR TITLE
phpExtensions.grpc: use shared system grpc

### DIFF
--- a/pkgs/development/php-packages/grpc/default.nix
+++ b/pkgs/development/php-packages/grpc/default.nix
@@ -1,18 +1,24 @@
 { buildPecl
-, zlib
+, pkg-config
 , lib
+, grpc
 }:
 
 buildPecl {
   pname = "grpc";
-  version = "1.56.0";
+  inherit (grpc) version src;
 
-  sha256 = "sha256-uzxYMUzExMBDtwv3FipOuuUHg0v1wqAUtn69jXAQnf4=";
+  sourceRoot = "${grpc.src.name}/src/php/ext/grpc";
+
+  patches = [
+    ./use-pkgconfig.patch # https://github.com/grpc/grpc/pull/35404
+    ./skip-darwin-test.patch # https://github.com/grpc/grpc/pull/35403
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ grpc ];
 
   doCheck = true;
-  checkTarget = "test";
-
-  nativeBuildInputs = [ zlib ];
 
   meta = {
     description = "A high performance, open source, general RPC framework that puts mobile and HTTP/2 first.";

--- a/pkgs/development/php-packages/grpc/skip-darwin-test.patch
+++ b/pkgs/development/php-packages/grpc/skip-darwin-test.patch
@@ -1,0 +1,22 @@
+From b1fa212d0bc29dcc72107ad67fb99d4ef573942a Mon Sep 17 00:00:00 2001
+From: Shyim <github@shyim.de>
+Date: Thu, 28 Dec 2023 10:28:21 +0100
+Subject: [PATCH] php: skip epoll1 test on darwin
+
+---
+ tests/grpc-set-ini.phpt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/grpc-set-ini.phpt b/tests/grpc-set-ini.phpt
+index 55c18ee526e24..b39348ea2e685 100644
+--- a/tests/grpc-set-ini.phpt
++++ b/tests/grpc-set-ini.phpt
+@@ -1,7 +1,7 @@
+ --TEST--
+ Ensure ini settings are handled
+ --SKIPIF--
+-<?php if (!extension_loaded("grpc")) print "skip"; ?>
++<?php if (!extension_loaded("grpc") || PHP_OS === "Darwin") print "skip"; ?>
+ --INI--
+ grpc.enable_fork_support = 1
+ grpc.poll_strategy = epoll1

--- a/pkgs/development/php-packages/grpc/use-pkgconfig.patch
+++ b/pkgs/development/php-packages/grpc/use-pkgconfig.patch
@@ -1,0 +1,82 @@
+From 24b4e273bd503760a485e92ca418e4699767ec51 Mon Sep 17 00:00:00 2001
+From: Shyim <github@shyim.de>
+Date: Thu, 28 Dec 2023 10:38:42 +0100
+Subject: [PATCH] [php]: add with-grpc-dir to configure and add pkg-config
+ support
+
+---
+ config.m4 | 48 +++++++++++++++++++++++++-------------
+ 1 file changed, 32 insertions(+), 16 deletions(-)
+
+diff --git a/config.m4 b/config.m4
+index 5600df34ccfa3..c2186a41d21f5 100755
+--- a/config.m4
++++ b/config.m4
+@@ -7,35 +7,51 @@ PHP_ARG_ENABLE(coverage, whether to include code coverage symbols,
+ PHP_ARG_ENABLE(tests, whether to compile helper methods for tests,
+ [  --enable-tests          Enable tests methods], no, no)
+ 
++PHP_ARG_WITH(grpc-dir,	for grpc,
++[	--with-grpc-dir[=DIR]	 Set the path to grpc install prefix.], yes)
++
+ dnl Check whether to enable tests
+ if test "$PHP_TESTS" != "no"; then
+   CPPFLAGS="$CPPFLAGS -DGRPC_PHP_DEBUG"
+ fi
+ 
+ if test "$PHP_GRPC" != "no"; then
+-  dnl Write more examples of tests here...
+-
+-  dnl # --with-grpc -> check with-path
+-  SEARCH_PATH="/usr/local /usr"     # you might want to change this
+-  SEARCH_FOR="include/grpc/grpc.h"  # you most likely want to change this
+-  if test -r $PHP_GRPC/$SEARCH_FOR; then # path given as parameter
+-    GRPC_DIR=$PHP_GRPC
+-  else # search default path list
++  AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
++
++  if test "$PHP_GRPC_DIR" = "yes" -a -x $PKG_CONFIG; then
++    AC_MSG_CHECKING([for grpc using pkg-config])
++
++    if ! $PKG_CONFIG --exists grpc ; then
++			AC_MSG_ERROR([grpc not found])
++		fi
++
++    GRPC_VERSION=`$PKG_CONFIG grpc --modversion`
++		AC_MSG_RESULT([found version $GRPC_VERSION])
++
++    PHP_GRPC_LIBS=`$PKG_CONFIG grpc --libs`
++		PHP_GRPC_INCS=`$PKG_CONFIG grpc --cflags`
++
++    PHP_EVAL_LIBLINE($PHP_GRPC_LIBS, AMQP_SHARED_LIBADD)
++    PHP_EVAL_INCLINE($PHP_GRPC_INCS)
++  else
+     AC_MSG_CHECKING([for grpc files in default path])
++
++    SEARCH_PATH="$PHP_GRPC_DIR /usr/local /usr"
++
+     for i in $SEARCH_PATH ; do
+-      if test -r $i/$SEARCH_FOR; then
++      if test -r $i/include/grpc/grpc.h; then
+         GRPC_DIR=$i
+         AC_MSG_RESULT(found in $i)
+       fi
+     done
+-  fi
+-  if test -z "$GRPC_DIR"; then
+-    AC_MSG_RESULT([not found])
+-    AC_MSG_ERROR([Please reinstall the grpc distribution])
+-  fi
+ 
+-  dnl # --with-grpc -> add include path
+-  PHP_ADD_INCLUDE($GRPC_DIR/include)
++    if test -z "$GRPC_DIR"; then
++      AC_MSG_RESULT([not found])
++      AC_MSG_ERROR([Please reinstall the grpc distribution])
++    fi
++
++    PHP_ADD_INCLUDE($GRPC_DIR/include)
++  fi
+ 
+   LIBS="-lpthread $LIBS"
+ 


### PR DESCRIPTION
## Description of changes

This allows us to use the system grpc instead of compiling grpc with his libraries again and then use it together with the PHP extension.

This reduces the build time from **~20 minutes** to just 5 seconds. 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).