### PR TITLE
batman-adv: fix redefinition of skb_vlan_eth_hdr

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
+, fetchpatch2
 , kernel
 }:
 
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
     url = "http://downloads.open-mesh.org/batman/releases/${pname}-${cfg.version}/${pname}-${cfg.version}.tar.gz";
     sha256 = cfg.sha256.${pname};
   };
+
+  patches = [
+    # batman-adv: compat: Fix skb_vlan_eth_hdr conflict in stable kernels
+    (fetchpatch2 {
+      url = "https://git.open-mesh.org/batman-adv.git/commitdiff_plain/be69e50e8c249ced085d41ddd308016c1c692174?hp=74d3c5e1c682a9efe31b75e8986668081a4b5341";
+      sha256 = "sha256-yfEiU74wuMSKal/6mwzgdccqDMEv4P7CkAeiSAEwvjA=";
+    })
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
   makeFlags = kernel.makeFlags ++ [


### PR DESCRIPTION
## Description of changes

Ran into an error while trying to deploy a new config. Seems to be due to a bumped kernel and it having received an backport of [`net: vlan: introduce skb_vlan_eth_hdr()`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=1f5020acb33f926030f62563c86dffca35c7b701)

The patch is from upstream: https://git.open-mesh.org/batman-adv.git/commit/be69e50e8c249ced085d41ddd308016c1c692174

Will need an backported to nixos-23.11 as i noticed the issue there first.


```
building '/nix/store/qf5sli2hxn7n626988wapvf5h4616ks3-batman-adv-2023.3-6.1.69.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/il1a30cbxg4z4g4n4rgh9gn77lsqrsfd-batman-adv-2023.3.tar.gz
source root is batman-adv-2023.3
setting SOURCE_DATE_EPOCH to timestamp 1700044610 of file batman-adv-2023.3/net/batman-adv/types.h
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash O=\$\(buildRoot\) CC=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc HOSTCC=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc HOSTLD=/nix/store/lwqnazddv8037sin49482dnzc9iwgg8l-binutils-wrapper-2.40/bin/ld ARCH=x86_64 KERNELPATH=/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/build
/build/batman-adv-2023.3/gen-compat-autoconf.sh /build/batman-adv-2023.3/compat-autoconf.h
make -C /nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/build M=/build/batman-adv-2023.3 PWD=/build/batman-adv-2023.3 REVISION= CONFIG_BATMAN_ADV=m CONFIG_BATMAN_ADV_DEBUG=n CONFIG_BATMAN_ADV_BLA=y CONFIG_BATMAN_ADV_DAT=y CONFIG_BATMAN_ADV_NC=n CONFIG_BATMAN_ADV_MCAST=y CONFIG_BATMAN_ADV_TRACING=n CONFIG_BATMAN_ADV_BATMAN_V=y INSTALL_MOD_PATH=/nix/store/95x7cs9vbsgb8dqr6gpvr94ajvqsnwk6-batman-adv-2023.3-6.1.69 INSTALL_MOD_DIR=updates/  modules
  CC [M]  /build/batman-adv-2023.3/net/batman-adv/bat_algo.o
In file included from /build/batman-adv-2023.3/net/batman-adv/main.h:210,
                 from /build/batman-adv-2023.3/net/batman-adv/bat_algo.c:7:
/build/batman-adv-2023.3/compat-include/linux/if_vlan.h:21:35: error: redefinition of 'skb_vlan_eth_hdr'
   21 | static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
      |                                   ^~~~~~~~~~~~~~~~
In file included from /build/batman-adv-2023.3/compat-include/linux/if_vlan.h:14:
/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/include/linux/if_vlan.h:68:35: note: previous definition of 'skb_vlan_eth_hdr' with type 'struct vlan_ethhdr *(const struct sk_buff *)'
   68 | static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
      |                                   ^~~~~~~~~~~~~~~~
make[3]: *** [/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/scripts/Makefile.build:250: /build/batman-adv-2023.3/net/batman-adv/bat_algo.o] Error 1
make[2]: *** [/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/scripts/Makefile.build:500: /build/batman-adv-2023.3/net/batman-adv] Error 2
make[1]: *** [/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/Makefile:2014: /build/batman-adv-2023.3] Error 2
make: *** [Makefile:67: all] Error 2
error: builder for '/nix/store/qf5sli2hxn7n626988wapvf5h4616ks3-batman-adv-2023.3-6.1.69.drv' failed with exit code 2;
       last 10 log lines:
       >    21 | static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
       >       |                                   ^~~~~~~~~~~~~~~~
       > In file included from /build/batman-adv-2023.3/compat-include/linux/if_vlan.h:14:
       > /nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/include/linux/if_vlan.h:68:35: note: previous definition of 'skb_vlan_eth_hdr' with type 'struct vlan_ethhdr *(const struct sk_buff *)'
       >    68 | static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
       >       |                                   ^~~~~~~~~~~~~~~~
       > make[3]: *** [/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/scripts/Makefile.build:250: /build/batman-adv-2023.3/net/batman-adv/bat_algo.o] Error 1
       > make[2]: *** [/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/scripts/Makefile.build:500: /build/batman-adv-2023.3/net/batman-adv] Error 2
       > make[1]: *** [/nix/store/j4phh7jxj54q7fn5hp3s84qid4dw8v68-linux-6.1.69-dev/lib/modules/6.1.69/source/Makefile:2014: /build/batman-adv-2023.3] Error 2
       > make: *** [Makefile:67: all] Error 2
       For full logs, run 'nix-store -l /nix/store/qf5sli2hxn7n626988wapvf5h4616ks3-batman-adv-2023.3-6.1.69.drv'.
error: 1 dependencies of derivation '/nix/store/6sfjrwl37f463fghkakp4qflbcnk0bag-kernel-modules.drv' failed to build
error: 1 dependencies of derivation '/nix/store/rnkjd58ivzdshgibjxh5f7q25cmhb3dc-linux-6.1.69-modules.drv' failed to build
error: 1 dependencies of derivation '/nix/store/6awla9gxnmh9n8rblfphnvgwfrk4n3d0-nixos-system-gw11-24.05pre-git.drv' failed to build
error: 1 dependencies of derivation '/nix/store/h5a4jnqgns86f2qgy5smsy43iinj4vxh-morph.drv' failed to build
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
