### PR TITLE
keepass-keeotp2: init at 1.5.9

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keeotp2/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keeotp2/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, buildEnv, fetchurl, mono }:
+
+let
+  version = "1.5.9";
+  drv = stdenv.mkDerivation {
+    pname = "keeotp2";
+    inherit version;
+
+    src = fetchurl {
+      url    = "https://github.com/tiuub/KeeOtp2/releases/download/v${version}/KeeOtp2.plgx";
+      sha256 = "f5c797cea710e0cd170c47133d6144faa8d14b9c3d1e045da2d08c82682990c9";
+    };
+
+    meta = with lib; {
+      description = "KeeOtp2 is a plugin for KeePass. It provides a form to display one time passwords and is fully compatible with the built-in OTP function.";
+      homepage    = "https://github.com/tiuub/KeeOtp2";
+      platforms   = with lib.platforms; linux;
+      license     = licenses.mit;
+      maintainers = [ ];
+    };
+
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $src $out/lib/dotnet/keepass/
+    '';
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31486,6 +31486,8 @@ with pkgs;
 
   keepass-keeagent = callPackage ../applications/misc/keepass-plugins/keeagent { };
 
+  keepass-keeotp2 = callPackage ../applications/misc/keepass-plugins/keeotp2 { };
+
   keepass-keepasshttp = callPackage ../applications/misc/keepass-plugins/keepasshttp { };
 
   keepass-keepassrpc = callPackage ../applications/misc/keepass-plugins/keepassrpc { };


### PR DESCRIPTION
## Description of changes
Package https://keepass.info/plugins.html#keeotp / https://github.com/tiuub/KeeOtp2
Basic TOTP functionality is built-in (since keepass 2.51) but this plugin still adds a few nice features like (e.g. hotkey support), and also may be needed by those who used in prior keepass versions to migrate info in their kdbx file to the `{TIMEOTP}` key used by keepass >= 2.51.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Replacement for a mishap in #210597 where I accidentally pushed a commit based on 23.11 instead of the one rebased to master, and thus caused a mass-ping: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#something-went-wrong-and-a-lot-of-people-were-pinged. Mea culpa.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc