### PR TITLE
mkdocs-rss-plugin: init at 1.8.0

### DIFF
--- a/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage {
+  pname = "mkdocs-rss-plugin";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "Guts";
+    repo = "mkdocs-rss-plugin";
+    rev = "1.8.0";
+    sha256 = "sha256-rCz1Uk5uqIsnIWw0b1oBsjAO6aK/tpVgqAX/8dVnAGw=";
+  };
+
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "MkDocs plugin to generate a RSS feeds for created and updated pages, using git log and YAML frontmatter (page.meta).";
+    homepage = "https://github.com/Guts/mkdocs-rss-plugin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ caarlos0 ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
@@ -5,7 +5,7 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "mkdocs-rss-plugin";
-  version = "1.8.0";
+  version = "1.15.0";
   pyproject = true;
 
   disabled = python3Packages.pythonOlder "3.8";
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
     owner = "Guts";
     repo = "mkdocs-rss-plugin";
     rev = "refs/tags/${version}";
-    hash = "sha256-rCz1Uk5uqIsnIWw0b1oBsjAO6aK/tpVgqAX/8dVnAGw=";
+    hash = "sha256-sGm6uWlZeW65uorfTK8pk8ZT2AE9nmsZhe+UYVrSr+8=";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -26,11 +26,17 @@ python3Packages.buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = with python3Packages; [
-    mkdocs
+    cachecontrol
+    feedparser
     gitpython
+    jsonfeed
+    mkdocs
+    mkdocs-material
+    pytest-cov
+    pytest-cov
+    requests
+    validator-collection
   ];
-
-  doCheck = false;
 
   meta = with lib; {
     description = "Plugin to generate a RSS feeds for created and updated pages";

--- a/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
@@ -1,14 +1,14 @@
 { lib
-, buildPythonPackage
+, python3Packages
 , fetchFromGitHub
 }:
 
-buildPythonPackage {
+python3Packages.buildPythonPackage rec {
   pname = "mkdocs-rss-plugin";
   version = "1.8.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = python3Packages.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Guts";
@@ -16,12 +16,18 @@ buildPythonPackage {
     rev = "refs/tags/${version}";
     hash = "sha256-rCz1Uk5uqIsnIWw0b1oBsjAO6aK/tpVgqAX/8dVnAGw=";
   };
-  nativeBuildInputs = [
+
+  nativeBuildInputs = with python3Packages; [
     setuptools
   ];
 
-  propagatedBuildInputs = [
-    ...
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    mkdocs
+    gitpython
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-rss-plugin/default.nix
@@ -6,20 +6,34 @@
 buildPythonPackage {
   pname = "mkdocs-rss-plugin";
   version = "1.8.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Guts";
     repo = "mkdocs-rss-plugin";
-    rev = "1.8.0";
-    sha256 = "sha256-rCz1Uk5uqIsnIWw0b1oBsjAO6aK/tpVgqAX/8dVnAGw=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-rCz1Uk5uqIsnIWw0b1oBsjAO6aK/tpVgqAX/8dVnAGw=";
   };
+  nativeBuildInputs = [
+    setuptools
+  ];
 
+  propagatedBuildInputs = [
+    ...
+  ];
 
   doCheck = false;
 
   meta = with lib; {
-    description = "MkDocs plugin to generate a RSS feeds for created and updated pages, using git log and YAML frontmatter (page.meta).";
+    description = "Plugin to generate a RSS feeds for created and updated pages";
+    longDescription = ''
+      MkDocs plugin to generate a RSS feeds for created and updated pages, using
+      git log and YAML frontmatter (page.meta).
+    '';
     homepage = "https://github.com/Guts/mkdocs-rss-plugin";
+    changelog = "https://github.com/Guts/mkdocs-rss-plugin/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ caarlos0 ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7074,6 +7074,7 @@ self: super: with self; {
   mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };
   mkdocs-simple-hooks = callPackage ../development/python-modules/mkdocs-simple-hooks { };
   mkdocs-swagger-ui-tag = callPackage ../development/python-modules/mkdocs-swagger-ui-tag { };
+  mkdocs-rss-plugin = callPackage ../development/python-modules/mkdocs-rss-plugin { };
 
   mkdocstrings = callPackage ../development/python-modules/mkdocstrings { };
 


### PR DESCRIPTION
## Description of changes

It's needed for mkdocs-material blog plugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
