### PR TITLE
nixos/sane: add nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -751,6 +751,7 @@ in {
   sabnzbd = handleTest ./sabnzbd.nix {};
   samba = handleTest ./samba.nix {};
   samba-wsdd = handleTest ./samba-wsdd.nix {};
+  sane = handleTest ./sane.nix {};
   sanoid = handleTest ./sanoid.nix {};
   scaphandre = handleTest ./scaphandre.nix {};
   schleuder = handleTest ./schleuder.nix {};

--- a/nixos/tests/sane.nix
+++ b/nixos/tests/sane.nix
@@ -1,0 +1,85 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+/*
+  SANE NixOS test
+  ===============
+  SANE is intrisically tied to hardware, so testing it is not straightforward.
+  However:
+  - a fake webcam can be created with v4l2loopback
+  - sane has a backend (v4l) to use a webcam as a scanner
+  This test creates a webcam /dev/video0, streams a still image with some text
+  through this webcam, uses SANE to scan from the webcam, and uses OCR to check
+  that the expected text was scanned.
+*/
+let
+  text = "66263666188646651519653683416";
+  fontsConf = pkgs.makeFontsConf {
+    fontDirectories = [
+      pkgs.dejavu_fonts.minimal
+    ];
+  };
+  # an image with black on white text spelling "${text}"
+  # for some reason, the test fails if it's jpg instead of png
+  # the font is quite large to make OCR easier
+  image = pkgs.runCommand "image.png"
+    {
+      # only imagemagickBig can render text
+      nativeBuildInputs = [ pkgs.imagemagickBig ];
+      FONTCONFIG_FILE = fontsConf;
+    } ''
+    magick -pointsize 100 label:${text} $out
+  '';
+in
+{
+  name = "sane";
+  nodes.machine = { pkgs, config, ... }: {
+    boot = {
+      # create /dev/video0 as a fake webcam whose content is filled by ffmpeg
+      extraModprobeConfig = ''
+        options v4l2loopback devices=1 max_buffers=2 exclusive_caps=1 card_label=VirtualCam
+      '';
+      kernelModules = [ "v4l2loopback" ];
+      extraModulePackages = [ config.boot.kernelPackages.v4l2loopback ];
+    };
+    systemd.services.fake-webcam = {
+      wantedBy = [ "multi-user.target" ];
+      description = "fill /dev/video0 with ${image}";
+      /* HACK: /dev/video0 is a v4l2 only device, it misses one single v4l1
+      ioctl, VIDIOCSPICT. But sane only supports v4l1, so it will log that this
+      ioctl failed, and assume that the pixel format is Y8 (gray). So we tell
+      ffmpeg to produce this pixel format.
+      */
+      serviceConfig.ExecStart = [ "${pkgs.ffmpeg}/bin/ffmpeg -framerate 30 -re -stream_loop -1 -i ${image} -f v4l2 -pix_fmt gray /dev/video0" ];
+    };
+    hardware.sane.enable = true;
+    system.extraDependencies = [ image ];
+    environment.systemPackages = [
+      pkgs.fswebcam
+      pkgs.tesseract
+      pkgs.v4l-utils
+    ];
+    environment.variables.SANE_DEBUG_V4L = "128";
+  };
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("fake-webcam.service")
+
+    # the device only appears when ffmpeg starts producing frames
+    machine.wait_until_succeeds("scanimage -L | grep /dev/video0")
+
+    machine.succeed("scanimage -L >&2")
+
+    with subtest("debugging: /dev/video0 works"):
+      machine.succeed("v4l2-ctl --all >&2")
+      machine.succeed("fswebcam --no-banner /tmp/webcam.jpg")
+      machine.copy_from_vm("/tmp/webcam.jpg", "webcam")
+
+    # scan with the webcam
+    machine.succeed("scanimage -o /tmp/scan.png >&2")
+    machine.copy_from_vm("/tmp/scan.png", "scan")
+
+    # the image should contain "${text}"
+    output = machine.succeed("tesseract /tmp/scan.png -")
+    print(output)
+    assert "${text}" in output, f"expected text ${text} was not found, OCR found {output!r}"
+  '';
+})

--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -3,6 +3,7 @@
 , avahi, libgphoto2, libieee1284, libjpeg, libpng, libtiff, libusb1, libv4l, net-snmp
 , curl, systemd, libxml2, poppler, gawk
 , sane-drivers
+, nixosTests
 
 # List of { src name backend } attibute sets - see installFirmware below:
 , extraFirmware ? []
@@ -131,6 +132,10 @@ stdenv.mkDerivation {
   # parallel install creates a bad symlink at $out/lib/sane/libsane.so.1 which prevents finding plugins
   # https://github.com/NixOS/nixpkgs/issues/224569
   enableParallelInstalling = false;
+
+  passthru.tests = {
+    inherit (nixosTests) sane;
+  };
 
   meta = with lib; {
     description = "SANE (Scanner Access Now Easy) backends";


### PR DESCRIPTION
## Description of changes

I have a few ideas to modify the sane module, and a test would be handy.

cc @Profpatsch @bjornfor  as people who touched sane.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
