### PR TITLE
elf-dissector: unstable-2023-06-06 -> unstable-2023-12-24

### DIFF
--- a/pkgs/applications/misc/elf-dissector/default.nix
+++ b/pkgs/applications/misc/elf-dissector/default.nix
@@ -1,24 +1,26 @@
 { lib
 , stdenv
-, fetchgit
+, fetchFromGitLab
 , cmake
+, elfutils
 , extra-cmake-modules
-, wrapQtAppsHook
 , kitemmodels
 , libiberty
-, libelf
 , libdwarf
 , libopcodes
+, wrapQtAppsHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "elf-dissector";
-  version = "unstable-2023-06-06";
+  version = "unstable-2023-12-24";
 
-  src = fetchgit {
-    url = "https://invent.kde.org/sdk/elf-dissector.git";
-    rev = "de2e80438176b4b513150805238f3333f660718c";
-    hash = "sha256-2yHPVPu6cncXhFCJvrSodcRFVAxj4vn+e99WhtiZniM=";
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "sdk";
+    repo = "elf-dissector";
+    rev = "613538bd1d87ce72d5115646551a49cf7ff2ee34";
+    hash = "sha256-fQFGFw8nZHMs8J1W2CcHAJCdcvaY2l2/CySyBSsKpyE=";
   };
 
   patches = [
@@ -27,12 +29,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
 
-  buildInputs = [ kitemmodels libiberty libelf libdwarf libopcodes ];
+  buildInputs = [ kitemmodels libiberty elfutils libopcodes libdwarf ];
 
   meta = with lib; {
     homepage = "https://invent.kde.org/sdk/elf-dissector";
     description = "Tools for inspecting, analyzing and optimizing ELF files";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ehmry ];
+    maintainers = with maintainers; [ ehmry philiptaron ];
   };
 }

--- a/pkgs/applications/misc/elf-dissector/fix_build_for_src_lib_disassembler_disassembler.diff
+++ b/pkgs/applications/misc/elf-dissector/fix_build_for_src_lib_disassembler_disassembler.diff
@@ -1,12 +1,16 @@
 diff --git a/src/lib/disassmbler/disassembler.cpp b/src/lib/disassmbler/disassembler.cpp
-index 3277544..e77ffc4 100644
+index 8ff058e..dbd4bbe 100644
 --- a/src/lib/disassmbler/disassembler.cpp
 +++ b/src/lib/disassmbler/disassembler.cpp
-@@ -127,7 +127,7 @@ QString Disassembler::disassembleBinutils(const unsigned char* data, uint64_t si
+@@ -144,11 +144,7 @@ QString Disassembler::disassembleBinutils(const unsigned char* data, uint64_t si
      QString result;
      disassembler_ftype disassemble_fn;
      disassemble_info info;
+-#if BINUTILS_VERSION >= BINUTILS_VERSION_CHECK(2, 39)
+-    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf, fprintf_styled);
+-#else
 -    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf);
+-#endif
 +    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf, qstring_printf);
  
      info.application_data = this;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31334,9 +31334,7 @@ with pkgs;
 
   electrum-ltc = libsForQt5.callPackage ../applications/misc/electrum/ltc.nix { };
 
-  elf-dissector = libsForQt5.callPackage ../applications/misc/elf-dissector {
-    libdwarf = libdwarf_20210528;
-  };
+  elf-dissector = libsForQt5.callPackage ../applications/misc/elf-dissector { };
 
   elfx86exts = callPackage ../applications/misc/elfx86exts { };
 


### PR DESCRIPTION
## Description of changes

The upstream made it possible to compile without libdwarf in https://invent.kde.org/sdk/elf-dissector/-/commit/7af9205a46fabce32b228e65e5416d32dd7e599c.

Part of #271473, to move dependencies from unmaintained libelf to elfutils.

I made myself a maintainer as a result of my interest in this file format, and removed the do-nothing `rec`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
