### PR TITLE
update-melpa: try to fix some compatiblility issues on cl-lib and url-retrive.

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/update-melpa.el
+++ b/pkgs/applications/editors/emacs/elisp-packages/update-melpa.el
@@ -6,7 +6,7 @@
 (require 'semaphore-promise)
 (require 'url)
 (require 'json)
-(require 'cl)
+(require 'cl-lib)
 (require 'subr-x)
 (require 'seq)
 
@@ -77,7 +77,7 @@ return Promise to resolve in that process."
 
 (defun parse-previous-archive (filename)
   (let ((idx (make-hash-table :test 'equal)))
-    (loop for desc in
+    (cl-loop for desc in
           (let ((json-object-type 'hash-table)
                 (json-array-type 'list)
                 (json-key-type 'symbol))
@@ -166,7 +166,7 @@ return Promise to resolve in that process."
 
 (defun recipe-info (recipe-index ename)
   (if-let (desc (gethash ename recipe-index))
-      (destructuring-bind (rcp-commit . rcp-sha256) desc
+      (cl-destructuring-bind (rcp-commit . rcp-sha256) desc
         `((commit . ,rcp-commit)
           (sha256 . ,rcp-sha256)))
     `((error . "No recipe info"))))
@@ -204,7 +204,7 @@ return Promise to resolve in that process."
                   (seq-let [recipe-index unstable-sha stable-sha] res
                     (append `((ename   . ,ename))
                             (if-let (desc (gethash ename recipe-index))
-                                (destructuring-bind (rcp-commit . rcp-sha256) desc
+                                (cl-destructuring-bind (rcp-commit . rcp-sha256) desc
                                   (append `((commit . ,rcp-commit)
                                             (sha256 . ,rcp-sha256))
                                           (when (not unstable-aprops)

--- a/pkgs/applications/editors/emacs/elisp-packages/update-melpa.el
+++ b/pkgs/applications/editors/emacs/elisp-packages/update-melpa.el
@@ -257,10 +257,9 @@ return Promise to resolve in that process."
       url (lambda (status)
             (funcall resolve (condition-case err
                                  (progn
-                                   (goto-char (point-min))
-                                   (search-forward "\n\n")
+                                   (url-http-parse-headers)
+                                   (goto-char url-http-end-of-headers)
                                    (message (buffer-substring (point-min) (point)))
-                                   (delete-region (point-min) (point))
                                    (funcall parser))
                                (funcall reject err))))))))
 


### PR DESCRIPTION
## Description of changes
Tested
```
cd nixpkgs/pkgs/applications/editors/emacs/elisp-packages
nix-shell -I nixpkgs=/nix/store/<my-flake-nixpkgs> updater-emacs.nix
emacs -Q update-melpa.el

M-x eval-buffer
M-: (run-update)
```
And the running result can be checked [here](https://gist.github.com/Vonfry/5d57b55d892baa0254eae0cea4e8dea3)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This commit try to fix it by some compatibility issues with the emacs update.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
