### PR TITLE
jetbrains: 2023.3.1 -> 2023.3.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -3,58 +3,58 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "3cde2fc25c759d4e114c5a768547e1d3083710e0fbe2591084a4ad4934490fc9",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.1.tar.gz",
-      "build_number": "233.11799.287"
+      "version": "2023.3.2",
+      "sha256": "f342d0f62454cea04b89db67dc1a720e6d2b767bbd93bafa270d9c92367086c2",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.2.tar.gz",
+      "build_number": "233.13135.93"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "4177882deb0380fba9b426c2580baea7dc4297bddefdd7bfb094433ff4cbb7b8",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.1.tar.gz",
-      "build_number": "233.11799.296"
+      "version": "2023.3.2",
+      "sha256": "6d7658b3ad07b6fc8891fd77f0e765dde781a697062de352b294b6530c0f7eed",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.2.tar.gz",
+      "build_number": "233.13135.68"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "0b5196dcc146cb163b1c9797986c46c651ad8132d3ee78dca92f9f9081f9f7e9",
-      "url": "https://download.jetbrains.com/python/dataspell-2023.3.1.tar.gz",
-      "build_number": "233.11799.285"
+      "version": "2023.3.2",
+      "sha256": "8467f4015dc81b91a6e577d059194aac74d9c9c3704dbc3fca8a5733c3e64dad",
+      "url": "https://download.jetbrains.com/python/dataspell-2023.3.2.tar.gz",
+      "build_number": "233.13135.105"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2023.3",
-      "sha256": "ecf0cdc671d83ba6b9251ab1ad0d40bc6ca86ea577437aa2d4b9fe5aa0449fad",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3.tar.gz",
-      "build_number": "233.11799.240"
+      "version": "2023.3.2",
+      "sha256": "0a18a9bc6e89210665a220ab92c71c6f47f36fef040db4a60aa84f240c646a83",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3.2.tar.gz",
+      "build_number": "233.13135.102"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "2fafd8f76979b174c598e58b6e39d2d796eef8e69d28da28abcb7a5c260992d6",
-      "url": "https://download.jetbrains.com/go/goland-2023.3.1.tar.gz",
-      "build_number": "233.11799.286"
+      "version": "2023.3.2",
+      "sha256": "d11c9ff18323f121eeb643bd093cd4cc9b3ca5f64e1e1dbe4b9b8139217032d1",
+      "url": "https://download.jetbrains.com/go/goland-2023.3.2.tar.gz",
+      "build_number": "233.13135.104"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "7afd70b71e1fcb8280393d59ec58ab72f2ccf369f5d6e0035e6b265600531e4a",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.1.tar.gz",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "d252110141046388e728532c5e7a312a6d40d6b75dabb493e88c0e2b8a914574",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.2.tar.gz",
+      "build_number": "233.13135.103"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "0a80d971e430786492acfd04e4ba73eda2e4ee60f752e3f9494a4476c6cad761",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.1.tar.gz",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "c763926c0bd1d14a1a9f07846a3cfd0330d5eacce31263c453710ac7a0f4c20f",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.2.tar.gz",
+      "build_number": "233.13135.103"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -67,117 +67,117 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "c8b034014e17c58def72aa351e44a441ca516403f795acef5325e964d5179983",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.1.tar.gz",
-      "build_number": "233.11799.297",
+      "version": "2023.3.2",
+      "sha256": "b8e2cb8938f148f8cf4f5fe80c3173365b1a20b834f49b50187654750b7e2f5d",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.2.tar.gz",
+      "build_number": "233.13135.108",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "95a03ad8abf2400e9691bb10b13d47407abfcbc25192cf3773e1a2dab42c0499",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.1.tar.gz",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "1a4a95648c68890f2f9eb41cbb9eb041dcd08388c75a91298dfbe73f83a858c8",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.2.tar.gz",
+      "build_number": "233.13135.95"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "f3a09cd2aebd2ffbc42f927467a613e55430d3ff76d57c263d31ccee3c1de110",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.1.tar.gz",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "add6cb45aed969a49b21322fbd2e34c896f2a618d2a9eb8c865a05602365ef6c",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.2.tar.gz",
+      "build_number": "233.13135.95"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "07dfbdc277d2befdb2700f515167b9bcb6464dd6d9fe59f98147c03233b6aa75",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.1.tar.gz",
-      "build_number": "233.11799.303"
+      "version": "2023.3.2",
+      "sha256": "22a35999146be6677260e603cf6af06dbbfa4c2d6e6ec653b2a9e322f954924d",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.2.tar.gz",
+      "build_number": "233.13135.100"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "35cd23c7a0f73add6ba05f246707e2f2550185033172f5d42a6b02e750253115",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.1.tar.gz",
-      "build_number": "233.11799.290"
+      "version": "2023.3.2",
+      "sha256": "b38417014e13ee5868c3a69f3a39f7f9a5a09c14ab31f01b6f2b34436efb0828",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.2.tar.gz",
+      "build_number": "233.13135.91"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
       "version": "2023.3 EAP",
-      "sha256": "07524c044de4565cbf052f9980044aa6c6e28064eefb3033587afa1e09ff69bf",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.284.tar.gz",
-      "build_number": "233.11799.284"
+      "sha256": "59cd5fac710b153efab94341594751bb50cdb1dff5d2292bb8067ec87085ad35",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.306.tar.gz",
+      "build_number": "233.11799.306"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "26a3acc9864c2c7715d377059d3b52b1085b90b708b254ec2d52b80f625eb442",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.1.tar.gz",
-      "build_number": "233.11799.293"
+      "version": "2023.3.2",
+      "sha256": "c4d69ebdb24bf8d84b406afc65ff34d6b7c22fd461df92c5fe32e5e3c88502a7",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.2.tar.gz",
+      "build_number": "233.13135.92"
     }
   },
   "aarch64-linux": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "8aa207ee92f518fafc93b5a3bece67f15ce65ee18b8e6c28a393e8dbc0a5ef4f",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.287"
+      "version": "2023.3.2",
+      "sha256": "b195897988f8f768b7af308d3a642da889cccdb1957477f267574dfc36a84657",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.93"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "dd76187e8598fd0e450b76e54767ca321e3e61f11d745a191b9039f71914b003",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.296"
+      "version": "2023.3.2",
+      "sha256": "2089429552435cd1905301be89256a38c124ba159e3758addde0376cafd45c53",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.68"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "ad49e53b159e321f07dc7b9f53a25a3a936cf49b5bffcf46357e5a80b1913ea9",
-      "url": "https://download.jetbrains.com/python/dataspell-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.285"
+      "version": "2023.3.2",
+      "sha256": "782181db5db36262030006fa83736e9639abf0ecde83c3832a477cf0cd1ddde1",
+      "url": "https://download.jetbrains.com/python/dataspell-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.105"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2023.3",
-      "sha256": "053f72669c30583b0cc4dce08b56cfcdd3252087e8f4b71986178e364c69b585",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3-aarch64.tar.gz",
-      "build_number": "233.11799.240"
+      "version": "2023.3.2",
+      "sha256": "878966c65d9b9355fbbc4eafaeb2518b1d7499985e33a12f96314bfd847704c7",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.102"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "87276008be7143efa3ad965194b4e5baf9528e59f9db5f6e5f856f0e0bb1554f",
-      "url": "https://download.jetbrains.com/go/goland-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.286"
+      "version": "2023.3.2",
+      "sha256": "6122c22763cd3f4440d7ebe1a926b8bc28e4afbd84a55a08cb02576e81f21f66",
+      "url": "https://download.jetbrains.com/go/goland-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.104"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "3a53972b56c9135c8ad1fb0c0d9d3ded2c79120f8e5461de272954f58c3637b4",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "f6bfa91109aa629dfb25998576b2d1a3ea4c87e0a0215ebcb952d2136654346d",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.103"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "cf6e7dc7d6ba1a7e807d80316364e51ee2e23aa471ab19ada93aff8fc9b1627d",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "769880e768e90a3ec0573b207a1089be522675f4a8c35627578c314ea1e4acdd",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.103"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -190,117 +190,117 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "c3c04f463beb798da48d08188980cde1505795c6f2cfaf788c9bca94f0f3c2d7",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.297",
+      "version": "2023.3.2",
+      "sha256": "69248c80483cb80d0343361748a137c9dbce8f3bd193382cc322d923d2e45b82",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.108",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "1b9a0c950d232d4a0418203dbbff19ba73279cbc933789d11c2a81ce80d0b485",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "1d63c0ea7dec718f67ad78e0ccef76058d92f63d07afe931a4ac6ff3f74c9052",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.95"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "eb649602ebd2212575631db51569029e3683a9f4842b5e506c1f2b573a777749",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "c910983a2d23d32265335cb5cb96b7d853879379cc0f8510ba690419afee1238",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.95"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "0a8328ce72821dc779724b4eb46ff8da98a374e178f5f0830141667371231ba6",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.303"
+      "version": "2023.3.2",
+      "sha256": "f73dc36e2c6eca10ea734e2f0c2e89a569bcd84d40092771681214578f5e3978",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.100"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "6c77b39006410a580d9e46bb7a44b8a524414b1e38e61042be839eff10021fac",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.290"
+      "version": "2023.3.2",
+      "sha256": "67f5699b60a4ae0fed9fb46d8aace321550dd191768edf021f70a1cac14af80c",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.91"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
       "version": "2023.3 EAP",
-      "sha256": "62b276acfb0c0233e84dd332cad95d84dc5d751e04e51cad6f0675e676674594",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.284-aarch64.tar.gz",
-      "build_number": "233.11799.284"
+      "sha256": "dd707c178a0eda9d47435a33dc0a8f2884f894753ed639f27e71609520e6952b",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.306-aarch64.tar.gz",
+      "build_number": "233.11799.306"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2023.3.1",
-      "sha256": "2de348e4df2ce5fb4f9da1b2f17fa30c359a97aec499329aaea8d1bdf12fd4eb",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.1-aarch64.tar.gz",
-      "build_number": "233.11799.293"
+      "version": "2023.3.2",
+      "sha256": "e21bac4babd922bc4cc5d879b3d867ffd4e13d4c881c045d14691790cef5644c",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.2-aarch64.tar.gz",
+      "build_number": "233.13135.92"
     }
   },
   "x86_64-darwin": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "199745463dee1f1a0c7f52b4fa5cc6a68121311d951a594cb4ce77fa4ed5ce2d",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.1.dmg",
-      "build_number": "233.11799.287"
+      "version": "2023.3.2",
+      "sha256": "0da27527ab17809c9ddd93e798793771a430e3d8f84e65ffff2b6c923e3a0e16",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.2.dmg",
+      "build_number": "233.13135.93"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "eb37ad83ecd5a74cbbdca5300e57e18ff9f946b0986b023921da07691b54498d",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.1.dmg",
-      "build_number": "233.11799.296"
+      "version": "2023.3.2",
+      "sha256": "8ca630f9f6d7fc004b5d521f437a9a48616108f312558f8c1c108cb9f1c9bbb1",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.2.dmg",
+      "build_number": "233.13135.68"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "4d6874a2bfecd3625808f1d6ce23c49974ce10cec482ed3a42e001bc6f7c720b",
-      "url": "https://download.jetbrains.com/python/dataspell-2023.3.1.dmg",
-      "build_number": "233.11799.285"
+      "version": "2023.3.2",
+      "sha256": "b558635c3abe9371c13dbf88057358df398f1a55b5c42c64dbb95c46b933a7ad",
+      "url": "https://download.jetbrains.com/python/dataspell-2023.3.2.dmg",
+      "build_number": "233.13135.105"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2023.3",
-      "sha256": "17fb60d9a13fc561e24054a651b2576426df43e4ec6ea6a07a7ce65648d9df5d",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3.dmg",
-      "build_number": "233.11799.240"
+      "version": "2023.3.2",
+      "sha256": "88ddef2fa3e96680e68222bc08f337ef223ca9f927a6549deb68e34b408bbbdc",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3.2.dmg",
+      "build_number": "233.13135.102"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "56c2e20dcac8b86da4cd4d9a52c061fd9839b968ee0f2960084a52ac1c2dfbbf",
-      "url": "https://download.jetbrains.com/go/goland-2023.3.1.dmg",
-      "build_number": "233.11799.286"
+      "version": "2023.3.2",
+      "sha256": "36c18551deb5e249896bd56b405e1fa4a29e48b6b203eecbe7875f0f83468121",
+      "url": "https://download.jetbrains.com/go/goland-2023.3.2.dmg",
+      "build_number": "233.13135.104"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "e65b75aa6fa957880f5e0b435d8eaea570a9f4408caa7e7475a90b5e1017cd2a",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.1.dmg",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "4aafb17af1cf299599a9c6a9ad56dcb5f93c2181ba2bc5c5222cd61cfd0b413a",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.2.dmg",
+      "build_number": "233.13135.103"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "06cddba143c5e5c6fdf9a733a79d05e3f9c41eb96469000dbd7577d74686747c",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.1.dmg",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "a08038442c3f5f60b0890a42ada905bc08928ec070bbfac075c07259ddf6518c",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.2.dmg",
+      "build_number": "233.13135.103"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -313,117 +313,117 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "dbf18efa0be9a029e09ecbc7f82f901643d81c2f96e75f73ec5ef12092c1008a",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.1.dmg",
-      "build_number": "233.11799.297",
+      "version": "2023.3.2",
+      "sha256": "a55592cd5e6122f75446588f7c1ea5372aed2f16bab7e188e53291e697ac04ae",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.2.dmg",
+      "build_number": "233.13135.108",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "48aabc8cc464c02a868527cda7a0fec7c3cb0339c1a6ad46590e2e2aa1530317",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.1.dmg",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "f0ad33ac5e0e90befa47499376e583ab28f5fe67ce0cd5f823abda7b9dce8219",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.2.dmg",
+      "build_number": "233.13135.95"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "ddb6f52803e1774bcf1d965b0dece128d152579a8c773dc65b06b44b70a0b395",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.1.dmg",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "9932498fa5287c86ccc838b0b4421990cf4c15156ccd387a5e6b6f9cf8c1346f",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.2.dmg",
+      "build_number": "233.13135.95"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "b076dfca4fbe732190176d62defb0c5a99885861a1aeab72a6d105b66e4a47ca",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.1.dmg",
-      "build_number": "233.11799.303"
+      "version": "2023.3.2",
+      "sha256": "1a44a42f5189a774e7c3da6475933b2d70c61afbf62817e314c0965c3338ff2a",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.2.dmg",
+      "build_number": "233.13135.100"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "4cce817269f230684ff08318ace108d54b9dded525048faf4a1787eff8ba4dc0",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.1.dmg",
-      "build_number": "233.11799.290"
+      "version": "2023.3.2",
+      "sha256": "061df5eda86fca0346a9dea32a7460eee8eda2347f82048149c57b88ebfcc371",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.2.dmg",
+      "build_number": "233.13135.91"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
       "version": "2023.3 EAP",
-      "sha256": "2ec2563a94abf3b873709c27cb81692fb0fbff44ee42b275cc38d0dc3c74e7af",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.284.dmg",
-      "build_number": "233.11799.284"
+      "sha256": "51131cf92383e1e9b345aed8ac99189385ecf9708dd0d4abc07c6c7925a129fe",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.306.dmg",
+      "build_number": "233.11799.306"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2023.3.1",
-      "sha256": "94cfc4db7574607555039c65a4bc6ecbb900192c19744bf9082ce9dfea5c7667",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.1.dmg",
-      "build_number": "233.11799.293"
+      "version": "2023.3.2",
+      "sha256": "2f2892f443f2c8a77cf19fdc85a9a5e791d1293cb9901df9549628699079a962",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.2.dmg",
+      "build_number": "233.13135.92"
     }
   },
   "aarch64-darwin": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "d8b0dfeb8a4b15339f296c90b0535cdc5b0b25ba3cbbfe2601f04a24a4289b95",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.287"
+      "version": "2023.3.2",
+      "sha256": "e763671a9290577e5dd669bdc640674a285d62f981b94b72873302706e6eaf19",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.93"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "c8a3d4c3679da1961f186d0d4fedc6510d8f967ceebe0cd34d867249f5729f34",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.296"
+      "version": "2023.3.2",
+      "sha256": "5abb6be00d9594c37a1ab5febb7855af216a8d0595f33c22e13d500c883f81ba",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.68"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "0dbdfe1c24334dc2b4e27c0390862343041c07fb4abeb00b0eeb6db5b7171e83",
-      "url": "https://download.jetbrains.com/python/dataspell-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.285"
+      "version": "2023.3.2",
+      "sha256": "65d776b4e441c6f6dc9e2bc119d1dc5df95633becff80b9096c5deedc5a493a2",
+      "url": "https://download.jetbrains.com/python/dataspell-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.105"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2023.3",
-      "sha256": "917a01af3f455fc8c6e72f838b9fe449f100ff0b7c93631cb7e778c5edee09ba",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3-aarch64.dmg",
-      "build_number": "233.11799.240"
+      "version": "2023.3.2",
+      "sha256": "60fe65202152ec445957c4d1eb21c174bec372718b9fca84b0c4b34cf88ea3c4",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.102"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "b0e29f8a5470c7b5de7565faacf90f206e6a353f1afaecc239899d66dbae48d8",
-      "url": "https://download.jetbrains.com/go/goland-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.286"
+      "version": "2023.3.2",
+      "sha256": "28669ecf701dd4b60f86218e9f96de0839536b1623dfb42186fd5bb54541b69c",
+      "url": "https://download.jetbrains.com/go/goland-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.104"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "0630913d6730073f8f06a26ef51a6b2e0599d93a5809718e74046bfea3023a86",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "dbe04f98d8b576ffb1f3f190c51a4065e111fd4f2d113fab9c8383f8ead46176",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.103"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "3f9bb300298dc900da342ee437e9475e762997095408c8b725ab499fec49e7bf",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.300"
+      "version": "2023.3.2",
+      "sha256": "0e47cdd338790bdfc7eb0c70feb1ba962e4cda115eb39f074dd2267e525caa12",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.103"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -436,59 +436,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "15cc0735cd2073d9e5a9bbbefa8d973cf05eabfd8fab0f77bd137e72cfd7f31c",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.297",
+      "version": "2023.3.2",
+      "sha256": "10713f0b4c8741bd940c650a3e2b084f69d7e3e7e910d81e6b52bd30545407e9",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.108",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "d4c425bb640dd8984706abd1e875db037feec5828737bf050e09f0ee7af4732c",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "9c6efca8ded53bf3470631c96833eb093299efd98ddd121e6b7600b202216704",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.95"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "c57ebac6ab0d7b01b53a600da675a16c8eb853d7bba9c9324d16f99f5a198874",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.298"
+      "version": "2023.3.2",
+      "sha256": "7acf9a37a34792766776897020e64a73984734d331986eae83ba65fca9482818",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.95"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "ddb85ddf7636c45f911848a76daa92a6ba7cd3c428f28d7d89ecf44db2b93bdc",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.303"
+      "version": "2023.3.2",
+      "sha256": "ff4fb3a6ec20d2a1808d6a69fea402946123e6d0256477fe15152893294584e1",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.100"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "5999eefdce0738a5599ce7f35455e228e5c964b26924f947c6839a9aee561204",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.290"
+      "version": "2023.3.2",
+      "sha256": "7e966c2ee874f5385e7b712e7c01c2554dde20bf0652954e6ec0c09fcf486daa",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.91"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
       "version": "2023.3 EAP",
-      "sha256": "beff1ad500e58cb150ef05ab66de69dab2b609ff7da836a4ee04d701d9d41e76",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.284-aarch64.dmg",
-      "build_number": "233.11799.284"
+      "sha256": "e80a287edb1982e307117c18428a9bf0a0aacae4d14cb27f56f029122329266a",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-233.11799.306-aarch64.dmg",
+      "build_number": "233.11799.306"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2023.3.1",
-      "sha256": "daca106f82dcefe66f00c1d34ed628f7b03db596c8852d855a1dfdd7066fd659",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.1-aarch64.dmg",
-      "build_number": "233.11799.293"
+      "version": "2023.3.2",
+      "sha256": "4b3e6dd439771e5e1b575cd68ba85200637709d34a17d0dfd2e94f33a7965e65",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.3.2-aarch64.dmg",
+      "build_number": "233.13135.92"
     }
   }
 }

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -18,16 +18,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +36,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "233.11799.300": "https://plugins.jetbrains.com/files/631/453254/python-233.11799.300.zip"
+        "233.13135.103": "https://plugins.jetbrains.com/files/631/456899/python-233.13135.103.zip"
       },
       "name": "python"
     },
@@ -47,8 +47,8 @@
         "mps"
       ],
       "builds": {
-        "232.10072.781": "https://plugins.jetbrains.com/files/6954/442937/kotlin-plugin-232-1.9.21-release-633-IJ10072.27.zip",
-        "233.11799.300": null
+        "232.10072.781": "https://plugins.jetbrains.com/files/6954/459286/kotlin-plugin-232-1.9.22-release-704-IJ10072.27.zip",
+        "233.13135.103": null
       },
       "name": "kotlin"
     },
@@ -70,16 +70,16 @@
       ],
       "builds": {
         "232.10072.781": null,
-        "233.11799.284": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip"
       },
       "name": "ini"
     },
@@ -89,8 +89,8 @@
         "phpstorm"
       ],
       "builds": {
-        "233.11799.297": "https://plugins.jetbrains.com/files/7219/447835/Symfony_Plugin-2022.1.261.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/7219/447835/Symfony_Plugin-2022.1.261.zip"
+        "233.13135.103": "https://plugins.jetbrains.com/files/7219/455636/Symfony_Plugin-2022.1.262.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/7219/455636/Symfony_Plugin-2022.1.262.zip"
       },
       "name": "symfony-support"
     },
@@ -100,8 +100,8 @@
         "phpstorm"
       ],
       "builds": {
-        "233.11799.297": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip"
+        "233.13135.103": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip"
       },
       "name": "php-annotations"
     },
@@ -114,11 +114,11 @@
         "rust-rover"
       ],
       "builds": {
-        "233.11799.284": "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/7322/456914/python-ce-233.13135.103.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/7322/456914/python-ce-233.13135.103.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/7322/456914/python-ce-233.13135.103.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/7322/456914/python-ce-233.13135.103.zip"
       },
       "name": "python-community-edition"
     },
@@ -139,15 +139,15 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/8182/395553/intellij-rust-0.4.201.5424-232.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip"
+        "233.13135.100": null,
+        "233.13135.103": null,
+        "233.13135.104": null,
+        "233.13135.108": null,
+        "233.13135.68": null,
+        "233.13135.91": null,
+        "233.13135.92": null,
+        "233.13135.93": null,
+        "233.13135.95": null
       },
       "name": "-deprecated-rust"
     },
@@ -168,15 +168,15 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip"
+        "233.13135.100": null,
+        "233.13135.103": null,
+        "233.13135.104": null,
+        "233.13135.108": null,
+        "233.13135.68": null,
+        "233.13135.91": null,
+        "233.13135.92": null,
+        "233.13135.93": null,
+        "233.13135.95": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -191,11 +191,11 @@
         "webstorm"
       ],
       "builds": {
-        "233.11799.286": "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip"
+        "233.13135.103": "https://plugins.jetbrains.com/files/8554/454574/featuresTrainer-233.13135.67.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/8554/454574/featuresTrainer-233.13135.67.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/8554/454574/featuresTrainer-233.13135.67.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/8554/454574/featuresTrainer-233.13135.67.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/8554/454574/featuresTrainer-233.13135.67.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -217,16 +217,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip"
       },
       "name": "nixidea"
     },
@@ -235,7 +235,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "233.11799.300": "https://plugins.jetbrains.com/files/9568/445967/go-plugin-233.11799.196.zip"
+        "233.13135.103": "https://plugins.jetbrains.com/files/9568/456905/go-plugin-233.13135.103.zip"
       },
       "name": "go"
     },
@@ -257,16 +257,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/10037/432491/CSVEditor-3.2.3-232.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/10037/432492/CSVEditor-3.2.3-233.zip"
       },
       "name": "csv-editor"
     },
@@ -288,16 +288,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/12062/364117/keymap-vscode-232.8660.88.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip"
       },
       "name": "vscode-keymap"
     },
@@ -319,16 +319,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/12559/364124/keymap-eclipse-232.8660.88.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -350,16 +350,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/13017/364038/keymap-visualStudio-232.8660.88.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -381,16 +381,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.284": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.286": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.287": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.290": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.293": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.296": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.297": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.298": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.300": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.11799.303": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "233.11799.306": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.100": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.103": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.104": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.108": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.68": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.91": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.92": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.93": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "233.13135.95": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -411,17 +411,17 @@
         "webstorm"
       ],
       "builds": {
-        "232.10072.781": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip"
+        "232.10072.781": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.11799.306": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip"
       },
       "name": "github-copilot"
     },
@@ -443,16 +443,16 @@
       ],
       "builds": {
         "232.10072.781": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.284": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.286": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.290": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.293": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.296": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.297": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.298": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.11799.303": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.100": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.104": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.108": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.68": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.91": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.92": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "233.13135.95": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -463,9 +463,9 @@
         "rust-rover"
       ],
       "builds": {
-        "233.11799.284": "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip",
-        "233.11799.287": "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip",
-        "233.11799.300": "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip"
+        "233.11799.306": "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip",
+        "233.13135.103": "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip",
+        "233.13135.93": "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip"
       },
       "name": "rust"
     }
@@ -481,20 +481,21 @@
     "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip": "sha256-Nb2tSxL+mAY1qJ3waipgV8ep+0R/BaYnzz7zfwtLHmk=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/442850/IdeaVim-2.7.5-signed.zip": "sha256-MiF8MVWBEQqupoYyI+QOyXhSvJcoSgptePENByURphI=",
-    "https://plugins.jetbrains.com/files/17718/450592/github-copilot-intellij-1.4.4.3955.zip": "sha256-JmME4MEN6nK1ueiz12VefCQHaE629jXYqYM5jxIyfGQ=",
+    "https://plugins.jetbrains.com/files/17718/454005/github-copilot-intellij-1.4.5.4049.zip": "sha256-5v8S7j05e7jxpJAqvJbv8MYMDP6ueBQFnXxIjAkBVpg=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/22407/452893/intellij-rust-233.21799.284.zip": "sha256-NKKCWf0g1k/20f2ZUAWlCT9EojXwUdo8wkozTLKgT14=",
-    "https://plugins.jetbrains.com/files/631/453254/python-233.11799.300.zip": "sha256-4CfaxRTO/GdTWYAnoz2TSqOGcsCKC7huNkJpCa8lhIU=",
-    "https://plugins.jetbrains.com/files/6954/442937/kotlin-plugin-232-1.9.21-release-633-IJ10072.27.zip": "sha256-fDIY4qolt/XZ3EMSKm3qCvrvknoLrxUd8XgiyMkYRto=",
+    "https://plugins.jetbrains.com/files/631/456899/python-233.13135.103.zip": "sha256-Y72+0CFzvzZQ2CSYVfT+thFO873hzEyd8nZhG2++x+E=",
+    "https://plugins.jetbrains.com/files/6954/459286/kotlin-plugin-232-1.9.22-release-704-IJ10072.27.zip": "sha256-3I/wmEkK+iL0VpwoqRlotI+G8G+sqcGN1MCcab+HX5E=",
     "https://plugins.jetbrains.com/files/6981/453409/ini-233.11799.300.zip": "sha256-AGMs/SNFsWkcW+MD3SR+Qb6akdDdJJxCVY0PecVw1fU=",
-    "https://plugins.jetbrains.com/files/7219/447835/Symfony_Plugin-2022.1.261.zip": "sha256-aHD22UQFtBjT9g6ZUe+jGvmpNtYXSVnREm8vljFx2eM=",
+    "https://plugins.jetbrains.com/files/6981/457466/ini-233.13135.108.zip": "sha256-0tlZngkbO0J88RQvaIXRwMu0wumo8sBv9XSW5vJ/ZX4=",
+    "https://plugins.jetbrains.com/files/7219/455636/Symfony_Plugin-2022.1.262.zip": "sha256-jnvjQ3M3K/G7UJa9T1pwAc0d5vj8R+clsbdgFh8WaEo=",
     "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip": "sha256-hT5K4w4lhvNwDzDMDSvsIDGj9lyaRqglfOhlbNdqpWs=",
     "https://plugins.jetbrains.com/files/7322/453268/python-ce-233.11799.300.zip": "sha256-dJIGcrHJUXuZ4u8nAVfajCmpY1lk3W700uNXksLi38M=",
+    "https://plugins.jetbrains.com/files/7322/456914/python-ce-233.13135.103.zip": "sha256-Yqb3FPG5M5+hNHX3OSEStBekjTjMlf4IV6Yr6+lfoRw=",
     "https://plugins.jetbrains.com/files/8182/372556/intellij-rust-0.4.200.5420-232-beta.zip": "sha256-ZlSfPvhPixEz5JxU9qyG0nL3jiSjr4gKaf/xYcQI1vQ=",
-    "https://plugins.jetbrains.com/files/8182/373256/intellij-rust-0.4.200.5421-232.zip": "sha256-NeAF3umfaSODjpd6J1dT8Ei5hF8g8OA+sgk7VjBodoU=",
     "https://plugins.jetbrains.com/files/8182/395553/intellij-rust-0.4.201.5424-232.zip": "sha256-pVwBEyUCx/DJET9uIm8vxFeChE8FskWyfLjDpfg2mAE=",
-    "https://plugins.jetbrains.com/files/8554/445635/featuresTrainer-233.11799.172.zip": "sha256-xN0FUCIa4KcqFAGwaOWf74qpIEY2f/QtksEeNTKG7zw=",
+    "https://plugins.jetbrains.com/files/8554/454574/featuresTrainer-233.13135.67.zip": "sha256-XgtOrfULS7TJ6yfWOwNX/EL6cEirvVyzMtPzlPJEkXM=",
     "https://plugins.jetbrains.com/files/8607/422943/NixIDEA-0.4.0.11.zip": "sha256-Dwitpu5yLPWx+IUilpN5iqnN8FkKgaxUNjroBEx5lkM=",
-    "https://plugins.jetbrains.com/files/9568/445967/go-plugin-233.11799.196.zip": "sha256-d8O5VRNdw7ru20l0VOicVJRUcVxje5A2Gua1O9yXogM="
+    "https://plugins.jetbrains.com/files/9568/456905/go-plugin-233.13135.103.zip": "sha256-ZhXm9iYlLuhoZwrpixpX4jry0jq1cgKyZECuX7/3miE="
   }
 }


### PR DESCRIPTION
## Description of changes

jetbrains.clion: 2023.3.1 -> 2023.3.2
jetbrains.datagrip: 2023.3.1 -> 2023.3.2
jetbrains.dataspell: 2023.3.1 -> 2023.3.2
jetbrains.gateway: 2023.3 -> 2023.3.2
jetbrains.goland: 2023.3.1 -> 2023.3.2
jetbrains.idea-community: 2023.3.1 -> 2023.3.2
jetbrains.idea-ultimate: 2023.3.1 -> 2023.3.2
jetbrains.phpstorm: 2023.3.1 -> 2023.3.2
jetbrains.pycharm-community: 2023.3.1 -> 2023.3.2
jetbrains.pycharm-professional: 2023.3.1 -> 2023.3.2
jetbrains.rider: 2023.3.1 -> 2023.3.2
jetbrains.ruby-mine: 2023.3.1 -> 2023.3.2
jetbrains.rust-rover: 2023.3 EAP -> 2023.3 EAP
jetbrains.webstorm: 2023.3.1 -> 2023.3.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
