### PR TITLE
jupyter.lib: init

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -13,6 +13,7 @@ firefox.section.md
 fish.section.md
 fuse.section.md
 ibus.section.md
+jupyter.section.md
 kakoune.section.md
 linux.section.md
 locales.section.md

--- a/doc/packages/jupyter.section.md
+++ b/doc/packages/jupyter.section.md
@@ -1,0 +1,32 @@
+# jupyter {#sec-jupyter}
+
+Jupyter has different frontends that can be configured: jupyter-console and
+jupyter-notebook. The approach is the same:
+1. create a folder that contains all the jupyter kernels
+2. wrap the executables
+
+```nix
+let
+  definitions = {
+      python = jupyterLib.mkKernelFromPythonEnv (python3.withPackages(ps: [
+      ps.numpy ]);
+      haskell = jupyterLib.mkKernelFromHaskellEnv (pkgs.haskellPackages.ghcWithPackages(hs: [ hs.aeson
+      ]);
+      # ... and all other kernels you are interested in
+  };
+  myKernels = jupyter-kernel.create {
+    inherit definitions;
+  };
+in
+  # pseudocode, real code in next sections
+  jupyter frontend wrapped with JUPYTER_PATH=myKernels
+```
+
+
+## How to run jupyter-console with arbitrary kernels ? {#sec-jupyter-console}
+
+```nix
+myJupyterConsole = jupyter-console.mkConsole {
+  inherit definitions;
+}
+```

--- a/pkgs/applications/editors/jupyter/console.nix
+++ b/pkgs/applications/editors/jupyter/console.nix
@@ -1,36 +1,16 @@
 { python3
 , jupyter-kernel
+, jupyterLib
 , lib
 }:
-
-let
-  mkConsole = {
-    definitions ? jupyter-kernel.default
-    , kernel ? null
-  }:
-    (python3.buildEnv.override {
-      extraLibs = [ python3.pkgs.jupyter-console ];
-      makeWrapperArgs = [
-        "--set JUPYTER_PATH ${jupyter-kernel.create { inherit definitions; }}"
-      ] ++ lib.optionals (kernel != null) [
-        "--add-flags --kernel"
-        "--add-flags ${kernel}"
-      ];
-    }).overrideAttrs (oldAttrs: {
-      # To facilitate running nix run .#jupyter-console
-      meta = oldAttrs.meta // { mainProgram = "jupyter-console"; };
-    });
-
-in
-
 {
   # Build a console derivation with an arbitrary set of definitions, and an optional kernel to use.
   # If the kernel argument is not supplied, Jupyter console will pick a kernel to run from the ones
   # available on the system.
-  inherit mkConsole;
+  inherit (jupyterLib) mkConsole;
 
   # An ergonomic way to start a console with a single kernel.
-  withSingleKernel = definition: mkConsole {
+  withSingleKernel = definition: jupyterLib.mkConsole {
     definitions = lib.listToAttrs [(lib.nameValuePair definition.language definition)];
     kernel = definition.language;
   };

--- a/pkgs/applications/editors/jupyter/default.nix
+++ b/pkgs/applications/editors/jupyter/default.nix
@@ -3,6 +3,7 @@
 { python3
 , jupyter-kernel
 , definitions ? jupyter-kernel.default
+, callPackage
 }:
 
 let
@@ -12,6 +13,8 @@ let
     makeWrapperArgs = ["--set JUPYTER_PATH ${jupyterPath}"];
   }).overrideAttrs(oldAttrs: {
     meta = oldAttrs.meta // { mainProgram = "jupyter-notebook"; };
+
+    passthru.tests = callPackage ./tests {};
   });
 in
 

--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -1,23 +1,9 @@
-{ lib, stdenv, python3}:
+{ lib, stdenv, python3, jupyterLib }:
 
 let
 
   default = {
-    python3 = let
-      env = (python3.withPackages (ps: with ps; [ ipykernel ]));
-    in {
-      displayName = "Python 3";
-      argv = [
-        env.interpreter
-        "-m"
-        "ipykernel_launcher"
-        "-f"
-        "{connection_file}"
-      ];
-      language = "python";
-      logo32 = "${env}/${env.sitePackages}/ipykernel/resources/logo-32x32.png";
-      logo64 = "${env}/${env.sitePackages}/ipykernel/resources/logo-64x64.png";
-    };
+    python3 = jupyterLib.mkKernelFromPythonEnv (python3.withPackages (ps: []));
   };
 
 in

--- a/pkgs/applications/editors/jupyter/lib.nix
+++ b/pkgs/applications/editors/jupyter/lib.nix
@@ -1,0 +1,65 @@
+{ jupyter-kernel, python3, lib, ...}:
+{
+  /* Generates a kernel definition from a haskell environment
+
+      Example:
+        let ghcEnv = pkgs.haskellPackages.ghcWithPackages (p: [ p.aeson ]);
+        in mkKernelFromHaskellEnv ghcEnv;
+
+      Type:
+        mkKernelFromHaskellEnv :: Derivation -> AttrSet
+  */
+  mkKernelFromHaskellEnv = ghcEnv:
+    let
+      ghcEnv' = ghcEnv.withPackages (p: [ p.ihaskell ]);
+    in
+
+    {
+      displayName = "Haskell";
+      argv = [
+        "${ghcEnv'}/bin/ihaskell"
+        "-l"
+        # the ihaskell flake does `-l $(${env}/bin/ghc --print-libdir`
+        # we guess the path via hardcoded
+        # we can't use name else we get the 'with-packages' suffix
+        "${ghcEnv}/lib/ghc-${ghcEnv.version}"
+        "kernel"
+        "{connection_file}"
+      ];
+      language = "haskell";
+      logo32 = null;
+      logo64 = null;
+    };
+
+
+    /* Generates a kernel definition from a python environment
+    Example:
+      let pyEnv = pkgs.python3.withPackages (p: [ p.numpy ]);
+      in mkKernelFromPythonEnv pyEnv;
+
+    Type:
+      mkKernelFromPythonEnv :: Derivation -> AttrSet
+     */
+    mkKernelFromPythonEnv = env: let
+      env' = env.override(prev: {
+        # fastai
+        extraLibs = prev.extraLibs ++ [ env.python.pkgs.ipykernel ];
+      });
+
+    in
+     {
+      displayName = "Python 3";
+      argv = [
+        env'.interpreter
+        "-m"
+        "ipykernel_launcher"
+        "-f"
+        "{connection_file}"
+      ];
+      language = "python";
+      logo32 = "${env}/${env.sitePackages}/ipykernel/resources/logo-32x32.png";
+      logo64 = "${env}/${env.sitePackages}/ipykernel/resources/logo-64x64.png";
+    };
+
+
+}

--- a/pkgs/applications/editors/jupyter/lib.nix
+++ b/pkgs/applications/editors/jupyter/lib.nix
@@ -61,5 +61,21 @@
       logo64 = "${env}/${env.sitePackages}/ipykernel/resources/logo-64x64.png";
     };
 
+  mkConsole = {
+    definitions ? jupyter-kernel.default
+    , kernel ? null
+  }:
+    (python3.buildEnv.override {
+      extraLibs = [ python3.pkgs.jupyter-console ];
+      makeWrapperArgs = [
+        "--set JUPYTER_PATH ${jupyter-kernel.create { inherit definitions; }}"
+      ] ++ lib.optionals (kernel != null) [
+        "--add-flags --kernel"
+        "--add-flags ${kernel}"
+      ];
+    }).overrideAttrs (oldAttrs: {
+      # To facilitate running nix run .#jupyter-console
+      meta = oldAttrs.meta // { mainProgram = "jupyter-console"; };
+    });
 
 }

--- a/pkgs/applications/editors/jupyter/tests/default.nix
+++ b/pkgs/applications/editors/jupyter/tests/default.nix
@@ -1,0 +1,11 @@
+{ pkgs }:
+{
+  jupyter-all = pkgs.jupyter.override {
+    definitions = {
+      clojure = pkgs.clojupyter.definition;
+      octave = pkgs.octave-kernel.definition;
+      # wolfram = wolfram-for-jupyter-kernel.definition; # unfree
+    };
+  };
+
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -435,6 +435,7 @@ mapAliases ({
   jfbview = throw "'jfbview' has been removed, because it depends on an outdated and insecure version of mupdf"; # Added 2023-06-27
   jira-cli = throw "jira-cli was removed because it is no longer maintained"; # Added 2023-02-28
   join-desktop = throw "'join-desktop' has been removed because it is unmaintained upstream"; # Added 2023-10-04
+  jupyter-all = jupyter.tests;
 
   # Julia
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9723,14 +9723,6 @@ with pkgs;
   jupyter = callPackage ../applications/editors/jupyter { };
   jupyterLib = callPackage ../applications/editors/jupyter/lib.nix { };
 
-  jupyter-all = jupyter.override {
-    definitions = {
-      clojure = clojupyter.definition;
-      octave = octave-kernel.definition;
-      # wolfram = wolfram-for-jupyter-kernel.definition; # unfree
-    };
-  };
-
   jupyter-console = callPackage ../applications/editors/jupyter/console.nix { };
 
   jupyter-kernel = callPackage ../applications/editors/jupyter/kernel.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9721,6 +9721,7 @@ with pkgs;
   jupp = callPackage ../applications/editors/jupp { };
 
   jupyter = callPackage ../applications/editors/jupyter { };
+  jupyterLib = callPackage ../applications/editors/jupyter/lib.nix { };
 
   jupyter-all = jupyter.override {
     definitions = {


### PR DESCRIPTION
## Description of changes

This is the first PR of hopefully others trying to tackle issues I mentioned in https://github.com/NixOS/nixpkgs/issues/269331, i.e., improve nixpkgs API regarding jupyter usage and document its usage.

This doesn't do everything I have in mind because I dont want to do N breaking changes before realizing jupyter maintainers disagree with the approach.

My idea is to merge small PRs like this iteratively so we can discuss the changes gradually since we have time until the next release.

For instance the documentation doesn't explain how to create jupyter-notebooks envs but this will be fixed by next release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
