### PR TITLE
canonicalize-jar: fix and refactor

### DIFF
--- a/pkgs/build-support/java/canonicalize-jar.sh
+++ b/pkgs/build-support/java/canonicalize-jar.sh
@@ -1,29 +1,22 @@
 # Canonicalize the manifest & repack with deterministic timestamps.
 canonicalizeJar() {
-    local input='' outer=''
-    input="$(realpath -sm -- "$1")"
-    outer="$(pwd)"
+    local input="$1"
+    echo "canonicalizing $input"
+    # -q|--quiet
+    # -F|--fix: fixes archive when it has some small problems
+    @zip@ -qF "$input" --out "$input.fix"
     # -qq: even quieter
-    @unzip@ -qq "$input" -d "$input-tmp"
-    canonicalizeJarManifest "$input-tmp/META-INF/MANIFEST.MF"
+    # -o: overrides existing files (when there are overlapping files in the archive)
+    @unzip@ -qqo "$input.fix" -d "$input-tmp"
+    rm "$input" "$input.fix"
+    pushd "$input-tmp" >/dev/null
     # Sets all timestamps to Jan 1 1980, the earliest mtime zips support.
-    find -- "$input-tmp" -exec touch -t 198001010000.00 {} +
-    rm "$input"
-    pushd "$input-tmp" 2>/dev/null
+    find . -exec touch -t 198001010000.00 {} +
     # -q|--quiet, -r|--recurse-paths
     # -o|--latest-time: canonicalizes overall archive mtime
     # -X|--no-extra: don't store platform-specific extra file attribute fields
-    @zip@ -qroX "$outer/tmp-out.jar" . 2> /dev/null
-    popd 2>/dev/null
+    @zip@ -qroX "$input" .
+    popd >/dev/null
     rm -rf "$input-tmp"
-    mv "$outer/tmp-out.jar" "$input"
 }
 
-# See also the Java specification's JAR requirements:
-# https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Notes_on_Manifest_and_Signature_Files
-canonicalizeJarManifest() {
-    local input=''
-    input="$(realpath -sm -- "$1")"
-    (head -n 1 "$input" && tail -n +2 "$input" | sort | grep -v '^\s*$') > "$input-tmp"
-    mv "$input-tmp" "$input"
-}

--- a/pkgs/build-support/setup-hooks/canonicalize-jars.sh
+++ b/pkgs/build-support/setup-hooks/canonicalize-jars.sh
@@ -7,10 +7,10 @@ fixupOutputHooks+=('if [ -z "$dontCanonicalizeJars" -a -e "$prefix" ]; then cano
 canonicalizeJarsIn() {
   local dir="$1"
   echo "canonicalizing jars in $dir"
-  dir="$(realpath -sm -- "$dir")"
+  find $dir -type f -name '*.jar' -print0 |
   while IFS= read -rd '' f; do
     canonicalizeJar "$f"
-  done < <(find -- "$dir" -type f -name '*.jar' -print0)
+  done
 }
 
 source @canonicalize_jar@


### PR DESCRIPTION
Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518
Alternative to: https://github.com/NixOS/nixpkgs/pull/286805


This PR introduces some changes to `canonicalize-jar` and `canonicalize-jars-hook`, which are quite underutilized currently in Nixpkgs.

They unpack `.jar` files, patch the creation dates (usually the MANIFEST.MF file needs this), then modify the `MANIFEST.MF` file and repack the jars.

## Motivation

I wanted to fix (make deterministic) some java-based derivations (mostly built with `ant`) but it turns out, there are some issues with `canonicalize-jar` currently.

I encountered one of the issues when trying to package `openrocket`, but after some searching I found that `projectlibre` also has this issue:
Sometimes, when you try to `unzip` a `.jar` file, it will complain about overriding existing files. This is because somehow in the build steps, some files were included in a `.jar` file multiple times.

The hook currently uses `unzip` for unpacking jars.
`unzip` will show a prompt for file replacement when encountering these overlapped files.
This can be circumvented by doing `unzip -o ...`
Sadly, this only works when there are not too many files (it worked with `projectlibre` jars)

However, when there are too many overlapped files (like with [`openrocket`](https://openrocket.info/downloads.html?vers=23.09#content-JAR), it will show the following error:
```
error: invalid zip file with overlapped components (possible zip bomb)
```
possible solutions:
### using `unzip`
There is a way to get `unzip` to not think the file is a zipbomb: first using `zip` with the `-F` or `-FF` flag to create a fixed version of the jar, which can afterwards be extracted with `unzip`. I went with this one for now.

Some other candidates that were not perfect:

### using `jdk`'s own `jar` execuable
This is the most obvious solution, as this is the official way of unpacking jars.
However there may be some concerns about this increasing closure size when the original derivation isn't using the same `jdk` version. This could be solved if we just expect the consumer of the hook to provide the proper jdk in `nativeBuildInputs`

### using `fastjar`
This seemed really promising at first, as `fastjar` is a standalone reimplementation of the `jar` command in `C`. A downside of using it would be that it is really outdated software.

### using `7zz`
`7zz` apparently doesn't have this "zipbomb" protection. However it struggled to unzip some special cases.


## Changes:

I did a general refactoring of the script(s)

Now unpacking `.jar` files will not throw an error in the above mentioned cases.

The implementation for the canonicalization of the manifest files was flawed as it was currently, as it didn't respect linebreaks in properties when sorting the lines.

If a line in a manifest file is set to have more than 72 bytes of characters, java forces the line to break to the next line with a space as an indentation.
Source: https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html

The sorting could be done properly with a custom script.
The original author of the line said in a PR that the manifest attributes can be random in order, that's why it needed to be sorted. After some experimenting it seems to me that the attributes have a stable order. Because of this, I have removed that part.

The hook will no long try to fix `MANIFEST.MF`, so this PR actually closes: https://github.com/NixOS/nixpkgs/issues/16409

## Remaining problems:
a zip/jar file doesn't always use the same compression type for all its entries. Because of the fact that we unzip the file, we lose this original type-info, so we cannot rezip it perfectly. This caused an issue in the case of Stirling-PDF (and would also for any other package using Spring Boot). Luckily, gradle has some built in ways of handling timestamps, so this hook wasn't needed.

## Conclusion
I don't believe this is the perfect way to fix jar files, as most build systems have their own way of patching timestamps. However, I think that in cases where there isn't a built-in way of setting a build-timestamp (e.g. `prismlauncher`), this can still be useful.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
