### PR TITLE
peruse: 1.2.20200208 -> 1.80

### DIFF
--- a/pkgs/tools/misc/peruse/default.nix
+++ b/pkgs/tools/misc/peruse/default.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ peterhoeg ];
     mainProgram = "peruse";
+    inherit (kirigami2.meta) platforms;
   };
 })

--- a/pkgs/tools/misc/peruse/default.nix
+++ b/pkgs/tools/misc/peruse/default.nix
@@ -1,9 +1,9 @@
-{ mkDerivation
-, fetchFromGitHub
+{ stdenv
+, fetchurl
 , lib
 , extra-cmake-modules
 , kdoctools
-, wrapGAppsHook
+, wrapQtAppsHook
 , baloo
 , karchive
 , kconfig
@@ -12,25 +12,25 @@
 , kinit
 , kirigami2
 , knewstuff
+, okular
 , plasma-framework
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "peruse";
-  version = "1.2.20200208";
+  # while technically a beta, the latest release is from 2016 and doesn't build without a lot of
+  # patching
+  version = "1.80";
 
-  # The last formal release from 2016 uses kirigami1 which is deprecated
-  src = fetchFromGitHub {
-    owner = "KDE";
-    repo = pname;
-    rev = "4a1b3f954d2fe7e4919c0c5dbee1917776da582e";
-    sha256 = "1s5yy240x4cvrk93acygnrp5m10xp7ln013gdfbm0r5xvd8xy19k";
+  src = fetchurl {
+    url = "mirror://kde/stable/peruse/peruse-${finalAttrs.version}.tar.xz";
+    hash = "sha256-xnSVnKF20jbxVoFW41A22NZWVZUry/F7G+Ts5NK6M1E=";
   };
 
   nativeBuildInputs = [
     extra-cmake-modules
     kdoctools
-    wrapGAppsHook
+    wrapQtAppsHook
   ];
 
   propagatedBuildInputs = [
@@ -42,16 +42,20 @@ mkDerivation rec {
     kinit
     kirigami2
     knewstuff
+    okular
     plasma-framework
   ];
+
+  # the build is otherwise crazy loud
+  cmakeFlags = [ "-Wno-dev" ];
 
   pathsToLink = [ "/etc/xdg/peruse.knsrc" ];
 
   meta = with lib; {
     description = "A comic book reader";
     homepage = "https://peruse.kde.org";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ peterhoeg ];
+    mainProgram = "peruse";
   };
-
-}
+})


### PR DESCRIPTION
## Description of changes

Upgrade to a beta instead of a random commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
