### PR TITLE
python311Packages.scikit-build-core: 0.5.1 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -16,24 +16,24 @@
 , pytestCheckHook
 , setuptools
 , tomli
+, virtualenv
 , wheel
 }:
 
 buildPythonPackage rec {
   pname = "scikit-build-core";
-  version = "0.5.1";
-  format = "pyproject";
+  version = "0.7.0";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "scikit_build_core";
     inherit version;
-    hash = "sha256-xtrVpRJ7Kr+qI8uR0jrCEFn9d83fcSKzP9B3kQJNz78=";
+    hash = "sha256-hffyRpxWjGzjWrL6Uv4tJqBODeUH06JMGrtyg3Vlf9M=";
   };
 
-  postPatch = ''
+  postPatch = lib.optionalString (pythonOlder "3.11") ''
     substituteInPlace pyproject.toml \
-      --replace 'minversion = "7.2"' "" \
-      --replace '"error",' '"error", "ignore::DeprecationWarning", "ignore::UserWarning",'
+      --replace '"error",' '"error", "ignore::UserWarning",'
   '';
 
   nativeBuildInputs = [
@@ -65,6 +65,7 @@ buildPythonPackage rec {
     pytest-subprocess
     pytestCheckHook
     setuptools
+    virtualenv
     wheel
   ] ++ passthru.optional-dependencies.pyproject;
 
@@ -76,6 +77,8 @@ buildPythonPackage rec {
     "tests/test_pyproject_pep660.py"
     "tests/test_setuptools_pep517.py"
     "tests/test_setuptools_pep518.py"
+    # store permissions issue in Nix:
+    "tests/test_editable.py"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Description of changes

Routine update.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
