### PR TITLE
neolink: init at unstable-2013-10-28

### DIFF
--- a/pkgs/by-name/ne/neolink/package.nix
+++ b/pkgs/by-name/ne/neolink/package.nix
@@ -1,0 +1,47 @@
+{ lib
+,fetchFromGitHub
+, rustPlatform
+, pkg-config
+, gst_all_1
+, openssl
+, protobuf
+}:
+
+rustPlatform.buildRustPackage rec {
+  version = "unstable-2013-10-28";
+  pname = "neolink";
+
+  src = fetchFromGitHub {
+    owner = "QuantumEntangledAndy";
+    repo = "neolink";
+    rev = "4a94a2ddb29bed207307eb2de744748190e8577f";
+    hash = "sha256-+yIjNcrd7TZx4eTc4u1SCDDmwXwGYUI90NPTtgkbXec=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    protobuf
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-rtsp-server
+  ];
+
+  # needed for internal protobuf c wrapper library
+  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC_INCLUDE = "${protobuf}/include";
+
+  cargoHash = "sha256-Cea110RJc3q6J1lclFOvR1ETR0yvNeD5/S4PuxRLmvk=";
+
+  meta = with lib; {
+    homepage = "https://github.com/QuantumEntangledAndy/neolink";
+    description = " An RTSP bridge to Reolink IP cameras ";
+    license = lib.licenses.agpl3;
+    maintainers = with lib.maintainers; [ fleaz ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes

Neolink is a RTSP bridge to get a propper videofeed from some low-budget Reolink cameras, that only implement a proprietary protocol.

Because the original [repo](https://github.com/thirtythreeforty/neolink) has become inactive with a lot of issues, I packaged a more active [fork](https://github.com/QuantumEntangledAndy/neolink)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
