### PR TITLE
liblangtag: pull upstream fixes for gcc-13

### DIFF
--- a/pkgs/development/libraries/liblangtag/default.nix
+++ b/pkgs/development/libraries/liblangtag/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook, gtk-doc, gettext
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, gtk-doc, gettext
 , pkg-config, glib, libxml2, gobject-introspection, gnome-common, unzip
 }:
 
@@ -22,6 +22,20 @@ stdenv.mkDerivation rec {
     url = "http://www.iana.org/assignments/language-subtag-registry";
     sha256 = "0y9x5gra6jri4sk16f0dp69p06almnsl48rs85605f035kf539qm";
   };
+
+  patches = [
+    # Pull upstream fix for gcc-13 build compatibility
+    (fetchpatch {
+      name = "gcc-13-p1.patch";
+      url = "https://bitbucket.org/tagoh/liblangtag/commits/0b6e9f4616a34146e7443c4e9a7197153645e40b/raw";
+      hash = "sha256-69wJDVwDCP5OPHKoRn9WZNrvfCvmlX3SwtRmcpJHn2o=";
+    })
+    (fetchpatch {
+      name = "gcc-13-p1.patch";
+      url = "https://bitbucket.org/tagoh/liblangtag/commits/1497c4477d0fa0b7df1886951b953dd3cea54427/raw";
+      hash = "sha256-k0Uaeg6YLxVze4fgf0kiyuiZJ5wh2Jq3h7cFPQPtwyo=";
+    })
+  ];
 
   postPatch = ''
     gtkdocize


### PR DESCRIPTION
Without the change build fails on `staging-next` against `gcc-13` as:

    lt-tag.c:36:1: note: include '<stdlib.h>' or provide a declaration of 'free'
       35 | #include "lt-tag-private.h"
      +++ |+#include <stdlib.h>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
