### PR TITLE
buildGoModule: warn if `-trimpath` or `-mod=` is used, remove explicit usage

### DIFF
--- a/pkgs/build-support/go/package.nix
+++ b/pkgs/build-support/go/package.nix
@@ -39,6 +39,8 @@
 
 , ldflags ? [ ]
 
+, GOFLAGS ? [ ]
+
 # needed for buildFlags{,Array} warning
 , buildFlags ? ""
 , buildFlagsArray ? ""
@@ -89,12 +91,12 @@ let
 
     GO111MODULE = "off";
     GOTOOLCHAIN = "local";
-    GOFLAGS = lib.optionals (!allowGoReference) [ "-trimpath" ];
+    GOFLAGS = GOFLAGS ++ lib.optional (!allowGoReference)  "-trimpath" ;
 
     GOARM = toString (lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
 
     # If not set to an explicit value, set the buildid empty for reproducibility.
-    ldflags = ldflags ++ lib.optionals (!lib.any (lib.hasPrefix "-buildid=") ldflags) [ "-buildid=" ];
+    ldflags = ldflags ++ lib.optional (!lib.any (lib.hasPrefix "-buildid=") ldflags) "-buildid=";
 
     configurePhase = args.configurePhase or (''
       runHook preConfigure
@@ -286,4 +288,5 @@ in
 lib.warnIf (buildFlags != "" || buildFlagsArray != "")
   "Use the `ldflags` and/or `tags` attributes instead of `buildFlags`/`buildFlagsArray`"
 lib.warnIf (builtins.elem "-buildid=" ldflags) "`-buildid=` is set by default as ldflag by buildGoModule"
+lib.warnIf (builtins.elem "-trimpath" GOFLAGS) "`-trimpath` is added by default to GOFLAGS by buildGoModule when allowGoReference isn't set to true"
   package

--- a/pkgs/by-name/gc/gcs/package.nix
+++ b/pkgs/by-name/gc/gcs/package.nix
@@ -56,7 +56,7 @@ buildGoModule rec {
   ];
 
   # flags are based on https://github.com/richardwilkes/gcs/blob/master/build.sh
-  flags = [ "-a -trimpath" ];
+  flags = [ "-a" ];
   ldflags = [ "-s" "-w" "-X github.com/richardwilkes/toolbox/cmdline.AppVersion=${version}" ];
 
   installPhase = ''

--- a/pkgs/by-name/gt/gtrash/package.nix
+++ b/pkgs/by-name/gt/gtrash/package.nix
@@ -23,7 +23,6 @@ buildGoModule rec {
   doCheck = false;
 
   CGO_ENABLED = 0;
-  GOFLAGS = [ "-trimpath" ];
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/by-name/up/uplosi/package.nix
+++ b/pkgs/by-name/up/uplosi/package.nix
@@ -18,7 +18,6 @@ buildGoModule rec {
 
   CGO_ENABLED = "0";
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
-  flags = [ "-trimpath" ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/tools/language-servers/jq-lsp/default.nix
+++ b/pkgs/development/tools/language-servers/jq-lsp/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   # based on https://github.com/wader/jq-lsp/blob/master/.goreleaser.yml
   CGO_ENABLED = 0;
-  GOFLAGS = [ "-trimpath" ];
+
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/tools/security/slsa-verifier/default.nix
+++ b/pkgs/tools/security/slsa-verifier/default.nix
@@ -17,8 +17,6 @@ buildGoModule rec {
   vendorHash = "sha256-rCGj2o59US2t/ckqXirEDgYn9dGvVSzMVcFEZosasBc=";
 
   CGO_ENABLED = 0;
-  GO111MODULE = "on";
-  GOFLAGS = "-trimpath";
 
   subPackages = [ "cli/slsa-verifier" ];
 

--- a/pkgs/tools/video/go2rtc/default.nix
+++ b/pkgs/tools/video/go2rtc/default.nix
@@ -16,10 +16,6 @@ buildGoModule rec {
 
   vendorHash = "sha256-KEW3ykEZvL6y1VacDIqtHW9B2RLHlHC29aqJjkEnRqQ=";
 
-  buildFlagArrays = [
-    "-trimpath"
-  ];
-
   CGO_ENABLED = 0;
 
   ldflags = [


### PR DESCRIPTION
## Description of changes

Follow up to https://github.com/NixOS/nixpkgs/pull/276685

Adding warnings if `-trimpath` or `-mod=` is explicitly set, as these flags are controlled by the builder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
