### PR TITLE
nfs-utils: enable ldap support, and update to 2.6.4

### DIFF
--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch, lib, pkg-config, util-linux, libcap, libtirpc, libevent
 , sqlite, libkrb5, kmod, libuuid, keyutils, lvm2, systemd, coreutils, tcp_wrappers
-, python3, buildPackages, nixosTests, rpcsvc-proto
-, enablePython ? true
+, python3, buildPackages, nixosTests, rpcsvc-proto, openldap
+, enablePython ? true, enableLdap ? true
 }:
 
 let
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libtirpc libcap libevent sqlite lvm2
     libuuid keyutils libkrb5 tcp_wrappers
-  ] ++ lib.optional enablePython python3;
+  ] ++ lib.optional enablePython python3
+    ++ lib.optional enableLdap  openldap;
 
   enableParallelBuilding = true;
 
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
       "--with-pluginpath=${placeholder "lib"}/lib/libnfsidmap" # this installs libnfsidmap
       "--with-rpcgen=${buildPackages.rpcsvc-proto}/bin/rpcgen"
       "--with-modprobedir=${placeholder "out"}/etc/modprobe.d"
-    ];
+    ] ++ lib.optional enableLdap "--with-ldap";
 
   patches = lib.optionals stdenv.hostPlatform.isMusl [
     # http://openwall.com/lists/musl/2015/08/18/10

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -10,11 +10,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "nfs-utils";
-  version = "2.6.2";
+  version = "2.6.4";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/nfs-utils/${version}/${pname}-${version}.tar.xz";
-    hash = "sha256-UgCHPoHE1hDiRi/CYv4YE18tvni3l5+VrM0VmuZNUBE=";
+    hash = "sha256-AbOw+5x9C7q/URTHNlQgMHSMeI7C/Zc0dEIB6bChEZ0=";
   };
 
   # libnfsidmap is built together with nfs-utils from the same source,
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
       substituteInPlace systemd/nfs-utils.service \
         --replace "/bin/true" "${coreutils}/bin/true"
 
-      substituteInPlace tools/nfsrahead/Makefile.in \
+      substituteInPlace tools/nfsrahead/Makefile.in systemd/Makefile.in \
         --replace "/usr/lib/udev/rules.d/" "$out/lib/udev/rules.d/"
 
       substituteInPlace utils/mount/Makefile.in \


### PR DESCRIPTION
## Description of changes

- Adds LDAP support
- Updates to 2.6.4 [Changelog](https://mirrors.edge.kernel.org/pub/linux/utils/nfs-utils/2.6.4/2.6.4-Changelog)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
