### PR TITLE
python311Packages.vacuum-map-parser-roborock: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/vacuum-map-parser-base/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-base/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "vacuum-map-parser-base";
+  version = "0.1.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "Python-package-${pname}";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-moCWUPzn9stxehVEnjqpx8ILYhxzuy8QG+uxR53rCew=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ pillow ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "vacuum_map_parser_base" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-base";
+    description = "Common code for vacuum map parsers";
+    changelog = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-base/releases/tag/v${version}";
+    maintainers = with maintainers; [ jamiemagee ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/vacuum-map-parser-roborock/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-roborock/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, pillow
+, vacuum-map-parser-base
+}:
+
+buildPythonPackage rec {
+  pname = "vacuum-map-parser-roborock";
+  version = "0.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "Python-package-${pname}";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-cZNmoqzU73iF965abFeM6qgEVmg6j2kIQHDhj1MYQpE=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    pillow
+    vacuum-map-parser-base
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "vacuum_map_parser_roborock" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock";
+    description = "Functionalities for Roborock vacuum map parsing";
+    changelog = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock/releases/tag/v${version}";
+    maintainers = with maintainers; [ jamiemagee ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3965,7 +3965,8 @@
     ];
     "roborock" = ps: with ps; [
       python-roborock
-    ]; # missing inputs: vacuum-map-parser-roborock
+      vacuum-map-parser-roborock
+    ];
     "rocketchat" = ps: with ps; [
     ]; # missing inputs: rocketchat-API
     "roku" = ps: with ps; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15685,6 +15685,8 @@ self: super: with self; {
 
   vacuum-map-parser-base = callPackage ../development/python-modules/vacuum-map-parser-base { };
 
+  vacuum-map-parser-roborock = callPackage ../development/python-modules/vacuum-map-parser-roborock { };
+
   validate-email = callPackage ../development/python-modules/validate-email { };
 
   validators = callPackage ../development/python-modules/validators { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15683,6 +15683,8 @@ self: super: with self; {
 
   vaa = callPackage ../development/python-modules/vaa { };
 
+  vacuum-map-parser-base = callPackage ../development/python-modules/vacuum-map-parser-base { };
+
   validate-email = callPackage ../development/python-modules/validate-email { };
 
   validators = callPackage ../development/python-modules/validators { };


### PR DESCRIPTION
## Description of changes

- Adds `vacuum-map-parser-base` at `0.1.2`
- Adds `vacuum-map-parser-roborock` at `0.1.1`
- Updates `home-assistant` component packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
