### PR TITLE
miraclecast: 1.0-20190403 -> 1.0-20231112

### DIFF
--- a/pkgs/os-specific/linux/miraclecast/default.nix
+++ b/pkgs/os-specific/linux/miraclecast/default.nix
@@ -1,24 +1,25 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config
-, glib, readline, pcre, systemd, udev }:
+, glib, readline, pcre, systemd, udev, iproute2 }:
 
 stdenv.mkDerivation {
   pname = "miraclecast";
-  version = "1.0-20190403";
+  version = "1.0-20231112";
 
   src = fetchFromGitHub {
     owner  = "albfan";
     repo   = "miraclecast";
-    rev    = "960a785e10523cc525885380dd03aa2c5ba11bc7";
-    sha256 = "05afqi33rv7k6pbkkw4mynj6p97vkzhhh13y5nh0yxkyhcgf45pm";
+    rev    = "af6ab257eae83bb0270a776a8fe00c0148bc53c4";
+    hash   = "sha256-3ZIAvA3w/ZhoJtVmUD444nch0PGD58PdBRke7zd9IuQ=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];
 
-  buildInputs = [ glib pcre readline systemd udev ];
+  buildInputs = [ glib pcre readline systemd udev iproute2 ];
 
   mesonFlags = [
     "-Drely-udev=true"
     "-Dbuild-tests=true"
+    "-Dip-binary=${iproute2}/bin/ip"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Note: still haven't gotten the screen-sharing to work on my computer. It does connect to the TV without raising an error though.

## Description of changes

Also fixed connection problems caused by not modifying location of ip command (caused by https://github.com/albfan/miraclecast/issues/370)

commit af6ab257eae83bb0270a776a8fe00c0148bc53c4
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Mon Nov 13 00:48:03 2023 +0100

    Remove systemd and it comes with DEP_LIBS

commit fdb8671c4087826541c4ffc14df5716c28acd62a
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Jul 14 21:54:44 2023 +0200

    fix autotools build for libm

commit 850a1c6f7c69b727b24fa1858d86490b7698c482
Author: Kai Jan Schmidt-Brauns <12021253+KaiJan57@users.noreply.github.com>
Date:   Thu Feb 16 16:32:53 2023 +0100

    Fix dependency check to be posix-compliant
    
    test with "==" operator works in bash but fails in other shells such as `sh`

commit f3debd5678e7699dfd8acfdcc77fda64e9509cae
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Jan 22 10:23:32 2023 +0100

    whitespace

commit 279303d0d6bf3ee1215686e5afd7517f35c50ae7
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Jan 22 10:17:44 2023 +0100

    fix double free reading custom parameter

commit c803c88572e843562ea28c049f981397146017e5
Author: Erik Andresen <erik@vontaene.de>
Date:   Sun Jan 8 16:28:02 2023 +0100

    CMakeLists: Remove duplicate systemd requirement
    
    closes #3

commit 3018aac1f2efa1387281e6d435a4dfe6b738309a
Author: Xiao Qiang Liang <xliang@lifesize.com>
Date:   Tue Jan 3 15:25:51 2023 +0100

    Fix cmake build for latest gcc
    
    libraries link order is relevant on latest gcc

commit a36e9bd19fe7500af00d555668eb9e32c17dba69
Author: Tanish Azad <73871477+Taz03@users.noreply.github.com>
Date:   Mon Nov 28 12:39:51 2022 +0000

    fixed error message

commit 439dac09c554d67eaa4f3d8bce8fa89415e60a26
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Nov 20 12:48:40 2022 +0100

    Ignore special chars on color prompt

commit 31f7fbba33d0a72a584ed03c555ac8534bd24698
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Nov 20 11:47:35 2022 +0100

    Set custom ctl names

commit abc9b2f92cca7fbdb6259eb00d87eb030a73c50f
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Nov 9 02:35:01 2022 +0100

    set wfd elements on source selected

commit 314aa5aed59b3500e8385f408ab523e190cba0ad
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Nov 9 00:12:03 2022 +0100

    Use default rstp port

commit 66c86f2971c0ef6dd0f1604f6beb91404b73039f
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Mon Nov 14 07:12:00 2022 +0100

    fix memory error settting wfd_video_formats

commit 788d37d7d27dbf6c26cb82ecafe48525504fa810
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Nov 13 11:29:16 2022 +0100

    CLI commands autocompletion

commit 20816ad138c7072fff46bfa76915d1861317766f
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Tue Nov 8 08:49:54 2022 +0100

    Add command friendly-name to sink controller

commit c215f05d5d93a6663935056ccb5df40d87fbf39e
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Tue Nov 8 08:42:05 2022 +0100

    Exit CLI if daemon is not available

commit f9a61faaa29ede4de92de06dd42a21bb9efc5911
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Tue Nov 8 08:34:45 2022 +0100

    Do not prefix command output with time

commit 8cd144271a8c38e96487e9fc60b1d5db3f5b9bc7
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Oct 30 01:28:28 2022 +0200

    log messages with time in human readable way

commit 7135a99e712f859e414222a3fe69a65ae593fd72
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sat Oct 29 22:42:43 2022 +0200

    Call script helpers from any path

commit 42c5bda976039d27976515d41f8a73e4e1c5b3a7
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sat Oct 29 01:32:45 2022 +0200

    fix cmake CI

commit f740af265576783565f9dabd7b2b5b9f01ef10d9
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sat Oct 29 01:02:28 2022 +0200

    Clean cmake files

commit 175495c729a91251898f733a1f88e3679f7365a4
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sat Oct 29 01:01:40 2022 +0200

    fix cmake dependencies for

commit 72f61549d9b9a969c54237ab4730154bb7d84c60
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Oct 28 08:36:17 2022 +0200

    log messages with time in human readable way

commit 380504b0f833faa46f12d3a1f3861b97d08d32a4
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Oct 16 23:02:57 2022 +0200

    helpers to start/stop wifi on several distros

commit b46679d5a4eb0cac5e3464472ee972e298768fcd
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Oct 16 22:44:07 2022 +0200

    Use posix functions

commit 6f84dc8b7dcbcac9f0884d4a79164247b6eedacf
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sat May 28 09:59:51 2022 +0200

    Add ENABLE_SYSTEMD config to meson and autotools

commit 85723432f965ee4860d08469f87873af964aa93b
Author: Andreas K. Hüttel <dilfridge@gentoo.org>
Date:   Thu Jan 3 10:43:31 2019 +0100

    Option to use elogind instead of whole systemd
    
    Signed-off-by: Andreas K. Hüttel <dilfridge@gentoo.org>

commit 7f263b06b41630eb1bff69312994c74de170fa58
Author: Semara Incorporated <semaraincorporated@gmail.com>
Date:   Tue Sep 20 18:45:06 2022 +0800

    Change kdus to kdbus
    
    Change kdus to kdbus in Arch linux aur installation instruction

commit a1590ecc17cb5c381acbc60a72feb3fa8b78b69f
Author: Fernando van Loenhout <ferrytinymailbox@gmail.com>
Date:   Mon Sep 19 10:35:36 2022 +0200

    Support more than 2 devices when testing the capabilities
    
    At the moment, this typo is preventing the test script from working when you have more than 2 devices plugged in. Fixes #449

commit 43505ab3dd3911084331f7e9bdb562d1f5047190
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri May 27 01:15:08 2022 +0200

    Allow to override/extend the request parameters

commit e816de93d3507584af5783403d520abd59051d5a
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sat May 28 10:37:53 2022 +0200

    Allow auto commands with any number of parameters

commit c42624885bbc1e0bfc3fd0aba597140dbb6de5aa
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Thu May 26 20:55:51 2022 +0200

    simplify pass request options

commit 3ab7d5913fbe67d7588904adac4790bce4468116
Author: Edward Betts <edward@4angle.com>
Date:   Tue Apr 12 07:56:39 2022 +0100

    Correct spelling mistakes

commit 0b72e0b4358b4908daf1932c8f77fbd11ad8d140
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Mar 9 17:45:30 2022 +0100

    cmake: fix build for Ninja generator

commit 125f4a847f2c56363c46c0d36d5d524109b0a0cc
Author: Коренберг ☢️  Марк <mark@ideco.ru>
Date:   Wed Jan 5 13:41:22 2022 +0500

    Fix .spec file

commit 264a222d242734da369ca287aa6cfc6ca4f1f7bf
Author: Michael Partridge <mcp292@nau.edu>
Date:   Fri Nov 19 17:42:08 2021 -0700

    Add wpa_supplicant to requirements

commit 4b229dc2825f5bda1bdc748d09d46c21527fdc9d
Author: Michael Partridge <mcp292@nau.edu>
Date:   Fri Nov 19 17:40:28 2021 -0700

    Move optional packages towards the end

commit 5ac3e0593f1ccb8ab2cc89f5ba1c8107a59186f3
Author: mcp292 <mcp292@nau.edu>
Date:   Thu Nov 18 09:20:16 2021 -0700

    Add missing period

commit e25d8d5a0bac4231ee196784da6705ca5e9a58f2
Author: mcp292 <mcp292@nau.edu>
Date:   Wed Nov 17 12:44:20 2021 -0700

    Fix broken relative link to #4 in README

commit df12df656cfe6a3b7d65b80eaacc3736a5d12c18
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Oct 27 07:35:43 2021 +0200

    Configurable ip binary path
    
    Different OS have ip binary on different locations
    
    It can be configured at:
      - compile time `IP_BINARY`
      - execution time `--ip-binary`

commit 65a7a0aad1e4f0fd6af791a7990a1921cdce4530
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Oct 27 12:10:40 2021 +0200

    Assig dupped string

commit 3f5270ee7aeff677878f8b238370ed568a7277ea
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Oct 27 12:02:54 2021 +0200

    Avoid automatic make commands on autotools

commit 506f1e7b2821eca80617de54f3de358bdee9b83f
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Wed Oct 27 07:35:43 2021 +0200

    whitespace

commit 7739a9cee0ce847db0fa0eed977e8e06839d3a08
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Tue Oct 26 20:00:52 2021 +0200

    Fix completion path on meson buildsystem

commit a66b998883d81ee0fa89aa35445550bb4ceae0de
Author: dzink <dzink@users.noreply.github.com>
Date:   Sun Sep 5 17:32:33 2021 -0400

    Update README to indicate that source is not yet implemented.
    
    Prevent issue duplication and manage user expectations by indicating up front that source is not yet implemented (see issue #4).

commit 0481252438deff45d05bb389d4d1c4213c5eab15
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Jul 9 15:57:40 2021 +0200

    Specify path for miracle utils script

commit a13c1b7c33d5e3b8b9d9c52643a3040ea8edbd89
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Jan 3 19:45:49 2021 +0100

    Do not fail stopping existing links

commit 62c5b8daa87bbb73bcb62cb2c62bdc22d020990a
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Jan 3 19:45:05 2021 +0100

    Do not fail if peers are found before links
    
    After discover peers, a miracle-sinkctl restart can lead to peers
    without links. Just ignore that

commit 8d6530ebc93a9e2657089d7cd261cd23a17c72d3
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Jan 3 14:07:44 2021 +0100

    protect from NULL binary path

commit 3b3531de5c6a7917024ba56cf919b1742b4db74b
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Sun Jan 3 14:04:38 2021 +0100

    Allow to set friendly name even if unmanaged

commit 92a8b0b2c6764deaf753b5f5f7861998e89975e5
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Jan 1 19:43:03 2021 +0100

    Detect miracle-wifid already running

commit 058c9cc3098e08f4beb58cc0a0665ccdffcd84fc
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Nov 13 16:50:57 2020 +0100

    Update travis build status

commit c864ff62461507d98cba93c335f21937e5ecab61
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Nov 13 10:53:38 2020 +0100

    Use new semaphore 2.0 CI

commit 4f37045eea9d5da1b3840144381160a905275244
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Fri Nov 13 10:29:13 2020 +0100

    Use travis as CI

commit be548047687d3a02ff23f8cac05bf57803e343b1
Author: Andrey Alekseenko <al42and@gmail.com>
Date:   Fri Feb 21 22:12:53 2020 -0500

    Remove access to freed memory
    
    If rtsp_unlink_waiting(m) is called and actually destroys m, it's not
    safe to pass it to rtsp_unlink_outgoing later.
    
    We make rtsp_unlink_waiting and rtsp_unlink_outgoing return true if they
    destroy the message, and in this case we make sure not to try freeing it
    again.

commit 57d05a18082d3d06a94dff1d83898237b7d28540
Author: Andrey Alekseenko <al42and@gmail.com>
Date:   Fri Feb 21 22:06:16 2020 -0500

    Remove double free
    
    The function parser_submit_data is only called from parser_feed_char_data_body, which frees the buffer pointer anyway.

commit 9edb225905d1a0e7e0195750a24263e2d06a39b5
Author: Andrey Alekseenko <al42and@gmail.com>
Date:   Fri Feb 21 21:59:48 2020 -0500

    Add option to use cppcheck in CMake

commit 2ef4c1f40feaca06173b34d2301315f4772f6e79
Author: Andrey Alekseenko <al42and@gmail.com>
Date:   Fri Feb 21 21:21:38 2020 -0500

    Random static analysis fixes

commit 41113335211463e122f7e5f782274c84752703c9
Author: Alberto Fanjul <albertofanjul@gmail.com>
Date:   Tue Aug 27 11:01:22 2019 +0200

    Set readline as required package
    
    autotools already set it, but cmake and meson no.

commit 58dd6c411e182265a69dd81ff6fb994a5ada02ed
Author: Warren Crossing <warren.crossing@juno-software.com>
Date:   Thu Aug 22 06:50:32 2019 +1000

    Add --syslog flag to see wpa logs in syslog


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x (still doesn't work)] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
