### PR TITLE
sonarr: 3.0.10.1567 -> 4.0.0.748

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -277,6 +277,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 - New options were added to the dnsdist module to enable and configure a DNSCrypt endpoint (see `services.dnsdist.dnscrypt.enable`, etc.).
   The module can generate the DNSCrypt provider key pair, certificates and also performs their rotation automatically with no downtime.
 
+- With a bump to `sonarr` v4, existing config database files will be upgraded automatically, but note that some old apparently-working configs [might actually be corrupt and fail to upgrade cleanly](https://forums.sonarr.tv/t/sonarr-v4-released/33089).
+
 - The Yama LSM is now enabled by default in the kernel, which prevents ptracing
   non-child processes. This means you will not be able to attach gdb to an
   existing process, but will need to start that process from gdb (so it is a

--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -1,12 +1,28 @@
-{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, nixosTests }:
+{ lib, stdenv, fetchurl, dotnet-runtime, icu, ffmpeg, openssl, sqlite, curl, makeWrapper, nixosTests }:
 
+let
+  os = if stdenv.isDarwin then "osx" else "linux";
+  arch = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+    aarch64-darwin = "arm64";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hash = {
+    x64-linux_hash = "sha256-XCCqAMxaOk9vGlTDHv7MB6VhTx0ODDTuPxkfvTBeJDk=";
+    arm64-linux_hash = "sha256-4jQzgjicPh4AmO2jY3h8YXlTlvIbk4uyDxMpOQtm+HI=";
+    x64-osx_hash = "sha256-MYLbAg9oCjWaZEMnSBmLEDEpab9vvcJjI8P8Fdmhmzs=";
+    arm64-osx_hash = "sha256-FyHffgNVoS/HPXz2YQGyxRowT04VFKtWZYEvsBZ9t4E=";
+  }."${arch}-${os}_hash";
+in
 stdenv.mkDerivation rec {
   pname = "sonarr";
-  version = "3.0.10.1567";
+  version = "4.0.0.748";
 
   src = fetchurl {
-    url = "https://download.sonarr.tv/v3/main/${version}/Sonarr.main.${version}.linux.tar.gz";
-    hash = "sha256-6zdp/Bg+9pcrElW5neB+BC16Vn1VhTjhMRRIxGrKhxc=";
+    url = "https://download.sonarr.tv/v4/main/${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";
+    inherit hash;
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -14,12 +30,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    cp -r * $out/bin/
-    makeWrapper "${mono}/bin/mono" $out/bin/NzbDrone \
-      --add-flags "$out/bin/Sonarr.exe" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-          curl sqlite libmediainfo ]}
+    mkdir -p $out/{bin,share/sonarr-${version}}
+    cp -r * $out/share/sonarr-${version}/.
+
+    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/NzbDrone \
+      --add-flags "$out/share/sonarr-${version}/Sonarr.dll" \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl sqlite openssl icu ]}
 
     runHook postInstall
   '';

--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -10,18 +10,18 @@ let
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   hash = {
-    x64-linux_hash = "sha256-XCCqAMxaOk9vGlTDHv7MB6VhTx0ODDTuPxkfvTBeJDk=";
-    arm64-linux_hash = "sha256-4jQzgjicPh4AmO2jY3h8YXlTlvIbk4uyDxMpOQtm+HI=";
-    x64-osx_hash = "sha256-MYLbAg9oCjWaZEMnSBmLEDEpab9vvcJjI8P8Fdmhmzs=";
-    arm64-osx_hash = "sha256-FyHffgNVoS/HPXz2YQGyxRowT04VFKtWZYEvsBZ9t4E=";
+    x64-linux_hash = "sha256-9YNhyhxnnn2CesXLJH5Cs7yB9w23YUAZPrk9vEHvevk=";
+    arm64-linux_hash = "sha256-RBCyfozmBpWrmsfMcdb1BqcBXj64CMDrgpMZTzj85ZQ=";
+    x64-osx_hash = "sha256-+AKENBZohBUEKQEM3L69EzC84MhCX3fGvsNFn5p2v84=";
+    arm64-osx_hash = "sha256-Arx8usecAN+d0NGL7Hv+rB4GG7p/KLAaqpJFgNg7C2Y=";
   }."${arch}-${os}_hash";
 in
 stdenv.mkDerivation rec {
   pname = "sonarr";
-  version = "4.0.0.748";
+  version = "4.0.1.929";
 
   src = fetchurl {
-    url = "https://download.sonarr.tv/v4/main/${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";
+    url = "https://github.com/Sonarr/Sonarr/releases/download/v${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";
     inherit hash;
   };
 

--- a/pkgs/servers/sonarr/update.sh
+++ b/pkgs/servers/sonarr/update.sh
@@ -1,7 +1,43 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq common-updater-scripts
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
+
+set -e
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    arch=$2
+    os=$3
+
+    hashKey="${arch}-${os}_hash"
+
+    url="https://download.sonarr.tv/v4/main/${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";
+    hash=$(nix-prefetch-url --type sha256 $url)
+    sriHash="$(nix hash to-sri --type sha256 $hash)"
+
+    sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd $dirname && nix eval --raw -f ../../.. sonarr.version)
 
 latestTag=$(curl https://api.github.com/repos/Sonarr/Sonarr/tags | jq -r '.[] | .name' | sort --version-sort | tail -1)
-version="$(expr $latestTag : 'v\(.*\)')"
+latestVersion="$(expr $latestTag : 'v\(.*\)')"
 
-update-source-version sonarr "$version"
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Sonarr is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion $latestVersion
+
+updateHash $latestVersion x64 linux
+updateHash $latestVersion arm64 linux
+updateHash $latestVersion x64 osx
+updateHash $latestVersion arm64 osx

--- a/pkgs/servers/sonarr/update.sh
+++ b/pkgs/servers/sonarr/update.sh
@@ -13,7 +13,7 @@ updateHash()
 
     hashKey="${arch}-${os}_hash"
 
-    url="https://download.sonarr.tv/v4/main/${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";
+    url="https://github.com/Sonarr/Sonarr/releases/download/v${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";
     hash=$(nix-prefetch-url --type sha256 $url)
     sriHash="$(nix hash to-sri --type sha256 $hash)"
 
@@ -27,7 +27,7 @@ updateVersion()
 
 currentVersion=$(cd $dirname && nix eval --raw -f ../../.. sonarr.version)
 
-latestTag=$(curl https://api.github.com/repos/Sonarr/Sonarr/tags | jq -r '.[] | .name' | sort --version-sort | tail -1)
+latestTag=$(curl https://api.github.com/repos/Sonarr/Sonarr/releases/latest | jq -r ".tag_name")
 latestVersion="$(expr $latestTag : 'v\(.*\)')"
 
 if [[ "$currentVersion" == "$latestVersion" ]]; then


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As pointed out in #278002 we were lagging a long way behind the latest releases, with v4 coming out in Nov 2022: https://forums.sonarr.tv/t/sonarr-v4-beta/31078

There's no longer a plain "linux" (actually cross-platform) package available for download, so I made an attempt to build from source (like jellyfin) but abandoned it due to obscure issues with an apparently-vendored .NET library, instead opting to follow the pattern of per-platform downloads used for `radarr`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
