### PR TITLE
updateAutotoolsGnuConfigScriptsHook: handle paths containing whitespace properly

### DIFF
--- a/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
+++ b/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
@@ -3,8 +3,11 @@ preConfigurePhases+=" updateAutotoolsGnuConfigScriptsPhase"
 updateAutotoolsGnuConfigScriptsPhase() {
     if [ -n "${dontUpdateAutotoolsGnuConfigScripts-}" ]; then return; fi
 
+    trap "$(shopt -p globstar)" RETURN
+    shopt -s globstar
+
     for script in config.sub config.guess; do
-        for f in $(find . -type f -name "$script"); do
+        for f in **/"$script"; do
             echo "Updating Autotools / GNU config script to a newer upstream version: $f"
             cp -f "@gnu_config@/$script" "$f"
         done


### PR DESCRIPTION
## Description of changes

The `updateAutotoolsGnuConfigScriptsHook` broke when a `config.sub` or `config.guess` file was under a path containing a whitespace, since the path would get broken up by bash word splitting and become two separate items in the `for` loop. 

For example, trying to build a backported standardnotes 3.183.22, the hook ran into trouble with the path `./opt/Standard Notes/resources/app.asar.unpacked/node_modules/sqlite3/build/Release/obj/gen/sqlite-autoconf-3410100/config.sub`:
```
Running phase: updateAutotoolsGnuConfigScriptsPhase
Updating Autotools / GNU config script to a newer upstream version: ./opt/Standard
Updating Autotools / GNU config script to a newer upstream version: Notes/resources/app.asar.unpacked/node_modules/sqlite3/build/Release/obj/gen/sqlite-autoconf-3410100/config.sub
cp: cannot create regular file 'Notes/resources/app.asar.unpacked/node_modules/sqlite3/build/Release/obj/gen/sqlite-autoconf-3410100/config.sub': No such file or directory
```

Using `**` instead of `find` avoids this, since pathname expansion takes place after word splitting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
