### PR TITLE
zabbix-agent2-plugin-postgresql: init at 6.0.25

### DIFF
--- a/pkgs/by-name/za/zabbix-agent2-plugin-postgresql/package.nix
+++ b/pkgs/by-name/za/zabbix-agent2-plugin-postgresql/package.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, fetchurl, pkg-config }:
+
+buildGoModule rec {
+  pname = "zabbix-agent2-plugin-postgresql";
+  version = "6.0.25";
+
+  src = fetchurl {
+    url = "https://cdn.zabbix.com/zabbix-agent2-plugins/sources/postgresql/zabbix-agent2-plugin-postgresql-${version}.tar.gz";
+    hash = "sha256-NFohopyUFO2C1k5moM4qkXX0Q9zc8W0Z+WrvZ5lgr1I=";
+  };
+
+  vendorHash = null;
+
+  meta = with lib; {
+    description = "Required tool for Zabbix agent integrated PostgreSQL monitoring";
+    homepage = "https://www.zabbix.com/integrations/postgresql";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gador ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Since the update of `zabbix` to >=6, the postgresql monitoring plugin has been phased out to a seperate plugin. 
This PR packages this plugin.

For reference: 

https://www.zabbix.com/documentation/current/en/manual/appendix/config/zabbix_agent2_plugins/postgresql_plugin
https://git.zabbix.com/projects/AP/repos/postgresql/browse?at=refs%2Fheads%2Frelease%2F6.4

My config to make the `postgresql` plugin work (again) is:

```nix
 services.zabbixAgent = {
        enable = true;
        server = cfg.agent.server;
        package = pkgs.zabbix.agent2;
        openFirewall = true;
        listen.ip = cfg.agent.ip;
        extraPackages = [ pkgs.zabbix-agent2-plugin-postgresql ];
        settings = {
          ServerActive = cfg.agent.server;
          Hostname = cfg.agent.hostname;
          Include = "/etc/zabbix/includes";
        };
      };
      environment.etc."zabbix/includes/postgresql.conf" = mkIf cfg.agent.userparameter.psql {
        text = ''
          Plugins.PostgreSQL.System.Path=${pkgs.zabbix-agent2-plugin-postgresql}/bin/postgresql
        '';
        mode = "0554";
        user = "zabbix-agent";
        group = "zabbix-agent";
      };
    };
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

tested on my server, which returned postgresql status updates and seems to be working as before.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
