### PR TITLE
sage: import 10.2.beta3 patches

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -131,6 +131,20 @@ stdenv.mkDerivation rec {
       url = "https://github.com/sagemath/sage/commit/461727b453712550a2c5dc0ae11933523255aaed.diff";
       sha256 = "sha256-mC8084VQoUBk4hocALF+Y9Cwb38Zt360eldi/SSjna8=";
     })
+
+    # https://github.com/sagemath/sage/pull/36218, landed in 10.2.beta3
+    (fetchpatch {
+      name = "sageenv-disable-file-validation.patch";
+      url = "https://github.com/sagemath/sage/commit/31a764f4a9ec54d3ea970aa9514a088c4e603ebd.diff";
+      sha256 = "sha256-NhYUTTmYlyjss3eS8HZXP8U11TElQY0cv6KW4wBOaJY=";
+    })
+
+    # https://github.com/sagemath/sage/pull/36235, landed in 10.2.beta3
+    (fetchpatch {
+      name = "ecl-23.9.9.patch";
+      url = "https://github.com/sagemath/sage/commit/b6b50a80e9660c002d069019f5b8f04e9324a423.diff";
+      sha256 = "sha256-nF+5oKad1VYms6Dxr1t9/V0XBkoMfhy0KCY/ZPddrm0=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
## Description of changes

- Import upstream patches:
  - doctest fix for python >= 3.11, sagemath/sage#36218
  - fix for ecl >= 23.9.9, sagemath/sage#36235
- Failing Hydra [logs](https://hydra.nixos.org/build/245175660), relevant lines:
  <details>

  ```
  [311/552] gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -I/nix/store/jh2dj172jmmlw74kw4bsqa5ycf1blv4v-libxcrypt-4.4.36/include -fPIC -Isage/libs -I/nix/store/kiw2pplx7iadra2zy0c204bhngrjw8xg-gmp-with-cxx-6.3.0-dev/include -I/nix/store/jjxwn04kkwqy4nmdzp4np2pdjq21vhzv-ecl-23.9.9/include -I./sage/cpython -I/nix/store/0ikyy1lm97f36psav3pn2z1anglx678n-python3.11-cysignals-1.11.2/lib/python3.11/site-packages/cysignals -I/build/sage-src-10.0/pkgs/sagemath-standard -I/nix/store/2z836nvlwm17ih2sy1d1l165jihdr2ha-python3.11-numpy-1.26.1/lib/python3.11/site-packages/numpy/core/include -I/nix/store/5k91mg4qjylxbfvrv748smfh51ppjq0g-python3-3.11.6/include/python3.11 -Ibuild/cythonized -I/nix/store/5k91mg4qjylxbfvrv748smfh51ppjq0g-python3-3.11.6/include/python3.11 -c build/cythonized/sage/libs/ecl.c -o build/temp.linux-x86_64-cpython-311/build/cythonized/sage/libs/ecl.o -fno-strict-aliasing -DCYTHON_CLINE_IN_TRACEBACK=1 -Dlinux
  In file included from build/cythonized/sage/libs/ecl.c:3373:
  build/cythonized/sage/libs/eclsig.h: In function ‘ecl_bignum_from_mpz’:
  build/cythonized/sage/libs/eclsig.h:48:45: error: ‘struct ecl_bignum’ has no member named ‘big_num’
     48 | #define ecl_mpz_from_bignum(obj) ((obj)->big.big_num)
        |                                             ^
  build/cythonized/sage/libs/eclsig.h:53:13: note: in expansion of macro ‘ecl_mpz_from_bignum’
     53 |     mpz_set(ecl_mpz_from_bignum(z), num);
        |             ^~~~~~~~~~~~~~~~~~~
  build/cythonized/sage/libs/ecl.c: In function ‘__pyx_f_4sage_4libs_3ecl_ecl_to_python’:
  build/cythonized/sage/libs/eclsig.h:48:45: error: ‘struct ecl_bignum’ has no member named ‘big_num’
     48 | #define ecl_mpz_from_bignum(obj) ((obj)->big.big_num)
        |                                             ^
  build/cythonized/sage/libs/ecl.c:7415:199: note: in expansion of macro ‘ecl_mpz_from_bignum’
   7415 |     ((struct __pyx_vtabstruct_4sage_5rings_7integer_Integer *)__pyx_v_N->__pyx_base.__pyx_base.__pyx_base.__pyx_base.__pyx_base.__pyx_base.__pyx_base.__pyx_base.__pyx_vtab)->set_from_mpz(__pyx_v_N, ecl_mpz_from_bignum(__pyx_v_o));
        |                                                                                                                                                                                                       ^~~~~~~~~~~~~~~~~~~
  ```
</details>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>cantor</li>
    <li>labplot</li>
    <li>sage</li>
    <li>sageWithDoc</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
