### PR TITLE
flint3: init at 3.0.1

### DIFF
--- a/pkgs/development/libraries/flint/3.nix
+++ b/pkgs/development/libraries/flint/3.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fast Library for Number Theory";
     license = licenses.gpl2Plus;
-    maintainers = teams.sage.members;
+    maintainers = with maintainers; [ smasher164 ] ++ teams.sage.members;
     platforms = platforms.unix;
     homepage = "https://www.flintlib.org/";
     downloadPage = "https://www.flintlib.org/downloads.html";

--- a/pkgs/development/libraries/flint/3.nix
+++ b/pkgs/development/libraries/flint/3.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchurl
+, gmp
+, mpfr
+, ntl
+, autoconf
+, automake
+, gettext
+, libtool
+, openblas ? null, blas, lapack
+, withBlas ? true
+, withNtl ? true
+}:
+
+assert withBlas -> openblas != null && blas.implementation == "openblas" && lapack.implementation == "openblas";
+
+stdenv.mkDerivation rec {
+  pname = "flint3";
+  version = "3.0.1";
+
+  src = fetchurl {
+    url = "https://www.flintlib.org/flint-${version}.tar.gz";
+    sha256 = "sha256-ezEaAFA6hjiB64F32+uEMi8pOZ89fXLzsaTJuh1XlLQ=";
+  };
+
+  propagatedBuildInputs = [
+    autoconf
+    automake
+    gettext
+    libtool
+  ];
+
+  buildInputs = [
+    gmp
+    mpfr
+  ] ++ lib.optionals withBlas [
+    openblas
+  ] ++ lib.optionals withNtl [
+    ntl
+  ];
+
+  # We're not using autoreconfHook because flint's bootstrap
+  # script calls autoreconf, among other things.
+  preConfigurePhase = ''
+    echo "Executing bootstrap.sh"
+    ./bootstrap.sh
+  '';
+
+  configureFlags = [
+    "--with-gmp=${gmp}"
+    "--with-mpfr=${mpfr}"
+  ] ++ lib.optionals withBlas [
+    "--with-blas=${openblas}"
+  ] ++ lib.optionals withNtl [
+    "--with-ntl=${ntl}"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Fast Library for Number Theory";
+    license = licenses.gpl2Plus;
+    maintainers = teams.sage.members;
+    platforms = platforms.unix;
+    homepage = "https://www.flintlib.org/";
+    downloadPage = "https://www.flintlib.org/downloads.html";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21279,6 +21279,8 @@ with pkgs;
 
   flint = callPackage ../development/libraries/flint { };
 
+  flint3 = callPackage ../development/libraries/flint/3.nix { };
+
   flite = callPackage ../development/libraries/flite { };
 
   fltk13 = callPackage ../development/libraries/fltk {


### PR DESCRIPTION
## Description of changes

Flint 3 breaks backwards compatibility with Flint 2, so I'm defining a new package.
The build instructions say to execute `bootstrap.sh` which internally runs `autoreconf`,
so I didn't add the hook.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
