### PR TITLE
geo-activity-playground: init and init several deps for it

### DIFF
--- a/pkgs/by-name/ge/geo-activity-playground/package.nix
+++ b/pkgs/by-name/ge/geo-activity-playground/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "geo-activity-playground";
+  version = "0.38.2";
+  src = fetchFromGitHub {
+    repo = "geo-activity-playground";
+    owner = "martin-ueding";
+    tag = version;
+    hash = "sha256-L4o4z659u0xrOmck/FLhZ694G7UdPzLDofjMumDGNog=";
+  };
+  pyproject = true;
+
+  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
+  build-system = [ python3.pkgs.poetry-core ];
+  dependencies = with python3.pkgs; [
+    shapely
+    coloredlogs
+    geojson
+    matplotlib
+    pandas
+    scipy
+    tqdm
+    requests
+    fitdecode
+    gpxpy
+    stravalib
+    flask
+    altair
+    tcxreader
+    pyarrow
+    vegafusion
+    vl-convert-python
+    xmltodict
+    appdirs
+    imagehash
+  ];
+  pythonRelaxDeps = [
+    "matplotlib"
+    "xmltodict"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Data analysis and visualization based on GPS tracked outdoor activities";
+    homepage = "https://martin-ueding.github.io/geo-activity-playground/";
+    changelog = "https://martin-ueding.github.io/geo-activity-playground/reference/changelog/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ antonmosich ];
+    mainProgram = "geo-activity-playground";
+  };
+}

--- a/pkgs/development/python-modules/fitdecode/default.nix
+++ b/pkgs/development/python-modules/fitdecode/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+}:
+
+buildPythonPackage rec {
+  pname = "fitdecode";
+  version = "0.10.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-G4XRMDyHZQwRN3pzInV+qhyvIpd2u9W1RVkd1oFRI+Q=";
+  };
+
+  doCheck = false;
+
+  meta = {
+    description = "A FIT file parsing and decoding library written in Python3";
+    homepage = "https://github.com/polyvertex/fitdecode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ antonmosich ];
+  };
+}

--- a/pkgs/development/python-modules/vegafusion-embed/default.nix
+++ b/pkgs/development/python-modules/vegafusion-embed/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  protobuf,
+}:
+buildPythonPackage rec {
+  pname = "vegafusion-embed";
+  version = "1.6.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hex-inc";
+    repo = "vegafusion";
+    rev = "v${version}";
+    hash = "sha256-CItZehy5cPIU38dTOBJA5Q6Xp+4R+6OvyxHXS6L/6xc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-KiXMEFxKSzKzD5D+EkKcs3GFhIhywGqZXyqB1b2GCf8=";
+  };
+
+  buildAndTestSubdir = "vegafusion-python-embed";
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+    protobuf
+  ];
+
+  meta = {
+    description = "A Python library that embeds the VegaFusion Runtime and select Connection";
+    license = lib.licenses.bsd3;
+    homepage = "https://github.com/hex-inc/vegafusion";
+    maintainers = with lib.maintainers; [ antonmosich ];
+  };
+}

--- a/pkgs/development/python-modules/vegafusion/default.nix
+++ b/pkgs/development/python-modules/vegafusion/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  altair,
+  pandas,
+  protobuf,
+  psutil,
+  pyarrow,
+  setuptools,
+  setuptools-scm,
+  vegafusion-embed,
+}:
+buildPythonPackage rec {
+  pname = "vegafusion";
+  version = "1.6.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hex-inc";
+    repo = "vegafusion";
+    rev = "v${version}";
+    hash = "sha256-CItZehy5cPIU38dTOBJA5Q6Xp+4R+6OvyxHXS6L/6xc=";
+  };
+
+  sourceRoot = "source/python/vegafusion";
+
+  patchPhase = ''
+    substituteInPlace pyproject.toml \
+      --replace "setuptools_scm >= 2.0.0, <3" "setuptools_scm >= 2.0.0"
+  '';
+
+  propagatedBuildInputs = [
+    vegafusion-embed
+    setuptools
+    setuptools-scm
+    protobuf
+    # Needed for pythonImportsCheck
+    pandas
+    psutil
+    pyarrow
+    altair
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "vegafusion"
+  ];
+
+  meta = {
+    description = "Serverside scaling for Vega and Altair visualizations";
+    maintainers = with lib.maintainers; [ antonmosich ];
+    homepage = "https://github.com/hex-inc/vegafusion";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/vl-convert/default.nix
+++ b/pkgs/development/python-modules/vl-convert/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  protobuf,
+  callPackage,
+  librusty_v8 ? callPackage ./librusty_v8.nix { },
+}:
+buildPythonPackage rec {
+  pname = "vl-convert-python";
+  version = "1.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "vega";
+    repo = "vl-convert";
+    rev = "v${version}";
+    hash = "sha256-dmfY05i5nCiM2felvBcSuVyY8G70HhpJP3KrRGQ7wq8=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-t952WH6zq7POVvdX3fI7kXXfPiaAXjfsvoqI/aq5Fn0=";
+  };
+
+  buildAndTestSubdir = "vl-convert-python";
+
+  RUSTY_V8_ARCHIVE = librusty_v8;
+
+  build-system = [
+    rustPlatform.maturinBuildHook
+    rustPlatform.cargoSetupHook
+  ];
+
+  nativeBuildInputs = [ protobuf ];
+
+  pythonImportsCheck = [ "vl_convert" ];
+
+  meta = {
+    description = "Utilities for converting Vega-Lite specs from the command line and Python";
+    license = lib.licenses.bsd3;
+    homepage = "https://github.com/vega/vl-convert";
+    maintainers = with lib.maintainers; [ antonmosich ];
+  };
+}

--- a/pkgs/development/python-modules/vl-convert/librusty_v8.nix
+++ b/pkgs/development/python-modules/vl-convert/librusty_v8.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  fetch_librusty_v8 =
+    args:
+    fetchurl {
+      name = "librusty_v8-${args.version}";
+      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+      sha256 = args.shas.${stdenv.hostPlatform.system};
+      meta = {
+        inherit (args) version;
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      };
+    };
+in
+fetch_librusty_v8 {
+  version = "0.105.1";
+  shas = {
+    x86_64-linux = "sha256-f7aDA74Jn2h4rp9sACGHX4DBbN6yevgWCEKdfI1fJDU=";
+    aarch64-linux = "sha256-vuEP7in+A/PrBXSunRq1SC77dOuMiScsKcA712AuNuk=";
+    x86_64-darwin = "sha256-sNe2VCwZvy64jdbPwx7pZ91fFRv1xosOcGiAtSPbt8A=";
+    aarch64-darwin = "sha256-GmwTJADMxArwOvRN/w5KVmWGc1+WfraBc/wWe7dxHMg=";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4871,6 +4871,8 @@ self: super: with self; {
 
   fitbit = callPackage ../development/python-modules/fitbit { };
 
+  fitdecode = callPackage ../development/python-modules/fitdecode { };
+
   fitfile = callPackage ../development/python-modules/fitfile { };
 
   fivem-api = callPackage ../development/python-modules/fivem-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18358,6 +18358,8 @@ self: super: with self; {
 
   vega-datasets = callPackage ../development/python-modules/vega-datasets { };
 
+  vegafusion = callPackage ../development/python-modules/vegafusion { };
+
   vegafusion-embed = callPackage ../development/python-modules/vegafusion-embed {
     inherit (pkgs) protobuf;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18358,6 +18358,10 @@ self: super: with self; {
 
   vega-datasets = callPackage ../development/python-modules/vega-datasets { };
 
+  vegafusion-embed = callPackage ../development/python-modules/vegafusion-embed {
+    inherit (pkgs) protobuf;
+  };
+
   vehicle = callPackage ../development/python-modules/vehicle { };
 
   velbus-aio = callPackage ../development/python-modules/velbus-aio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18438,6 +18438,10 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  vl-convert-python = callPackage ../development/python-modules/vl-convert {
+    inherit (pkgs) protobuf;
+  };
+
   vllm = callPackage ../development/python-modules/vllm { };
 
   vmprof = callPackage ../development/python-modules/vmprof { };


### PR DESCRIPTION
## Description of changes
I wrote this to package geo-activity-playground. This required several python dependencies which had not been packaged and have thus been packaged here.
`vegafusion` has a lot of tests, which fail if enabled. I have not really delved deeper into the reason for the failures.
Also, if there's a better way for `vegafusion` and `vegafusion-embed` to share one source (they both come from the same repository), please let me know.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I also want to emphasize I did not test this on any other platform that x86_64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
