### PR TITLE
gprename: init at 20230429

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15137,7 +15137,7 @@
     name = "Jonathan Wright";
   };
   quantenzitrone = {
-    email = "quantenzitrone@protonmail.com";
+    email = "nix@dev.quantenzitrone.eu";
     github = "quantenzitrone";
     githubId = 74491719;
     matrix = "@quantenzitrone:matrix.org";

--- a/pkgs/by-name/gp/gprename/package.nix
+++ b/pkgs/by-name/gp/gprename/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  moreutils,
+  perlPackages,
+  gettext,
+  glib,
+  gtk3,
+  gobject-introspection,
+  pango,
+  harfbuzz,
+  gdk-pixbuf,
+  at-spi2-atk,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gprename";
+  version = "20230429";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/gprename/gprename-${finalAttrs.version}.zip";
+    hash = "sha256-Du9OO2qeB1jUEJFcVYmLbJAGi2p/IVe3sqladq09AyY=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    moreutils
+  ];
+
+  postPatch = ''
+    grep -Ev 'desktop-file-install|update-desktop-database' Makefile | sponge Makefile
+
+    substituteInPlace Makefile \
+      --replace '/usr/share' '$(DESTDIR)/share'
+
+    substituteInPlace bin/gprename \
+      --replace '/usr/share' $out/share \
+      --replace '/usr/local/share' $out/share
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+  buildInputs = [
+    perlPackages.perl
+    pango
+  ];
+  postInstall = ''
+    wrapProgram $out/bin/gprename \
+      --set PERL5LIB ${
+        perlPackages.makeFullPerlPath (
+          with perlPackages; [
+            Pango
+            Glib
+            Gtk3
+            LocaleGettext
+            libintl-perl
+          ]
+        )
+      } \
+      --prefix GI_TYPELIB_PATH : ${
+        lib.makeSearchPath "/lib/girepository-1.0" [
+          gtk3
+          pango.out
+          harfbuzz
+          gdk-pixbuf
+          at-spi2-atk
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Complete batch renamer for files and directories";
+    homepage = "https://gprename.sourceforge.net/index.php";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "gprename";
+    maintainers = with lib.maintainers; [ quantenzitrone ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Most of the packaging was done on the Chaos Communication Congress in Hamburg.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
