### PR TITLE
openswitcher: init at 0.9.1

### DIFF
--- a/pkgs/by-name/op/openswitcher/package.nix
+++ b/pkgs/by-name/op/openswitcher/package.nix
@@ -1,0 +1,80 @@
+{ lib
+, python3Packages
+, fetchFromSourcehut
+, desktop-file-utils
+, gobject-introspection
+, gtk3
+, libhandy
+, meson
+, ninja
+, pkg-config
+, scdoc
+, wrapGAppsHook
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "openswitcher";
+  version = "0.9.1";
+  format = "other";
+
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = "pyatem";
+    rev = version;
+    hash = "sha256-264XqBl+1qsAc5vOxJabbkubY+F72xo06WWishVEQOI=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gobject-introspection
+    gtk3
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wrapGAppsHook
+  ];
+
+  dontWrapGApps = true;
+
+  buildInputs = [
+    gtk3
+    libhandy
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    # for switcher-control, bmd-setup
+    paho-mqtt
+    pyatem
+    pygobject3
+    # for atemswitch
+    requests
+    # for openswitcher-proxy
+    toml
+  ];
+
+  postInstall = ''
+    install -Dm644 -t $out/lib/udev/rules.d/ $src/100-blackmagicdesign.rules
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    description = "Blackmagic Design mixer control application";
+    downloadPage = "https://git.sr.ht/~martijnbraam/pyatem";
+    homepage = "https://openswitcher.org/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pyatem/default.nix
+++ b/pkgs/development/python-modules/pyatem/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromSourcehut
+
+# build-system
+, setuptools
+
+# dependencies
+, pyusb
+, tqdm
+, zeroconf
+
+# tests
+, pillow
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyatem";
+  version = "0.9.0"; # check latest version in setup.py
+  pyproject = true;
+
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = "pyatem";
+    rev = version;
+    hash = "sha256-ntwUhgC8Cgrim+kU3B3ckgPDmPe+aEHDP4wsB45KbJg=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    pyusb
+    tqdm
+    zeroconf
+  ];
+
+  nativeCheckInputs = [
+    pillow
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    TESTDIR=$(mktemp -d)
+    cp -r pyatem/{test_*.py,fixtures} $TESTDIR/
+    pushd $TESTDIR
+  '';
+
+  disabledTests = lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+    # colorspace mapping has weird, but constant offsets on aarch64-linux
+    "test_blueramp"
+    "test_greenramp"
+    "test_hues"
+    "test_primaries"
+    "test_redramp"
+  ];
+
+  postCheck = ''
+    popd
+  '';
+
+  pythonImportsCheck = [
+    "pyatem"
+  ];
+
+  meta = with lib; {
+    description = "Library for controlling Blackmagic Design ATEM video mixers";
+    homepage = "https://git.sr.ht/~martijnbraam/pyatem";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9362,6 +9362,8 @@ self: super: with self; {
 
   pyatag = callPackage ../development/python-modules/pyatag { };
 
+  pyatem = callPackage ../development/python-modules/pyatem { };
+
   pyatome = callPackage ../development/python-modules/pyatome { };
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };


### PR DESCRIPTION
## Description of changes

Packages https://git.sr.ht/~martijnbraam/pyatem
- openswitcher, atemswitch, bmd-setup, openswitcher-proxy applications
- pyatem library

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] pkgsCross.aarch64-multiplatform
  - [ ] aarch64-linux (failing tests)
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
