### PR TITLE
nixos/zammad: refactor package, module and nixos-test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -30,6 +30,8 @@
 
 - Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
 
+- `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
+
 - `kanata` was updated to v1.7.0, which introduces several breaking changes.
   See the release notes of
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)

--- a/nixos/tests/zammad.nix
+++ b/nixos/tests/zammad.nix
@@ -15,34 +15,6 @@ import ./make-test-python.nix (
       services.zammad.secretKeyBaseFile = pkgs.writeText "secret" ''
         52882ef142066e09ab99ce816ba72522e789505caba224a52d750ec7dc872c2c371b2fd19f16b25dfbdd435a4dd46cb3df9f82eb63fafad715056bdfe25740d6
       '';
-
-      systemd.services.zammad-locale-cheat =
-        let cfg = config.services.zammad; in
-        {
-          serviceConfig = {
-            Type = "oneshot";
-            Restart = "on-failure";
-
-            User = "zammad";
-            Group = "zammad";
-            PrivateTmp = true;
-            StateDirectory = "zammad";
-            WorkingDirectory = cfg.dataDir;
-          };
-          wantedBy = [ "zammad-web.service" ];
-          description = "Hack in the locale files so zammad doesn't try to access the internet";
-          script = ''
-            mkdir -p ./config/translations
-            VERSION=$(cat ${cfg.package}/VERSION)
-
-            # If these files are not in place, zammad will try to access the internet.
-            # For the test, we only need to supply en-us.
-            echo '[{"locale":"en-us","alias":"en","name":"English (United States)","active":true,"dir":"ltr"}]' \
-              > ./config/locales-$VERSION.yml
-            echo '[{"locale":"en-us","format":"time","source":"date","target":"mm/dd/yyyy","target_initial":"mm/dd/yyyy"},{"locale":"en-us","format":"time","source":"timestamp","target":"mm/dd/yyyy HH:MM","target_initial":"mm/dd/yyyy HH:MM"}]' \
-              > ./config/translations/en-us-$VERSION.yml
-          '';
-        };
     };
 
     testScript = ''


### PR DESCRIPTION
## Description of changes

This PR refactors the Zammad package, NixOS module and NixOS test. It does the following things:
- Use `inherit (lib) ...` instead of `with lib;`
- Make the Zammad system user and group configurable
- Use symlinks in the package to prevent the content of the package being copied to the state directory at every start of the systemd unit
- Drop MySQL support for multiple reasons:
  - It wasn't really supported by the module before, since the `zammad-web` unit hard depended on a **local** PostgreSQL database (especially in the check if a database initialization is required)
  - Support for MySQL will be dropped in Zammad 7 (see [here](https://docs.zammad.org/en/latest/prerequisites/software.html#database-server))
- Replace complicated, PostgreSQL specific query to check if the database was already seeded with a simple file in the state directory
  - This also enables compatibility with other DB Backends that may be supported in the future
- Fix the systemd unit dependencies so that it only depends on a local PostgreSQL DB if it is created locally
- Remove locale hack in the test since it is not required anymore
- Remove hardcoded debug log level
- Add a cleanup task to the `preScript` of the `zammad-web` unit to clean the old package contents out of the state directory

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
