### PR TITLE
oatmeal: init at 0.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5006,6 +5006,15 @@
       fingerprint = "9484 44FC E03B 05BA 5AB0  591E C37B 1C1D 44C7 86EE";
     }];
   };
+  dustinblackman = {
+    email = "nix@dustinblackman.com";
+    github = "dustinblackman";
+    githubId = 5246169;
+    name = "Dustin Blackman";
+    keys = [{
+      fingerprint = "6A34 CFEE 77FE 8257 C3BB  92FE 24C3 FC5D 6987 904B";
+    }];
+  };
   dwarfmaster = {
     email = "nixpkgs@dwarfmaster.net";
     github = "dwarfmaster";

--- a/pkgs/by-name/oa/oatmeal/package.nix
+++ b/pkgs/by-name/oa/oatmeal/package.nix
@@ -1,0 +1,84 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, makeRustPlatform
+, installShellFiles
+}:
+let
+  version = "0.12.3";
+
+  oatmeal = fetchFromGitHub {
+    name = "oatmeal";
+    owner = "dustinblackman";
+    repo = "oatmeal";
+    rev = "v${version}";
+    hash = "sha256-le9yLZVBqnw4vvOBVLsb0XrmXqs1iQ1duCmLKtYAA7s=";
+  };
+
+  arrayToSrc = arr: lib.forEach arr (e:
+    fetchFromGitHub {
+      inherit (e) rev repo owner;
+      hash = e.nix-hash;
+      name = e.repo;
+    }
+  );
+
+  assets = lib.importTOML (oatmeal + "/assets.toml");
+  syntaxes = arrayToSrc assets.syntaxes;
+  themes = arrayToSrc assets.themes;
+
+  allSyntaxDirs = lib.concatStringsSep " " (lib.forEach syntaxes (e: "${e}"));
+  allThemeDirs = lib.concatStringsSep " " (lib.forEach themes (e: "${e}"));
+
+in
+rustPlatform.buildRustPackage {
+  pname = "oatmeal";
+  inherit version;
+  srcs = [ oatmeal ] ++ syntaxes ++ themes;
+  sourceRoot = oatmeal.name;
+
+  cargoLock.lockFile = oatmeal + "/Cargo.lock";
+
+  env = {
+    VERGEN_IDEMPOTENT = 1;
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  preConfigure = ''
+    # Copy in assets
+    export OATMEAL_BUILD_DOWNLOADED_THEMES_DIR="$(mktemp -d)"
+    export OATMEAL_BUILD_DOWNLOADED_SYNTAXES_DIR="$(mktemp -d)"
+    export OATMEAL_LOG_DIR="$(mktemp -d)"
+    cp -r ${allSyntaxDirs} $OATMEAL_BUILD_DOWNLOADED_SYNTAXES_DIR
+    cp -r ${allThemeDirs} $OATMEAL_BUILD_DOWNLOADED_THEMES_DIR
+  '';
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
+    $out/bin/oatmeal manpages 1>oatmeal.1
+    installManPage oatmeal.1
+
+    installShellCompletion --cmd oatmeal \
+      --bash <($out/bin/oatmeal completions -s bash) \
+      --fish <($out/bin/oatmeal completions -s fish) \
+      --zsh <($out/bin/oatmeal completions -s zsh)
+  '';
+
+  meta = {
+    description = "Terminal UI to chat with large language models (LLM)";
+    longDescription = ''
+      Oatmeal is a terminal UI chat application that speaks with LLMs, complete with
+      slash commands and fancy chat bubbles. It features agnostic backends to allow
+      switching between the powerhouse of ChatGPT, or keeping things private with
+      Ollama. While Oatmeal works great as a stand alone terminal application, it
+      works even better paired with an editor like Neovim!
+    '';
+    homepage = "https://github.com/dustinblackman/oatmeal/";
+    changelog = "https://github.com/dustinblackman/oatmeal/blob/main/CHANGELOG.md";
+    downloadPage = "https://github.com/dustinblackman/oatmeal/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dustinblackman ];
+    mainProgram = "oatmeal";
+  };
+}


### PR DESCRIPTION
## Description of changes

Works towards solving https://github.com/dustinblackman/oatmeal/issues/7

Adds Oatmeal, a terminal UI chat application that speaks with LLMs, complete with slash commands and fancy chat bubbles. It features agnostic backends to allow switching between the powerhouse of ChatGPT, or keeping things private with Ollama. While Oatmeal works great as a stand alone terminal application, it works even better paired with an editor like Neovim!

- https://github.com/dustinblackman/oatmeal
- https://dustinblackman.com/posts/oatmeal/

This file is originally from my NUR generated by GoReleaser, ported here with the addition of adding myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
