### PR TITLE
nixosTests.slurm: ..?

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -780,9 +780,9 @@ in {
   simple = handleTest ./simple.nix {};
   sing-box = handleTest ./sing-box.nix {};
   slimserver = handleTest ./slimserver.nix {};
-  slurm = handleTest ./slurm.nix {};
-  snmpd = handleTest ./snmpd.nix {};
+  slurm = runTest ./slurm/test.nix;
   smokeping = handleTest ./smokeping.nix {};
+  snmpd = handleTest ./snmpd.nix {};
   snapcast = handleTest ./snapcast.nix {};
   snapper = handleTest ./snapper.nix {};
   snipe-it = runTest ./web-apps/snipe-it.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -780,7 +780,7 @@ in {
   simple = handleTest ./simple.nix {};
   sing-box = handleTest ./sing-box.nix {};
   slimserver = handleTest ./slimserver.nix {};
-  slurm = runTest ./slurm/test.nix;
+  slurm = makeOverridable (import ./slurm/default.nix) { inherit runTest; };
   smokeping = handleTest ./smokeping.nix {};
   snmpd = handleTest ./snmpd.nix {};
   snapcast = handleTest ./snapcast.nix {};

--- a/nixos/tests/slurm/default.nix
+++ b/nixos/tests/slurm/default.nix
@@ -1,0 +1,7 @@
+{
+  runTest,
+  extraModules ? [ ],
+}:
+
+runTest
+  { imports = extraModules ++ [ ./test.nix ]; }

--- a/nixos/tests/slurm/mpitest.c
+++ b/nixos/tests/slurm/mpitest.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+
+int
+main (int argc, char *argv[])
+{
+  int rank, size, length;
+  char name[512];
+
+  MPI_Init (&argc, &argv);
+  MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+  MPI_Comm_size (MPI_COMM_WORLD, &size);
+  MPI_Get_processor_name (name, &length);
+
+  if ( rank == 0 ) printf("size=%d\n", size);
+
+  printf ("%s: hello world from process %d of %d\n", name, rank, size);
+
+  MPI_Finalize ();
+
+  return EXIT_SUCCESS;
+}

--- a/nixos/tests/slurm/test.nix
+++ b/nixos/tests/slurm/test.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ lib, pkgs, ... }:
+({ lib, pkgs, ... }:
 let
     slurmconfig = {
       services.slurm = {

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -289,8 +289,8 @@ in
           singularity-tools.buildImage {
             name = "saxpy";
             contents = [ cudaPackages.saxpy ];
-            memSize = 2048;
-            diskSize = 2048;
+            memSize = 8192;
+            diskSize = 8192;
             singularity = finalAttrs.finalPackage;
           })
         { };

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -1,16 +1,28 @@
-{ stdenv, lib, fetchurl, perl, gfortran
-, openssh, hwloc, python3
-# either libfabric or ucx work for ch4backend on linux. On darwin, neither of
-# these libraries currently build so this argument is ignored on Darwin.
-, ch4backend
-# Process managers to build (`--with-pm`),
-# cf. https://github.com/pmodels/mpich/blob/b80a6d7c24defe7cdf6c57c52430f8075a0a41d6/README.vin#L562-L586
-, withPm ? [ "hydra" "gforker" ]
-, pmix
-# PMIX support is likely incompatible with process managers (`--with-pm`)
-# https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
-, pmixSupport ? false
-} :
+{
+  stdenv,
+  lib,
+  fetchurl,
+  perl,
+  gfortran,
+  openssh,
+  hwloc,
+  python3,
+  # either libfabric or ucx work for ch4backend on linux. On darwin, neither of
+  # these libraries currently build so this argument is ignored on Darwin.
+  ch4backend,
+  # Process managers to build (`--with-pm`),
+  # cf. https://github.com/pmodels/mpich/blob/b80a6d7c24defe7cdf6c57c52430f8075a0a41d6/README.vin#L562-L586
+  withPm ? [
+    "hydra"
+    "gforker"
+  ],
+  pmix,
+  # PMIX support is likely incompatible with process managers (`--with-pm`)
+  # https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
+  pmixSupport ? false,
+  nixosTests,
+  mpich-pmix,
+}:
 
 let
   withPmStr = if withPm != [ ] then builtins.concatStringsSep ":" withPm else "no";
@@ -18,7 +30,7 @@ in
 
 assert (ch4backend.pname == "ucx" || ch4backend.pname == "libfabric");
 
-stdenv.mkDerivation  rec {
+stdenv.mkDerivation rec {
   pname = "mpich";
   version = "4.1.2";
 
@@ -27,23 +39,34 @@ stdenv.mkDerivation  rec {
     sha256 = "sha256-NJLpitq2K1l+8NKS+yRZthI7yABwqKoKML5pYgdaEvA=";
   };
 
-  outputs = [ "out" "doc" "man" ];
-
-  configureFlags = [
-    "--enable-shared"
-    "--with-pm=${withPmStr}"
-  ] ++ lib.optionals (lib.versionAtLeast gfortran.version "10") [
-    "FFLAGS=-fallow-argument-mismatch" # https://github.com/pmodels/mpich/issues/4300
-    "FCFLAGS=-fallow-argument-mismatch"
-  ] ++ lib.optionals pmixSupport [
-    "--with-pmix=${lib.getDev pmix}"
+  outputs = [
+    "out"
+    "doc"
+    "man"
   ];
+
+  configureFlags =
+    [
+      "--enable-shared"
+      "--with-pm=${withPmStr}"
+    ]
+    ++ lib.optionals (lib.versionAtLeast gfortran.version "10") [
+      "FFLAGS=-fallow-argument-mismatch" # https://github.com/pmodels/mpich/issues/4300
+      "FCFLAGS=-fallow-argument-mismatch"
+    ]
+    ++ lib.optionals pmixSupport [ "--with-pmix=${lib.getDev pmix}" ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ gfortran python3 ];
-  buildInputs = [ perl openssh hwloc ]
-    ++ lib.optional (!stdenv.isDarwin) ch4backend;
+  nativeBuildInputs = [
+    gfortran
+    python3
+  ];
+  buildInputs = [
+    perl
+    openssh
+    hwloc
+  ] ++ lib.optional (!stdenv.isDarwin) ch4backend;
 
   doCheck = true;
 
@@ -53,6 +76,33 @@ stdenv.mkDerivation  rec {
     sed -i 's:CXX="g++":CXX=${stdenv.cc}/bin/g++:' $out/bin/mpicxx
     sed -i 's:FC="gfortran":FC=${gfortran}/bin/gfortran:' $out/bin/mpifort
   '';
+
+  passthru.tests.slurm-mpirun = nixosTests.slurm.override {
+    extraModules = [
+      {
+        node.pkgsReadOnly = false;
+        defaults.nixpkgs.overlays = lib.mkForce [
+          (final: _: { mpi = final.mpich.override { pmixSupport = false; }; })
+        ];
+
+        slurmTest.steps."30-srun-cpi".enable = false; # no direct-srun
+        slurmTest.steps."30-srun-pmix".enable = false; # No pmix
+
+        # tests a failure, but only fails with openmpi?
+        slurmTest.steps."30-srun-pmix-cpi-asan".enable = false;
+
+        slurmTest.steps."30-mpirun-cpi".enable = true;
+      }
+    ];
+  };
+  passthru.tests.slurm-pmix = nixosTests.slurm.override {
+    extraModules = [
+      {
+        node.pkgsReadOnly = false;
+        defaults.nixpkgs.overlays = lib.mkForce [ (final: _: { mpi = final.mpich-pmix; }) ];
+      }
+    ];
+  };
 
   meta = with lib; {
     # As far as we know, --with-pmix silently disables all of `--with-pm`

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -20,6 +20,8 @@
   # PMIX support is likely incompatible with process managers (`--with-pm`)
   # https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
   pmixSupport ? false,
+  withSlurm ? true,
+  slurm,
   nixosTests,
   mpich-pmix,
 }:
@@ -54,6 +56,11 @@ stdenv.mkDerivation rec {
       "FFLAGS=-fallow-argument-mismatch" # https://github.com/pmodels/mpich/issues/4300
       "FCFLAGS=-fallow-argument-mismatch"
     ]
+    ++ lib.optionals withSlurm
+    [
+      "--with-pmi=pmi2"
+      "--with-pmilib=slurm"
+    ]
     ++ lib.optionals pmixSupport [ "--with-pmix=${lib.getDev pmix}" ];
 
   enableParallelBuilding = true;
@@ -66,7 +73,9 @@ stdenv.mkDerivation rec {
     perl
     openssh
     hwloc
-  ] ++ lib.optional (!stdenv.isDarwin) ch4backend;
+  ]
+  ++ lib.optionals withSlurm [ (lib.getLib slurm) (lib.getDev slurm) ]
+  ++ lib.optionals (!stdenv.isDarwin) [ ch4backend ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -56,7 +56,13 @@ stdenv.mkDerivation rec {
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ]
     ++ lib.optionals fortranSupport [ gfortran ];
 
-  configureFlags = lib.optional (!cudaSupport) "--disable-mca-dso"
+  configureFlags =
+    [
+      "--with-ucc=${lib.getDev ucc}"
+      "--with-ucx=${lib.getDev ucx}"
+      "--with-ucx-libdir=${lib.getLib ucx}/lib"
+    ]
+    ++ lib.optional (!cudaSupport) "--disable-mca-dso"
     ++ lib.optional (!fortranSupport) "--disable-mpi-fortran"
     ++ lib.optionals stdenv.isLinux  [
       "--with-libnl=${lib.getDev libnl}"
@@ -69,7 +75,10 @@ stdenv.mkDerivation rec {
     # TODO: add UCX support, which is recommended to use with cuda for the most robust OpenMPI build
     # https://github.com/openucx/ucx
     # https://www.open-mpi.org/faq/?category=buildcuda
-    ++ lib.optionals cudaSupport [ "--with-cuda=${cudaPackages.cuda_cudart}" "--enable-dlopen" ]
+    ++ lib.optionals cudaSupport [
+      "--with-cuda=${cudaPackages.cuda_cudart}"
+      "--enable-dlopen"
+    ]
     ++ lib.optionals fabricSupport [ "--with-psm2=${lib.getDev libpsm2}" "--with-libfabric=${lib.getDev libfabric}" ]
     ;
 


### PR DESCRIPTION
## Description of changes

Demonstrates current failure cases:
- Unreliable startup. The issue is concealed by the automatic restarts in real deployments, and by manual `systemctl restart`s in the NixOS test. Related: https://github.com/NixOS/nixpkgs/pull/275080, https://github.com/NixOS/nixpkgs/pull/267936
- MPI libraries not passing sanitizer checks (https://github.com/NixOS/nixpkgs/issues/274584)

Combines the following drafts:
- https://github.com/NixOS/nixpkgs/pull/274578/files
- 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
