### PR TITLE
gradle: auto-detect native version and patch file-events

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -3,7 +3,7 @@
 rec {
   gen =
 
-    { version, nativeVersion, hash,
+    { version, hash,
 
       # The default JDK/JRE that will be used for derived Gradle packages.
       # A current LTS version of a JDK is a good choice.
@@ -36,6 +36,7 @@ rec {
     , testers
     , runCommand
     , writeText
+    , autoPatchelfHook
 
     # The JDK/JRE used for running Gradle.
     , java ? defaultJava
@@ -57,8 +58,22 @@ rec {
 
       dontBuild = true;
 
-      nativeBuildInputs = [ makeWrapper unzip ];
-      buildInputs = [ java ];
+      nativeBuildInputs = [
+        makeWrapper
+        unzip
+      ] ++ lib.optionals stdenv.isLinux [
+        autoPatchelfHook
+      ];
+
+      buildInputs = [
+        java
+        stdenv.cc.cc
+        ncurses5
+        ncurses6
+      ];
+
+      # We only need to patchelf some libs embedded in JARs.
+      dontAutoPatchelf = true;
 
       installPhase = with builtins;
         let
@@ -87,16 +102,13 @@ rec {
 
       fixupPhase = let arch = if stdenv.is64bit then "amd64" else "i386";
       in ''
+        . ${./patching.sh}
+
+        nativeVersion="$(extractVersion native-platform $out/lib/gradle/lib/native-platform-*.jar)"
         for variant in "" "-ncurses5" "-ncurses6"; do
-          mkdir "patching$variant"
-          pushd "patching$variant"
-          jar xf $out/lib/gradle/lib/native-platform-linux-${arch}$variant-${nativeVersion}.jar
-          patchelf \
-            --set-rpath "${stdenv.cc.cc.lib}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ncurses5 ncurses6 ]}" \
-            net/rubygrapefruit/platform/linux-${arch}$variant/libnative-platform*.so
-          jar cf native-platform-linux-${arch}$variant-${nativeVersion}.jar .
-          mv native-platform-linux-${arch}$variant-${nativeVersion}.jar $out/lib/gradle/lib/
-          popd
+          autoPatchelfInJar \
+            $out/lib/gradle/lib/native-platform-linux-${arch}$variant-''${nativeVersion}.jar \
+            "${stdenv.cc.cc.lib}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ncurses5 ncurses6 ]}"
         done
 
         # The scanner doesn't pick up the runtime dependency in the jar.
@@ -162,21 +174,18 @@ rec {
 
   gradle_8 = gen {
     version = "8.10";
-    nativeVersion = "0.22-milestone-26";
     hash = "sha256-W5xes/n8LJSrrqV9kL14dHyhF927+WyFnTdBGBoSvyo=";
     defaultJava = jdk21;
   };
 
   gradle_7 = gen {
     version = "7.6.4";
-    nativeVersion = "0.22-milestone-25";
     hash = "sha256-vtHaM8yg9VerE2kcd/OLtnOIEZ5HlNET4FEDm4Cvm7E=";
     defaultJava = jdk17;
   };
 
   gradle_6 = gen {
     version = "6.9.4";
-    nativeVersion = "0.22-milestone-20";
     hash = "sha256-PiQCKFON6fGHcqV06ZoLqVnoPW7zUQFDgazZYxeBOJo=";
     defaultJava = jdk11;
   };

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -111,6 +111,13 @@ rec {
             "${stdenv.cc.cc.lib}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ncurses5 ncurses6 ]}"
         done
 
+        # The file-events library _seems_ to follow the native-platform version, but
+        # we won’t assume that.
+        fileEventsVersion="$(extractVersion file-events $out/lib/gradle/lib/file-events-*.jar)"
+        autoPatchelfInJar \
+          $out/lib/gradle/lib/file-events-linux-${arch}-''${fileEventsVersion}.jar \
+          "${stdenv.cc.cc.lib}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+
         # The scanner doesn't pick up the runtime dependency in the jar.
         # Manually add a reference where it will be found.
         mkdir $out/nix-support

--- a/pkgs/development/tools/build-managers/gradle/patching.sh
+++ b/pkgs/development/tools/build-managers/gradle/patching.sh
@@ -1,0 +1,29 @@
+extractVersion() {
+    local jar version
+    local prefix="$1"
+    shift
+    local candidates="$@"
+
+    jar="$(basename -a $candidates | sort | head -n1)"
+
+    version="${jar#$prefix-}"
+
+    echo "${version%.jar}"
+}
+
+autoPatchelfInJar() {
+    local file="$1" rpath="$2"
+    local work
+
+    work="$(mktemp -dt patching.XXXXXXXXXX)"
+    pushd "$work"
+
+    jar xf "$file"
+    rm "$file"
+
+    autoPatchelf -- .
+
+    jar cf "$file" .
+
+    popd
+}

--- a/pkgs/development/tools/build-managers/gradle/update.sh
+++ b/pkgs/development/tools/build-managers/gradle/update.sh
@@ -49,20 +49,7 @@ do
     read -d "\n" gradle_hash gradle_path < <(nix-prefetch-url --print-path $url)
     gradle_hash=$(nix-hash --to-sri --type sha256 "$gradle_hash")
 
-    # Prefix and suffix for "native-platform" dependency.
-    gradle_native_prefix="gradle-$v/lib/native-platform-"
-    gradle_native_suffix=".jar"
-    tmp=$(mktemp)
-    zipinfo -1 "$gradle_path" "$gradle_native_prefix*$gradle_native_suffix" > $tmp
-    gradle_native=$(cat $tmp | head -n1)
-    gradle_native=${gradle_native#"$gradle_native_prefix"}
-    gradle_native=${gradle_native%"$gradle_native_suffix"}
-
-    # Supported architectures
-    #grep -Pho "(linux|osx)-\w+" $tmp | sort | uniq
-    rm -f $tmp
-
-    echo -e "{\\n  version = \"$v\";\\n  nativeVersion = \"$gradle_native\";\\n  sha256 = \"$gradle_hash\";\\n}" > $f
+    echo -e "{\\n  version = \"$v\";\\n  sha256 = \"$gradle_hash\";\\n}" > $f
 
     echo "$v DONE"
 done


### PR DESCRIPTION
## Description of changes

Drop the requirement to specify the version of the native-platform library at Nix level. We use the non-platform-specific `native-platform-<version>.jar` to resolve the version of that library at fixup.

Hoping that we might be able to use `nix-update-script` to automate updates, but have not tested that yet.

I also noticed there is a bundled file-events library that requires libstdc++, so added a similar patch for that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
