### PR TITLE
libminc: 2.4.05 -> 2.4.06

### DIFF
--- a/pkgs/development/libraries/libminc/default.nix
+++ b/pkgs/development/libraries/libminc/default.nix
@@ -1,16 +1,14 @@
 { lib, stdenv, fetchFromGitHub, cmake, zlib, netcdf, nifticlib, hdf5 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname   = "libminc";
-  version = "2.4.05";
-
-  owner = "BIC-MNI";
+  version = "2.4.06";
 
   src = fetchFromGitHub {
-    inherit owner;
-    repo   = pname;
-    rev    = "aa08255f0856e70fb001c5f9ee1f4e5a8c12d47d";  # new release, but no git tag
-    sha256 = "XMTO6/HkyrrQ0s5DzJLCmmWheye2DGMnpDbcGdP6J+A=";
+    owner = "BIC-MNI";
+    repo = "libminc";
+    rev = "refs/tags/release-${finalAttrs.version}";
+    hash = "sha256-HTt3y0AFM9pkEkWPb9cDmvUz4iBQWfpX7wLF9Vlg8hc=";
   };
 
   postPatch = ''
@@ -18,8 +16,14 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ zlib nifticlib ];
-  propagatedBuildInputs = [ netcdf hdf5 ];
+  buildInputs = [
+    zlib
+    nifticlib
+  ];
+  propagatedBuildInputs = [
+    netcdf
+    hdf5
+  ];
 
   cmakeFlags = [
     "-DLIBMINC_MINC1_SUPPORT=ON"
@@ -41,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.free;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Routine update.

The dependency tree is now too large for `nixpkgs-review` to build on my laptop but all the direct dependencies build fine.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
