### PR TITLE
ibus: 1.5.28 -> 1.5.29

### DIFF
--- a/pkgs/tools/inputmethods/ibus/build-without-dbus-launch.patch
+++ b/pkgs/tools/inputmethods/ibus/build-without-dbus-launch.patch
@@ -1,19 +1,24 @@
 diff --git a/data/dconf/make-dconf-override-db.sh b/data/dconf/make-dconf-override-db.sh
-index 601c1c3f..fcb7305d 100755
+index 32cb1530..375baa41 100755
 --- a/data/dconf/make-dconf-override-db.sh
 +++ b/data/dconf/make-dconf-override-db.sh
-@@ -12,10 +12,6 @@ export XDG_CACHE_HOME="$TMPDIR/cache"
+@@ -12,15 +12,6 @@ export XDG_CACHE_HOME="$TMPDIR/cache"
  export GSETTINGS_SCHEMA_DIR="$TMPDIR/schemas"
  mkdir -p $XDG_CONFIG_HOME $XDG_CACHE_HOME $GSETTINGS_SCHEMA_DIR
  
 -eval `dbus-launch --sh-syntax`
 -
--trap 'rm -rf $TMPDIR; kill $DBUS_SESSION_BUS_PID' ERR
+-trap cleanup EXIT
+-
+-cleanup() {
+-  test $? -eq 0 && exit
+-  rm -rf $TMPDIR; kill $DBUS_SESSION_BUS_PID
+-}
 -
  # in case that schema is not installed on the system
  glib-compile-schemas --targetdir "$GSETTINGS_SCHEMA_DIR" "$PWD"
  
-@@ -52,5 +48,3 @@ if [ -d $TMPDIR/cache/gvfs ] ; then
+@@ -57,5 +48,3 @@ if [ -d $TMPDIR/cache/gvfs ] ; then
      umount $TMPDIR/cache/gvfs
  fi
  rm -rf $TMPDIR

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , substituteAll
 , fetchFromGitHub
-, fetchpatch
 , autoreconfHook
 , gettext
 , makeWrapper
@@ -17,6 +17,7 @@
 , gtk3
 , gtk4
 , gtk-doc
+, libdbusmenu-gtk3
 , runCommand
 , isocodes
 , cldr-annotations
@@ -26,7 +27,7 @@
 , json-glib
 , libnotify ? null
 , enableUI ? true
-, withWayland ? false
+, withWayland ? true
 , libxkbcommon
 , wayland
 , buildPackages
@@ -46,23 +47,24 @@ let
   };
   # make-dconf-override-db.sh needs to execute dbus-launch in the sandbox,
   # it will fail to read /etc/dbus-1/session.conf unless we add this flag
-  dbus-launch = runCommand "sandbox-dbus-launch" {
-    nativeBuildInputs = [ makeWrapper ];
-  } ''
-      makeWrapper ${dbus}/bin/dbus-launch $out/bin/dbus-launch \
-        --add-flags --config-file=${dbus}/share/dbus-1/session.conf
+  dbus-launch = runCommand "sandbox-dbus-launch"
+    {
+      nativeBuildInputs = [ makeWrapper ];
+    } ''
+    makeWrapper ${dbus}/bin/dbus-launch $out/bin/dbus-launch \
+      --add-flags --config-file=${dbus}/share/dbus-1/session.conf
   '';
 in
 
 stdenv.mkDerivation rec {
   pname = "ibus";
-  version = "1.5.28";
+  version = "1.5.29";
 
   src = fetchFromGitHub {
     owner = "ibus";
     repo = "ibus";
     rev = version;
-    sha256 = "sha256-zjV+QkhVkrHFs9Vt1FpbvmS4nRHxwKaKU3mQkSgyLaQ=";
+    sha256 = "sha256-d4EUIg0v8rfHdvzG5USc6GLY6QHtQpIJp1PrPaaBxxE=";
   };
 
   patches = [
@@ -72,27 +74,17 @@ stdenv.mkDerivation rec {
       pythonSitePackages = python3.sitePackages;
     })
     ./build-without-dbus-launch.patch
-    # unicode and emoji input are broken before 1.5.29
-    # https://github.com/NixOS/nixpkgs/issues/226526
-    (fetchpatch {
-      url = "https://github.com/ibus/ibus/commit/7c8abbe89403c2fcb08e3fda42049a97187e53ab.patch";
-      hash = "sha256-59HzAdLq8ahrF7K+tFGLjTodwIiTkJGEkFe8quqIkhU=";
-    })
-    # fix SIGABRT in X11 https://github.com/ibus/ibus/issues/2484
-    (fetchpatch {
-      url = "https://github.com/ibus/ibus/commit/8f706d160631f1ffdbfa16543a38b9d5f91c16ad.patch";
-      hash = "sha256-YzS9TmUWW0OmheDeCeU00kFK2U2QEmKYMSRJAbu14ec=";
-    })
-    # fix missing key releases in Wine https://github.com/ibus/ibus/issues/2480
-    (fetchpatch {
-      url = "https://github.com/ibus/ibus/commit/497f0c74230a65309e22ce5569060ce48310406b.patch";
-      hash = "sha256-PAZcUxmzjChs1/K8hXgOcytyS4LYoNL1dtU6X5Tx8ic=";
-    })
   ];
 
   outputs = [ "out" "dev" "installedTests" ];
 
   postPatch = ''
+    # Maintainer does not want to create separate tarballs for final release candidate and release versions,
+    # so we need to set `ibus_released` to `1` in `configure.ac`. Otherwise, anyone running `ibus version` gets
+    # a version with an inaccurate `-rcX` suffix.
+    # https://github.com/ibus/ibus/issues/2584
+    substituteInPlace configure.ac --replace "m4_define([ibus_released], [0])" "m4_define([ibus_released], [1])"
+
     patchShebangs --build data/dconf/make-dconf-override-db.sh
     cp ${buildPackages.gtk-doc}/share/gtk-doc/data/gtk-doc.make .
     substituteInPlace bus/services/org.freedesktop.IBus.session.GNOME.service.in --replace "ExecStart=sh" "ExecStart=${runtimeShell}"
@@ -102,6 +94,11 @@ stdenv.mkDerivation rec {
   preAutoreconf = "touch ChangeLog";
 
   configureFlags = [
+    # The `AX_PROG_{CC,CXX}_FOR_BUILD` autoconf macros can pick up unwrapped GCC binaries,
+    # so we set `{CC,CXX}_FOR_BUILD` to override that behavior.
+    # https://github.com/NixOS/nixpkgs/issues/21751
+    "CC_FOR_BUILD=${stdenv.cc}/bin/cc"
+    "CXX_FOR_BUILD=${stdenv.cc}/bin/c++"
     "--disable-memconf"
     (lib.enableFeature (dconf != null) "dconf")
     (lib.enableFeature (libnotify != null) "libnotify")
@@ -114,12 +111,6 @@ stdenv.mkDerivation rec {
     "--with-emoji-annotation-dir=${cldr-annotations}/share/unicode/cldr/common/annotations"
     "--with-ucd-dir=${unicode-character-database}/share/unicode"
   ];
-
-  # missing make dependency
-  # https://github.com/NixOS/nixpkgs/pull/218120#issuecomment-1514027173
-  preBuild = ''
-    make -C src ibusenumtypes.h
-  '';
 
   makeFlags = [
     "test_execsdir=${placeholder "installedTests"}/libexec/installed-tests/ibus"
@@ -154,6 +145,7 @@ stdenv.mkDerivation rec {
     isocodes
     json-glib
     libnotify
+    libdbusmenu-gtk3
   ] ++ lib.optionals withWayland [
     libxkbcommon
     wayland


### PR DESCRIPTION
## Description of changes

https://github.com/ibus/ibus/releases/tag/1.5.29
https://github.com/ibus/ibus/releases/tag/1.5.29-rc1

This update is motivated by upstream changes that make this package build reproducibly when using parallel `make`.

See: #230290

Changes:
- Adds libdbusmenu-gtk3 dependency, now required for appindicator support
- Adds workaround for interaction between `AX_PROG_{CC,CXX}` autoconf macro and unwrapped GCC binaries (see #21751)
- Patches generated version number to remove incorrect `-rcX` suffix
- Removes upstreamed patches, rebases `build-without-dbus-launch.patch`
- Formatted with `nixpkgs-fmt`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>gnomeExtensions.easyScreenCast</li>
  </ul>
</details>
<details>
  <summary>82 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>budgie.budgie-control-center</li>
    <li>budgie.budgie-control-center.debug</li>
    <li>budgie.budgie-desktop</li>
    <li>budgie.budgie-desktop-with-plugins</li>
    <li>budgie.budgie-gsettings-overrides</li>
    <li>budgiePlugins.budgie-analogue-clock-applet</li>
    <li>budgiePlugins.budgie-user-indicator-redux</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>emacsPackages.ac-mozc</li>
    <li>emacsPackages.mozc</li>
    <li>emacsPackages.mozc-cand-posframe</li>
    <li>emacsPackages.mozc-im</li>
    <li>emacsPackages.mozc-popup</li>
    <li>emacsPackages.mozc-temp</li>
    <li>enlightenment.econnman</li>
    <li>enlightenment.ecrire</li>
    <li>enlightenment.efl</li>
    <li>enlightenment.enlightenment</li>
    <li>enlightenment.ephoto</li>
    <li>enlightenment.evisum</li>
    <li>enlightenment.rage</li>
    <li>enlightenment.terminology</li>
    <li>gnome-browser-connector</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnome.gnome-flashback</li>
    <li>gnome.gnome-panel-with-modules</li>
    <li>gnome.gnome-session</li>
    <li>gnome.gnome-session.debug</li>
    <li>gnome.gnome-session.sessions</li>
    <li>gnome.gnome-shell</li>
    <li>gnome.gnome-shell.debug</li>
    <li>gnome.gnome-shell.devdoc</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.gnome-tweaks</li>
    <li>gnome.nixos-gsettings-overrides</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.gsconnect.installedTests</li>
    <li>ibus</li>
    <li>ibus-engines.anthy</li>
    <li>ibus-engines.hangul</li>
    <li>ibus-engines.kkc</li>
    <li>ibus-engines.libpinyin</li>
    <li>ibus-engines.libthai</li>
    <li>ibus-engines.m17n</li>
    <li>ibus-engines.mozc</li>
    <li>ibus-engines.openbangla-keyboard</li>
    <li>ibus-engines.rime</li>
    <li>ibus-engines.table</li>
    <li>ibus-engines.table-chinese</li>
    <li>ibus-engines.table-others</li>
    <li>ibus-engines.typing-booster</li>
    <li>ibus-engines.typing-booster-unwrapped</li>
    <li>ibus-engines.uniemoji</li>
    <li>ibus-with-plugins</li>
    <li>ibus.dev</li>
    <li>ibus.installedTests</li>
    <li>latte-dock</li>
    <li>libsForQt5.kdeplasma-addons</li>
    <li>libsForQt5.plasma-desktop</li>
    <li>mlterm</li>
    <li>mlterm-wayland</li>
    <li>mojave-gtk-theme</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.switchboard-plug-keyboard</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-keyboard</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>polychromatic</li>
    <li>python310Packages.pythonefl</li>
    <li>python310Packages.pythonefl.dist</li>
    <li>python311Packages.pythonefl</li>
    <li>python311Packages.pythonefl.dist</li>
    <li>snippetexpanderx</li>
    <li>snippetpixie</li>
    <li>vimix-gtk-themes</li>
    <li>whitesur-gtk-theme</li>
  </ul>
</details>

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>ibus-engines.openbangla-keyboard</li>
  </ul>
</details>
<details>
  <summary>81 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>budgie.budgie-control-center</li>
    <li>budgie.budgie-control-center.debug</li>
    <li>budgie.budgie-desktop</li>
    <li>budgie.budgie-desktop-with-plugins</li>
    <li>budgie.budgie-gsettings-overrides</li>
    <li>budgiePlugins.budgie-analogue-clock-applet</li>
    <li>budgiePlugins.budgie-user-indicator-redux</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>emacsPackages.ac-mozc</li>
    <li>emacsPackages.mozc</li>
    <li>emacsPackages.mozc-cand-posframe</li>
    <li>emacsPackages.mozc-im</li>
    <li>emacsPackages.mozc-popup</li>
    <li>emacsPackages.mozc-temp</li>
    <li>enlightenment.econnman</li>
    <li>enlightenment.ecrire</li>
    <li>enlightenment.efl</li>
    <li>enlightenment.enlightenment</li>
    <li>enlightenment.ephoto</li>
    <li>enlightenment.evisum</li>
    <li>enlightenment.rage</li>
    <li>enlightenment.terminology</li>
    <li>gnome-browser-connector</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnome.gnome-flashback</li>
    <li>gnome.gnome-panel-with-modules</li>
    <li>gnome.gnome-session</li>
    <li>gnome.gnome-session.debug</li>
    <li>gnome.gnome-session.sessions</li>
    <li>gnome.gnome-shell</li>
    <li>gnome.gnome-shell.debug</li>
    <li>gnome.gnome-shell.devdoc</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.gnome-tweaks</li>
    <li>gnome.nixos-gsettings-overrides</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.gsconnect.installedTests</li>
    <li>ibus</li>
    <li>ibus-engines.anthy</li>
    <li>ibus-engines.hangul</li>
    <li>ibus-engines.kkc</li>
    <li>ibus-engines.libpinyin</li>
    <li>ibus-engines.libthai</li>
    <li>ibus-engines.m17n</li>
    <li>ibus-engines.mozc</li>
    <li>ibus-engines.rime</li>
    <li>ibus-engines.table</li>
    <li>ibus-engines.table-chinese</li>
    <li>ibus-engines.table-others</li>
    <li>ibus-engines.typing-booster</li>
    <li>ibus-engines.typing-booster-unwrapped</li>
    <li>ibus-engines.uniemoji</li>
    <li>ibus-with-plugins</li>
    <li>ibus.dev</li>
    <li>ibus.installedTests</li>
    <li>latte-dock</li>
    <li>libsForQt5.kdeplasma-addons</li>
    <li>libsForQt5.plasma-desktop</li>
    <li>mlterm</li>
    <li>mlterm-wayland</li>
    <li>mojave-gtk-theme</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.switchboard-plug-keyboard</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-keyboard</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>polychromatic</li>
    <li>python310Packages.pythonefl</li>
    <li>python310Packages.pythonefl.dist</li>
    <li>python311Packages.pythonefl</li>
    <li>python311Packages.pythonefl.dist</li>
    <li>snippetexpanderx</li>
    <li>snippetpixie</li>
    <li>vimix-gtk-themes</li>
    <li>whitesur-gtk-theme</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
