### PR TITLE
mediathekview: Add desktop file and add JVM options

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -67,6 +67,8 @@
   services.portunus.ldap.package = pkgs.openldap.override { libxcrypt = pkgs.libxcrypt-legacy; };
   ```
 
+- The `mediathek` package no longer contains the `mediathekview` and `MediathekView_ipv4` programs.
+
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/applications/video/mediathekview/default.nix
+++ b/pkgs/applications/video/mediathekview/default.nix
@@ -35,16 +35,8 @@ stdenv.mkDerivation rec {
     install -m644 MediathekView.jar $out/lib
     install -m644 MediathekView.svg $out/share/pixmaps
 
-    makeWrapper ${jre}/bin/java $out/bin/mediathek \
-      --add-flags "${jvmArgs} -jar $out/lib/MediathekView.jar" \
-      --suffix LD_LIBRARY_PATH : "${libraryPath}"
-
     makeWrapper ${jre}/bin/java $out/bin/MediathekView \
       --add-flags "${jvmArgs} -jar $out/lib/MediathekView.jar" \
-      --suffix LD_LIBRARY_PATH : "${libraryPath}"
-
-    makeWrapper ${jre}/bin/java $out/bin/MediathekView_ipv4 \
-      --add-flags "${jvmArgs} -Djava.net.preferIPv4Stack=true -jar $out/lib/MediathekView.jar" \
       --suffix LD_LIBRARY_PATH : "${libraryPath}"
 
     runHook postInstall
@@ -52,7 +44,7 @@ stdenv.mkDerivation rec {
 
   desktopItems = makeDesktopItem {
     name = "MediathekView";
-    exec = "mediathek";
+    exec = "MediathekView";
     icon = "MediathekView";
     desktopName = "MediathekView";
     comment = "Offers access to the Mediathek of different tv stations (ARD, ZDF, Arte, etc.)";
@@ -66,7 +58,7 @@ stdenv.mkDerivation rec {
     homepage = "https://mediathekview.de/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;
-    mainProgram = "mediathek";
+    mainProgram = "MediathekView";
     maintainers = with maintainers; [ moredread ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/video/mediathekview/default.nix
+++ b/pkgs/applications/video/mediathekview/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, libglvnd, libnotify, jre, copyDesktopItems, makeDesktopItem, zip }:
+{ lib, stdenv, fetchurl, makeWrapper, libglvnd, libnotify, jre, copyDesktopItems, makeDesktopItem, zip, xorg }:
 
 stdenv.mkDerivation rec {
   version = "14.0.0";
@@ -8,12 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-vr0yqKVRodtXalHEIsm5gdEp9wPU9U5nnYhMk7IiPF4=";
   };
 
-
   nativeBuildInputs = [ copyDesktopItems makeWrapper zip ];
 
   installPhase =
   let
-    libraryPath = lib.strings.makeLibraryPath [ libglvnd libnotify ];
+    libraryPath = lib.makeLibraryPath ([ libglvnd libnotify ]
+      ++ lib.optional stdenv.isLinux xorg.libXxf86vm);
     # add JVM args from
     # https://github.com/mediathekview/MediathekView/blob/9105485f50ec10d863727b4817c8c4ffcbb02643/pom.xml#L136-L139
     jvmArgList = [

--- a/pkgs/applications/video/mediathekview/default.nix
+++ b/pkgs/applications/video/mediathekview/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, libglvnd, libnotify, jre, zip }:
+{ lib, stdenv, fetchurl, makeWrapper, libglvnd, libnotify, jre, copyDesktopItems, makeDesktopItem, zip }:
 
 stdenv.mkDerivation rec {
   version = "14.0.0";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
 
-  nativeBuildInputs = [ makeWrapper zip ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper zip ];
 
   installPhase =
   let
@@ -18,9 +18,10 @@ stdenv.mkDerivation rec {
   ''
     runHook preInstall
 
-    mkdir -p $out/{bin,lib}
+    mkdir -p $out/{bin,lib} $out/share/pixmaps
 
     install -m644 MediathekView.jar $out/lib
+    install -m644 MediathekView.svg $out/share/pixmaps
 
     makeWrapper ${jre}/bin/java $out/bin/mediathek \
       --add-flags "-jar $out/lib/MediathekView.jar" \
@@ -36,6 +37,17 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  desktopItems = makeDesktopItem {
+    name = "MediathekView";
+    exec = "mediathek";
+    icon = "MediathekView";
+    desktopName = "MediathekView";
+    comment = "Offers access to the Mediathek of different tv stations (ARD, ZDF, Arte, etc.)";
+    type = "Application";
+    categories = [ "Video" "AudioVideo" ];
+    startupNotify = true;
+  };
 
   meta = with lib; {
     description = "Offers access to the Mediathek of different tv stations (ARD, ZDF, Arte, etc.)";


### PR DESCRIPTION
## Description of changes

1. add a desktop file, so that mediathekview is available from launchers

2. add the recommended JVM options to the wrapper. These options are checked for on startup and a warning dialog is displayed each time if these flags are not passed (the check can be disabled using the `-nj, --no-jvm-param-checks` CLI option).

3. avoid an `UnsatisfiedLinkError` for libprism_es2.so on Linux, the library depends on the xf86vm xorg extension


Fixes #288255

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
