### PR TITLE
linearmouse: init at 0.9.5

### DIFF
--- a/pkgs/os-specific/darwin/linearmouse/default.nix
+++ b/pkgs/os-specific/darwin/linearmouse/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenvNoCC, fetchurl }:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "linearmouse";
+  version = "0.9.5";
+
+  src = fetchurl {
+    url = "https://github.com/linearmouse/linearmouse/releases/download/v${finalAttrs.version}/LinearMouse.dmg";
+    hash = "sha256-T25H2CmDBt3J5zaC8gy87PyJONPsDZpF7S5eksRzgrA=";
+  };
+
+  sourceRoot = "LinearMouse.app";
+
+  # https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura/25873
+  unpackCmd = ''
+    echo "File to unpack: $curSrc"
+    if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
+    mnt=$(mktemp -d -t ci-XXXXXXXXXX)
+
+    function finish {
+      echo "Detaching $mnt"
+      /usr/bin/hdiutil detach $mnt -force
+      rm -rf $mnt
+    }
+    trap finish EXIT
+
+    echo "Attaching $mnt"
+    /usr/bin/hdiutil attach -nobrowse -readonly $src -mountpoint $mnt
+
+    # echo "What's in the mount dir"?
+    echo "What is inside?"
+    ls -la $mnt/
+
+    echo "Copying contents"
+    cp -a $mnt/LinearMouse.app "$PWD/"
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/Applications/LinearMouse.app"
+    cp -a ./. "$out/Applications/LinearMouse.app/"
+  '';
+
+  meta = {
+    description = "The mouse and trackpad utility for Mac.";
+    homepage = "https://github.com/linearmouse/linearmouse";
+    license = lib.licenses.mit;
+    mainProgram = "linearmouse";
+    maintainers = [];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/os-specific/darwin/linearmouse/default.nix
+++ b/pkgs/os-specific/darwin/linearmouse/default.nix
@@ -10,6 +10,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   sourceRoot = "LinearMouse.app";
 
+  # `undmg` doesn't support unpacking APFS dmgs, so we use some of the macOS built-ins to do it for us.
   # https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura/25873
   unpackCmd = ''
     echo "File to unpack: $curSrc"
@@ -40,10 +41,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "The mouse and trackpad utility for Mac.";
+    description = "The mouse and trackpad utility for Mac";
     homepage = "https://github.com/linearmouse/linearmouse";
     license = lib.licenses.mit;
-    mainProgram = "linearmouse";
+    mainProgram = "LinearMouse";
     maintainers = [];
     platforms = lib.platforms.darwin;
   };


### PR DESCRIPTION
## Description of changes

Homepage: https://linearmouse.app

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
