### PR TITLE
libtas: init at 1.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17255,6 +17255,12 @@
     githubId = 3789764;
     name = "skykanin";
   };
+  skyrina = {
+    email = "sorryu02@gmail.com";
+    github = "skyrina";
+    githubId = 116099351;
+    name = "Skylar";
+  };
   slam-bert = {
     github = "slam-bert";
     githubId = 106779009;

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, SDL2
+, alsa-lib
+, ffmpeg
+, lua5_3
+, qt5
+, file
+, makeDesktopItem
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libtas";
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "clementgallet";
+    repo = "libTAS";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-n4iaJG9k+/TFfGMDCYL83Z6paxpm/gY3thP9T84GeQU=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook qt5.wrapQtAppsHook pkg-config ];
+  buildInputs = [ SDL2 alsa-lib ffmpeg lua5_3 qt5.qtbase ];
+
+  configureFlags = [
+    "--enable-release-build"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib
+    mv $out/bin/libtas*.so $out/lib/
+  '';
+
+  enableParallelBuilding = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/libTAS \
+      --suffix PATH : ${lib.makeBinPath [ file ]} \
+      --set-default LIBTAS_SO_PATH $out/lib/libtas.so
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "libTAS";
+      desktopName = "libTAS";
+      exec = "libTAS %U";
+      icon = "libTAS";
+      startupWMClass = "libTAS";
+      keywords = [ "libTAS" ];
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "https://clementgallet.github.io/libTAS/";
+    description = "GNU/Linux software to give TAS tools to games";
+    license = lib.licenses.gpl3Only;
+    maintainers = with maintainers; [ skyrina ];
+    mainProgram = "libTAS";
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

adds [libTAS](https://github.com/clementgallet/libTAS)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
