### PR TITLE
nixos/pam: Use secure default for `sshAgentAuth.authorizedKeysFiles`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -47,6 +47,20 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `himalaya` was updated to v1.0.0-beta, which introduces breaking changes. Check out the [release note](https://github.com/soywod/himalaya/releases/tag/v1.0.0-beta) for details.
 
+- `security.pam.enableSSHAgentAuth` was replaced by the `sshAgentAuth` attrset, and **only**
+  `authorized_keys` files listed in [`sshAgentAuth.authorizedKeysFiles`] are trusted,
+  defaulting to `/etc/ssh/authorized_keys.d/%u`.
+  ::: {.warning}
+  Users of {manpage}`pam_ssh_agent_auth(8)` must take care that the pubkeys they use (for instance with `sudo`)
+  are listed in [`sshAgentAuth.authorizedKeysFiles`]..
+  :::
+  ::: {.note}
+  Previously, all `services.openssh.authorizedKeysFiles` were trusted, including `~/.ssh/authorized_keys`,
+  which results in an **insecure** configuration; see [#31611](https://github.com/NixOS/nixpkgs/issues/31611).
+  :::
+
+[`sshAgentAuth.authorizedKeysFiles`]: #opt-security.pam.sshAgentAuth.authorizedKeysFiles
+
 - The `power.ups` module now generates `upsd.conf`, `upsd.users` and `upsmon.conf` automatically from a set of new configuration options. This breaks compatibility with existing `power.ups` setups where these files were created manually. Back up these files before upgrading NixOS.
 
 - `k9s` was updated to v0.31. There have been various breaking changes in the config file format,
@@ -148,10 +162,6 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   `redirectCode`.
 
 - The source of the `mockgen` package has changed to the [go.uber.org/mock](https://github.com/uber-go/mock) fork because [the original repository is no longer maintained](https://github.com/golang/mock#gomock).
-
-- `security.pam.enableSSHAgentAuth` was renamed to `security.pam.sshAgentAuth.enable` and an `authorizedKeysFiles`
-  option was added, to control which `authorized_keys` files are trusted.  It defaults to the previous behaviour,
-  **which is insecure**: see [#31611](https://github.com/NixOS/nixpkgs/issues/31611).
 
 - [](#opt-boot.kernel.sysctl._net.core.wmem_max_) changed from a string to an integer because of the addition of a custom merge option (taking the highest value defined to avoid conflicts between 2 services trying to set that value), just as [](#opt-boot.kernel.sysctl._net.core.rmem_max_) since 22.11.
 

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1050,9 +1050,7 @@ in
           See [issue #31611](https://github.com/NixOS/nixpkgs/issues/31611)
           :::
         '';
-        example = [ "/etc/ssh/authorized_keys.d/%u" ];
-        default = config.services.openssh.authorizedKeysFiles;
-        defaultText = literalExpression "config.services.openssh.authorizedKeysFiles";
+        default = [ "/etc/ssh/authorized_keys.d/%u" ];
       };
     };
 


### PR DESCRIPTION
Follow-up on #277620, blocked until it is merged.

## Description of changes

Change the default value of `security.pam.sshAgentAuth.authorizedKeysFiles` to `[ "/etc/ssh/authorized_keys.d/%u" ]`.
This breaks backwards-compatibility to fix a security vulnerability: #31611

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - `nixosTests.ssh-agent-auth` once #266332 is merged.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
