### PR TITLE
rgp: 1.15.1 -> 2.0

### DIFF
--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -9,25 +9,27 @@
 , glib
 , libGLU
 , libglvnd
+, libICE
+, libkrb5
+, libSM
 , libX11
 , libxcb
 , libXi
+, libxkbcommon
 , ncurses
-, qtbase
-, qtdeclarative
 , zlib
 }:
 
 let
-  buildNum = "2023-05-22-1083";
+  buildNum = "2023-12-04-1282";
 in
 stdenv.mkDerivation {
   pname = "rgp";
-  version = "1.15.1";
+  version = "2.0";
 
   src = fetchurl {
     url = "https://gpuopen.com/download/radeon-developer-tool-suite/RadeonDeveloperToolSuite-${buildNum}.tgz";
-    hash = "sha256-WSSiNiiIVw1wwt9vxgyirBDe+SPzH87LU1GlSdUhZB8=";
+    hash = "sha256-gGkINq0tmOCkZJMxtoURHikqEGXGuRAP6Y6PEOLqmI0=";
   };
 
   nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
@@ -39,16 +41,16 @@ stdenv.mkDerivation {
     glib
     libGLU
     libglvnd
+    libICE
+    libkrb5
+    libSM
     libX11
     libxcb
     libXi
+    libxkbcommon
     ncurses
-    qtbase
-    qtdeclarative
     zlib
   ];
-
-  dontWrapQtApps = true;
 
   installPhase = ''
     mkdir -p $out/opt/rgp $out/bin
@@ -59,10 +61,16 @@ stdenv.mkDerivation {
 
     for prog in RadeonDeveloperPanel RadeonDeveloperService RadeonDeveloperServiceCLI RadeonGPUAnalyzer RadeonGPUProfiler RadeonMemoryVisualizer RadeonRaytracingAnalyzer rga rtda; do
       # makeWrapper is needed so that executables are started from the opt
-      # directory, where qt.conf and other tools are
+      # directory, where qt.conf and other tools are.
+      # Unset Qt theme, it does not work if the nixos Qt version is different from the packaged one.
+      # The packaged Qt version only supports X11, so enforce that.
       makeWrapper \
         $out/opt/rgp/$prog \
-        $out/bin/$prog
+        $out/bin/$prog \
+        --unset QT_QPA_PLATFORMTHEME \
+        --unset QT_STYLE_OVERRIDE \
+        --set QT_QPA_PLATFORM xcb \
+        --prefix LD_LIBRARY_PATH : $out/opt/rgp/lib
     done
   '';
 


### PR DESCRIPTION
Update Radeon GPU Profiler package.
Changelogs:
https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v1.16 https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v2.0

Replace Qt dependencies with packaged libraries and unset Qt theming environment variables.
The applications do not start with them set.

## Description of changes
Update Radeon GPU Profiler package.
Changelogs:
https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v1.16 https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v2.0

Replace Qt dependencies with packaged libraries and unset Qt theming environment variables.
The applications do not start with them set.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
