### PR TITLE
[23.11] squid: add patches for several CVEs

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, perl, openldap, pam, db, cyrus_sasl, libcap
 , expat, libxml2, openssl, pkg-config, systemd
 , cppunit
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +12,39 @@ stdenv.mkDerivation rec {
     url = "http://www.squid-cache.org/Versions/v5/${pname}-${version}.tar.xz";
     hash = "sha256-P+XCAH2idXRGr5G275dPFUsggSCpo5OW6mgeXEq7BLU=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-46847.patch";
+      url = "http://www.squid-cache.org/Versions/v5/SQUID-2023_3.patch";
+      hash = "sha256-ofY9snWOsfHTCZcK7HbsLD0j5nP+O0eitWU4fK/mSqA=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-50269.patch";
+      url = "http://www.squid-cache.org/Versions/v5/SQUID-2023_10.patch";
+      hash = "sha256-xa81wd2WAUboUhMpDcsj33sKoIzPF00tZDY/pw76XYQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-49285.patch";
+      url = "http://www.squid-cache.org/Versions/v5/SQUID-2023_7.patch";
+      hash = "sha256-G6DZhHCfzoIb+q+sw0a5cMF6rSvrLhT7ntp0KiiCVSA=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-46848.patch";
+      url = "http://www.squid-cache.org/Versions/v5/SQUID-2023_5.patch";
+      hash = "sha256-aduHoEqU/XKuh57y7tUDr7zIRprfC24Ifw5Ep0aboCg=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-46724.patch";
+      url = "http://www.squid-cache.org/Versions/v5/SQUID-2023_4.patch";
+      hash = "sha256-Ptt/yweUmB3lfg/o3mdBIjzpntCkRR9wDruQNYJifmE=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-46846.patch";
+      url = "http://www.squid-cache.org/Versions/v5/SQUID-2023_1.patch";
+      hash = "sha256-Tu8oJTlYleKlZPfD3rslNfkLVcB8sjp25+N/9S423+8=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
@@ -55,6 +89,12 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ raskin ];
-    knownVulnerabilities = [ "Squid has multiple unresolved security vulnerabilities, for more information see https://megamansec.github.io/Squid-Security-Audit/" ];
+    knownVulnerabilities = [
+      "GHSA-rj5h-46j6-q2g5"
+      "CVE-2023-5824"
+      "CVE-2023-46728"
+      "CVE-2023-49286"
+      "Several outstanding, unnumbered issues from https://megamansec.github.io/Squid-Security-Audit/ with unclear status"
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

_Some_ of the CVEs from https://megamansec.github.io/Squid-Security-Audit/ have been addressed with patches that are available for 5.x, so although it's not a complete fix, we should still probably apply them:

https://nvd.nist.gov/vuln/detail/CVE-2023-46847
https://nvd.nist.gov/vuln/detail/CVE-2023-50269
https://nvd.nist.gov/vuln/detail/CVE-2023-49285
https://nvd.nist.gov/vuln/detail/CVE-2023-46848
https://nvd.nist.gov/vuln/detail/CVE-2023-46724
https://nvd.nist.gov/vuln/detail/CVE-2023-46846

Also change `knownVulnerabilities` to explicitly name those CVEs we know aren't addressed in this version. There are still some issues mentioned in https://megamansec.github.io/Squid-Security-Audit/ that are un-numbered (or mis-numbered) where the status is unclear.

I wonder if we should backport the bump in #273464 as `squid_6`? cc @wahjava 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
