### PR TITLE
at-spi2-core: add flag to disable systemd support

### DIFF
--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -19,6 +19,7 @@
 , libXext
 , gnome
 , systemd
+, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
 }:
 
 stdenv.mkDerivation rec {
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
     libXi
     # libXext is a transitive dependency of libXi
     libXext
-  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemd) [
+  ] ++ lib.optionals systemdSupport [
     # libsystemd is a needed for dbus-broker support
     systemd
   ];
@@ -71,9 +72,11 @@ stdenv.mkDerivation rec {
     # including the entire dbus closure in libraries linked with
     # the at-spi2-core libraries.
     "-Ddbus_daemon=/run/current-system/sw/bin/dbus-daemon"
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+  ] ++ lib.optionals systemdSupport [
     # Same as the above, but for dbus-broker
     "-Ddbus_broker=/run/current-system/sw/bin/dbus-broker-launch"
+  ] ++ lib.optionals (!systemdSupport) [
+    "-Duse_systemd=false"
   ];
 
   passthru = {


### PR DESCRIPTION
# at-spi2-core: add flag to disable systemd support

Instead of assuming that systemd is desired whenever it is availabe, introduce
flag that allows disabling systemd. This flag is still defaults to true as long
as systemd is available on the host platform.

This is no-rebuild change.
