### PR TITLE
 himalaya 0.7.1 -> 1.0.0-beta

### DIFF
--- a/pkgs/applications/networking/mailreaders/himalaya/default.nix
+++ b/pkgs/applications/networking/mailreaders/himalaya/default.nix
@@ -1,5 +1,5 @@
 { lib
-, rustPlatform
+, rustPackages_1_70
 , fetchFromGitHub
 , stdenv
 , installShellFiles
@@ -15,18 +15,21 @@
 , withSmtpSender ? true
 }:
 
+let
+  rustPlatform = rustPackages_1_70.rustPlatform;
+in
 rustPlatform.buildRustPackage rec {
   pname = "himalaya";
-  version = "0.7.1";
+  version = "1.0.0-beta";
 
   src = fetchFromGitHub {
     owner = "soywod";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-yAfNH9LSXlS/Hzi5kAuur5BX2vITMucprDzxhlV8RiY=";
+    sha256 = "sha256-39XYtxmo/12hkCS7zVIQi3UbLzaIKH1OwfdDB/ghU98=";
   };
 
-  cargoSha256 = "sha256-FXfh6T8dNsnD/V/wYSMDWs+ll0d1jg1Dc3cQT39b0ws=";
+  cargoSha256 = "sha256-HIDmBPrcOcK2coTaD4v8ntIZrv2SwTa8vUTG8Ky4RhM=";
 
   nativeBuildInputs = [ ]
     ++ lib.optional (installManPages || installShellCompletions) installShellFiles
@@ -37,10 +40,10 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withNotmuchBackend notmuch;
 
   buildNoDefaultFeatures = true;
-  buildFeatures = [ ]
-    ++ lib.optional withImapBackend "imap-backend"
-    ++ lib.optional withNotmuchBackend "notmuch-backend"
-    ++ lib.optional withSmtpSender "smtp-sender";
+  buildFeatures = [ "maildir" "sendmail" ]
+    ++ lib.optional withImapBackend "imap"
+    ++ lib.optional withNotmuchBackend "notmuch"
+    ++ lib.optional withSmtpSender "smtp";
 
   postInstall = lib.optionalString installManPages ''
     mkdir -p $out/man


### PR DESCRIPTION
## Description of changes

- https://github.com/soywod/himalaya/releases/tag/v0.7.2
- https://github.com/soywod/himalaya/releases/tag/v0.7.3
- https://github.com/soywod/himalaya/releases/tag/v0.8.0
- https://github.com/soywod/himalaya/releases/tag/v0.8.1
- https://github.com/soywod/himalaya/releases/tag/v0.8.2
- https://github.com/soywod/himalaya/releases/tag/v0.8.3
- https://github.com/soywod/himalaya/releases/tag/v0.8.4
- https://github.com/soywod/himalaya/releases/tag/v0.9.0
- https://github.com/soywod/himalaya/releases/tag/v1.0.0-beta

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
