### PR TITLE
ayatana-indicator-datetime: init at 23.10.1

### DIFF
--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -27,6 +27,7 @@ in {
     services.ayatana-indicators = {
       enable = true;
       packages = with pkgs; [
+        ayatana-indicator-datetime
         ayatana-indicator-messages
       ] ++ (with pkgs.lomiri; [
         lomiri-indicator-network
@@ -69,7 +70,7 @@ in {
 
     # Now check if all indicators were brought up successfully, and kill them for later
   '' + (runCommandOverAyatanaIndicators (service: let serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service; in ''
-    machine.succeed("pgrep -f ${serviceExec}")
+    machine.succeed("pgrep -u ${user} -f ${serviceExec}")
     machine.succeed("pkill -f ${serviceExec}")
   '')) + ''
 

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , gitUpdater
 , nixosTests
 , ayatana-indicator-messages
@@ -28,14 +29,31 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ayatana-indicator-datetime";
-  version = "23.10.0";
+  version = "23.10.1";
 
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "ayatana-indicator-datetime";
-    rev = finalAttrs.version;
-    hash = "sha256-Ba7Csk7HzhmXzzm4SiwTXHBDKc42wIKX+MHDRpHgK+w=";
+    # Release wasn't tagged?
+    # https://github.com/AyatanaIndicators/ayatana-indicator-datetime/issues/121
+    rev = "d8debd706fe92de09e5c654c4ea2cc5dd5ce0529";
+    hash = "sha256-cm1zhG9TODGe79n/fGuyVnWL/sjxUc3ZCu9FhqA1NLE=";
   };
+
+  patches = [
+    # Fix test-menus building & running
+    # Remove when https://github.com/AyatanaIndicators/ayatana-indicator-datetime/pull/122 merged & in release
+    (fetchpatch {
+      name = "0001-ayatana-indicator-datetime-tests-test-menu-Fix-build.patch";
+      url = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/commit/a6527e90d855d43f43e1ff9bccda2fa22d3c60ab.patch";
+      hash = "sha256-RZY51UnrMcXbZbwyuCHSxY6toGByaObSEntVnIMz7+w=";
+    })
+    (fetchpatch {
+      name = "0002-ayatana-indicator-datetime-tests-Fix-show_alarms-tests.patch";
+      url = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/commit/5186b51c004ec25e8a44fe5918bceb3d45abb108.patch";
+      hash = "sha256-goVcpN0MNOic8mpdJdhjgS9LHQLVEZT6ZEg1PqLvmsE=";
+    })
+  ];
 
   postPatch = ''
     # Queries systemd user unit dir via pkg_get_variable, can't override prefix
@@ -124,7 +142,8 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       inherit (nixosTests) ayatana-indicators;
     };
-    updateScript = gitUpdater { };
+    # Latest release wasn't tagged, Don't try to bump down
+    #updateScript = gitUpdater { };
   };
 
   meta = with lib; {
@@ -134,7 +153,9 @@ stdenv.mkDerivation (finalAttrs: {
       event management tool.
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime";
-    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/blob/${finalAttrs.version}/ChangeLog";
+    # Latest release wasn't tagged
+    # changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/blob/${finalAttrs.version}/ChangeLog";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/blob/${finalAttrs.finalPackage.src.rev}/ChangeLog";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.linux;

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -1,0 +1,142 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, nixosTests
+, ayatana-indicator-messages
+, cmake
+, dbus
+, dbus-test-runner
+, evolution-data-server
+, glib
+, gst_all_1
+, gtest
+, intltool
+, libaccounts-glib
+, libayatana-common
+, libical
+, libnotify
+, libuuid
+, lomiri
+, pkg-config
+, properties-cpp
+, python3
+, systemd
+, tzdata
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-datetime";
+  version = "23.10.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-datetime";
+    rev = finalAttrs.version;
+    hash = "sha256-Ba7Csk7HzhmXzzm4SiwTXHBDKc42wIKX+MHDRpHgK+w=";
+  };
+
+  postPatch = ''
+    # Queries systemd user unit dir via pkg_get_variable, can't override prefix
+    substituteInPlace data/CMakeLists.txt \
+      --replace 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_DIR ''${CMAKE_INSTALL_PREFIX}/lib/systemd/user)' \
+      --replace '/etc' "\''${CMAKE_INSTALL_SYSCONFDIR}"
+
+    # Looking for Lomiri schemas for code generation
+    substituteInPlace src/CMakeLists.txt \
+      --replace '/usr/share/accountsservice' '${lomiri.lomiri-schemas}/share/accountsservice'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # for schema hook
+    intltool
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    ayatana-indicator-messages
+    evolution-data-server
+    glib
+    libaccounts-glib
+    libayatana-common
+    libical
+    libnotify
+    libuuid
+    properties-cpp
+    systemd
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+  ]) ++ (with lomiri; [
+    cmake-extras
+    lomiri-schemas
+    lomiri-sounds
+    lomiri-url-dispatcher
+  ]);
+
+  nativeCheckInputs = [
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+    tzdata
+  ];
+
+  checkInputs = [
+    dbus-test-runner
+    gtest
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+    (lib.cmakeBool "ENABLE_LOMIRI_FEATURES" true)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
+      # Exclude tests
+      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
+        # evolution-data-server tests have been silently failing on upstream CI for awhile,
+        # 23.10.0 release has fixed the silentness but left the tests broken.
+        # https://github.com/AyatanaIndicators/ayatana-indicator-datetime/commit/3e65062b5bb0957b5bb683ff04cb658d9d530477
+        "^test-eds-ics"
+      ]})")
+    ]))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export XDG_DATA_DIRS=${glib.passthru.getSchemaDataDirPath libayatana-common}
+  '';
+
+  passthru = {
+    ayatana-indicators = [
+      "ayatana-indicator-datetime"
+    ];
+    tests = {
+      inherit (nixosTests) ayatana-indicators;
+    };
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana Indicator providing clock and calendar";
+    longDescription = ''
+      This Ayatana Indicator provides a combined calendar, clock, alarm and
+      event management tool.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards https://github.com/NixOS/nixpkgs/issues/99090.

[`ayatana-indicator-datetime`](https://github.com/AyatanaIndicators/ayatana-indicator-datetime), an indicator interface for date & time information.

Not sure about 23.10.1 yet, seems abit messy. Might revert to 23.10.0 if any issues arise with it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
