### PR TITLE
nixos/acpid: refactor and add initrd support

### DIFF
--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -3,153 +3,189 @@
 with lib;
 
 let
-  cfg = config.services.acpid;
+  stage1Cfg = config.boot.initrd.services.acpid;
+  stage2Cfg = config.services.acpid;
 
-  canonicalHandlers = {
-    powerEvent = {
-      event = "button/power.*";
-      action = cfg.powerEventCommands;
-    };
-
-    lidEvent = {
-      event = "button/lid.*";
-      action = cfg.lidEventCommands;
-    };
-
-    acEvent = {
-      event = "ac_adapter.*";
-      action = cfg.acEventCommands;
-    };
-  };
-
-  acpiConfDir = pkgs.runCommand "acpi-events" { preferLocalBuild = true; }
-    ''
-      mkdir -p $out
-      ${
-        # Generate a configuration file for each event. (You can't have
-        # multiple events in one config file...)
-        let f = name: handler:
-          ''
-            fn=$out/${name}
-            echo "event=${handler.event}" > $fn
-            echo "action=${pkgs.writeShellScriptBin "${name}.sh" handler.action }/bin/${name}.sh '%e'" >> $fn
-          '';
-        in concatStringsSep "\n" (mapAttrsToList f (canonicalHandlers // cfg.handlers))
-      }
+  # Created as a single derivation for simpler use in initrd
+  mkAcpiHandlers = handlers: let
+    mkScript = name: handler: ''
+      echo ${lib.escapeShellArg handler.action} > "$out/scripts/${name}.sh"
+      chmod +x "$out/scripts/${name}.sh"
     '';
 
-in
+    mkHandler = name: handler: ''
+      echo "event=${handler.event}" > "$out/handlers/${name}"
+      echo "action=$out/scripts/${name}.sh" >> "$out/handlers/${name}"
+    '';
+  in pkgs.runCommand "acpi-events" { preferLocalBuild = true; } ''
+    mkdir -p $out/scripts
+    mkdir -p $out/handlers
+    ${concatStringsSep "\n" (mapAttrsToList mkScript handlers)}
+    ${concatStringsSep "\n" (mapAttrsToList mkHandler handlers)}
+  '';
 
-{
-
-  ###### interface
-
-  options = {
-
-    services.acpid = {
-
-      enable = mkEnableOption (lib.mdDoc "the ACPI daemon");
-
-      logEvents = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc "Log all event activity.";
+  acpiConfFor = cfg: let
+    canonicalHandlers = {
+      powerEvent = {
+        event = "button/power.*";
+        action = cfg.powerEventCommands;
       };
 
-      handlers = mkOption {
-        type = types.attrsOf (types.submodule {
-          options = {
-            event = mkOption {
-              type = types.str;
-              example = literalExpression ''"button/power.*" "button/lid.*" "ac_adapter.*" "button/mute.*" "button/volumedown.*" "cd/play.*" "cd/next.*"'';
-              description = lib.mdDoc "Event type.";
-            };
-
-            action = mkOption {
-              type = types.lines;
-              description = lib.mdDoc "Shell commands to execute when the event is triggered.";
-            };
-          };
-        });
-
-        description = lib.mdDoc ''
-          Event handlers.
-
-          ::: {.note}
-          Handler can be a single command.
-          :::
-        '';
-        default = {};
-        example = {
-          ac-power = {
-            event = "ac_adapter/*";
-            action = ''
-              vals=($1)  # space separated string to array of multiple values
-              case ''${vals[3]} in
-                  00000000)
-                      echo unplugged >> /tmp/acpi.log
-                      ;;
-                  00000001)
-                      echo plugged in >> /tmp/acpi.log
-                      ;;
-                  *)
-                      echo unknown >> /tmp/acpi.log
-                      ;;
-              esac
-            '';
-          };
-        };
+      lidEvent = {
+        event = "button/lid.*";
+        action = cfg.lidEventCommands;
       };
 
-      powerEventCommands = mkOption {
-        type = types.lines;
-        default = "";
-        description = lib.mdDoc "Shell commands to execute on a button/power.* event.";
+      acEvent = {
+        event = "ac_adapter.*";
+        action = cfg.acEventCommands;
       };
+    };
+  in mkAcpiHandlers ((lib.filterAttrs (_: handler: handler.action != "") canonicalHandlers) // cfg.handlers);
 
-      lidEventCommands = mkOption {
-        type = types.lines;
-        default = "";
-        description = lib.mdDoc "Shell commands to execute on a button/lid.* event.";
-      };
+  options = stage2: {
+    enable = mkEnableOption (lib.mdDoc "the ACPI daemon");
+    package = mkPackageOption pkgs "acpid" {};
 
-      acEventCommands = mkOption {
-        type = types.lines;
-        default = "";
-        description = lib.mdDoc "Shell commands to execute on an ac_adapter.* event.";
-      };
-
+    logEvents = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc "Log all event activity";
     };
 
+    handlers = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          event = mkOption {
+            type = types.str;
+            description = lib.mdDoc (''
+              Event type
+            '' + lib.optionalString (!stage2) ''
+
+              ::: {.note}
+              Many events will require kernel modules to be available via `boot.initrd.availableKernelModules`.
+              :::
+            '');
+
+            example = literalExpression ''
+              "button/power.*" "button/lid.*" "ac_adapter.*" "button/mute.*" "button/volumedown.*" "cd/play.*" "cd/next.*"
+            '';
+          };
+
+          action = mkOption {
+            type = types.lines;
+            description = "Shell commands to execute when the event is triggered";
+          };
+        };
+      });
+
+      description = lib.mdDoc ''
+        Event handlers
+
+        ::: {.note}
+        Handler can be a single command.
+        :::
+      '';
+
+      default = {};
+      example = {
+        ac-power = {
+          event = "ac_adapter/*";
+
+          action = ''
+            vals=($1)  # space separated string to array of multiple values
+            case ''${vals[3]} in
+              00000000)
+                echo unplugged >> /tmp/acpi.log
+                ;;
+              00000001)
+                echo plugged in >> /tmp/acpi.log
+                ;;
+              *)
+                echo unknown >> /tmp/acpi.log
+                ;;
+            esac
+          '';
+        };
+      };
+    };
+
+    powerEventCommands = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Shell commands to execute on a button/power.* event";
+    };
+
+    lidEventCommands = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Shell commands to execute on a button/lid.* event";
+    };
+
+    acEventCommands = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Shell commands to execute on an ac_adapter.* event";
+    };
   };
 
-
-  ###### implementation
-
-  config = mkIf cfg.enable {
-
+  mkConfig = cfg: mkIf cfg.enable {
     systemd.services.acpid = {
       description = "ACPI Daemon";
       documentation = [ "man:acpid(8)" ];
 
-      wantedBy = [ "multi-user.target" ];
+      # Acpid requires /var/run to exist but dosen't create it, and no systemd service seems to create it either.
+      # Note this is only a problem for stage1.
+      script = ''
+        ln -s /run /var/run || true
 
-      serviceConfig = {
-        ExecStart = escapeShellArgs
-          ([ "${pkgs.acpid}/bin/acpid"
-             "--foreground"
-             "--netlink"
-             "--confdir" "${acpiConfDir}"
-           ] ++ optional cfg.logEvents "--logevents"
-          );
-      };
+        ${cfg.package}/bin/acpid \
+          --foreground \
+          --netlink \
+          --confdir "${acpiConfFor cfg}/handlers" \
+          ${lib.optionalString cfg.logEvents "--logevents"}
+      '';
+
       unitConfig = {
         ConditionVirtualization = "!systemd-nspawn";
         ConditionPathExists = [ "/proc/acpi" ];
       };
-
     };
-
+  };
+in {
+  options = {
+    services.acpid = options true;
+    boot.initrd.services.acpid = options false;
   };
 
+  config = mkMerge [
+    (mkConfig stage2Cfg)
+    { boot.initrd = mkConfig stage1Cfg; }
+
+    (mkIf stage2Cfg.enable {
+      systemd.services.acpid.wantedBy = [ "multi-user.target" ];
+    })
+
+    (mkIf stage1Cfg.enable {
+      assertions = [ {
+        assertion = config.boot.initrd.systemd.enable;
+        message = "the acpid module only works with systemd based initrd";
+      } ];
+
+      boot.initrd = {
+        # Add the kernel modules required by each canonical command type if present
+        availableKernelModules = mkMerge [
+          (mkIf (stage1Cfg.powerEventCommands != "" || stage1Cfg.lidEventCommands != "") [ "button" ])
+          (mkIf (stage1Cfg.acEventCommands != "") [ "ac" ])
+        ];
+
+        systemd = {
+          initrdBin = [ stage1Cfg.package ];
+          storePaths = [ (acpiConfFor stage1Cfg) ];
+
+          services.acpid.wantedBy = [ "initrd.target" ];
+        };
+      };
+    })
+  ];
 }

--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -14,12 +14,13 @@ let
     '';
 
     mkHandler = name: handler: ''
-      echo "event=${handler.event}" > "$out/handlers/${name}"
-      echo "action=$out/scripts/${name}.sh" >> "$out/handlers/${name}"
+      {
+        echo "event=${handler.event}"
+        echo "action=$out/scripts/${name}.sh"
+      } > "$out/handlers/${name}"
     '';
-  in pkgs.runCommand "acpi-events" { preferLocalBuild = true; } ''
-    mkdir -p $out/scripts
-    mkdir -p $out/handlers
+  in pkgs.runCommandLocal "acpi-events" {} ''
+    mkdir -p $out/scripts $out/handlers
     ${concatStringsSep "\n" (mapAttrsToList mkScript handlers)}
     ${concatStringsSep "\n" (mapAttrsToList mkHandler handlers)}
   '';
@@ -139,7 +140,7 @@ let
       script = ''
         ln -s /run /var/run || true
 
-        ${cfg.package}/bin/acpid \
+        ${lib.getExe cfg.package} \
           --foreground \
           --netlink \
           --confdir "${acpiConfFor cfg}/handlers" \

--- a/pkgs/os-specific/linux/acpid/default.nix
+++ b/pkgs/os-specific/linux/acpid/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://sourceforge.net/projects/acpid2/";
     description = "A daemon for delivering ACPI events to userspace programs";
+    mainProgram = "acpid";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

Adds initrd/stage1 support to the acpid module. Also pretty much a complete refactor.

## Things done

Tested stage1 and stage2 support in personal configurations using `powerEventCommands` and `handlers`.

##### (self) Reviewed points

- [x] changes are backward compatible
- [x] (N/A) removed options are declared with `mkRemovedOptionModule`
- [x] (N/A) changes that are not backward compatible are documented in release notes
- [x] (N/A) module tests succeed on ARCHITECTURE
- [x] options types are appropriate
- [x] options description is set
- [x] options example is provided
- [x] documentation affected by the changes is updated

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
