### PR TITLE
mpvScripts.buildLua: make `extraScripts` accept directories, preserve mode

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -2,7 +2,10 @@
 , stdenvNoCC }:
 
 let
-  escapedList = with lib; concatMapStringsSep " " (s: "'${escape [ "'" ] s}'");
+  # Escape strings for embedding in shell scripts
+  escaped = s: "'${lib.escape [ "'" ] s}'";
+  escapedList = lib.concatMapStringsSep " " escaped;
+
   fileName = pathStr: lib.last (lib.splitString "/" pathStr);
   scriptsDir = "$out/share/mpv/scripts";
 
@@ -56,8 +59,8 @@ lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
         mkdir -p "${scriptsDir}"
         cp -a "${scriptPath}" "${scriptsDir}/${scriptName}"
       else
-        install -m644 -Dt "${scriptsDir}" \
-          ${escapedList ([ scriptPath ] ++ extraScripts)}
+        install -m644 -Dt "${scriptsDir}" ${escaped scriptPath}
+        ${lib.optionalString (extraScripts != []) ''cp -at "${scriptsDir}/" ${escapedList extraScripts}''}
       fi
 
       runHook postInstall

--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -53,7 +53,7 @@ lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
         }
         [ ${with builtins; toString (length extraScripts)} -eq 0 ] || {
           echo "mpvScripts.buildLua does not support 'extraScripts'" \
-               "when 'scriptPath' is a directory"
+               "when 'scriptPath' is a directory" >&2
           exit 1
         }
         mkdir -p "${scriptsDir}"

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -29,7 +29,6 @@ buildLua {
   extraScripts = [ "c_concat.sh" ];
 
   postInstall = ''
-    chmod 0755 $out/share/mpv/scripts/c_concat.sh
     wrapProgram $out/share/mpv/scripts/c_concat.sh \
       --run "mkdir -p ~/.config/mpv/cutter/"
   '';

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -32,7 +32,7 @@ buildLua {
       --replace 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
   '';
 
-  postInstall = "cp -a sponsorblock_shared $out/share/mpv/scripts/";
+  extraScripts = [ "sponsorblock_shared" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];


### PR DESCRIPTION
## Description of changes

In `mpvScripts.buildLua`'s `installPhase`:
- Handle `extraScripts` separately from `scriptPath`, using `cp -a`
  this makes directories work in `extraScripts`, and preserve file modes (so executables don't need to be chmod'ed in `postInstall`)
- Output error message about `extraScripts` to stderr

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Only difference in outputs are the input hashes (based on `diff -r`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
