### PR TITLE
teams: remove liff from maintainers

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -20,7 +20,7 @@ let
     downloadPage = "https://teams.microsoft.com/downloads";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ liff tricktron ];
+    maintainers = with maintainers; [ tricktron ];
     platforms = [ "x86_64-darwin" "aarch64-darwin" ];
     mainProgram = "teams";
   };


### PR DESCRIPTION
I was the maintainer of the Linux package, but as I don’t run macOS, I probably should not be the maintainer anymore.