### PR TITLE
vscode-extensions.sumneko.lua: 3.6.19 -> 3.7.3

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/sumneko.lua/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sumneko.lua/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "lua";
     publisher = "sumneko";
-    version = "3.6.19";
-    sha256 = "sha256-7f8zovJS1lNwrUryxgadrBbNRw/OwFqry57JWKY1D8E=";
+    version = "3.7.3";
+    sha256 = "sha256-JsZrCeT843QvQkebyOVlO9MI2xbEQI8xX0DrPacfGrM=";
   };
 
   # Running chmod in runtime will lock up extension

--- a/pkgs/applications/editors/vscode/extensions/sumneko.lua/remove-chmod.patch
+++ b/pkgs/applications/editors/vscode/extensions/sumneko.lua/remove-chmod.patch
@@ -1,14 +1,14 @@
 --- a/client/out/languageserver.js
 +++ b/client/out/languageserver.js
-@@ -145,11 +145,9 @@
+@@ -164,11 +164,9 @@ class LuaClient extends vscode_1.Disposable {
                      break;
                  case "linux":
-                     command = this.context.asAbsolutePath(path.join('server', binDir ? binDir : 'bin-Linux', 'lua-language-server'));
--                    yield fs.promises.chmod(command, '777');
+                     command = this.context.asAbsolutePath(path.join("server", binDir ? binDir : "bin-Linux", "lua-language-server"));
+-                    yield fs.promises.chmod(command, "777");
                      break;
                  case "darwin":
-                     command = this.context.asAbsolutePath(path.join('server', binDir ? binDir : 'bin-macOS', 'lua-language-server'));
--                    yield fs.promises.chmod(command, '777');
+                     command = this.context.asAbsolutePath(path.join("server", binDir ? binDir : "bin-macOS", "lua-language-server"));
+-                    yield fs.promises.chmod(command, "777");
                      break;
                  default:
                      throw new Error(`Unsupported operating system "${platform}"!`);


### PR DESCRIPTION
## Description of changes

- https://github.com/LuaLS/lua-language-server/releases/tag/3.7.3
- https://github.com/LuaLS/lua-language-server/compare/3.6.19...3.7.3

Patch had to be adjusted because the source was changed.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
