### PR TITLE
fontconfig: Port to Meson

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch2
 , pkg-config
 , python3
 , freetype
@@ -15,24 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "fontconfig";
-  version = "2.14.2";
+  version = "2.15.0";
 
   outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/fontconfig/release/${pname}-${version}.tar.xz";
-    hash = "sha256-26aVtXvOFQI9LO7e+CBiwrkl5R9dTMSu9zbPE/YKRos=";
+    hash = "sha256-Y6BljQ4G4PqIYQZFK1jvBPIfWCAuoCqUw53g0zNdfA4=";
   };
-
-  patches = [
-    # Provide 11-lcdfilter-none.conf for NixOS module
-    # https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/268
-    (fetchpatch2 {
-      name = "add-optional-11-lcdfilter-none-configuration.patch";
-      url = "https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/c2666a6d9a6ed18b1bfcef8176e25f62993e24db.patch";
-      hash = "sha256-UBzkxy3uxFO+g0aQtPnBZv7OncgQdinwzNwWS8ngjcE=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -1,14 +1,21 @@
 { stdenv
 , lib
 , fetchurl
+, fetchpatch
 , pkg-config
 , python3
 , freetype
 , expat
 , libxslt
+, gettext
+, docbook-xsl-nons
+, fop
+, withPdf ? false
+, docbook_xml_dtd_45
 , gperf
 , dejavu_fonts
-, autoreconfHook
+, meson
+, ninja
 , CoreFoundation
 }:
 
@@ -23,12 +30,27 @@ stdenv.mkDerivation rec {
     hash = "sha256-Y6BljQ4G4PqIYQZFK1jvBPIfWCAuoCqUw53g0zNdfA4=";
   };
 
+  patches = [
+    # TODO: wait until it is merged.
+    # https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/304
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/304.patch";
+      hash = "";
+    })
+  ];
+
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    ninja
+    gettext
+    docbook-xsl-nons
+    docbook_xml_dtd_45
     gperf
     libxslt
     pkg-config
     python3
+  ] ++ lib.optionals withPdf [
+    fop
   ];
 
   buildInputs = [
@@ -39,33 +61,39 @@ stdenv.mkDerivation rec {
     freetype
   ];
 
-  postPatch = ''
-    # Requires networking.
-    sed -i '/check_PROGRAMS += test-crbug1004254/d' test/Makefile.am
-  '';
-
-  configureFlags = [
+  mesonFlags = [
+    # otherwise the fallback is in $out/
     "--sysconfdir=/etc"
-    "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
-    "--with-cache-dir=/var/cache/fontconfig" # otherwise the fallback is in $out/
+    "--localstatedir=/var"
     # just <1MB; this is what you get when loading config fails for some reason
-    "--with-default-fonts=${dejavu_fonts.minimal}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-Ddefault-fonts-dirs=${dejavu_fonts.minimal}"
+    (lib.mesonEnable "doc-pdf" withPdf)
   ];
-
-  enableParallelBuilding = true;
 
   doCheck = true;
 
-  installFlags = [
-    # Don't try to write to /var/cache/fontconfig at install time.
-    "fc_cachedir=$(TMPDIR)/dummy"
-    "RUN_FC_CACHE_TEST=false"
-    "sysconfdir=${placeholder "out"}/etc"
-  ];
+  postPatch = ''
+    patchShebangs \
+      conf.d/write-35-lang-normalize-conf.py \
+      doc/edit-xml.py \
+      doc/extract-man-list.py \
+      doc/run-quiet.py \
+      fc-case/fc-case.py \
+      fc-lang/fc-lang.py
+  '';
 
   postInstall = ''
+    # Move stuff from DESTDIR to proper location.
+    for o in $(getAllOutputNames); do
+        mv "$DESTDIR''${!o}" "$(dirname "''${!o}")"
+    done
+
+    mv "$DESTDIR/etc" "$out"
+
+    # Ensure we did not forget to install anything.
+    rmdir --parents --ignore-fail-on-non-empty "$DESTDIR${builtins.storeDir}"
+    ! test -e "$DESTDIR"
+
     cd "$out/etc/fonts"
     xsltproc --stringparam fontDirectories "${dejavu_fonts.minimal}" \
       --path $out/share/xml/fontconfig \
@@ -76,6 +104,16 @@ stdenv.mkDerivation rec {
     # probably not so useful.
     rm -r $bin/share/man/man3
   '';
+
+  env = {
+    # HACK: We want to install configuration files to $out/etc
+    # but fontconfig should read them from /etc on a NixOS system.
+    # With autotools, it was possible to override Make variables
+    # at install time but Meson does not support this
+    # so we need to convince it to install all files to a temporary
+    # location using DESTDIR and then move it to proper one in postInstall.
+    DESTDIR = "dest";
+  };
 
   meta = with lib; {
     description = "A library for font customization and configuration";


### PR DESCRIPTION
## Description of changes

Depends on https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/304
Depends on https://github.com/NixOS/nixpkgs/pull/277627

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
