### PR TITLE
python311Packages.python-memcached: 1.59 -> 1.60

### DIFF
--- a/pkgs/development/python-modules/pymemcache/default.nix
+++ b/pkgs/development/python-modules/pymemcache/default.nix
@@ -5,6 +5,7 @@
 , mock
 , six
 , pytestCheckHook
+, python-memcached
 , pythonOlder
 , zstd
 , stdenv
@@ -32,6 +33,7 @@ buildPythonPackage rec {
     faker
     mock
     pytestCheckHook
+    python-memcached
     zstd
   ];
 
@@ -39,10 +41,7 @@ buildPythonPackage rec {
     sed -i "/--cov/d" setup.cfg
   '';
 
-  disabledTests = [
-    # python-memcached is not available (last release in 2017)
-    "TestClientSocketConnect"
-  ] ++ lib.optionals stdenv.is32bit [
+  disabledTests = lib.optionals stdenv.is32bit [
     # test_compressed_complex is broken on 32-bit platforms
     # this can be removed on the next version bump
     # see also https://github.com/pinterest/pymemcache/pull/480

--- a/pkgs/development/python-modules/python-memcached/default.nix
+++ b/pkgs/development/python-modules/python-memcached/default.nix
@@ -1,25 +1,25 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, six
+, setuptools
 , mock
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-memcached";
-  version = "1.59";
-  format = "setuptools";
+  version = "1.60";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "linsomniac";
     repo = "python-memcached";
     rev = version;
-    hash = "sha256-tHqkwNloPTXOrEGtuDLu1cTw4SKJ4auv8UUbqdNp698=";
+    hash = "sha256-ByW6WaR7OyWlKuzxVw12L0W5b88seLlIf5N5MKxiAog=";
   };
 
-  propagatedBuildInputs = [
-    six
+  nativeBuildInputs = [
+    setuptools
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/linsomniac/python-memcached/compare/1.59...1.60



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
