### PR TITLE
libewf: 20201230 -> 20231119

### DIFF
--- a/pkgs/development/libraries/libewf/default.nix
+++ b/pkgs/development/libraries/libewf/default.nix
@@ -1,21 +1,13 @@
 { fetchurl, fetchpatch, lib, stdenv, zlib, openssl, libuuid, pkg-config, bzip2 }:
 
 stdenv.mkDerivation rec {
-  version = "20201230";
+  version = "20231119";
   pname = "libewf";
 
   src = fetchurl {
     url = "https://github.com/libyal/libewf/releases/download/${version}/libewf-experimental-${version}.tar.gz";
-    hash = "sha256-10r4jPzsA30nHQzjdg/VkwTG1PwOskwv8Bra34ZPMgc=";
+    hash = "sha256-7AjUEaXasOzJV9ErZK2a4HMTaqhcBbLKd8M+A5SbKrc=";
   };
-
-  patches = [
-    # fix build with OpenSSL 3.0
-    (fetchpatch {
-      url = "https://github.com/libyal/libewf/commit/033ea5b4e5f8f1248f74a2ec61fc1be183c6c46b.patch";
-      hash = "sha256-R4+NO/91kiZP48SJyVF9oYjKCg1h/9Kh8/0VOEmJXPQ=";
-    })
-  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ zlib openssl libuuid ]


### PR DESCRIPTION
## Description of changes

Fixes: #278341

<details>
<summary>18 packages built:</summary>
<ul>cutter</ul> 
<ul>cutterPlugins.jsdec</ul> 
<ul>cutterPlugins.rz-ghidra</ul> 
<ul>diffoscope diffoscope.dist</ul> 
<ul>diffoscope.man</ul>
<ul>iaito</ul> 
<ul>libewf</ul> 
<ul>python310Packages.r2pipe</ul> 
<ul>python310Packages.r2pipe.dist</ul> 
<ul>python311Packages.r2pipe</ul> 
<ul>python311Packages.r2pipe.dist</ul> 
<ul>radare2</ul> 
<ul>rizin</ul> 
<ul>rizinPlugins.rz-ghidra</ul> 
<ul>sleuthkit</ul> 
<ul>testdisk</ul> 
<ul>testdisk-qt</ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
