### PR TITLE
frei0r: 1.8.0 -> 2.3.1

### DIFF
--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -1,7 +1,7 @@
 { lib
 , config
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , cairo
 , cmake
 , opencv
@@ -13,11 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "frei0r-plugins";
-  version = "1.8.0";
+  version = "2.3.1";
 
-  src = fetchurl {
-    url = "https://files.dyne.org/frei0r/releases/${pname}-${version}.tar.gz";
-    hash = "sha256-RaKGVcrwVyJ7RCuADKOJnpNJBRXIHiEtIZ/fSnYT9cQ=";
+  src = fetchFromGitHub {
+    owner = "dyne";
+    repo = "frei0r";
+    rev = "v${version}";
+    hash = "sha256-5itlZfnloQXV/aCiNgOOZzEeO1d+NLY4qSk8uMVAOmA=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
## Description of changes

Bump frei0r from 1.8.0 to 2.3.1.

Also get the source from Github since that's what the website links to now (instead of their own archive).

The changes aren't very interesting—most of these are just getting GitHub actions to work and build releases properly.

Changelogs:
- [v1.9.0](https://github.com/dyne/frei0r/releases/tag/v1.9.0): some plugin changes
- [v1.9.2](https://github.com/dyne/frei0r/releases/tag/v1.9.2): nothing interesting
- [v1.9.3](https://github.com/dyne/frei0r/releases/tag/v1.9.3): nothing interesting
- [v1.9.4](https://github.com/dyne/frei0r/releases/tag/v1.9.4): nothing interesting
- [v1.9.5](https://github.com/dyne/frei0r/releases/tag/v1.9.5): nothing interesting
- [v1.9.6](https://github.com/dyne/frei0r/releases/tag/v1.9.6): nothing interesting
- [v1.10.0](https://github.com/dyne/frei0r/releases/tag/v1.10.0): some fixes and plugin changes
- [v2.0.0](https://github.com/dyne/frei0r/releases/tag/v2.0.0): dropped automake support (doesn't matter to us), plugin changes
- [v2.1.0](https://github.com/dyne/frei0r/releases/tag/v2.1.0): nothing interesting
- [v2.2.0](https://github.com/dyne/frei0r/releases/tag/v2.2.0): nothing interesting
- [v2.3.0](https://github.com/dyne/frei0r/releases/tag/v2.3.0): fixes
- [v2.3.1](https://github.com/dyne/frei0r/releases/tag/v2.3.1): new filter, fixes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
