### PR TITLE
dkimproxy: fix running

### DIFF
--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ perlPackages.perl ];
-  propagatedBuildInputs = with perlPackages; [ Error MailDKIM MIMETools NetServer ];
+  propagatedBuildInputs = with perlPackages; [ CryptX Error MailDKIM MIMETools NetServer ];
 
   meta = with lib; {
     description = "SMTP-proxy that signs and/or verifies emails";


### PR DESCRIPTION
Tested on my production NixOS 23.11. Without this, starting the dkimproxy-out module fails with a "failed to compile" issue referencing Crypto::PK::Ed25519.

Currently being the only maintainer, I'll self-merge this as soon as tests pass, as well as backport :)