### PR TITLE
ibus-engines.cangjie: init at unstable-2023-07-25

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-cangjie/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-cangjie/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gettext
+, pkg-config
+, wrapGAppsHook
+, ibus
+, glib
+, gobject-introspection
+, gtk3
+, python3
+, autoreconfHook
+, intltool
+}:
+
+let
+  pythonModules = with python3.pkgs; [
+    pygobject3
+    pycangjie
+    (toPythonModule ibus)
+  ];
+
+  # Upstream builds Python packages as a part of a non-python
+  # autotools build, making it awkward to rely on Nixpkgs Python builders.
+  # Hence we manually set up PYTHONPATH.
+  pythonPath = "$out/${python3.sitePackages}" + ":" + python3.pkgs.makePythonPath pythonModules;
+
+in
+stdenv.mkDerivation {
+  pname = "ibus-cangjie";
+  version = "unstable-2023-07-25";
+
+  src = fetchFromGitHub {
+    owner = "Cangjians";
+    repo = "ibus-cangjie";
+    rev = "46c36f578047bb3cb2ce777217abf528649bc58d";
+    sha256 = "sha256-msVqWougc40bVXIonJA6K/VgurnDeR2TdtGKfd9rzwM=";
+  };
+
+  buildInputs = [
+    glib
+    gtk3
+    ibus
+    python3
+  ] ++ pythonModules;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    intltool
+    gettext
+    gobject-introspection
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  # Upstream builds Python packages as a part of a non-python
+  # autotools build, making it awkward to rely on Nixpkgs Python builders.
+  postInstall = ''
+    gappsWrapperArgs+=(--prefix PYTHONPATH : "${pythonPath}")
+  '';
+
+  postFixup = ''
+    wrapGApp $out/lib/ibus-cangjie/ibus-engine-cangjie
+  '';
+
+  meta = {
+    isIbusEngine = true;
+    description = "An IBus engine for users of the Cangjie and Quick input methods";
+    homepage = "https://github.com/Cangjians/ibus-cangjie";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ adisbladis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7090,6 +7090,8 @@ with pkgs;
 
     bamboo = callPackage ../tools/inputmethods/ibus-engines/ibus-bamboo { };
 
+    cangjie = callPackage ../tools/inputmethods/ibus-engines/ibus-cangjie { };
+
     hangul = callPackage ../tools/inputmethods/ibus-engines/ibus-hangul { };
 
     kkc = callPackage ../tools/inputmethods/ibus-engines/ibus-kkc { };


### PR DESCRIPTION
## Description of changes

Adding an IBus engine for users of the Cangjie and Quick input methods

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


cc libcangjie maintainer @linquize
cc ibus maintainers @yanalunaterra @ttuegel 