### PR TITLE
Nixos/qbittorrent init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1234,6 +1234,7 @@
   ./services/torrent/rtorrent.nix
   ./services/torrent/transmission.nix
   ./services/torrent/torrentstream.nix
+  ./services/torrent/qbittorrent.nix
   ./services/tracing/tempo.nix
   ./services/ttys/getty.nix
   ./services/ttys/gpm.nix

--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -1,0 +1,105 @@
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.services.qbittorrent;
+  inherit (lib.types) str unspecified;
+  inherit (lib.meta) getExe maintainers;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption mdDoc;
+  inherit (lib.modules) mkIf;
+
+  inherit (builtins) concatStringsSep isAttrs;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.strings) escape;
+  inherit (lib.generators) toINI mkKeyValueDefault mkValueStringDefault;
+  gendeepINI = toINI {
+    mkKeyValue = let
+      sep = "=";
+    in
+      k: v:
+        if isAttrs v
+        then
+          concatStringsSep "\n"
+          (mapAttrsToList (k2: v2:
+            "${escape [sep] "${k}\\${k2}"}${sep}${mkValueStringDefault {} v2}"
+            )
+          v)
+        else mkKeyValueDefault {} sep k v;
+  };
+in
+{
+  options.services.qbittorrent = {
+    enable = mkEnableOption (mdDoc "qbittorrent, BitTorrent client.");
+
+    user = mkOption {
+      type = str;
+      default = "qbittorrent";
+      description = mdDoc "User account under which qbittorrent runs.";
+    };
+
+    group = mkOption {
+      type = str;
+      default = "qbittorrent";
+      description = mdDoc "Group under which qbittorrent runs.";
+    };
+
+    package = mkPackageOption pkgs "qbittorrent-nox" { };
+
+    profileDir = mkOption {
+      type = str;
+      default = "/var/lib/qBittorrent/";
+      description = mdDoc "the path passed to qbittorrent via --profile";
+    };
+
+    serverConfig = mkOption {
+      type = unspecified;
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd = {
+      tmpfiles.settings = {
+        profileDir = {
+          "${cfg.profileDir}/qBittorrent/"."d" = {
+            mode = "700";
+            inherit (cfg) user group;
+          };
+        };
+        configFile = {
+          "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"."L+" = {
+            mode = "400";
+            inherit (cfg) user group;
+            argument = "${pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig)}";
+          };
+        };
+      };
+      # based on https://github.com/qbittorrent/qBittorrent/blob/master/dist/unix/systemd/qbittorrent-nox%40.service.in
+      services.qbittorrent = {
+        description = "qbittorrent BitTorrent client";
+        wants = [ "network-online.target" ];
+        after = [ "local-fs.target" "network-online.target" "nss-lookup.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          UMask = "0077";
+          PrivateTmp = false;
+          ExecStart = "${getExe cfg.package} --profile=${cfg.profileDir}";
+          TimeoutStopSec = 1800;
+        };
+      };
+    };
+
+    users = {
+      users = mkIf (cfg.user == "qbittorrent") {
+        qbittorrent = {
+          inherit (cfg) group;
+          isSystemUser = true;
+        };
+      };
+      groups = mkIf (cfg.group == "qbittorrent") {
+        qbittorrent = {};
+      };
+    };
+  };
+  meta.maintainers = with maintainers; [ nu-nu-ko ];
+}


### PR DESCRIPTION
## Description of changes
work for adding a qbittorrent module option to nixos

what works.
1. basic profile location definition
2. `qBittorrent/config/qBittorrent.conf` definition with `genINI` ( should have a defined custom type.. )

what does not or may not work
1. openFirewall

potentially nice extras.

1. custom webui definition.
    my first idea for this was to make packages for each webui project and add them to extraPackages to then reference their place in the `RootFolder` option.

2. a nice way to include search plugins.
    they seem to accept just web links so id assume there's some reasonably nice way to supply a list of links that are downloaded to the appropriate location, from there it seems the program will maintain them on its own including updates and imports etc

I'm using this already but obviously having troubles, for reference you can see my use [here](https://github.com/nu-nu-ko/crystal/blob/main/mods/services/qbit.nix)

Drafting this so i can get feedback and collect thoughts on how to approach problems like including custom webuis and search plugins, any insight is appreciated.


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
