### PR TITLE
renode-unstable: init at 1.14.0+20231229gita76dac0ae, renode: init at 1.14.0

### DIFF
--- a/pkgs/by-name/re/renode-unstable/package.nix
+++ b/pkgs/by-name/re/renode-unstable/package.nix
@@ -1,0 +1,16 @@
+{ renode
+, fetchurl
+, buildUnstable ? true
+}:
+
+(renode.override {
+  inherit buildUnstable;
+}).overrideAttrs (finalAttrs: _: {
+  pname = "renode-unstable";
+  version = "1.14.0+20231229gita76dac0ae";
+
+  src = fetchurl {
+    url = "https://builds.renode.io/renode-${finalAttrs.version}.linux-portable.tar.gz";
+    hash = "sha256-fvwNN3sT8VZ7XJPrfpAbjSiuAB274QhuPeekwz0AU3c=";
+  };
+})

--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -1,0 +1,103 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, writeScript
+, glibcLocales
+, python3Packages
+, gtk-sharp-2_0
+, gtk2-x11
+, screen
+, buildUnstable ? false
+}:
+
+let
+  pythonLibs = with python3Packages; makePythonPath [
+    construct
+    psutil
+    pyyaml
+    requests
+    robotframework
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "renode";
+  version = "1.14.0";
+
+  src = fetchurl {
+    url = "https://builds.renode.io/renode-${finalAttrs.version}.linux-portable.tar.gz";
+    hash = "sha256-1wfVHtCYc99ACz8m2XEg1R0nIDh9xP4ffV/vxeeEHxE=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = [
+    gtk2-x11
+    gtk-sharp-2_0
+    screen
+  ];
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,libexec/renode}
+
+    mv * $out/libexec/renode
+    mv .renode-root $out/libexec/renode
+    chmod +x $out/libexec/renode/*.so
+
+    makeWrapper "$out/libexec/renode/renode" "$out/bin/renode" \
+      --prefix PATH : "$out/libexec/renode" \
+      --suffix LD_LIBRARY_PATH : "${gtk2-x11}/lib" \
+      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+
+    makeWrapper "$out/libexec/renode/renode-test" "$out/bin/renode-test" \
+      --prefix PATH : "$out/libexec/renode" \
+      --prefix PYTHONPATH : "${pythonLibs}" \
+      --suffix LD_LIBRARY_PATH : "${gtk2-x11}/lib" \
+      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+
+    substituteInPlace "$out/libexec/renode/renode-test" \
+      --replace '$PYTHON_RUNNER' '${python3Packages.python}/bin/python3'
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript =
+    let
+      versionRegex =
+        if buildUnstable
+        then "[0-9\.\+]+[^\+]*."
+        else "[0-9\.]+[^\+]*.";
+    in
+    writeScript "${finalAttrs.pname}-updater" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts curl gnugrep gnused pup
+
+      latestVersion=$(
+        curl -sS https://builds.renode.io \
+          | pup 'a text{}' \
+          | egrep 'renode-${versionRegex}\.linux-portable\.tar\.gz' \
+          | head -n1 \
+          | sed -e 's,renode-\(.*\)\.linux-portable\.tar\.gz,\1,g'
+      )
+
+      update-source-version ${finalAttrs.pname} "$latestVersion" \
+        --file=pkgs/by-name/re/${finalAttrs.pname}/package.nix \
+        --system=x86_64-linux
+    '';
+
+  meta = {
+    description = "Virtual development framework for complex embedded systems";
+    homepage = "https://renode.org";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ otavio ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

### What is Renode?

Renode is a virtual development tool created by Antmicro for multi-node embedded networks (wired and wireless). Its purpose is to enable a scalable workflow for creating effective, tested, and secure IoT systems. Renode makes it fast, cost-effective, and reliable to develop, test, debug, and simulate unmodified software for IoT devices.

Supported architectures include:

- ARMv7 and ARMv8 Cortex-A, Cortex-R and Cortex-M
- x86
- RISC-V
- SPARC
- POWER
- Xtensa

The derivations are based on previous work done by @katyo and @thoughtpolice. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc