### PR TITLE
ocrodjvu: init at 0.13.2

### DIFF
--- a/pkgs/by-name/oc/ocrodjvu/package.nix
+++ b/pkgs/by-name/oc/ocrodjvu/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  djvulibre,
+  docbook-xsl-ns,
+  glibcLocales,
+  libxml2,
+  libxml2Python,
+  libxslt,
+  pkg-config,
+  tesseract5,
+  withCuneiform ? false,
+  cuneiform,
+  withGocr ? false,
+  gocr,
+  withOcrad ? false,
+  ocrad,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ocrodjvu";
+  version = "0.13.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "FriedrichFroebel";
+    repo = "ocrodjvu";
+    rev = version;
+    hash = "sha256-EiMCrRFUAJbu9QLgKpFIKqigCZ77lpTDD6AvZuMbyhA=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  propagatedBuildInputs =
+    [
+    ]
+    ++ lib.optional withCuneiform cuneiform
+    ++ lib.optional withGocr gocr
+    ++ lib.optional withOcrad ocrad;
+
+  dependencies = with python3Packages; [
+    lxml
+    python-djvulibre
+    pyicu
+    html5lib
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.unittestCheckHook
+    python3Packages.pillow
+    djvulibre
+    glibcLocales
+    libxml2
+    libxml2Python
+    tesseract5
+  ];
+
+  unittestFlagsArray = [
+    "tests"
+    "-v"
+  ];
+
+  meta = with lib; {
+    description = "Wrapper for OCR systems that allows you to perform OCR on DjVu files";
+    homepage = "https://github.com/FriedrichFroebel/ocrodjvu";
+    changelog = "https://github.com/FriedrichFroebel/ocrodjvu/blob/${version}/doc/changelog";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dansbandit ];
+    mainProgram = "ocrodjvu";
+  };
+}


### PR DESCRIPTION
## Description of changes

ocrodjvu is a wrapper for OCR systems that allows you to perform OCR on [DjVu](http://djvu.org/) files.
https://github.com/FriedrichFroebel/ocrodjvu

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc