### PR TITLE
eff: 5.0 → 5.1

### DIFF
--- a/pkgs/development/interpreters/eff/default.nix
+++ b/pkgs/development/interpreters/eff/default.nix
@@ -1,30 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, which, ocamlPackages }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
-stdenv.mkDerivation rec {
+with ocamlPackages; buildDunePackage rec {
   pname = "eff";
-  version = "5.0";
+  version = "5.1";
 
   src = fetchFromGitHub {
     owner = "matijapretnar";
     repo = "eff";
     rev = "v${version}";
-    sha256 = "1fslfj5d7fhj3f7kh558b8mk5wllwyq4rnhfkyd96fpy144sdcka";
+    hash = "sha256-0U61y41CA0YaoNk9Hsj7j6eb2V6Ku3MAjW9lMEimiC0=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.ml --replace js_of_ocaml.ocamlbuild js_of_ocaml-ocamlbuild
-  '';
+  nativeBuildInputs = [ menhir ];
 
-  strictDeps = true;
-
-  nativeBuildInputs = [ which ] ++ (with ocamlPackages; [
-    ocaml findlib ocamlbuild menhir
-  ]);
-
-  buildInputs = with ocamlPackages; [ js_of_ocaml js_of_ocaml-ocamlbuild ];
+  buildInputs = [ js_of_ocaml ];
 
   doCheck = true;
-  checkTarget = "test";
 
   meta = with lib; {
     homepage = "https://www.eff-lang.org";
@@ -36,7 +27,6 @@ stdenv.mkDerivation rec {
       backtracking, multi-threading, and much more...
     '';
     license = licenses.bsd2;
-    inherit (ocamlPackages.ocaml.meta) platforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }


### PR DESCRIPTION
## Description of changes

Compatibility with latest OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
