### PR TITLE
cc-nexus: init at 0.5.1 (and one dependency package)

### DIFF
--- a/pkgs/by-name/cc/cc-nexus/package.nix
+++ b/pkgs/by-name/cc/cc-nexus/package.nix
@@ -1,0 +1,114 @@
+{
+  copyDesktopItems,
+  fetchFromGitHub,
+  lib,
+  makeDesktopItem,
+  python3,
+  xvfb-run,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nexus";
+  version = "0.5.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "CharaChorder";
+    repo = "nexus";
+    tag = "v${version}";
+    hash = "sha256-Db9XNFRlJ7HgAt57dn2Yhy4HByw9nuQW41oj+4aOPQ0=";
+  };
+
+  disabled = python3.pythonOlder "3.11";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    python3.pkgs.pyside6-essentials
+  ];
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    cryptography
+    pynput
+    pyside6-essentials
+    pyserial
+    requests
+  ];
+
+  preBuild =
+    let
+      sitePackages = "$out/${python3.sitePackages}";
+      packageDir = "${sitePackages}/${pname}";
+    in
+    ''
+      mkdir -p ${packageDir}/{translations,ui}
+
+      for file in ui/*.ui; do
+        NEW_NAME=$(echo $file | cut --delimiter="." --fields=1).py
+        pyside6-uic $file -o ${packageDir}/$NEW_NAME
+      done
+
+      mkdir ${sitePackages}/resources_rc
+      pyside6-rcc ui/resources.qrc -o ${sitePackages}/resources_rc/__init__.py
+
+      pyside6-lupdate ui/*.ui nexus/GUI.py -ts translations/i18n_en.ts
+      for file in translations/*.ts; do
+        NEW_NAME=$(echo $file | cut --delimiter="." --fields=1).qm
+        pyside6-lrelease $file -qm ${packageDir}/$NEW_NAME
+      done
+    '';
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp ui/images/icon.svg $out/share/icons/hicolor/scalable/apps/${pname}.svg
+  '';
+
+  nativeCheckInputs =
+    (with python3.pkgs; [
+      flake8
+      pytest
+      pytest-cov
+    ])
+    ++ [
+      xvfb-run
+    ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # The following line tries to access the filesystem:
+    # https://github.com/CharaChorder/nexus/blob/v0.5.1/nexus/Freqlog/Definitions.py#L41
+    # Imported here:
+    # https://github.com/CharaChorder/nexus/blob/v0.5.1/tests/Freqlog/backends/SQLite/test_SQLiteBackend.py#L6
+    export HOME=$TMPDIR
+
+    xvfb-run pytest
+
+    runHook postCheck
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      comment = "CharaChorder's all-in-one desktop app";
+      desktopName = "Nexus";
+      exec = "nexus";
+      icon = pname;
+      name = pname;
+      startupNotify = true;
+      startupWMClass = "nexus";
+      terminal = false;
+      type = "Application";
+    })
+  ];
+
+  meta = {
+    description = "CharaChorder's logging and analysis desktop app";
+    downloadPage = "https://github.com/CharaChorder/nexus/releases/tag/${src.tag}";
+    homepage = "https://github.com/CharaChorder/nexus/";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ getpsyched ];
+    mainProgram = "nexus";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/charachorderpy/default.nix
+++ b/pkgs/development/python-modules/charachorderpy/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  inquirer,
+  pyserial,
+  setuptools,
+}:
+
+let
+  version = "0.6.0";
+in
+buildPythonPackage {
+  pname = "charachorder.py";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "CharaChorder";
+    repo = "charachorder.py";
+    tag = "v${version}";
+    hash = "sha256-IQ7mNhiBFGUK05W8fYsuIwDK/uBjvV1RUgQgXgCDas0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    inquirer
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "charachorder" ];
+
+  meta = {
+    description = "Wrapper for CharaChorder's Serial API written in Python";
+    downloadPage = "https://pypi.org/project/charachorder.py/#files";
+    homepage = "https://github.com/CharaChorder/charachorder.py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ getpsyched ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2430,6 +2430,8 @@ self: super: with self; {
 
   channels-redis = callPackage ../development/python-modules/channels-redis { };
 
+  charachorderpy = callPackage ../development/python-modules/charachorderpy { };
+
   character-encoding-utils = callPackage ../development/python-modules/character-encoding-utils { };
 
   characteristic = callPackage ../development/python-modules/characteristic { };


### PR DESCRIPTION
## Description of changes

Nexus is a utility software for [CharaChorder](https://www.charachorder.com/) devices which currently supports logging of characters and chords.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
