### PR TITLE
backgroundremover: init at 0.2.6

### DIFF
--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -1,0 +1,92 @@
+{ python3
+, lib
+, runCommand
+, fetchFromGitHub
+, fetchurl
+}:
+
+let
+  p = python3.pkgs;
+  self = p.buildPythonApplication rec {
+    pname = "backgroundremover";
+    version = "0.2.6";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "nadermx";
+      repo = "backgroundremover";
+      rev = "v${version}";
+      hash = "sha256-dDOo7NPwvdfV+ae2oMUytCGC+2HF6xUI7dyKk2we23w=";
+    };
+
+    models = runCommand "background-remover-models" {} ''
+      mkdir $out
+      cat ${src}/models/u2a{a,b,c,d} > $out/u2net.pth
+      cat ${src}/models/u2ha{a,b,c,d} > $out/u2net_human_seg.pth
+      cp ${src}/models/u2netp.pth $out
+    '';
+
+    postPatch = ''
+      substituteInPlace backgroundremover/bg.py backgroundremover/u2net/detect.py \
+        --replace 'os.path.expanduser(os.path.join("~", ".u2net", model_name + ".pth"))' "os.path.join(\"$models\", model_name + \".pth\")"
+    '';
+
+    nativeBuildInputs = [ p.setuptools p.wheel ];
+
+    propagatedBuildInputs = [
+      p.certifi
+      p.charset-normalizer
+      p.ffmpeg-python
+      p.filelock
+      p.filetype
+      p.hsh
+      p.idna
+      p.more-itertools
+      p.moviepy
+      p.numpy
+      p.pillow
+      p.pymatting
+      p.pysocks
+      p.requests
+      p.scikit-image
+      p.scipy
+      p.six
+      p.torch
+      p.torchvision
+      p.tqdm
+      p.urllib3
+      p.waitress
+    ];
+
+    pythonImportsCheck = [ "backgroundremover" ];
+
+    passthru = {
+      inherit models;
+      tests = {
+        image = let
+          # random no copyright car image from the internet
+          demoImage = fetchurl {
+            url = "https://pics.craiyon.com/2023-07-16/38653769ac3b4e068181cb5ab1e542a1.webp";
+            hash = "sha256-Kvd06eZdibgDbabVVe0+cNTeS1rDnMXIZZpPlHIlfBo=";
+          };
+        in runCommand "backgroundremover-image-test.png" {
+          buildInputs = [ self ];
+        } ''
+          export NUMBA_CACHE_DIR=$(mktemp -d)
+          backgroundremover -i ${demoImage} -o $out
+        '';
+      };
+    };
+
+    doCheck = false; # no tests
+
+    meta = with lib; {
+      mainProgram = "backgroundremover";
+      description = "Command line tool to remove background from image and video, made by nadermx to power";
+      homepage = "https://BackgroundRemoverAI.com";
+      downloadPage = "https://github.com/nadermx/backgroundremover/releases";
+      license = licenses.mit;
+      maintainers = [ maintainers.lucasew ];
+    };
+  };
+in self

--- a/pkgs/by-name/ba/backgroundremover/test-script.py
+++ b/pkgs/by-name/ba/backgroundremover/test-script.py
@@ -1,0 +1,20 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+import backgroundremover.utilities as utilities
+from backgroundremover import bg
+
+parser = ArgumentParser()
+
+parser.add_argument('input', type=Path)
+parser.add_argument('output', type=Path)
+
+args = parser.parse_args()
+
+input_bytes = args.input.read_bytes()
+
+output_bytes = bg.remove(
+  input_bytes,
+)
+
+args.output.write_bytes(output_bytes)

--- a/pkgs/development/python-modules/hsh/default.nix
+++ b/pkgs/development/python-modules/hsh/default.nix
@@ -1,0 +1,42 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, commandlines
+, unittestCheckHook
+, pexpect
+, naked
+, nix-update-script
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "hsh";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chrissimpkins";
+    repo = "hsh";
+    rev = "v${version}";
+    hash = "sha256-bAAytoidFHH2dSXqN9aqBd2H4p/rwTWXIZa1t5Djdz0=";
+  };
+
+  propagatedBuildInputs = [ commandlines ];
+
+  nativeBuildInputs = [ setuptools wheel ];
+
+  nativeCheckInputs = [ unittestCheckHook pexpect naked ];
+
+  preCheck = "cd tests";
+
+  pythonImportsCheck = [ "hsh" ];
+
+  meta = with lib; {
+    description = "Cross-platform command line application that generates file hash digests and performs file integrity checks via file hash digest comparisons";
+    homepage = "https://github.com/chrissimpkins/hsh";
+    downloadPage = "https://github.com/chrissimpkins/hsh/releases";
+    license = licenses.mit;
+    maintainers = [ maintainers.lucasew ];
+  };
+}

--- a/pkgs/development/python-modules/naked/default.nix
+++ b/pkgs/development/python-modules/naked/default.nix
@@ -1,0 +1,103 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, requests
+, pyyaml
+, setuptools
+, wheel
+, nodejs
+, ruby
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "naked";
+  version = "0.1.32";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chrissimpkins";
+    repo = "naked";
+    rev = "v${version}";
+    hash = "sha256-KhygnURFggvUTR9wwWtORtfQES8ANd5sIaCONvIhfRM=";
+  };
+
+  postPatch = ''
+    # fix hardcoded absolute paths
+    substituteInPlace **/*.* \
+      --replace /Users/ces/Desktop/code/naked /build/source
+  '';
+
+  nativeBuildInputs = [ wheel setuptools ];
+
+  propagatedBuildInputs = [
+    requests
+    pyyaml
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook nodejs ruby ];
+
+  preCheck =''
+    cd tests
+
+    PATH=$PATH:$out/bin
+  '';
+
+  disabledTestPaths = [ "testfiles" ];
+
+  disabledTests = [
+    # test_NETWORK.py
+    "test_http_get"
+    "test_http_get_binary_file_absent"
+    "test_http_get_binary_file_exists"
+    "test_http_get_bin_type"
+    "test_http_get_follow_redirects"
+    "test_http_get_follow_redirects_false_content"
+    "test_http_get_follow_redirects_false_on_nofollow_arg"
+    "test_http_get_response_check_200"
+    "test_http_get_response_check_301"
+    "test_http_get_response_check_404"
+    "test_http_get_response_obj_present"
+    "test_http_get_ssl"
+    "test_http_get_status_check_true"
+    "test_http_get_status_ssl"
+    "test_http_get_status_ssl_redirect"
+    "test_http_get_text_absent"
+    "test_http_get_text_exists_request_overwrite"
+    "test_http_get_type"
+    "test_http_post"
+    "test_http_post_binary_file_absent"
+    "test_http_post_binary_file_present"
+    "test_http_post_binary_file_present_request_overwrite"
+    "test_http_post_reponse_status_200"
+    "test_http_post_response_status_200_ssl"
+    "test_http_post_ssl"
+    "test_http_post_status_check_true"
+    "test_http_post_text_file_absent"
+    "test_http_post_text_file_present_request_overwrite"
+    "test_http_post_type"
+    # test_SHELL.py
+    "test_muterun_missing_option_exitcode"
+    # test_SYSTEM.py
+    "test_sys_list_all_files"
+    "test_sys_list_all_files_cwd"
+    "test_sys_list_all_files_emptydir"
+    "test_sys_list_filter_files"
+    "test_sys_match_files"
+    "test_sys_match_files_fullpath"
+    "test_sys_meta_file_mod"
+    # test_TYPES.py
+    "test_xdict_key_random"
+    "test_xdict_key_random_sample"
+  ];
+
+  pythonImportsCheck = [ "Naked" ];
+
+  meta = with lib; {
+    description = "A Python command line application framework";
+    homepage = "https://github.com/chrissimpkins/naked";
+    downloadPage = "https://github.com/chrissimpkins/naked/tags";
+    license = licenses.mit;
+    maintainers = [ maintainers.lucasew ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8097,6 +8097,8 @@ self: super: with self; {
 
   nagiosplugin = callPackage ../development/python-modules/nagiosplugin { };
 
+  naked = callPackage ../development/python-modules/naked { };
+
   namedlist = callPackage ../development/python-modules/namedlist { };
 
   nameparser = callPackage ../development/python-modules/nameparser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5203,6 +5203,8 @@ self: super: with self; {
 
   hsaudiotag3k = callPackage ../development/python-modules/hsaudiotag3k { };
 
+  hsh = callPackage ../development/python-modules/hsh { };
+
   hsluv = callPackage ../development/python-modules/hsluv { };
 
   hstspreload = callPackage ../development/python-modules/hstspreload { };


### PR DESCRIPTION
## Description of changes
Basically I copypasted what still isn't there from https://github.com/NixOS/nixpkgs/pull/231950, updated what has updates (in this case backgroundremover only) and tested if it works with a random car image from the internet.


An extra is that this implementation has `meta.mainProgram` set up so `nix run` and `lib.getExe` works fine out of the box.

Thanks @JayRovacsek for the leverage!

![out](https://github.com/NixOS/nixpkgs/assets/15693688/74390b5d-5cec-4a24-a29c-93d2fb825f8b)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
