### PR TITLE
mfcl5750dw: init at 3.5.1-1

### DIFF
--- a/pkgs/by-name/mf/mfcl5750dw/fix-perm.patch
+++ b/pkgs/by-name/mf/mfcl5750dw/fix-perm.patch
@@ -1,0 +1,10 @@
+--- a/opt/brother/Printers/MFCL5750DW/cupswrapper/lpdwrapper	2020-01-29 08:26:18.000000000 +0100
++++ b/opt/brother/Printers/MFCL5750DW/cupswrapper/lpdwrapper	2023-12-29 14:12:44.522567053 +0100
+@@ -383,6 +383,7 @@
+ close $temprch;
+ 
+ `cp  $basedir/inf/br${PRINTER}rc  $TEMPRC`;
++`chmod 666 $TEMPRC`;
+ $ENV{BRPRINTERRCFILE} = $TEMPRC;
+ 
+ logprint( 0 , "TEMPRC    = $TEMPRC\n");

--- a/pkgs/by-name/mf/mfcl5750dw/package.nix
+++ b/pkgs/by-name/mf/mfcl5750dw/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  perl,
+  gnused,
+  ghostscript,
+  file,
+  coreutils,
+  gnugrep,
+  which,
+}:
+
+let
+  arches = [
+    "x86_64"
+    "i686"
+    "armv7l"
+  ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mfcl5750dw";
+  version = "3.5.1-1";
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [ perl ];
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf102614/mfcl5750dwcupswrapper-${finalAttrs.version}.i386.deb";
+    sha256 = "afe6d18e17d26348f3b8a4f9a003107984940c429a7dd193054303a21f5e65b5";
+  };
+
+  lpr_src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf102613/mfcl5750dwlpr-${finalAttrs.version}.i386.deb";
+    sha256 = "b1b9c1f9ae8522a65fdd2db1e760aed835807ba593d001ac5471635a157cd1f1";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+    dpkg-deb -x $lpr_src .
+  '';
+
+  patches = [
+    # The brother lpdwrapper uses a temporary file to convey the printer settings.
+    # The original settings file will be copied with "400" permissions and the "brprintconflsr3"
+    # binary cannot alter the temporary file later on. This fixes the permissions so the can be modified.
+    # Since this is all in briefly in the temporary directory of systemd-cups and not accessible by others,
+    # it shouldn't be a security concern.
+    ./fix-perm.patch
+  ];
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p $out
+      cp -ar opt $out/opt
+
+      # delete unnecessary files for the current architecture
+    ''
+    + lib.concatMapStrings (arch: ''
+      echo Deleting files for ${arch}
+      rm -r "$out/opt/brother/Printers/MFCL5750DW/lpd/${arch}"
+    '') (builtins.filter (arch: arch != stdenvNoCC.hostPlatform.linuxArch) arches)
+    + ''
+      # bundled scripts don't understand the arch subdirectories for some reason
+      ln -s \
+        "$out/opt/brother/Printers/MFCL5750DW/lpd/${stdenvNoCC.hostPlatform.linuxArch}/"* \
+        "$out/opt/brother/Printers/MFCL5750DW/lpd/"
+
+      # Fix global references and replace auto discovery mechanism with hardcoded values
+      substituteInPlace $out/opt/brother/Printers/MFCL5750DW/lpd/lpdfilter \
+        --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/MFCL5750DW\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"MFCL5750DW\"; #"
+
+      substituteInPlace $out/opt/brother/Printers/MFCL5750DW/cupswrapper/lpdwrapper \
+      --replace "my \$basedir = C" "my \$basedir = \"$out/opt/brother/Printers/MFCL5750DW\" ; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL5750DW\"; #"
+
+      # Make sure all executables have the necessary runtime dependencies available
+      find "$out" -executable -and -type f | while read file; do
+        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+      done
+      # Symlink filter and ppd into a location where CUPS will discover it
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+      mkdir -p $out/etc/opt/brother/Printers/MFCL5750DW/inf
+      ln -s $out/opt/brother/Printers/MFCL5750DW/inf/brMFCL5750DWrc \
+      $out/etc/opt/brother/Printers/MFCL5750DW/inf/brMFCL5750DWrc
+      ln -s \
+      $out/opt/brother/Printers/MFCL5750DW/cupswrapper/lpdwrapper \
+      $out/lib/cups/filter/brother_lpdwrapper_MFCL5750DW
+      ln -s \
+      $out/opt/brother/Printers/MFCL5750DW/cupswrapper/brother-MFCL5750DW-cups-en.ppd \
+      $out/share/cups/model/
+      runHook postInstall
+    '';
+  meta = {
+    homepage = "https://www.brother.com/";
+    description = "Brother MFCL5750DW CUPS driver";
+    license = lib.licenses.unfree;
+    platforms = builtins.map (arch: "${arch}-linux") arches;
+    maintainers = with lib.maintainers; [ qdlmcfresh ];
+  };
+})


### PR DESCRIPTION
Add CUPS driver for Brother MFC-L5750DW printer

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
