### PR TITLE
python311Packages.pylibjpeg: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pylibjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, numpy
+, pydicom
+, pylibjpeg-libjpeg
+}:
+
+let
+  pylibjpeg-data = buildPythonPackage rec {
+    pname = "pylibjpeg-data";
+    version = "1.0.0dev0";
+    pyproject = true;
+
+    nativeBuildInputs = [ setuptools ];
+
+    src = fetchFromGitHub {
+      owner = "pydicom";
+      repo = "pylibjpeg-data";
+      rev = "2ab4b8a65b070656eca2582bd23197a3d01cdccd";
+      hash = "sha256-cFE1XjrqyGqwHCYGRucXK+q4k7ftUIbYwBw4WwIFtEc=";
+    };
+
+    doCheck = false;
+  };
+in
+
+buildPythonPackage rec {
+  pname = "pylibjpeg";
+  version = "1.4.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = "pylibjpeg";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Px1DyYDkKAUdYo+ZxZ1w7TkPzWN++styiFl02iQOvyQ=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [ numpy ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pydicom
+    pylibjpeg-data
+    pylibjpeg-libjpeg
+  ];
+
+  pythonImportsCheck = [ "pylibjpeg" ];
+
+  meta = with lib; {
+    description = "Python framework for decoding JPEG images, with a focus on supporting Pydicom";
+    homepage = "https://github.com/pydicom/pylibjpeg";
+    changelog = "https://github.com/pydicom/pylibjpeg/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+    # several test failures of form
+    # "pydicom.errors.InvalidDicomError: File is missing DICOM File Meta Information header or the 'DICM' prefix is missing from the header. ..."
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10602,6 +10602,8 @@ self: super: with self; {
     inherit (pkgs) libusb1;
   };
 
+  pylibjpeg = callPackage ../development/python-modules/pylibjpeg { };
+
   pylibjpeg-libjpeg = callPackage ../development/python-modules/pylibjpeg-libjpeg { };
 
   pyliblo = callPackage ../development/python-modules/pyliblo { };


### PR DESCRIPTION
## Description of changes

Init a package.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
