### PR TITLE
lomiri.cmake-extras: unstable-2022-11-21 -> 1.7

### DIFF
--- a/pkgs/desktops/lomiri/development/cmake-extras/default.nix
+++ b/pkgs/desktops/lomiri/development/cmake-extras/default.nix
@@ -5,21 +5,21 @@
 , qtbase
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cmake-extras";
-  version = "unstable-2022-11-21";
+  version = "1.7";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/cmake-extras";
-    rev = "99aab4514ee182cb7a94821b4b51e4d8cb9a82ef";
-    hash = "sha256-axj5QxgDrHy0HiZkfrbm22hVvSCKkWFoQC8MdQMm9tg=";
+    rev = finalAttrs.version;
+    hash = "sha256-5bLMk21pSZkuU3jAGTnjPc9ZrvVZqMUWSfFgkTtkYLw=";
   };
 
   postPatch = ''
     # We have nothing to build here, no need to depend on a C compiler
     substituteInPlace CMakeLists.txt \
-      --replace 'project(cmake-extras)' 'project(cmake-extras NONE)'
+      --replace 'project(cmake-extras' 'project(cmake-extras LANGUAGES NONE'
 
     # This is in a function that reverse dependencies use to determine where to install their files to
     substituteInPlace src/QmlPlugins/QmlPluginsConfig.cmake \
@@ -46,4 +46,4 @@ stdenvNoCC.mkDerivation {
     maintainers = teams.lomiri.members;
     platforms = platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Basically the same, just tagged as a release now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
