### PR TITLE
android-studio-for-platform: init at 2023.2.1.20

### DIFF
--- a/pkgs/applications/editors/android-studio-for-platform/common.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/common.nix
@@ -1,6 +1,8 @@
-{ bash
+{ channel, pname, version, sha256Hash }:
+
+{ android-tools
+, bash
 , buildFHSEnv
-, cacert
 , coreutils
 , dpkg
 , e2fsprogs
@@ -12,6 +14,7 @@
 , gnutar
 , gtk2, gnome_vfs, glib, GConf
 , gzip
+, fontsConf
 , fontconfig
 , freetype
 , libX11
@@ -24,7 +27,6 @@
 , makeWrapper
 , ncurses5
 , openssl
-, pkgsi686Linux
 , ps
 , python3
 , lib
@@ -41,38 +43,24 @@
 }:
 
 let
-  pname = "android-studio-for-platform";
-  version = "2023.2.1.20";
-
-  drvName = "android-studio-for-platform-${version}";
+  drvName = "${pname}-${version}";
   filename = "asfp-${version}-linux.deb";
-
-  fontsConf = makeFontsConf {
-    fontDirectories = [];
-  };
 
   androidStudioForPlatform = stdenv.mkDerivation {
     name = "${drvName}-unwrapped";
 
     src = fetchurl {
       url = "https://dl.google.com/android/asfp/${filename}";
-      sha256 = "sha256-cM/pkSghqLUUvJVF/OVLDOxVBJlJLH8ge1bfZtDUegY=";
+      sha256 = sha256Hash;
     };
 
     nativeBuildInputs = [
       dpkg
-      unzip
       makeWrapper
     ];
 
-    dontUnpack = true;
-
-    # Causes the shebangs in interpreter scripts deployed to mobile devices to be patched, which Android does not understand
-    dontPatchShebangs = true;
-
     installPhase = ''
-      dpkg -x $src .
-      cp -r ./opt/android-studio-for-platform/ $out
+      cp -r "./opt/${pname}/" $out
       wrapProgram $out/bin/studio.sh \
         --set-default JAVA_HOME "$out/jbr" \
         --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
@@ -95,6 +83,7 @@ let
           git
           ps
           usbutils
+          android-tools
 
           # For Soong sync
           openssl
@@ -132,7 +121,7 @@ let
     name = pname;
     exec = pname;
     icon = pname;
-    desktopName = "Android Studio for Platform";
+    desktopName = "Android Studio for Platform (${channel} channel)";
     comment = "The official Android IDE for Android platform development";
     categories = [ "Development" "IDE" ];
     startupNotify = true;

--- a/pkgs/applications/editors/android-studio-for-platform/default.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/default.nix
@@ -1,0 +1,32 @@
+{ callPackage, makeFontsConf, gnome2, buildFHSEnv, tiling_wm ? false }:
+
+let
+  mkStudio = opts: callPackage (import ./common.nix opts) {
+    fontsConf = makeFontsConf {
+      fontDirectories = [];
+    };
+    inherit (gnome2) GConf gnome_vfs;
+    inherit buildFHSEnv;
+    inherit tiling_wm;
+  };
+  stableVersion = {
+    version = "2023.2.1.20"; # Android Studio Iguana | 2023.2.1 Beta 2
+    sha256Hash = "sha256-cM/pkSghqLUUvJVF/OVLDOxVBJlJLH8ge1bfZtDUegY=";
+  };
+  canaryVersion = {
+    version = "2023.3.2.1"; # Android Studio Jellyfish | 2023.3.2 Canary 1
+    sha256Hash = "sha256-XOsbMyNentklfEp1k49H3uFeiRNMCV/Seisw9K1ganM=";
+  };
+in {
+  # Attributes are named by their corresponding release channels
+
+  stable = mkStudio (stableVersion // {
+    channel = "stable";
+    pname = "android-studio-for-platform";
+  });
+
+  canary = mkStudio (canaryVersion // {
+    channel = "canary";
+    pname = "android-studio-for-platform-canary";
+  });
+}

--- a/pkgs/by-name/an/android-studio-for-platform/package.nix
+++ b/pkgs/by-name/an/android-studio-for-platform/package.nix
@@ -1,0 +1,197 @@
+{ bash
+, buildFHSEnv
+, cacert
+, coreutils
+, dpkg
+, e2fsprogs
+, fetchurl
+, findutils
+, git
+, gnugrep
+, gnused
+, gnutar
+, gtk2, gnome_vfs, glib, GConf
+, gzip
+, fontconfig
+, freetype
+, libX11
+, libXext
+, libXi
+, libXrandr
+, libXrender
+, libXtst
+, makeFontsConf
+, makeWrapper
+, ncurses5
+, openssl
+, pkgsi686Linux
+, ps
+, python3
+, lib
+, stdenv
+, unzip
+, usbutils
+, which
+, runCommand
+, xkeyboard_config
+, zip
+, zlib
+, makeDesktopItem
+, tiling_wm ? false # if we are using a tiling wm, need to set _JAVA_AWT_WM_NONREPARENTING in wrapper
+}:
+
+let
+  pname = "android-studio-for-platform";
+  version = "2023.2.1.20";
+
+  drvName = "android-studio-for-platform-${version}";
+  filename = "asfp-${version}-linux.deb";
+
+  fontsConf = makeFontsConf {
+    fontDirectories = [];
+  };
+
+  androidStudioForPlatform = stdenv.mkDerivation {
+    name = "${drvName}-unwrapped";
+
+    src = fetchurl {
+      url = "https://dl.google.com/android/asfp/${filename}";
+      sha256 = "sha256-cM/pkSghqLUUvJVF/OVLDOxVBJlJLH8ge1bfZtDUegY=";
+    };
+
+    nativeBuildInputs = [
+      dpkg
+      unzip
+      makeWrapper
+    ];
+
+    dontUnpack = true;
+
+    # Causes the shebangs in interpreter scripts deployed to mobile devices to be patched, which Android does not understand
+    dontPatchShebangs = true;
+
+    installPhase = ''
+      dpkg -x $src .
+      cp -r ./opt/android-studio-for-platform/ $out
+      wrapProgram $out/bin/studio.sh \
+        --set-default JAVA_HOME "$out/jbr" \
+        --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
+        ${lib.optionalString tiling_wm "--set _JAVA_AWT_WM_NONREPARENTING 1"} \
+        --set FONTCONFIG_FILE ${fontsConf} \
+        --prefix PATH : "${lib.makeBinPath [
+
+          # Checked in studio.sh
+          coreutils
+          findutils
+          gnugrep
+          which
+          gnused
+
+          # Used during setup wizard
+          gnutar
+          gzip
+
+          # Runtime stuff
+          git
+          ps
+          usbutils
+
+          # For Soong sync
+          openssl
+          python3
+          unzip
+          zip
+          e2fsprogs
+        ]}" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+          # Crash at startup without these
+          fontconfig
+          freetype
+          libXext
+          libXi
+          libXrender
+          libXtst
+          libX11
+
+          # Support multiple monitors
+          libXrandr
+
+          # For GTKLookAndFeel
+          gtk2
+          gnome_vfs
+          glib
+          GConf
+
+          # For Soong sync
+          e2fsprogs
+        ]}"
+    '';
+  };
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    desktopName = "Android Studio for Platform";
+    comment = "The official Android IDE for Android platform development";
+    categories = [ "Development" "IDE" ];
+    startupNotify = true;
+    startupWMClass = "jetbrains-studio";
+  };
+
+  # Android Studio for Platform downloads prebuilt binaries as part of the SDK. These tools
+  # (e.g. `mksdcard`) have `/lib/ld-linux.so.2` set as the interpreter. An FHS
+  # environment is used as a work around for that.
+  fhsEnv = buildFHSEnv {
+    name = "${drvName}-fhs-env";
+    multiPkgs = pkgs: [
+      zlib
+      ncurses5
+      ncurses5.dev
+    ];
+    profile = ''
+      export ALLOW_NINJA_ENV=true
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib:/usr/lib32
+    '';
+  };
+in runCommand
+  drvName
+  {
+    startScript = ''
+      #!${bash}/bin/bash
+      ${fhsEnv}/bin/${drvName}-fhs-env ${androidStudioForPlatform}/bin/studio.sh "$@"
+    '';
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+    passthru = {
+      unwrapped = androidStudioForPlatform;
+    };
+    meta = with lib; {
+      description = "The Official IDE for Android platform development";
+      longDescription = ''
+        Android Studio for Platform (ASfP) is the version of the Android Studio IDE
+        for Android Open Source Project (AOSP) platform developers who build with the Soong build system.
+      '';
+      homepage = "https://developer.android.com/studio/platform.html";
+      license = with licenses; [ asl20 unfree ]; # The code is under Apache-2.0, but:
+      # If one selects Help -> Licenses in Android Studio, the dialog shows the following:
+      # "Android Studio includes proprietary code subject to separate license,
+      # including JetBrains CLion(R) (www.jetbrains.com/clion) and IntelliJ(R)
+      # IDEA Community Edition (www.jetbrains.com/idea)."
+      # Also: For actual development the Android SDK is required and the Google
+      # binaries are also distributed as proprietary software (unlike the
+      # source-code itself).
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [ robbins ];
+      mainProgram = pname;
+    };
+  }
+  ''
+    mkdir -p $out/{bin,share/pixmaps}
+
+    echo -n "$startScript" > $out/bin/${pname}
+    chmod +x $out/bin/${pname}
+
+    ln -s ${androidStudioForPlatform}/bin/studio.png $out/share/pixmaps/${pname}.png
+    ln -s ${desktopItem}/share/applications $out/share/applications
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30413,7 +30413,9 @@ with pkgs;
     (callPackage ../applications/editors/android-studio { });
   android-studio = androidStudioPackages.stable;
 
-  android-studio-for-platform = callPackage ../by-name/an/android-studio-for-platform/package.nix { inherit (gnome2) GConf gnome_vfs; };
+  androidStudioForPlatformPackages = recurseIntoAttrs
+    (callPackage ../applications/editors/android-studio-for-platform { });
+  android-studio-for-platform = androidStudioForPlatformPackages.stable;
 
   antfs-cli = callPackage ../applications/misc/antfs-cli { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30413,6 +30413,8 @@ with pkgs;
     (callPackage ../applications/editors/android-studio { });
   android-studio = androidStudioPackages.stable;
 
+  android-studio-for-platform = callPackage ../by-name/an/android-studio-for-platform/package.nix { inherit (gnome2) GConf gnome_vfs; };
+
   antfs-cli = callPackage ../applications/misc/antfs-cli { };
 
   antimony = libsForQt5.callPackage ../applications/graphics/antimony { };


### PR DESCRIPTION
## Description of changes

`android-studio-for-platform` is a variant of the Android Studio IDE designed specifically for working on AOSP.
homepage: https://developer.android.com/studio/platform

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
