### PR TITLE
bitbake-language-server: 0.0.6 -> 0.0.7, python310Packages.oelint-parser: 2.12.3 -> 2.13.3

### DIFF
--- a/pkgs/by-name/bi/bitbake-language-server/package.nix
+++ b/pkgs/by-name/bi/bitbake-language-server/package.nix
@@ -2,54 +2,31 @@
 , nix-update-script
 , python3
 , fetchFromGitHub
-, cmake
-, ninja
 }:
-let
-  tree-sitter-bitbake = fetchFromGitHub {
-    owner = "amaanq";
-    repo = "tree-sitter-bitbake";
-    rev = "v1.0.0";
-    hash = "sha256-HfWUDYiBCmtlu5fFX287BSDHyCiD7gqIVFDTxH5APAE=";
-  };
-in
+
 python3.pkgs.buildPythonApplication rec {
   pname = "bitbake-language-server";
-  version = "0.0.6";
+  version = "0.0.7";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Freed-Wu";
     repo = pname;
     rev = version;
-    hash = "sha256-UOeOvaQplDn7jM+3sUZip1f05TbczoaRQKMxVm+euDU=";
+    hash = "sha256-FQKZtrzfjEkAIyzrJvI7qiB4gV2yAH9w1fwO6oLPhNc=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
-    cmake
-    ninja
-    pathspec
-    pyproject-metadata
-    scikit-build-core
     setuptools-scm
+    setuptools-generate
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    lsprotocol
-    platformdirs
+    oelint-parser
     pygls
-    tree-sitter
   ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
-  # The scikit-build-core runs CMake internally so we must let it run the configure step itself.
-  dontUseCmakeConfigure = true;
-  SKBUILD_CMAKE_ARGS = lib.strings.concatStringsSep ";" [
-    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
-    "-DFETCHCONTENT_QUIET=OFF"
-    "-DFETCHCONTENT_SOURCE_DIR_TREE-SITTER-BITBAKE=${tree-sitter-bitbake}"
-  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/oelint-parser/default.nix
+++ b/pkgs/development/python-modules/oelint-parser/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "oelint-parser";
-  version = "2.12.3";
+  version = "2.13.3";
   format = "setuptools";
 
   src = fetchPypi {
     inherit version;
     pname = "oelint_parser";
-    hash = "sha256-fzHEy9/BxstPAYhVTG0o7Gn2D9UKuSZvI0X5ynZ+oEk=";
+    hash = "sha256-pjonw0VZlDK3xf8cfgn+qT4jZSYD8wRSDLz1Go9Y5so=";
   };
 
   buildInputs = [ pip ];


### PR DESCRIPTION
## Description of changes

The new `bitbake-language-server` release uses `oelint-parser`, but it requires the 2.13.x release so the update.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
