### PR TITLE
hyprprop: init at 1.0-20230314

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14008,6 +14008,12 @@
     githubId = 1449319;
     name = "Pacien Tran-Girard";
   };
+  pacificviking = {
+    email = "johnhaoallwood@gmail.com";
+    github = "PacificViking";
+    githubId = 32098177;
+    name = "John Hao";
+  };
   pacman99 = {
     email = "pachum99@gmail.com";
     matrix = "@pachumicchu:myrdd.info";

--- a/pkgs/by-name/hy/hyprevents/package.nix
+++ b/pkgs/by-name/hy/hyprevents/package.nix
@@ -1,0 +1,45 @@
+{ fetchFromGitHub
+, lib
+, makeWrapper
+, stdenv
+, hyprland
+, bash
+}:
+
+stdenv.mkDerivation {
+  pname = "hyprevents";
+  version = "unstable-2024-01-15";
+
+  src = fetchFromGitHub {
+    owner = "vilari-mickopf";
+    repo = "hyprevents";
+    rev = "09b54e782bfe04dc29a01238e559822afdb23d94";
+    hash = "sha256-YlTPZK2tbY9MowtKV387o7GGaTchUFN2KpOJKi9zKcI=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
+
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    export PREFIX="$out"
+    make install
+
+    wrapProgram "$out/bin/hyprevents" \
+      --prefix PATH : "$out/bin:${lib.makeBinPath [ hyprland ]}"
+
+    runHook postInstall
+  '';
+  passthru.scriptName = "hyprevents";
+
+  meta = with lib; {
+    description = "Invoke shell functions in response to Hyprland socket2 events. Forked from hyprwm";
+    homepage = "https://github.com/vilari-mickopf/hyprevents";
+    maintainers = with maintainers; [ pacificviking ];
+    platforms = platforms.linux;
+    mainProgram = "hyprevents";
+  };
+}

--- a/pkgs/by-name/hy/hyprevents/package.nix
+++ b/pkgs/by-name/hy/hyprevents/package.nix
@@ -1,12 +1,12 @@
 { fetchFromGitHub
 , lib
 , makeWrapper
-, stdenv
+, stdenvNoCC
 , hyprland
 , bash
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "hyprevents";
   version = "unstable-2024-01-15";
 
@@ -22,18 +22,14 @@ stdenv.mkDerivation {
   buildInputs = [ bash ];
 
   dontBuild = true;
-  installPhase = ''
-    runHook preInstall
-
-    export PREFIX="$out"
-    make install
-
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+  
+  postInstall = ''
     wrapProgram "$out/bin/hyprevents" \
       --prefix PATH : "$out/bin:${lib.makeBinPath [ hyprland ]}"
-
-    runHook postInstall
   '';
-  passthru.scriptName = "hyprevents";
 
   meta = with lib; {
     description = "Invoke shell functions in response to Hyprland socket2 events. Forked from hyprwm";

--- a/pkgs/by-name/hy/hyprevents/package.nix
+++ b/pkgs/by-name/hy/hyprevents/package.nix
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation {
   makeFlags = [
     "PREFIX=$(out)"
   ];
-  
+
   postInstall = ''
     wrapProgram "$out/bin/hyprevents" \
       --prefix PATH : "$out/bin:${lib.makeBinPath [ hyprland ]}"

--- a/pkgs/by-name/hy/hyprprop/package.nix
+++ b/pkgs/by-name/hy/hyprprop/package.nix
@@ -1,0 +1,50 @@
+{ fetchFromGitHub
+, socat
+, jq
+, lib
+, makeWrapper
+, slurp
+, stdenv
+, hyprland
+, hyprevents
+, bash
+}:
+
+stdenv.mkDerivation {
+  # pkill is a dependency here.. but its in PATH and its hyprevents (not hyprprop) that needs to access it...
+  pname = "hyprprop";
+  version = "unstable-2024-01-15";
+
+  src = fetchFromGitHub {
+    owner = "vilari-mickopf";
+    repo = "hyprprop";
+    rev = "46d12dbc002917917a79c59bcaefd5e2b3901898";
+    hash = "sha256-J3GM+o+kcp1rprWREJTSUbIPZheoPOu2wT43/GaO7oA=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
+
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    export PREFIX="$out"
+    make install
+
+    wrapProgram "$out/bin/hyprprop" \
+      --prefix PATH : "$out/bin:${lib.makeBinPath [ socat jq slurp hyprland hyprevents ]}"
+
+    runHook postInstall
+  '';
+  passthru.scriptName = "hyprprop";
+
+  meta = with lib; {
+    description = "xprop for Hyprland";
+    homepage = "https://github.com/vilari-mickopf/hyprprop";
+    maintainers = with maintainers; [ pacificviking ];
+    platforms = platforms.linux;
+    mainProgram = "hyprprop";
+  };
+}

--- a/pkgs/by-name/hy/hyprprop/package.nix
+++ b/pkgs/by-name/hy/hyprprop/package.nix
@@ -4,13 +4,13 @@
 , lib
 , makeWrapper
 , slurp
-, stdenv
+, stdenvNoCC
 , hyprland
 , hyprevents
 , bash
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   # pkill is a dependency here.. but its in PATH and its hyprevents (not hyprprop) that needs to access it...
   pname = "hyprprop";
   version = "unstable-2024-01-15";
@@ -27,18 +27,14 @@ stdenv.mkDerivation {
   buildInputs = [ bash ];
 
   dontBuild = true;
-  installPhase = ''
-    runHook preInstall
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
 
-    export PREFIX="$out"
-    make install
-
+  postInstall = ''
     wrapProgram "$out/bin/hyprprop" \
       --prefix PATH : "$out/bin:${lib.makeBinPath [ socat jq slurp hyprland hyprevents ]}"
-
-    runHook postInstall
   '';
-  passthru.scriptName = "hyprprop";
 
   meta = with lib; {
     description = "xprop for Hyprland";


### PR DESCRIPTION
## Description of changes

Added hyprprop and its dependency hyprevents

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note: hyprevents is probably only ever used for hyprprop, and I didn't test it independently of hyprprop. I'm only keeping them separate because its how packages work, hence the same pull request for the two packages.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
