### PR TITLE
show-midi: init at 0.8.0

### DIFF
--- a/pkgs/by-name/sh/show-midi/package.nix
+++ b/pkgs/by-name/sh/show-midi/package.nix
@@ -1,0 +1,83 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, alsa-lib
+, freetype
+, libX11
+, libXrandr
+, libXinerama
+, libXext
+, libXcursor
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "show-midi";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "gbevin";
+    repo = "ShowMIDI";
+    rev = finalAttrs.version;
+    hash = "sha256-BtkfeHZyeSZH6wIojj3dd2nCS5R535dSWsis/hXJbPc=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    alsa-lib
+    freetype
+    libX11
+    libXrandr
+    libXinerama
+    libXext
+    libXcursor
+  ];
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "-C Builds/LinuxMakefile"
+    "CONFIG=Release"
+    # Specify targets by hand, because it tries to build VST by default,
+    # even though it's not supported in JUCE anymore
+    "LV2"
+    "LV2_MANIFEST_HELPER"
+    "Standalone"
+    "VST3"
+    "VST3_MANIFEST_HELPER"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/share/ShowMIDI/themes Themes/*
+
+    mkdir -p $out/bin $out/lib/lv2 $out/lib/vst3
+    cd Builds/LinuxMakefile/build/
+    cp -r ShowMIDI.lv2 $out/lib/lv2
+    cp -r ShowMIDI.vst3 $out/lib/vst3
+    cp ShowMIDI $out/bin
+
+    runHook postInstall
+  '';
+
+  # JUCE dlopens these, make sure they are in rpath
+  # Otherwise, segfault will happen
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
+
+  meta = with lib; {
+    description = "Multi-platform GUI application to effortlessly visualize MIDI activity";
+    homepage = "https://github.com/gbevin/ShowMIDI";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ minijackson ];
+    mainProgram = "ShowMIDI";
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Really nice tool to show MIDI events: https://github.com/gbevin/ShowMIDI

ShowMIDI is compatible with macOS, but I don't have one so for now this package is Linux only. Help for a macOS port would be appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested basic functionality of LV2 and VST3 plugins
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
