### PR TITLE
frequest: init at 1.2a

### DIFF
--- a/pkgs/by-name/fr/frequest/package.nix
+++ b/pkgs/by-name/fr/frequest/package.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchFromGitHub, qt5 }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "frequest";
+  version = "1.2a";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "fabiobento512";
+      name = "frequest";
+      repo = "FRequest";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-fdn3MK5GWBOhJjpMtRaytO9EsVzz6KJknDhqWtAyXCc=";
+    })
+    # The application depends on hard-coded relative paths to ../CommonLibs and ../CommonUtils.
+    # See https://github.com/fabiobento512/FRequest/wiki/Building-FRequest for more info.
+    # Upstream provides no tags for these dependencies, use latest commit on their `master` branch.
+    # Changing the name of these srcs will break the build.
+    (fetchFromGitHub {
+      owner = "fabiobento512";
+      name = "CommonLibs";
+      repo = "CommonLibs";
+      rev = "d3906931bb06ddf4194ff711a59e1dcff80fa82f";
+      hash = "sha256-iLJJ95yJ+VjNPuk8fNEDvYBI0db0rcfJF12a9azGv1Y=";
+    })
+    (fetchFromGitHub {
+      owner = "fabiobento512";
+      name = "CommonUtils";
+      repo = "CommonUtils";
+      rev = "53970984f6538d78350be1b9426032bcb5bcf818";
+      hash = "sha256-nRv9DriSOuAiWhy+KkOVNEz5oSgNNNJZqk8sNwgbx8U=";
+    })
+  ];
+  sourceRoot = "frequest";
+
+  buildInputs = [
+    qt5.qtbase
+  ];
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    qt5.qmake
+  ];
+
+  # Without this, nothing gets installed in $out.
+  postInstall = ''
+    install -D FRequest $out/bin/FRequest
+    install -D LinuxAppImageDeployment/frequest.desktop $out/share/applications/frequest.desktop
+    install -D LinuxAppImageDeployment/frequest_icon.png $out/share/icons/hicolor/128x128/apps/frequest_icon.png
+  '';
+
+  meta = {
+    description = "A fast, lightweight and opensource desktop application to make HTTP(s) requests";
+    homepage = "https://fabiobento512.github.io/FRequest";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ eliandoran ];
+    platforms = lib.platforms.linux;
+    mainProgram = "frequest";
+  };
+})


### PR DESCRIPTION
## Description of changes

>A fast, lightweight and opensource desktop application to make HTTP(s) requests 

Official website: [fabiobento512.github.io/FRequest](https://fabiobento512.github.io/FRequest)

Upstream repo: https://github.com/fabiobento512/FRequest

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
