### PR TITLE
libserdes: 6.2.0 -> 7.5.3

### DIFF
--- a/pkgs/development/libraries/libserdes/default.nix
+++ b/pkgs/development/libraries/libserdes/default.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation rec {
     chmod -x ''${!outputInclude}/include/libserdes/*.h
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "A schema-based serializer/deserializer C/C++ library with support for Avro and the Confluent Platform Schema Registry";
     homepage = "https://github.com/confluentinc/libserdes";

--- a/pkgs/development/libraries/libserdes/default.nix
+++ b/pkgs/development/libraries/libserdes/default.nix
@@ -1,41 +1,34 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , perl
+, which
 , boost
 , rdkafka
 , jansson
 , curl
 , avro-c
-, avro-cpp }:
+, avro-cpp
+, nix-update-script }:
 
 stdenv.mkDerivation rec {
   pname = "libserdes";
-  version = "6.2.0";
+  version = "7.5.3";
 
   src = fetchFromGitHub {
     owner = "confluentinc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "194ras18xw5fcnjgg1isnb24ydx9040ndciniwcbdb7w7wd901gc";
+    hash = "sha256-rg4SWa9nIDT6JrnnCDwdiFE1cvpUn0HWHn+bPkXMHQ4=";
   };
 
   outputs = [ "dev" "out" ];
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl which ];
 
   buildInputs = [ boost rdkafka jansson curl avro-c avro-cpp ];
 
   makeFlags = [ "GEN_PKG_CONFIG=y" ];
-
-  patches = [
-    # Fix compatibility with Avro master branch
-    (fetchpatch {
-      url = "https://github.com/confluentinc/libserdes/commit/d7a355e712ab63ec77f6722fb5a9e8056e7416a2.patch";
-      sha256 = "14bdx075n4lxah63kp7phld9xqlz3pzs03yf3wbq4nmkgwac10dh";
-    })
-  ];
 
   postPatch = ''
     patchShebangs configure lds-gen.pl


### PR DESCRIPTION
## Description of changes

Hasn’t been updated in a while, so bump to latest release and add an update script for future automatic updates.

The only dependent is kcat, which builds and runs with this, but I did not try actually (de)serializing messages. That said, the [diff](https://github.com/confluentinc/libserdes/compare/v6.2.0...v7.5.3) doesn’t seem to have any big changes other than the patch, which could be removed from the derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
