### PR TITLE
quartus-prime-lite: 20.1.1.720 -> 22.1std.2.922

### DIFF
--- a/pkgs/applications/editors/quartus-prime/quartus.nix
+++ b/pkgs/applications/editors/quartus-prime/quartus.nix
@@ -25,20 +25,20 @@ let
   ) deviceIds;
 
   componentHashes = {
-    "arria_lite" = "140jqnb97vrxx6398cpgpw35zrrx3z5kv1x5gr9is1xdbnf4fqhy";
-    "cyclone" = "116kf69ryqcmlc2k8ra0v32jy7nrk7w4s5z3yll7h3c3r68xcsfr";
-    "cyclone10lp" = "07wpgx9bap6rlr5bcmr9lpsxi3cy4yar4n3pxfghazclzqfi2cyl";
-    "cyclonev" = "11baa9zpmmfkmyv33w1r57ipf490gnd3dpi2daripf38wld8lgak";
-    "max" = "1zy2d42dqmn97fwmv4x6pmihh4m23jypv3nd830m1mj7jkjx9kcq";
-    "max10" = "1hvi9cpcjgbih3l6nh8x1vsp0lky5ax85jb2yqmzla80n7dl9ahs";
+    "arria_lite" = "07p862i3dn2c0s3p39y23g94id59nzrpzbwdmrdnhy61ca3m0vzp";
+    "cyclone" = "0dic35j9q1ndrn8i2vdqg9176fr3kn6c8iiv0c03nni0m4ar3ykn";
+    "cyclone10lp" = "03w4f71fhhwvnkzzly9m15nrdf0jw8m0ckhhzv1vg3nd9pkk86jh";
+    "cyclonev" = "091mlg2iy452fk28idbiwi3rhcgkbhg7ggh3xvnqa9jrfffq9pjc";
+    "max" = "0r649l2n6hj6x5v6hx8k4xnvd6df6wxajx1xp2prq6dpapjfb06y";
+    "max10" = "1p5ds3cq2gq2mzq2hjwwjhw50c931kgiqxaf7ss228c6s7rv6zpk";
   };
 
-  version = "20.1.1.720";
+  version = "22.1std.2.922";
 
   download = {name, sha256}: fetchurl {
     inherit name sha256;
-    # e.g. "20.1.1.720" -> "20.1std.1/720"
-    url = "https://downloads.intel.com/akdlm/software/acdsinst/${lib.versions.majorMinor version}std.${lib.versions.patch version}/${lib.elemAt (lib.splitVersion version) 3}/ib_installers/${name}";
+    # e.g. "22.1std.2.922" -> "22.1std.2/922"
+    url = "https://downloads.intel.com/akdlm/software/acdsinst/${lib.versions.majorMinor version}std.${lib.elemAt (lib.splitVersion version) 3}/${lib.elemAt (lib.splitVersion version) 4}/ib_installers/${name}";
   };
 
 in stdenv.mkDerivation rec {
@@ -47,10 +47,10 @@ in stdenv.mkDerivation rec {
 
   src = map download ([{
     name = "QuartusLiteSetup-${version}-linux.run";
-    sha256 = "0mjp1rg312dipr7q95pb4nf4b8fwvxgflnd1vafi3g9cshbb1c3k";
+    sha256 = "078x42pbc51n6ynrvzpwiwgi6g2sg4csv6x2vnnzjgx6bg5kq6l3";
   } {
-    name = "ModelSimSetup-${version}-linux.run";
-    sha256 = "1cqgv8x6vqga8s4v19yhmgrr886rb6p7sbx80528df5n4rpr2k4i";
+    name = "QuestaSetup-${version}-linux.run";
+    sha256 = "04pv5fq3kfy3xsjnj435zzpj5kf6329cbs1xgvkgmq1gpn4ji5zy";
   }] ++ (map (id: {
     name = "${id}-${version}.qdz";
     sha256 = lib.getAttr id componentHashes;
@@ -68,12 +68,12 @@ in stdenv.mkDerivation rec {
         patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $TEMP/${installer.name}
       '';
     copyComponent = component: "cp ${component} $TEMP/${component.name}";
-    # leaves enabled: quartus, modelsim_ase, devinfo
+    # leaves enabled: quartus, questa_fse, devinfo
     disabledComponents = [
       "quartus_help"
       "quartus_update"
-      # not modelsim_ase
-      "modelsim_ae"
+      # not questa_fse
+      "questa_fe"
     ] ++ (lib.attrValues unsupportedDeviceIds);
   in ''
       ${lib.concatMapStringsSep "\n" copyInstaller installers}


### PR DESCRIPTION
## Description of changes

Update Quartus Prime Lite to 22.1.2.
Homepage of this version is https://www.intel.com/content/www/us/en/software-kit/785085/intel-quartus-prime-lite-edition-design-software-version-22-1-2-for-linux.html

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

PRs related to this one (possibly in conflict):
- https://github.com/NixOS/nixpkgs/pull/204401

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
