### PR TITLE
[staging-next] qt6.qtwebengine: fix build with libxml 2.12

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -131,6 +131,10 @@ qtModule {
 
     # Override locales install path so they go to QtWebEngine's $out
     ../patches/qtwebengine-locales-path.patch
+
+    # Cherry-pick libxml 2.12 build fix
+    # FIXME: remove for 6.7
+    ../patches/qtwebengine-libxml-2.12.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-libxml-2.12.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-libxml-2.12.patch
@@ -1,0 +1,22 @@
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor.h
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor.h
+@@ -77,7 +77,7 @@ class XSLTProcessor final : public ScriptWrappable {
+ 
+   void reset();
+ 
+-  static void ParseErrorFunc(void* user_data, xmlError*);
++  static void ParseErrorFunc(void* user_data, const xmlError*);
+   static void GenericErrorFunc(void* user_data, const char* msg, ...);
+ 
+   // Only for libXSLT callbacks
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
+@@ -66,7 +66,7 @@ void XSLTProcessor::GenericErrorFunc(void*, const char*, ...) {
+   // It would be nice to do something with this error message.
+ }
+ 
+-void XSLTProcessor::ParseErrorFunc(void* user_data, xmlError* error) {
++void XSLTProcessor::ParseErrorFunc(void* user_data, const xmlError* error) {
+   FrameConsole* console = static_cast<FrameConsole*>(user_data);
+   if (!console)
+     return;


### PR DESCRIPTION
## Description of changes

Cherry-pick an upstream change to fix function signatures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
