### PR TITLE
wivrn: init at 0.10.1

### DIFF
--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -1,0 +1,123 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, vulkan-headers
+, vulkan-loader
+, x264
+, xorg
+, eigen
+, boost
+, glm
+, spdlog
+, monado
+, openxr-loader
+, nlohmann_json
+, harfbuzz
+, freetype
+, glslang
+, python3
+, udev
+, ffmpeg
+, libva
+, libdrm
+, avahi
+, libpulseaudio
+, pkgs
+}:
+let
+  # We need tiny_gltf.h and draco doesn't provide it
+  tinygltf = pkgs.callPackage "${pkgs.path}/pkgs/development/libraries/draco/tinygltf.nix" {};
+
+  # The commit of monado specified in CMakeLists.txt
+  vendorMonado = monado.overrideAttrs rec {
+    postInstall = ''
+      mv src/xrt/compositor/libcomp_main.a $out/lib/libcomp_main.a
+    '';
+    version = "79bf8eb8fa168f65f4e5505e0525ee74aa88783e";
+    src = pkgs.fetchgit {
+      url = "https://gitlab.freedesktop.org/monado/monado.git";
+      rev = version;
+      hash = "sha256-lzvu8xw/10pMP4pWzEDYKKoBL6GbzsmbeOCqLsuN2lk=";
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "wivrn";
+  version = "0.10.1";
+
+  CPM_LOCAL_PACKAGES_ONLY = "ON";
+
+  src = fetchFromGitHub {
+    owner = "Meumeu";
+    repo = "WiVRn";
+#    rev = version;
+#    hash = "sha256-3+ljuRLrhs0j6AYjGcfPKNR7byk6qnFk3COLefNu85A=";
+    rev = "v${version}";
+    hash = "sha256-e9wcy9t2SdumQ+8I1pPUVuPOwnD+CK3NUZvOAAUXs4w=";
+  };
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    x264
+    eigen
+    boost
+    glm
+    spdlog
+    vendorMonado
+    tinygltf
+    xorg.libX11
+    xorg.libXrandr
+    openxr-loader
+    nlohmann_json
+    harfbuzz
+    freetype
+    glslang
+    udev
+    ffmpeg
+    libva
+    libdrm
+    avahi
+    libpulseaudio
+  ];
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'FetchContent_Declare(boostpfr      URL https://github.com/boostorg/pfr/archive/refs/tags/2.0.3.tar.gz)' "find_package(Boost COMPONENTS headers)"
+
+    substituteInPlace server/CMakeLists.txt \
+      --replace 'Boost::pfr' 'Boost::headers'
+
+    substituteInPlace common/CMakeLists.txt \
+      --replace 'FetchContent_MakeAvailable(boostpfr)' "find_package(Boost COMPONENTS headers)" \
+      --replace 'target_link_libraries(wivrn-common PUBLIC Boost::pfr)' 'target_link_libraries(wivrn-common PUBLIC Boost::headers)'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_FREETYPE=1"
+    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+    "-DFETCHCONTENT_SOURCE_DIR_MONADO=${vendorMonado.src}"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=1"
+  ];
+
+  postFixup = ''
+    substituteInPlace $out/share/openxr/1/openxr_wivrn.json --replace "../../../" ""
+  '';
+
+  meta = with lib; {
+    description = "An OpenXR streaming application to a standalone headset";
+    homepage = "https://github.com/Meumeu/WiVRn/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ matthewcroughan ];
+    mainProgram = "wivrn-server";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

There's a few problems such as needing to override monado, and `callPackage` tinygltf since draco doesn't provide tiny_gtlf.h, if anyone can recommend ways around that I'd love to hear it, but I'm putting my work in a PR so it doesn't go to waste and so that others can continue it.

Adding cuda is also another TODO.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
