### PR TITLE
kxstitch: init at unstable-2023-12-31

### DIFF
--- a/pkgs/by-name/kx/kxstitch/package.nix
+++ b/pkgs/by-name/kx/kxstitch/package.nix
@@ -1,0 +1,44 @@
+{ stdenv, lib, fetchgit, cmake, extra-cmake-modules, imagemagick, libsForQt5 }:
+
+stdenv.mkDerivation {
+  pname = "kxstitch";
+  version = "unstable-2023-12-31";
+
+  src = fetchgit {
+    url = "https://invent.kde.org/graphics/kxstitch.git";
+    rev = "4bb575dcb89e3c997e67409c8833e675962e101a";
+    hash = "sha256-pi+RpuT8YQYp1ogGtIgXpTPdYSFk19TUHTHDVyOcrMI=";
+  };
+
+  buildInputs = with libsForQt5; [
+    qtbase
+    kconfig
+    kconfigwidgets
+    kcompletion
+    kio
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    imagemagick
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  postInstall = ''
+    install -D $src/org.kde.kxstitch.desktop $out/share/applications/org.kde.kxstitch.desktop
+
+    for size in 16 22 32 48 64 128 256; do
+      install -D $src/icons/app/$size-apps-kxstitch.png $out/share/icons/hicolor/$size\x$size/kxstitch.png
+    done
+  '';
+
+  meta = {
+    homepage = "https://invent.kde.org/graphics/kxstitch";
+    description = "Cross stitch pattern and chart creation";
+    maintainers = with lib.maintainers; [ eliandoran ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "kxstitch";
+  };
+}


### PR DESCRIPTION
## Description of changes

> Cross stitch pattern and chart creation

Official website: https://invent.kde.org/graphics/kxstitch 

Did not place into the KDE-specific directories since it's not part of KDE gear, even though it's hosted on invent.kde.org.

The import of an image failed while testing the results on Pantheon:

```
kf.kio.widgets: Failed to check which JobView API is supported "The name org.kde.kuiserver was not provided by any .service files"
```

To investigate if it acts the same if it's added to `systemPackages`. ==> seems to work just fine.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
