### PR TITLE
lunacy: init at 9.4.2.5022

### DIFF
--- a/pkgs/by-name/lu/lunacy/package.nix
+++ b/pkgs/by-name/lu/lunacy/package.nix
@@ -1,0 +1,114 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, zlib
+, libgcc
+, fontconfig
+, libX11
+, lttng-ust
+, icu
+, libICE
+, libSM
+, libXcursor
+, openssl
+, imagemagick
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lunacy";
+  version = "9.4.2.5022";
+
+  src = fetchurl {
+    url = "https://lcdn.icons8.com/setup/Lunacy_${finalAttrs.version}.deb";
+    hash = "sha256-69CO1SPdO+JhAH/G/DihyHDueQOLaaJCf32MjBc77j4=";
+  };
+
+  unpackCmd = ''
+    mkdir -p root
+    dpkg-deb -x $src root
+  '';
+
+  buildInputs = [
+    zlib
+    libgcc
+    stdenv.cc.cc
+    lttng-ust
+    fontconfig.lib
+
+    # Runtime deps
+    libICE
+    libSM
+    libX11
+    libXcursor
+  ];
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  # adds to the RPATHS of all shared objects (exe and libs)
+  appendRunpaths = map (pkg: (lib.getLib pkg) + "/lib") [
+    icu
+    openssl
+    stdenv.cc.libc
+    stdenv.cc.cc
+  ] ++ [
+    # technically, this should be in runtimeDependencies but will not work as
+    # "lib" is appended to all elements in the array
+    "${placeholder "out"}/lib/lunacy"
+  ];
+
+  # will add to the RPATH of executable only
+  runtimeDependencies = [
+    libICE
+    libSM
+    libX11
+    libXcursor
+  ];
+
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib";
+    cp -R "opt/icons8/lunacy" "$out/lib"
+    cp -R "usr/share" "$out/share"
+
+    # Prepare the desktop icon, the upstream icon is 200x200 but the hicolor theme does not
+    # support this resolution. Nearest sizes are 192x192 and 256x256.
+    ${imagemagick}/bin/convert "opt/icons8/lunacy/Assets/LunacyLogo.png" -resize 192x192 lunacy.png
+    install -D lunacy.png "$out/share/icons/hicolor/192x192/apps/${finalAttrs.pname}.png"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/applications/lunacy.desktop \
+      --replace "Exec=/opt/icons8/lunacy/Lunacy" "Exec=${finalAttrs.pname}" \
+      --replace "Icon=/opt/icons8/lunacy/Assets/LunacyLogo.png" "Icon=${finalAttrs.pname}"
+  '';
+
+  postFixup = ''
+    mkdir $out/bin
+
+    # Fixes runtime error regarding missing libSkiaSharp.so (which is in the same directory as the binary).
+    ln -s "$out/lib/lunacy/Lunacy" "$out/bin/${finalAttrs.pname}"
+  '';
+
+  meta = with lib; {
+    description = "Free design software that keeps your flow with AI tools and built-in graphics";
+    homepage = "https://icons8.com/lunacy";
+    changelog = "https://lunacy.docs.icons8.com/release-notes/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.eliandoran ];
+    platforms = platforms.linux;
+    sourceProvenance = [ sourceTypes.binaryBytecode ];
+    mainProgram = "lunacy";
+  };
+
+})


### PR DESCRIPTION
## Description of changes

> (un)Free design software that keeps your flow with AI tools and built-in graphics

Home page: https://icons8.com/lunacy

Closes package request #201926

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
