### PR TITLE
insync: 3.8.6.50504 -> 3.8.7.50508

### DIFF
--- a/pkgs/by-name/in/insync/package.nix
+++ b/pkgs/by-name/in/insync/package.nix
@@ -1,22 +1,27 @@
 { lib
 , writeShellScript
-, buildFHSEnvBubblewrap
+, buildFHSEnv
 , stdenvNoCC
 , fetchurl
 , autoPatchelfHook
 , dpkg
 , nss
+, cacert
+, alsa-lib
 , libvorbis
 , libdrm
 , libGL
 , wayland
 , xkeyboard_config
 , libthai
+, libsForQt5
 }:
 
 let
   pname = "insync";
+  # Find a binary from https://www.insynchq.com/downloads/linux#ubuntu.
   version = "3.8.6.50504";
+  ubuntu-dist = "mantic_amd64";
   meta = with lib; {
     platforms = ["x86_64-linux"];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
@@ -45,21 +50,26 @@ let
     inherit version meta;
 
     src = fetchurl {
-      # Find a binary from https://www.insynchq.com/downloads/linux#ubuntu.
-      url = "https://cdn.insynchq.com/builds/linux/insync_${version}-lunar_amd64.deb";
-      sha256 = "sha256-BxTFtQ1rAsOuhKnH5vsl3zkM7WOd+vjA4LKZGxl4jk0=";
+      url = "https://cdn.insynchq.com/builds/linux/insync_${version}-${ubuntu-dist}.deb";
+      sha256 = "sha256-QfSfTJjMTWShQETlUQqXQTYT7mBNhmj0HHoT5bjF0o8=";
     };
+
+    nativeBuildInputs = [
+      dpkg
+      autoPatchelfHook
+      libsForQt5.qt5.wrapQtAppsHook
+    ];
 
     buildInputs = [
       nss
+      alsa-lib
       libvorbis
       libdrm
       libGL
       wayland
       libthai
+      libsForQt5.qt5.qtvirtualkeyboard
     ];
-
-    nativeBuildInputs = [ autoPatchelfHook dpkg ];
 
     unpackPhase = ''
       dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
@@ -71,15 +81,6 @@ let
       mkdir -p $out
       cp -R usr/* $out/
 
-      # use system glibc
-      rm $out/lib/insync/{libgcc_s.so.1,libstdc++.so.6}
-
-      # remove badly packaged plugins
-      rm $out/lib/insync/PySide2/plugins/platforminputcontexts/libqtvirtualkeyboardplugin.so
-
-      # remove the unused vendor wrapper
-      rm $out/bin/insync
-
       runHook postInstall
     '';
 
@@ -87,31 +88,43 @@ let
     dontStrip = true;
   };
 
-in buildFHSEnvBubblewrap {
+in buildFHSEnv {
   name = pname;
   inherit meta;
 
   targetPkgs = pkgs: with pkgs; [
-    insync-pkg
+    cacert
     libudev0-shim
+    insync-pkg
   ];
 
-  runScript = writeShellScript "insync-wrapper.sh" ''
-    # QT_STYLE_OVERRIDE was used to suppress a QT warning, it should have no actual effect for this binary.
-    echo Unsetting QT_STYLE_OVERRIDE=$QT_STYLE_OVERRIDE
-    echo Unsetting QT_QPA_PLATFORMTHEME=$QT_QPA_PLATFORMTHEME
-    unset QT_STYLE_OVERRIDE
-    unset QPA_PLATFORMTHEME
+  extraInstallCommands = ''
+    cp -rsHf "${insync-pkg}"/share $out
+  '';
 
+  runScript = writeShellScript "insync-wrapper.sh" ''
     # xkb configuration needed: https://github.com/NixOS/nixpkgs/issues/236365
     export XKB_CONFIG_ROOT=${xkeyboard_config}/share/X11/xkb/
-    echo XKB_CONFIG_ROOT=$XKB_CONFIG_ROOT
 
-    # For debuging:
+    # For debugging:
     # export QT_DEBUG_PLUGINS=1
-    # find -L /usr/share -name "*insync*"
 
-    exec /usr/lib/insync/insync "$@"
+    # This is a workaround for an unidentified issue:
+    #
+    # When bbwrap-ed insync is launched in daemon mode, lots of red-herring issues appear. Namely, certificate
+    # not found issues.
+    #
+    # This workaround simply does not allow insync to be run in a daemon unless explictly doing so.
+    if [ "$1" == start ]; then
+        shift
+        set -- start --no-daemon "$@"
+    elif [ "$1" == start_daemon ]; then
+        shift
+        set -- start "$@"
+    fi
+
+    mkdir -p ~/.config/Insync
+    LC_TIME=C exec /usr/lib/insync/insync "$@" &>>~/.config/Insync/out.txt
     '';
 
   # As intended by this bubble wrap, share as much namespaces as possible with user.
@@ -121,6 +134,6 @@ in buildFHSEnvBubblewrap {
   unshareNet    = false;
   unshareUts    = false;
   unshareCgroup = false;
-  # Since "insync start" command starts a daemon, this daemon should die with it.
-  dieWithParent = false;
+
+  dieWithParent = true;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35316,8 +35316,6 @@ with pkgs;
 
   myfitnesspal = with python3Packages; toPythonApplication myfitnesspal;
 
-  insync = callPackage ../applications/networking/insync { };
-
   lemurs = callPackage ../applications/display-managers/lemurs { };
 
   libstrangle = callPackage ../tools/X11/libstrangle {


### PR DESCRIPTION
other changes:

- moved under pkgs/by-name/
- applied a hugly workaround to the start command's deamon crashing issue in the fhs wrapper.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
