### PR TITLE
msfpc: init at unstable-2021-01-07

### DIFF
--- a/pkgs/by-name/ms/msfpc/package.nix
+++ b/pkgs/by-name/ms/msfpc/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, metasploit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "msfpc";
+  version = "unstable-2021-01-07";
+
+  src = fetchFromGitHub {
+    owner = "g0tmi1k";
+    repo = "msfpc";
+    rev = "8007ef2142e43dc5e97edf84f40ac012f94a3e8f";
+    hash = "sha256-/FNhQcjIEIzB+wRKF2e3eYEnuVrl0egBZvjZidCwvHg=";
+  };
+
+  postPatch = ''
+    patchShebangs msfpc.sh
+  '';
+
+  buildInputs = [ metasploit ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    chmod +x msfpc.sh
+    cp msfpc.sh $out/bin/${pname}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/g0tmi1k/msfpc";
+    description = "A wrapper to generate multiple types of payloads";
+    maintainers = with maintainers; [ d3vil0p3r ];
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.mit;
+    mainProgram = "msfpc";
+  };
+}


### PR DESCRIPTION
To be added in https://github.com/NixOS/nixpkgs/issues/81418

Waiting for approval of being added as maintainer: https://github.com/NixOS/nixpkgs/pull/276997/files#diff-c1fcec3afa1da96245de1d7954ca721c979a5f25aee0e8b59d59d3d21e31f8fa

If possible, please backport to stable (23.11).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
