### PR TITLE
Make Management Frame Encryption Configurable

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -639,6 +639,14 @@ in {
                     '';
                   };
 
+                  encryptManagementFrames = mkOption {
+                    default = true;
+                    type = types.bool;
+                    description = mdDoc ''
+                      Encrypt management frames to protect against deauthentication and similar attacks.
+                    '';
+                  };
+
                   settings = mkOption {
                     default = {};
                     example = { multi_ap = true; };
@@ -922,11 +930,6 @@ in {
 
                     ignore_broadcast_ssid = bssCfg.ignoreBroadcastSsid;
 
-                    # IEEE 802.11i (authentication) related configuration
-                    # Encrypt management frames to protect against deauthentication and similar attacks
-                    ieee80211w = mkDefault 1;
-                    sae_require_mfp = mkDefault 1;
-
                     # Only allow WPA by default and disable insecure WEP
                     auth_algs = mkDefault 1;
                     # Always enable QoS, which is required for 802.11n and above
@@ -943,6 +946,9 @@ in {
                     );
                   } // optionalAttrs (bssCfg.bssid != null) {
                     bssid = bssCfg.bssid;
+                  } // optionalAttrs bssCfg.encryptManagementFrames {
+                    ieee80211w = mkDefault 1;
+                    sae_require_mfp = mkDefault 1;
                   } // optionalAttrs (bssCfg.macAllow != [] || bssCfg.macAllowFile != null || bssCfg.authentication.saeAddToMacAllow) {
                     accept_mac_file = "/run/hostapd/${bssCfg._module.args.name}.mac.allow";
                   } // optionalAttrs (bssCfg.macDeny != [] || bssCfg.macDenyFile != null) {


### PR DESCRIPTION
## Description of changes

Some Wifi hardware, like the Raspberry Pi Zero 2 W, doesn't support encrypted management frames. This option should therefore be configurable, defaulting to `true`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
