### PR TITLE
c-blosc: 1.21.1 -> 1.21.5

### DIFF
--- a/pkgs/development/libraries/c-blosc/default.nix
+++ b/pkgs/development/libraries/c-blosc/default.nix
@@ -1,15 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
 
 stdenv.mkDerivation rec {
   pname = "c-blosc";
-  version = "1.21.1";
+  version = "1.21.5";
 
   src = fetchFromGitHub {
     owner = "Blosc";
     repo = "c-blosc";
     rev = "v${version}";
-    sha256 = "sha256-6SKEyciwDOxcbO8chvmxrLCxLkc93zxo6eH0c/lRyT8=";
+    sha256 = "sha256-bz922lWiap3vMy8qS9dmXa8zUg5NJlg0bx3+/xz7QAk=";
   };
+
+  # https://github.com/NixOS/nixpkgs/issues/144170
+  postPatch = ''
+    sed -i -E \
+      -e '/^libdir[=]/clibdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      -e '/^includedir[=]/cincludedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@' \
+      blosc.pc.in
+  '';
 
   nativeBuildInputs = [ cmake ];
 
@@ -18,5 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.blosc.org";
     license = licenses.bsd3;
     platforms = platforms.all;
+    maintainers = with maintainers; [ ris ];
   };
 }

--- a/pkgs/development/libraries/c-blosc/default.nix
+++ b/pkgs/development/libraries/c-blosc/default.nix
@@ -2,16 +2,23 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, testers
+
+, static ? stdenv.hostPlatform.isStatic
+
+, lz4
+, zlib
+, zstd
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "c-blosc";
   version = "1.21.5";
 
   src = fetchFromGitHub {
     owner = "Blosc";
     repo = "c-blosc";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-bz922lWiap3vMy8qS9dmXa8zUg5NJlg0bx3+/xz7QAk=";
   };
 
@@ -25,11 +32,38 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  buildInputs = [
+    lz4
+    zlib
+    zstd
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_STATIC=${if static then "ON" else "OFF"}"
+    "-DBUILD_SHARED=${if static then "OFF" else "ON"}"
+
+    "-DPREFER_EXTERNAL_LZ4=ON"
+    "-DPREFER_EXTERNAL_ZLIB=ON"
+    "-DPREFER_EXTERNAL_ZSTD=ON"
+
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_BENCHMARKS=OFF"
+    "-DBUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
+  ];
+
+  doCheck = !static;
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta = with lib; {
     description = "A blocking, shuffling and loss-less compression library";
     homepage = "https://www.blosc.org";
+    changelog = "https://github.com/Blosc/c-blosc/releases/tag/v${version}";
+    pkgConfigModules = [
+      "blosc"
+    ];
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ ris ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

This hasn't been updated in quite a while.

There's also now a c-blosc2 which we should create a package for. Not sure how compatible it is - it's maintained in a different tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
