### PR TITLE
python311Packages.pint: 0.22 -> 0.23

### DIFF
--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -13,6 +13,7 @@
 # tests
 , pytestCheckHook
 , pytest-subtests
+, pytest-benchmark
 , numpy
 , matplotlib
 , uncertainties
@@ -20,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "pint";
-  version = "0.22";
+  version = "0.23";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -28,7 +29,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "Pint";
-    hash = "sha256-LROfarvPMBbK19POwFcH/pCKxPmc9Zrt/W7mZ7emRDM=";
+    hash = "sha256-4VCbkWBtvFJSfGAKTvdP+sEv/3Boiv8g6QckCTRuybQ=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +44,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-subtests
+    pytest-benchmark
     numpy
     matplotlib
     uncertainties
@@ -53,8 +55,8 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # https://github.com/hgrecco/pint/issues/1825
-    "test_equal_zero_nan_NP"
+    # https://github.com/hgrecco/pint/issues/1898
+    "test_load_definitions_stage_2"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
