### PR TITLE
linux: avoid re-adding unsupported kernel branches (4.14) in this case in updater scripts

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/update.py
+++ b/pkgs/os-specific/linux/kernel/hardened/update.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p "python3.withPackages (ps: [ps.pygithub])" git gnupg
+#! nix-shell -i python -p "python3.withPackages (ps: [ps.pygithub ps.packaging])" git gnupg
 
 # This is automatically called by ../update.sh.
 
@@ -27,6 +27,8 @@ from typing import (
 from github import Github
 from github.GitRelease import GitRelease
 
+from packaging.version import parse as parse_version, Version
+
 VersionComponent = Union[int, str]
 Version = List[VersionComponent]
 
@@ -37,6 +39,11 @@ Patch = TypedDict("Patch", {
     "version": str,
     "sha256": str,
 })
+
+
+def read_min_kernel_branch() -> List[str]:
+    with open(NIXPKGS_KERNEL_PATH / "kernels-org.json") as f:
+        return list(parse_version(sorted(json.load(f).keys())[0]).release)
 
 
 @dataclass
@@ -51,7 +58,7 @@ NIXPKGS_PATH = HERE.parents[4]
 HARDENED_GITHUB_REPO = "anthraxx/linux-hardened"
 HARDENED_TRUSTED_KEY = HERE / "anthraxx.asc"
 HARDENED_PATCHES_PATH = HERE / "patches.json"
-MIN_KERNEL_VERSION: Version = [4, 14]
+MIN_KERNEL_VERSION: Version = read_min_kernel_branch()
 
 
 def run(*args: Union[str, Path]) -> subprocess.CompletedProcess[bytes]:

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -27,10 +27,6 @@
         "version": "4.19.303",
         "hash": "sha256:0dlbl47xs7z4yf9cxbxqzd7zs1f9070jr6ck231wgppa6lwwwb82"
     },
-    "4.14": {
-        "version": "4.14.334",
-        "hash": "sha256:0iaaqdkszmfarvjfszc9rf7y9zsv3w82934xmvmzmsbiz86547ca"
-    },
     "6.6": {
         "version": "6.6.8",
         "hash": "sha256:05i4ayj9wyjkd1s8ixx7bxwcyagqyx8rhj1zvbc3cjqyw4sc8djh"


### PR DESCRIPTION
## Description of changes

As pointed out by @alyssais : https://github.com/NixOS/nixpkgs/pull/274275#issuecomment-1872198407

* Added a textfile indicating the oldest supported kernel branch (currently 4.19) and use that for the hardened updater: fd6404922513bded6ee3d3db11fe96724aa9892a
* Also take oldest supported branch into account when generating kernels-org.json: cdbffe4c58426b4e7adf8e4302ce4654bca6cd08
* Remove leftover 4.14 information.
* <del>Decided to also push the kernel updates that I made while testing the script :) </del> done in #278085

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
