### PR TITLE
python311Packages.rdkit: 2023.09.1 -> 2023.09.3; coordgenlibs: fix build with clang

### DIFF
--- a/pkgs/development/libraries/coordgenlibs/default.nix
+++ b/pkgs/development/libraries/coordgenlibs/default.nix
@@ -7,15 +7,15 @@
 , maeparser
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "coordgenlibs";
   version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "schrodinger";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-casFPNbPv9mkKpzfBENW7INClypuCO1L7clLGBXvSvI=";
+    repo = "coordgenlibs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-casFPNbPv9mkKpzfBENW7INClypuCO1L7clLGBXvSvI=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -29,7 +29,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Schrodinger-developed 2D Coordinate Generation";
+    homepage = "https://github.com/schrodinger/coordgenlibs";
+    changelog = "https://github.com/schrodinger/coordgenlibs/releases/tag/${finalAttrs.version}";
     maintainers = [ maintainers.rmcgibbo ];
     license = licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/libraries/coordgenlibs/default.nix
+++ b/pkgs/development/libraries/coordgenlibs/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost zlib maeparser ];
 
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = "-Wno-unused-but-set-variable";
+  };
+
   meta = with lib; {
     description = "Schrodinger-developed 2D Coordinate Generation";
     maintainers = [ maintainers.rmcgibbo ];

--- a/pkgs/development/libraries/coordgenlibs/default.nix
+++ b/pkgs/development/libraries/coordgenlibs/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     NIX_CFLAGS_COMPILE = "-Wno-unused-but-set-variable";
   };
 
+  doCheck = true;
+
   meta = with lib; {
     description = "Schrodinger-developed 2D Coordinate Generation";
     maintainers = [ maintainers.rmcgibbo ];

--- a/pkgs/development/python-modules/rdkit/default.nix
+++ b/pkgs/development/python-modules/rdkit/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , comic-neue
 , boost
-, catch2
+, catch2_3
 , inchi
 , cairo
 , eigen
@@ -42,8 +42,8 @@ let
 in
 buildPythonPackage rec {
   pname = "rdkit";
-  version = "2023.09.1";
-  format = "other";
+  version = "2023.09.3";
+  pyproject = false;
 
   src =
     let
@@ -53,7 +53,7 @@ buildPythonPackage rec {
       owner = pname;
       repo = pname;
       rev = "Release_${versionTag}";
-      hash = "sha256-qaYD/46oCTnso1FbD08zr2JuatKmSSqNBhOYlfeIiAA=";
+      hash = "sha256-bewOdmpnm6cArD5iaMKNqT8z4GUIpih+JzJ+wdo/lrI=";
     };
 
   unpackPhase = ''
@@ -84,6 +84,7 @@ buildPythonPackage rec {
   buildInputs = [
     boost
     cairo
+    catch2_3
   ] ++ lib.optionals (stdenv.system == "x86_64-darwin") [
     memorymappingHook
   ];
@@ -109,7 +110,6 @@ buildPythonPackage rec {
   '';
 
   cmakeFlags = [
-    "-DCATCH_DIR=${catch2}/include/catch2"
     "-DINCHI_LIBRARY=${inchi}/lib/libinchi.so"
     "-DINCHI_LIBRARIES=${inchi}/lib/libinchi.so"
     "-DINCHI_INCLUDE_DIR=${inchi}/include/inchi"


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/rdkit/rdkit/compare/Release_2023_09_1...Release_2023_09_3

Changelog: https://github.com/rdkit/rdkit/releases/tag/Release_2023_09_3

This also includes fixes to the dependent coordgenlibs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
