### PR TITLE
sqlelf: init at 0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13545,6 +13545,13 @@
     githubId = 13149442;
     name = "Nico Pulido-Mateo";
   };
+  nrabulinski = {
+    email = "1337-nix@nrab.lol";
+    matrix = "@niko:nrab.lol";
+    github = "nrabulinski";
+    githubId = 24574288;
+    name = "Nikodem Rabuliński";
+  };
   nrdxp = {
     email = "tim.deh@pm.me";
     matrix = "@timdeh:matrix.org";

--- a/pkgs/by-name/sq/sqlelf/package.nix
+++ b/pkgs/by-name/sq/sqlelf/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, python3Packages
+, fetchPypi
+
+# ls and cat binaries are referenced in tests
+, coreutils
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sqlelf";
+  version = "0.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-S2D918B/zuIpoF/FBTQKMjmPLjXt11wnxXMQ5rZrp7s=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    capstone
+    lief
+    apsw
+    sh
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  # Those tests depend on ls and cat being x86_64 Linux ELF files.
+  # The x86_64 check should be relaxed once sqlelf supports other architectures.
+  disabledTestPaths = lib.optionals (!stdenv.isLinux || !stdenv.isx86_64) [
+    "tests/test_sql.py"
+  ];
+
+  pytestFlagsArray = [
+    "-m" "not\\ slow"
+  ];
+
+  preCheck = ''
+    for test in tests/*.py; do
+      substituteInPlace "$test" \
+        --replace "/bin/ls" "${lib.getExe' coreutils "ls"}" \
+        --replace "/bin/cat" "${lib.getExe' coreutils "cat"}"
+    done
+  '';
+
+  meta = with lib; {
+    mainProgram = "sqlelf";
+    changelog = "https://github.com/fzakaria/sqlelf/releases/tag/v${version}";
+    description = "Explore ELF objects through the power of SQL";
+    homepage = "https://github.com/fzakaria/sqlelf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nrabulinski ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Added [sqlelf](https://github.com/fzakaria/sqlelf) - a tool that utilizes SQLite's virtual table functionality to allow you to explore Linux ELF objects through SQL.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc