### PR TITLE
vimPlugins.codeium-vim: patch to use nix's codeium

### DIFF
--- a/pkgs/by-name/co/codeium/package.nix
+++ b/pkgs/by-name/co/codeium/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, gzip, autoPatchelfHook }:
+{ stdenv, lib, fetchurl, gzip, autoPatchelfHook, darwin }:
 let
 
   inherit (stdenv.hostPlatform) system;
@@ -14,9 +14,9 @@ let
 
   hash = {
     x86_64-linux = "sha256-t+PM6ZYj/Lrho2wEiu+EUC27ApBPXyp78uoDUolov+4=";
-    aarch64-linux = "sha256-XdPsfhH4P9rWRC1+weSdRvCvCp8EETIN+QWHYIFh5w8=";
+    aarch64-linux = "";
     x86_64-darwin = "sha256-p9eDWtvxLipjcQnv35SMo9qRWJFEJN+gd+dzA/7LuHY=";
-    aarch64-darwin = "sha256-rlq5NG1nqAfrveLpH79edvTdPjlmigsjycqz99+Mb2I=";
+    aarch64-darwin = "";
   }.${system} or throwSystem;
 
   bin = "$out/bin/codeium_language_server";
@@ -33,17 +33,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ gzip ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
+  # buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+  #   CoreFoundation
+  #   CoreServices
+  # ]);
+
   dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    gzip -dc $src > ${bin}
-    chmod +x ${bin}
-    runHook postInstall
-  '';
+  # installPhase = ''
+  #   runHook preInstall
+  #   mkdir -p $out/bin
+  #   gzip -dc $src > ${bin}
+  #   chmod +x ${bin}
+  #   runHook postInstall
+  # '';
 
   passthru.updateScript = ./update.sh;
 


### PR DESCRIPTION
## Description of changes

By default, the `codeium.vim` plugin tries to download and install the `codeium` language server from the internet.
This patch injects the path to the nix `codeium` binary in the plugin code.
The same approach has already been adopted for the `codeium.nvim` plugin.

I tested this locally and it works fine !

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
