### PR TITLE
Add FSMRMP font package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15571,6 +15571,12 @@
     githubId = 145816;
     name = "David McKay";
   };
+  rayne = {
+    email = "rayne+nix@digitalrayne.net";
+    github = "digitalrayne";
+    githubId = 1829286;
+    name = "Rayne";
+  };
   rayslash = {
     email = "stevemathewjoy@tutanota.com";
     github = "rayslash";

--- a/pkgs/by-name/fs/fsmrmp/package.nix
+++ b/pkgs/by-name/fs/fsmrmp/package.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, python3
+, fontforge
+, unar
+}: let
+  mgensrc = fetchurl {
+    url = "https://ftp.iij.ad.jp/pub/osdn.jp/users/8/8599/rounded-x-mgenplus-20150602.7z";
+    hash = "sha256-xgQnp1Az/ML57lZF337c9MPZFRnZaGALgxXF9qTlAl0=";
+  };
+  fantasquesrc = fetchurl {
+    url = "https://fontlibrary.org/assets/downloads/fantasque-sans-mono/b0cbb25e73a9f8354e96d89524f613e7/fantasque-sans-mono.zip";
+    hash = "sha256-a7OyRBO3ju0Z/6m9IzrlVZguOxhb0wPlfdHgW+vxc1I=";
+  };
+  notosrc = fetchurl {
+    url = "https://fonts.google.com/download?family=Noto%20Emoji";
+    hash = "sha256-092mGv0FRdn+827QD+TxlOk+KY8kpdbe0k459NtleaQ=";
+  };
+  isfitsrc = fetchurl {
+    url = "https://github.com/uwabami/isfit-plus/raw/master/dists/isfit-plus.ttf";
+    hash = "sha256-evL7bpTxTsReyrhKMqdp/fe4bus1EEVDi2FheyZzRlw=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "fsmrmp";
+  version = "2023-08-24";
+
+  src = fetchFromGitHub {
+    owner = "uwabami";
+    repo = "fsmrmp";
+    rev = "1615d02332df4a3879b6b9fd1ac7a08dd861ba20";
+    hash = "sha256-B6VEkBxcoC2E1H4L6jlmT4deYgz2VmEMsQRvNjG36yA=";
+  };
+
+  nativeBuildInputs = [
+    python3
+    fontforge
+    unar
+  ];
+
+  buildPhase = ''
+    mkdir -p tmp sourceFonts dists
+    unar ${mgensrc} -o rounded-x-mgenplus
+    cp -v rounded-x-mgenplus/*/rounded-x-mgenplus-1mn*.ttf sourceFonts/
+    unar ${fantasquesrc} -o fantasque-sans-mono
+    cp -v fantasque-sans-mono/*/*.ttf sourceFonts/
+    unar ${notosrc} -o noto-emoji
+    cp -v noto-emoji/*/static/NotoEmoji-Regular.ttf sourceFonts/
+    cp -v ${isfitsrc} sourceFonts/isfit-plus.ttf
+    find ${python3.withPackages (pp: [ pp.fontforge ])}
+    PYTHONPATH=$PWD/scripts ${python3.withPackages (pp: [ pp.fontforge ])}/bin/python3 -c "import sys; import build; sys.exit(build.build('${version}'))"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 dists/*.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/uwabami/fsmrmp";
+    description = "A patched font combining Fantasque Sans Mono, Rounded Mgen+, Noto Emoji (mono) and isfit+ icons";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.rayne ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds a new font package, FSMRMP, a patched font combining [Fantasque Sans Mono](https://fontlibrary.org/en/font/fantasque-sans-mono), [Rounded Mgen plus](http://jikasei.me/font/rounded-mgenplus/), [Noto Emoji](https://fonts.google.com/noto/specimen/Noto+Emoji) (Monochrome) and [isfit+](https://github.com/uwabami/isfit-plus) icons. It is a font similar in style to Fantasque Sans Mono but also useful for reading & writing Japanese.

I have replicated the functionality of the project Makefile in the Nix packaging definition so that all required font sources can be downloaded prior to build - the original Makefile downloads them at build time which doesn't work with sandboxing.

This package builds the font at package build time as the project does not release compiled font files which could otherwise be downloaded. I've done a test build on x86_64 under NixOS and the package builds - however this is my first contribution to Nix so I'm still learning and any help and guidance around where I could improve would be very much appreciated 🙏🏻 

The GitHub project is [here](https://github.com/uwabami/fsmrmp) for reference.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
