### PR TITLE
libgedit-amtk: 5.6.1 → 5.8.0, renamed from amtk

### DIFF
--- a/pkgs/applications/editors/gedit/default.nix
+++ b/pkgs/applications/editors/gedit/default.nix
@@ -8,18 +8,17 @@
 , gtk3
 , gtk-mac-integration
 , glib
-, amtk
 , tepl
+, libgedit-amtk
+, libgedit-gtksourceview
 , libpeas
 , libxml2
-, gtksourceview4
 , gsettings-desktop-schemas
 , wrapGAppsHook
 , gtk-doc
 , gobject-introspection
 , docbook-xsl-nons
 , ninja
-, libsoup
 , gnome
 , gspell
 , perl
@@ -30,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gedit";
-  version = "44.2";
+  version = "46.1";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${lib.versions.major version}/gedit-${version}.tar.xz";
-    sha256 = "O7sbN3XUwnfa9UqqtEsOuDpOsfCfA5GAAEHJ5WiT7BE=";
+    sha256 = "oabjfwQXZd/3InofVXi29J+q8Bax4X6GnK9b+5TGqk4=";
   };
 
   patches = [
@@ -64,15 +63,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    amtk
     tepl
     glib
     gsettings-desktop-schemas
     gspell
     gtk3
-    gtksourceview4
+    libgedit-amtk
+    libgedit-gtksourceview
     libpeas
-    libsoup
   ] ++ lib.optionals stdenv.isDarwin [
     gtk-mac-integration
   ];
@@ -96,7 +94,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Apps/Gedit";
     description = "Former GNOME text editor";
-    maintainers = [ ];
+    maintainers = with maintainers; [ bobby285271 ];
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     mainProgram = "gedit";

--- a/pkgs/applications/editors/gnome-latex/default.nix
+++ b/pkgs/applications/editors/gnome-latex/default.nix
@@ -8,10 +8,10 @@
 , wrapGAppsHook
 , gsettings-desktop-schemas
 , gspell
-, gtksourceview4
+, libgedit-amtk
+, libgedit-gtksourceview
 , libgee
 , tepl
-, amtk
 , gnome
 , glib
 , pkg-config
@@ -21,12 +21,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.44.0";
+  version = "3.46.0";
   pname = "gnome-latex";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "iL1TQL0ox+0Bx5ZqOgBzK72QJ3PfWsZZvmrRGAap50Q=";
+    sha256 = "1nVVY5sqFaiuvVTzNTVORP40MxQ648s8ynqOJvgRKto=";
   };
 
   nativeBuildInputs = [
@@ -41,12 +41,12 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    amtk
     gnome.adwaita-icon-theme
     glib
     gsettings-desktop-schemas
     gspell
-    gtksourceview4
+    libgedit-amtk
+    libgedit-gtksourceview
     libgee
     libxml2
     tepl
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Apps/GNOME-LaTeX";
     description = "A LaTeX editor for the GNOME desktop";
-    maintainers = [ maintainers.manveru ];
+    maintainers = with maintainers; [ manveru bobby285271 ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     mainProgram = "gnome-latex";

--- a/pkgs/by-name/li/libgedit-amtk/package.nix
+++ b/pkgs/by-name/li/libgedit-amtk/package.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchurl
+, fetchFromGitHub
 , glib
 , gtk3
 , meson
@@ -10,20 +10,22 @@
 , gobject-introspection
 , gtk-doc
 , docbook-xsl-nons
-, gnome
+, gitUpdater
 , dbus
 , xvfb-run
 }:
 
 stdenv.mkDerivation rec {
-  pname = "amtk";
-  version = "5.6.1";
+  pname = "libgedit-amtk";
+  version = "5.8.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1QEVuFyHKqwpaTS17nJqP6FWxvWtltJ+Dt0Kpa0XMig=";
+  src = fetchFromGitHub {
+    owner = "gedit-technology";
+    repo = "libgedit-amtk";
+    rev = version;
+    hash = "sha256-U77/KMZw9k9ukebCXVXAsCa4uJaTgw9irfZ/l0303kk=";
   };
 
   strictDeps = true;
@@ -39,7 +41,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    # Required by amtk-5.pc
+    # Required by libgedit-amtk-5.pc
     glib
     gtk3
   ];
@@ -60,15 +62,14 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  passthru.updateScript = gnome.updateScript {
-    packageName = pname;
-    versionPolicy = "none";
+  passthru.updateScript = gitUpdater {
+    odd-unstable = true;
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/Amtk";
+    homepage = "https://github.com/gedit-technology/libgedit-amtk";
     description = "Actions, Menus and Toolbars Kit for GTK applications";
-    maintainers = [ maintainers.manveru ];
+    maintainers = with maintainers; [ manveru bobby285271 ];
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/li/libgedit-gtksourceview/nix-share-path.patch
+++ b/pkgs/by-name/li/libgedit-gtksourceview/nix-share-path.patch
@@ -1,0 +1,11 @@
+--- a/gtksourceview/gtksourceutils.c
++++ b/gtksourceview/gtksourceutils.c
+@@ -232,6 +232,8 @@
+ 							 NULL));
+ 	}
+ 
++	g_ptr_array_add (dirs, g_build_filename (DATADIR, GSV_DATA_SUBDIR, basename, NULL));
++
+ 	g_ptr_array_add (dirs, NULL);
+ 
+ 	return (gchar **) g_ptr_array_free (dirs, FALSE);

--- a/pkgs/by-name/li/libgedit-gtksourceview/package.nix
+++ b/pkgs/by-name/li/libgedit-gtksourceview/package.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, docbook-xsl-nons
+, gobject-introspection
+, gtk-doc
+, meson
+, ninja
+, pkg-config
+, libxml2
+, glib
+, gtk3
+, shared-mime-info
+, gitUpdater
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libgedit-gtksourceview";
+  version = "299.0.5";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchFromGitHub {
+    owner = "gedit-technology";
+    repo = "libgedit-gtksourceview";
+    rev = finalAttrs.version;
+    hash = "sha256-PQ7cpul9h1JzywDWm9YyD95B1ONSdUUk0EQJMEGoRN0=";
+  };
+
+  patches = [
+    # By default, the library loads syntaxes from XDG_DATA_DIRS and user directory
+    # but not from its own datadr (it assumes it will be in XDG_DATA_DIRS).
+    # Since this is not generally true with Nix, let’s add $out/share unconditionally.
+    ./nix-share-path.patch
+  ];
+
+  nativeBuildInputs = [
+    docbook-xsl-nons
+    gobject-introspection
+    gtk-doc
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxml2
+  ];
+
+  propagatedBuildInputs = [
+    # Required by libgedit-gtksourceview-300.pc
+    glib
+    gtk3
+    # Used by gtk_source_language_manager_guess_language
+    shared-mime-info
+  ];
+
+  passthru.updateScript = gitUpdater {
+    odd-unstable = true;
+  };
+
+  meta = with lib; {
+    description = "Source code editing widget for GTK";
+    homepage = "https://github.com/gedit-technology/libgedit-gtksourceview";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ bobby285271 ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/development/libraries/amtk/default.nix
+++ b/pkgs/development/libraries/amtk/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, glib
 , gtk3
 , meson
 , mesonEmulatorHook
@@ -38,7 +39,9 @@ stdenv.mkDerivation rec {
     mesonEmulatorHook
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
+    # Required by amtk-5.pc
+    glib
     gtk3
   ];
 

--- a/pkgs/development/libraries/amtk/default.nix
+++ b/pkgs/development/libraries/amtk/default.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    dbus
     gobject-introspection
     gtk-doc
     docbook-xsl-nons
@@ -45,12 +44,20 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
+  nativeCheckInputs = [
+    dbus # For dbus-run-session
+  ];
+
   doCheck = stdenv.isLinux;
   checkPhase = ''
+    runHook preCheck
+
     export NO_AT_BRIDGE=1
     ${xvfb-run}/bin/xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus}/share/dbus-1/session.conf \
       meson test --print-errorlogs
+
+    runHook postCheck
   '';
 
   passthru.updateScript = gnome.updateScript {

--- a/pkgs/development/libraries/tepl/default.nix
+++ b/pkgs/development/libraries/tepl/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchurl
 , meson
 , mesonEmulatorHook
 , ninja
-, amtk
 , gnome
 , gobject-introspection
 , gtk3
-, gtksourceview4
 , icu
+, libgedit-amtk
+, libgedit-gtksourceview
 , pkg-config
 , gtk-doc
 , docbook-xsl-nons
@@ -16,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tepl";
-  version = "6.4.0";
+  version = "6.8.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "XlayBmnQzwX6HWS1jIw0LFkVgSLcUYEA0JPVnfm4cyE=";
+    sha256 = "Rubl8b/bxS5ZVvBq3VdenHaXxnPVPTgD3+do9JC1YPA=";
   };
 
   strictDeps = true;
@@ -42,9 +43,9 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    amtk
-    gtksourceview4
     gtk3
+    libgedit-amtk
+    libgedit-gtksourceview
   ];
 
   doCheck = false;
@@ -62,7 +63,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Projects/Tepl";
     description = "Text editor product line";
-    maintainers = [ maintainers.manveru ];
+    maintainers = with maintainers; [ manveru bobby285271 ];
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -67,6 +67,7 @@ mapAliases ({
   alsaPlugins = alsa-plugins; # Added 2021-06-10
   alsaTools = alsa-tools; # Added 2021-06-10
   alsaUtils = alsa-utils; # Added 2021-06-10
+  amtk = throw "amtk has been renamed to libgedit-amtk and is now maintained by Gedit Technology"; # Added 2023-12-31
   angelfish = libsForQt5.kdeGear.angelfish; # Added 2021-10-06
   ansible_2_12 = throw "Ansible 2.12 goes end of life in 2023/05 and can't be supported throughout the 23.05 release cycle"; # Added 2023-05-16
   apacheAnt_1_9 = throw "Ant 1.9 has been removed since it's not used in nixpkgs anymore"; # Added 2023-11-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18153,8 +18153,6 @@ with pkgs;
 
   h3 = h3_3;
 
-  amtk = callPackage ../development/libraries/amtk { };
-
   avrlibc      = callPackage ../development/misc/avr/libc { };
   avrlibcCross = callPackage ../development/misc/avr/libc {
     stdenv = crossLibcStdenv;


### PR DESCRIPTION
https://gitlab.gnome.org/Archive/amtk/-/commit/c836cc2801950cb006e79c1309c9e019421bca80, Unfortunately this breaks all its reverse dependencies (obviously), so this PR also bumps all of them.

Note that https://github.com/gedit-technology/libgedit-gtksourceview#about-versions suggests that 299.x.y can also be stable version as long as minor version is even.

\* *bobby285271 grabs popcorn.*


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
