### PR TITLE
python3Packages.scipy: Disable tests on i686

### DIFF
--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -123,6 +123,9 @@ in buildPythonPackage {
     "hyp2f1_test_case47"
     "hyp2f1_test_case3"
     "test_uint64_max"
+  ] ++ lib.optionals stdenv.isi686 [
+    "test_basic"          # see https://github.com/scipy/scipy/issues/12931
+    "test_x0_equals_Mb"   # see https://github.com/scipy/scipy/issues/17912
   ];
 
   doCheck = !(stdenv.isx86_64 && stdenv.isDarwin);


### PR DESCRIPTION
## Description of changes

scipy fails on `nixos-23.11` (`i686-linux`) with the following error:

```
[gw0] linux -- Python 3.11.6 /nix/store/i07jalkvz6ynwsck43yigmcyawnhbwl2-python3-3.11.6/bin/python3.11
lib/python3.11/site-packages/scipy/sparse/linalg/_isolve/tests/test_iterative.py:532: in test_x0_equals_Mb
    assert info == 0
E   assert -11 == 0
        A          = <10x10 sparse matrix of type '<class 'numpy.complex64'>'
	with 19 stored elements in Compressed Sparse Row format>
        b          = array([0., 1., 2., 3., 4., 5., 6., 7., 8., 9.])
        case       = <nonsymposdef-F>
        info       = -11
        solver     = <function bicgstab at 0xf2167208>
        sup        = <numpy.testing._private.utils.suppress_warnings object at 0xd72aa950>
        tol        = 1e-08
        x          = array([0.        +0.j, 0.49999272+0.j, 1.25007169+0.j, 2.12617093+0.j,
       3.06661642+0.j, 4.03650608+0.j, 5.01656828+0.j, 6.00407387+0.j,
       7.        +0.j, 8.        +0.j])
        x0         = 'Mb'
=========================== short test summary info ============================
FAILED lib/python3.11/site-packages/scipy/signal/tests/test_filter_design.py::TestCheby1::test_basic - AssertionError: 
FAILED lib/python3.11/site-packages/scipy/sparse/linalg/_isolve/tests/test_iterative.py::test_x0_equals_Mb[bicgstab-nonsymposdef-F] - assert -11 == 0
= 2 failed, 42282 passed, 2687 skipped, 484 xfailed, 11 xpassed in 579.05s (0:09:39) =
```

The errors can be tracked down to two issues in upstream, #12931 and #17912. One of them should have already been fixed by a bump of numpy (but it didn't seem to work). Disabling them on i686 allows the build to run.

The build for `scipy` does not work on `master` at the moment since it fails with:

```
[ 10%] Building CXX object test/CMakeFiles/test_xsimd.dir/test_api.cpp.o
In file included from /build/source/include/xsimd/types/../arch/./xsimd_generic.hpp:18,
                 from /build/source/include/xsimd/types/../arch/xsimd_isa.hpp:88,
                 from /build/source/include/xsimd/types/xsimd_batch.hpp:491,
                 from /build/source/include/xsimd/xsimd.hpp:61,
                 from /build/source/test/test_basic_math.cpp:12:
/build/source/include/xsimd/types/../arch/././generic/xsimd_generic_math.hpp: In function 'xsimd::batch<float, A> xsimd::kernel::cbrt(const xsimd::batch<float, A>&, requires_arch<xsimd::generic>)':
/build/source/include/xsimd/types/../arch/././generic/xsimd_generic_math.hpp:152:45: error: 'batch_bool_cast' was not declared in this scope; did you mean 'batch_cast'?
  152 |             const batch_type cbrt2 = select(batch_bool_cast<float>(flag), CBRT2, CBRT2I);
      |                                             ^~~~~~~~~~~~~~~
      |                                             batch_cast
/build/source/include/xsimd/types/../arch/././generic/xsimd_generic_math.hpp:152:61: error: expected primary-expression before 'float'
  152 |             const batch_type cbrt2 = select(batch_bool_cast<float>(flag), CBRT2, CBRT2I);
      |                                                             ^~~~~
```

This is an upstream bug in `xsimd` that was fixed in a later version (see https://github.com/xtensor-stack/xsimd/issues/986). This is already done in nixpkgs in #272992, but it's not available yet in `master` (it's in `staging`). Combined with this, the `scipy` builds successfully on i686.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] i686-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
