### PR TITLE
makeNugetSource: Avoid infinite recursion in meta

### DIFF
--- a/pkgs/build-support/dotnet/make-nuget-source/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-source/default.nix
@@ -5,34 +5,31 @@
 , deps ? []
 }:
 
-let
-  nuget-source = stdenvNoCC.mkDerivation {
-    inherit name;
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit name;
 
-    nativeBuildInputs = [ python3 ];
+  nativeBuildInputs = [ python3 ];
 
-    buildCommand = ''
-      mkdir -p $out/{lib,share}
+  buildCommand = ''
+    mkdir -p $out/{lib,share}
 
-      # use -L to follow symbolic links. When `projectReferences` is used in
-      # buildDotnetModule, one of the deps will be a symlink farm.
-      find -L ${lib.concatStringsSep " " deps} -type f -name '*.nupkg' -exec \
-        ln -s '{}' -t $out/lib ';'
+    # use -L to follow symbolic links. When `projectReferences` is used in
+    # buildDotnetModule, one of the deps will be a symlink farm.
+    find -L ${lib.concatStringsSep " " deps} -type f -name '*.nupkg' -exec \
+      ln -s '{}' -t $out/lib ';'
 
-      # Generates a list of all licenses' spdx ids, if available.
-      # Note that this currently ignores any license provided in plain text (e.g. "LICENSE.txt")
-      python ${./extract-licenses-from-nupkgs.py} $out/lib > $out/share/licenses
-    '';
+    # Generates a list of all licenses' spdx ids, if available.
+    # Note that this currently ignores any license provided in plain text (e.g. "LICENSE.txt")
+    python ${./extract-licenses-from-nupkgs.py} $out/lib > $out/share/licenses
+  '';
 
-    meta.description = description;
-  } // { # We need data from `$out` for `meta`, so we have to use overrides as to not hit infinite recursion.
-    meta = nuget-source.meta // {
-      licenses = let
-        # TODO: avoid IFD
-        depLicenses = lib.splitString "\n" (builtins.readFile "${nuget-source}/share/licenses");
+  meta = {
+    inherit description;
+    licenses = let
+      # TODO: avoid IFD
+      depLicenses = lib.splitString "\n" (builtins.readFile "${finalAttrs.finalPackage}/share/licenses");
       in lib.flatten (lib.forEach depLicenses (spdx:
         lib.optionals (spdx != "") (lib.getLicenseFromSpdxId spdx)
       ));
-    };
   };
-in nuget-source
+})


### PR DESCRIPTION
## Description of changes

Slight improvement. A further step would be to get rid of the IFD, by adding license data to the nuget-deps.nix files. Closes #277628.

Tested with

```
$ nix-instantiate --eval --json --strict --option allow-import-from-derivation true . -A godot3-mono.nugetSource.meta | jq
{
  "available": true,
  "broken": false,
  "description": "A Nuget source with dependencies for godot3-mono",
  "insecure": false,
  "licenses": [
    {
      "deprecated": false,
      "free": true,
      "fullName": "MIT License",
      "redistributable": true,
      "shortName": "mit",
      "spdxId": "MIT",
      "url": "https://spdx.org/licenses/MIT.html"
    }
  ],
  "name": "godot3-mono-nuget-source",
  "outputsToInstall": [
    "out"
  ],
  "position": "/home/admin/src/nixpkgs/pkgs/build-support/dotnet/make-nuget-source/default.nix:27",
  "unfree": false,
  "unsupported": false
}
```

@NixOS/dotnet 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
