### PR TITLE
python311Packages.pydantic-compat: init at 0.1.2, python311Packages.app-model: 0.2.2 -> 0.2.4 

### DIFF
--- a/pkgs/development/python-modules/app-model/default.nix
+++ b/pkgs/development/python-modules/app-model/default.nix
@@ -1,28 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, hatch-vcs
+, hatchling
 , in-n-out
 , psygnal
 , pydantic
+, pydantic-compat
 , pytestCheckHook
 , pythonOlder
 , typing-extensions
-, hatch-vcs
-, hatchling
 }:
 
 buildPythonPackage rec {
   pname = "app-model";
-  version = "0.2.2";
-  format = "pyproject";
+  version = "0.2.4";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pyapp-kit";
-    repo = pname;
+    repo = "app-model";
     rev = "refs/tags/v${version}";
-    hash = "sha256-vo10BHUzvYlldAqTw/1LxgvSXgTM3LAls9jQIeB5LcU=";
+    hash = "sha256-idie99ditHJG/6rv97LDaF71iTjjgJyhLiTrbkQmbts=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -35,6 +36,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     psygnal
     pydantic
+    pydantic-compat
     in-n-out
     typing-extensions
   ];

--- a/pkgs/development/python-modules/pydantic-compat/default.nix
+++ b/pkgs/development/python-modules/pydantic-compat/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, git
+, hatch-vcs
+, hatchling
+, importlib-metadata
+, pydantic
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pydantic-compat";
+  version = "0.1.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pyapp-kit";
+    repo = "pydantic-compat";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-YJUfWu+nyGlwpJpxYghCKzj3CasdAaqYoNVCcfo/7YE=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [
+    git
+    hatch-vcs
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    importlib-metadata
+    pydantic
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pydantic_compat"
+  ];
+
+  meta = with lib; {
+    description = "Compatibility layer for pydantic v1/v2";
+    homepage = "https://github.com/pyapp-kit/pydantic-compat";
+    changelog = "https://github.com/pyapp-kit/pydantic-compat/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10202,6 +10202,8 @@ self: super: with self; {
 
   pydantic = callPackage ../development/python-modules/pydantic { };
 
+  pydantic-compat = callPackage ../development/python-modules/pydantic-compat { };
+
   pydantic-core = callPackage ../development/python-modules/pydantic-core { };
 
   pydantic-extra-types = callPackage ../development/python-modules/pydantic-extra-types { };


### PR DESCRIPTION
Diff: https://github.com/pyapp-kit/app-model/compare/refs/tags/v0.2.2...v0.2.4

Changelog: https://github.com/pyapp-kit/app-model/blob/v0.2.4/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
