### PR TITLE
haskell.packages.ghcjs: fix unevaluatable packages

### DIFF
--- a/pkgs/development/compilers/ghcjs/8.10/default.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/default.nix
@@ -47,6 +47,7 @@ let
     inherit (bootGhcjs) version;
     isGhcjs = true;
 
+    llvmPackages = null;
     enableShared = true;
 
     socket-io = pkgsHostHost.nodePackages."socket.io";

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -8,7 +8,11 @@ in
 
 self: super: {
 
-  llvmPackages = pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
+  # ghcjs does not use `llvmPackages` and exposes `null` attribute.
+  llvmPackages =
+    if self.ghc.llvmPackages != null
+    then pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages
+    else null;
 
   # Disable GHC 8.10.x core libraries.
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -26,7 +26,7 @@ self: super:
 
   # GHCJS does not ship with the same core packages as GHC.
   # https://github.com/ghcjs/ghcjs/issues/676
-  stm = doJailbreak self.stm_2_5_1_0;
+  stm = doJailbreak self.stm_2_5_3_0;
   exceptions = dontCheck self.exceptions_0_10_7;
 
 ## OTHER PACKAGES


### PR DESCRIPTION
`haskell.packages.ghcjs` has a few packages that fails to evaluate by referring non-existent attributes. This turns evaluation attempts into unrecoverable errors.

Before the change an attempt to instantiate all `ghcjs` packages failed as:

    $ nix-instantiate --strict --eval --expr 'with import ./. {}; lib.mapAttrs (n: v: builtins.tryEval (lib.isDerivation v)) haskell.packages.ghcjs'
    error:
       … while evaluating the attribute 'llvmPackages'
       error: attribute 'llvmPackages' missing
       at pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix:11:48:

           10|
           11|   llvmPackages = pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
             |                                                ^

The change follows definition of `pkgs/top-level/haskell-packages.nix` and also sets `llvmPackages` to `null`. While at it dropped other references to deleted packages like `stm` pin.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
