### PR TITLE
rsync: fix missing ipv6 support

### DIFF
--- a/pkgs/applications/networking/sync/rsync/configure.ac-fix-failing-IPv6-check.patch
+++ b/pkgs/applications/networking/sync/rsync/configure.ac-fix-failing-IPv6-check.patch
@@ -1,0 +1,12 @@
+diff -rup rsync-3.2.7/configure.sh rsync-3.2.7-fixed/configure.sh
+--- rsync-3.2.7/configure.sh	2022-10-20 17:57:22
++++ rsync-3.2.7-fixed/configure.sh	2024-01-01 19:51:58
+@@ -7706,7 +7706,7 @@ else $as_nop
+ #include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-main()
++int main()
+ {
+    if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
+      exit(1);

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     # https://github.com/WayneD/rsync/issues/511#issuecomment-1774612577
     # original source: https://build.opensuse.org/package/view_file/network/rsync/rsync-fortified-strlcpy-fix.patch?expand=1&rev=3f8dd2f4a404c96c0f69176e60893714
     ./rsync-fortified-strlcpy-fix.patch
+    # https://github.com/WayneD/rsync/pull/558
+    ./configure.ac-fix-failing-IPv6-check.patch
   ];
 
   buildInputs = [ libiconv zlib popt ]


### PR DESCRIPTION
## Description of changes

Added a patch to apply https://github.com/WayneD/rsync/pull/558.

Somehow aarch64-linux is okay:

* https://hydra.nixos.org/build/242874385/nixlog/1256

While aarch64-darwin is not:

* https://hydra.nixos.org/build/243173677/nixlog/1

I think it broke with clang-16:

```
ivan@vm:~/projects/rsync$ clang-15 -o derp -g -O2 -Wall -W derp.c
derp.c:4:1: warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
main()
^
int
1 warning generated.
```

```
ivan@vm:~/projects/rsync$ clang-16 -o derp -g -O2 -Wall -W derp.c
derp.c:4:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
main()
^
int
1 error generated.
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).