### PR TITLE
python311Packages.highdicom: init at 0.22.0

### DIFF
--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, numpy
+, pillow
+, pillow-jpls
+, pydicom
+, pylibjpeg
+, pylibjpeg-libjpeg
+}:
+
+let
+  test_data = fetchFromGitHub {
+    owner = "pydicom";
+    repo = "pydicom-data";
+    rev = "cbb9b2148bccf0f550e3758c07aca3d0e328e768";
+    hash = "sha256-nF/j7pfcEpWHjjsqqTtIkW8hCEbuQ3J4IxpRk0qc1CQ=";
+  };
+in
+buildPythonPackage rec {
+  pname = "highdicom";
+  version = "0.22.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "MGHComputationalPathology";
+    repo = "highdicom";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-KHSJWEnm8u0xHkeeLF/U7MY4FfiWb6Q0GQQy2w1mnKw=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    pillow
+    pillow-jpls
+    pydicom
+  ];
+
+  passthru.optional-dependencies = {
+    libjpeg = [
+      pylibjpeg
+      pylibjpeg-libjpeg
+      #pylibjpeg-openjpeg  # not in nixpkgs yet
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ] ++ passthru.optional-dependencies.libjpeg;
+  preCheck = ''
+    export HOME=$TMP/test-home
+    mkdir -p $HOME/.pydicom/
+    ln -s ${test_data}/data_store/data $HOME/.pydicom/data
+  '';
+
+  pythonImportsCheck = [
+    "highdicom"
+    "highdicom.legacy"
+    "highdicom.ann"
+    "highdicom.ko"
+    "highdicom.pm"
+    "highdicom.pr"
+    "highdicom.seg"
+    "highdicom.sr"
+    "highdicom.sc"
+  ];
+
+  meta = with lib; {
+    description = "High-level DICOM abstractions for Python";
+    homepage = "https://highdicom.readthedocs.io";
+    changelog = "https://github.com/ImagingDataCommons/highdicom/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pillow-jpls/default.nix
+++ b/pkgs/development/python-modules/pillow-jpls/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchPypi
+, fetchpatch
+, pythonOlder
+, pytestCheckHook
+, cmake
+, ninja
+, scikit-build-core
+, charls
+, eigen
+, fmt
+, numpy
+, pillow
+, pybind11
+, setuptools
+, pathspec
+, pyproject-metadata
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "pillow-jpls";
+  version = "1.3.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "planetmarshall";
+    repo = "pillow-jpls";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Rc4/S8BrYoLdn7eHDBaoUt1Qy+h0TMAN5ixCAuRmfPU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace '"conan~=2.0.16",' ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pybind11
+    scikit-build-core
+    setuptools
+    setuptools_scm
+  ];
+  buildInputs = [
+    charls
+    eigen
+    fmt
+  ];
+  propagatedBuildInputs = [
+    numpy
+    pillow
+    pathspec
+    pyproject-metadata
+  ];
+
+  pypaBuildFlags = [ "-C" "cmake.args='--preset=sysdeps'" ];
+  dontUseCmakeConfigure = true;
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+  # prevent importing from build during test collection:
+  preCheck = ''rm -rf pillow_jpls'';
+
+  pythonImportsCheck = [
+    "pillow_jpls"
+  ];
+
+  meta = with lib; {
+    description = "A JPEG-LS plugin for the Python Pillow library";
+    homepage = "https://github.com/planetmarshall/pillow-jpls";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9259,6 +9259,8 @@ self: super: with self; {
 
   pillow-heif = callPackage ../development/python-modules/pillow-heif { };
 
+  pillow-jpls = callPackage ../development/python-modules/pillow-jpls { };
+
   pillow-simd = callPackage ../development/python-modules/pillow-simd {
       inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
       inherit (pkgs.xorg) libX11;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5110,6 +5110,8 @@ self: super: with self; {
 
   hickle = callPackage ../development/python-modules/hickle { };
 
+  highdicom = callPackage ../development/python-modules/highdicom { };
+
   hid = callPackage ../development/python-modules/hid {
     inherit (pkgs) hidapi;
   };


### PR DESCRIPTION
python311Packages.pillow-jpls: init at 1.3.2

## Description of changes

Init `highdicom`, a package for handling DICOM abstractions in Python.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
