### PR TITLE
emscripten_3_1_49: init at 3.1.49

### DIFF
--- a/pkgs/development/compilers/emscripten/0001-emulate-clang-sysroot-include-logic-3.1.49.patch
+++ b/pkgs/development/compilers/emscripten/0001-emulate-clang-sysroot-include-logic-3.1.49.patch
@@ -1,0 +1,42 @@
+From 4bbbb640934aa653bcfec0335798b77a8935b815 Mon Sep 17 00:00:00 2001
+From: Yureka <yuka@yuka.dev>
+Date: Sat, 7 Aug 2021 09:16:46 +0200
+Subject: [PATCH] emulate clang 'sysroot + /include' logic
+
+Authored-By: Alexander Khovansky <alex@khovansky.me>
+Co-Authored-By: Yureka <yuka@yuka.dev>
+
+Clang provided by nix patches out logic that appends 'sysroot + /include'
+to the include path as well as automatic inclusion of libcxx includes (/include/c++/v1).
+The patch below adds that logic back by introducing cflags emulating this behavior to emcc
+invocations directly.
+
+Important note: with non-nix clang, sysroot/include dir ends up being the last
+in the include search order, right after the resource root.
+Hence usage of -idirafter. Clang also documents an -isystem-after flag
+but it doesn't appear to work
+---
+ emcc.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/emcc.py b/emcc.py
+index ba8d1b556..7d89644c5 100755
+--- a/emcc.py
++++ b/emcc.py
+@@ -883,7 +883,12 @@ def parse_s_args(args):
+ 
+ 
+ def emsdk_cflags(user_args):
+-  cflags = ['--sysroot=' + cache.get_sysroot(absolute=True)]
++  cflags = [
++    '--sysroot=' + cache.get_sysroot(absolute=True),
++    '-resource-dir=@resourceDir@',
++    '-idirafter' + cache.get_sysroot(absolute=True) + os.path.join('/include'),
++    '-iwithsysroot' + os.path.join('/include','c++','v1')
++  ]
+ 
+   def array_contains_any_of(hay, needles):
+     for n in needles:
+-- 
+2.40.0
+

--- a/pkgs/development/compilers/emscripten/3.1.49.nix
+++ b/pkgs/development/compilers/emscripten/3.1.49.nix
@@ -1,0 +1,141 @@
+{ lib, stdenv, fetchFromGitHub, python3, nodejs, closurecompiler
+, jre, binaryen
+, llvmPackages
+, symlinkJoin, makeWrapper, substituteAll
+, buildNpmPackage
+, emscripten
+}:
+
+stdenv.mkDerivation rec {
+  pname = "emscripten";
+  version = "3.1.49";
+
+  llvmEnv = symlinkJoin {
+    name = "emscripten-llvm-${version}";
+    paths = with llvmPackages; [ clang-unwrapped clang-unwrapped.lib lld llvm ];
+  };
+
+  nodeModules = buildNpmPackage {
+    name = "emscripten-node-modules-${version}";
+    inherit pname version src;
+
+    npmDepsHash = "sha256-Qft+//za5ed6Oquxtcdpv7g5oOc2WmWuRJ/CDe+FEiI=";
+
+    dontBuild = true;
+
+    # Copy node_modules directly.
+    installPhase = ''
+      cp -r node_modules $out/
+    '';
+  };
+
+  src = fetchFromGitHub {
+    owner = "emscripten-core";
+    repo = "emscripten";
+    hash = "sha256-gXZEOE/mpRZSrCIzBQFjtXxvF3IrKXezXJ47rfK5j7E=";
+    rev = version;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ nodejs python3 ];
+
+  patches = [
+    (substituteAll {
+      src = ./0001-emulate-clang-sysroot-include-logic-3.1.49.patch;
+      resourceDir = "${llvmEnv}/lib/clang/16/";
+    })
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    patchShebangs .
+
+    # fixes cmake support
+    sed -i -e "s/print \('emcc (Emscript.*\)/sys.stderr.write(\1); sys.stderr.flush()/g" emcc.py
+
+    sed -i "/^def check_sanity/a\\  return" tools/shared.py
+
+    echo "EMSCRIPTEN_ROOT = '$out/share/emscripten'" > .emscripten
+    echo "LLVM_ROOT = '${llvmEnv}/bin'" >> .emscripten
+    echo "NODE_JS = '${nodejs}/bin/node'" >> .emscripten
+    echo "JS_ENGINES = [NODE_JS]" >> .emscripten
+    echo "CLOSURE_COMPILER = ['${closurecompiler}/bin/closure-compiler']" >> .emscripten
+    echo "JAVA = '${jre}/bin/java'" >> .emscripten
+    # to make the test(s) below work
+    # echo "SPIDERMONKEY_ENGINE = []" >> .emscripten
+    echo "BINARYEN_ROOT = '${binaryen}'" >> .emscripten
+
+    # make emconfigure/emcmake use the correct (wrapped) binaries
+    sed -i "s|^EMCC =.*|EMCC='$out/bin/emcc'|" tools/shared.py
+    sed -i "s|^EMXX =.*|EMXX='$out/bin/em++'|" tools/shared.py
+    sed -i "s|^EMAR =.*|EMAR='$out/bin/emar'|" tools/shared.py
+    sed -i "s|^EMRANLIB =.*|EMRANLIB='$out/bin/emranlib'|" tools/shared.py
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    appdir=$out/share/emscripten
+    mkdir -p $appdir
+    cp -r . $appdir
+    chmod -R +w $appdir
+
+    mkdir -p $appdir/node_modules
+    cp -r ${nodeModules}/* $appdir/node_modules
+
+    mkdir -p $out/bin
+    for b in em++ em-config emar embuilder.py emcc emcmake emconfigure emmake emranlib emrun emscons emsize; do
+      makeWrapper $appdir/$b $out/bin/$b \
+        --set NODE_PATH ${nodeModules} \
+        --set EM_EXCLUSIVE_CACHE_ACCESS 1 \
+        --set PYTHON ${python3}/bin/python
+    done
+
+    # precompile libc (etc.) in all variants:
+    pushd $TMPDIR
+    echo 'int __main_argc_argv( int a, int b ) { return 42; }' >test.c
+    for LTO in -flto ""; do
+      for BIND in "" "--bind"; do
+        # starting with emscripten 3.1.32+,
+        # if pthreads and relocatable are both used,
+        # _emscripten_thread_exit_joinable must be exported
+        # (see https://github.com/emscripten-core/emscripten/pull/18376)
+        # TODO: get library cache to build with both enabled and function exported
+        $out/bin/emcc $LTO $BIND test.c
+        $out/bin/emcc $LTO $BIND -s RELOCATABLE test.c
+        # starting with emscripten 3.1.48+,
+        # to use pthreads, _emscripten_check_mailbox must be exported
+        # (see https://github.com/emscripten-core/emscripten/pull/20604)
+        # TODO: get library cache to build with pthreads at all
+        # $out/bin/emcc $LTO $BIND -s USE_PTHREADS test.c
+      done
+    done
+    popd
+
+    export PYTHON=${python3}/bin/python
+    export NODE_PATH=${nodeModules}
+    pushd $appdir
+    python test/runner.py test_hello_world
+    popd
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    # HACK: Make emscripten look more like a cc-wrapper to GHC
+    # when building the javascript backend.
+    targetPrefix = "em";
+    bintools = emscripten;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/emscripten-core/emscripten";
+    description = "An LLVM-to-JavaScript Compiler";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ raitobezarius willcohen ];
+    license = licenses.ncsa;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7946,6 +7946,10 @@ with pkgs;
     llvmPackages = llvmPackages_17;
   };
 
+  emscripten_3_1_49 = callPackage ../development/compilers/emscripten/3.1.49.nix {
+    llvmPackages = llvmPackages_16;
+  };
+
   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });
 
   emscriptenStdenv = stdenv // { mkDerivation = buildEmscriptenPackage; };


### PR DESCRIPTION
## Description of changes

Adds a pinned version of emscripten at 3.1.49 to allow GHC to continue to build.

@sternenseemann I have no interaction with that ecosystem, but if you can let me know which packages I should change the dependency on, I can add them to this PR for ofborg to check!

@RaitoBezarius 

Per https://github.com/NixOS/nixpkgs/pull/269904#issuecomment-1873937282

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
